### PR TITLE
Fixed mobs attack range being too long

### DIFF
--- a/source/Mobs/Monster.cpp
+++ b/source/Mobs/Monster.cpp
@@ -1,3 +1,4 @@
+
 #include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
 
 #include "Monster.h"


### PR DESCRIPTION
It was set to 5, I think 2 is better because now mobs can kill you when there is a block (or 2) between you and monster.
