### PR TITLE
Allow the user to override the compiler 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,8 +21,11 @@
 # Macros
 #
 
+# allow user to override compiler
+# if no compiler is specified make specifies cc
+ifeq ($(CC),cc)
 CC = /usr/bin/g++
-
+endif
 
 all: MCServer/MCServer
 


### PR DESCRIPTION
Allow the user to override the compiler using the CC enviromental varible when building. this makes it easier to test other platforms like clang
