### PR TITLE
Increased wait tick delay for pistons

### DIFF
--- a/source/Piston.cpp
+++ b/source/Piston.cpp
@@ -21,7 +21,7 @@ extern bool g_BlockPistonBreakable[];
 
 
 /// Number of ticks that the piston extending / retracting waits before setting the block
-const int PISTON_TICK_DELAY = 30;
+const int PISTON_TICK_DELAY = 10;
 
 
 


### PR DESCRIPTION
xoft, a 5 tick delay is not nearly enough (tested)!

1.5 seconds should be good.
