### PR TITLE
Crop blocks now respect water and light.

### DIFF
--- a/source/Blocks/BlockCrops.h
+++ b/source/Blocks/BlockCrops.h
@@ -78,14 +78,13 @@ public:
 	void OnUpdate(cWorld * a_World, int a_BlockX, int a_BlockY, int a_BlockZ) override
 	{
 		NIBBLETYPE Meta = a_World->GetBlockMeta(a_BlockX, a_BlockY, a_BlockZ);
-		NIBBLETYPE Water = a_World->GetBlockMeta(a_BlockX, a_BlockY - 1, a_BlockZ);
 		NIBBLETYPE Light = a_World->GetBlockBlockLight(a_BlockX, a_BlockY, a_BlockZ);
 		
-		if ((Meta < 7) && (Water > 0) && (Light > 8))
+		if ((Meta < 7) && (Light > 8))
 		{
 			a_World->FastSetBlock(a_BlockX, a_BlockY, a_BlockZ, E_BLOCK_CROPS, ++Meta);
 		}
-		else if ((!Water) ||  (Light < 9))
+		else if (Light < 9)
 		{
 			a_World->DigBlock(a_BlockX, a_BlockY, a_BlockZ);
 		}


### PR DESCRIPTION
Now if the block does not have water or doesn't have enough light, it will break. However, the block has to be watered farmland before you can plant anything on it.
Also, crops do not drop seeds yet if they die due to lack of water or light.
