### PR TITLE
Mob spawning changes

### DIFF
--- a/source/World.cpp
+++ b/source/World.cpp
@@ -772,10 +772,10 @@ void cWorld::TickSpawnMobs(float a_Dt)
 			// Spawn nether mobs
 			switch (nightRand)
 			{
-				case 0: MobType = cMonster::mtGhast;        break;
-				case 1: MobType = cMonster::mtBlaze;        break;
-				case 2: MobType = cMonster::mtZombiePigman; break;
-				case 3: MobType = cMonster::mtZombiePigman; break;
+				case 0: MobType = cMonster::mtBlaze;        break;
+				case 1: MobType = cMonster::mtGhast;        break;
+				case 2: MobType = cMonster::mtGhast;        break;
+				case 3: MobType = cMonster::mtGhast;        break;
 				case 4: MobType = cMonster::mtZombiePigman; break;
 				case 5: MobType = cMonster::mtZombiePigman; break;
 				case 6: MobType = cMonster::mtZombiePigman; break;


### PR DESCRIPTION
Added EnderDragon, Blaze and Horse spawning.
I'm not sure about that, there could be more than 1 enderdragon in world and blazes should only spawn on nether fortresses, but I think for now it's the best way to spawn these mobs.
