### PR TITLE
Both the LoadWorlds() function and cAuthenticator now use the cIniFile object from the Root::Start() function.

### DIFF
--- a/source/Authenticator.cpp
+++ b/source/Authenticator.cpp
@@ -44,7 +44,7 @@ cAuthenticator::~cAuthenticator()
 
 
 /// Read custom values from INI
-void cAuthenticator::ReadINI(cIniFile IniFile)
+void cAuthenticator::ReadINI(cIniFile & IniFile)
 {
 	m_Server  = IniFile.GetValue("Authentication", "Server");
 	m_Address = IniFile.GetValue("Authentication", "Address");
@@ -93,7 +93,7 @@ void cAuthenticator::Authenticate(int a_ClientID, const AString & a_UserName, co
 
 
 
-void cAuthenticator::Start(cIniFile IniFile)
+void cAuthenticator::Start(cIniFile & IniFile)
 {
 	ReadINI(IniFile);
 	m_ShouldTerminate = false;

--- a/source/Authenticator.h
+++ b/source/Authenticator.h
@@ -37,13 +37,13 @@ public:
 	~cAuthenticator();
 
 	/// (Re-)read server and address from INI:
-	void ReadINI(cIniFile IniFile);
+	void ReadINI(cIniFile & IniFile);
 
 	/// Queues a request for authenticating a user. If the auth fails, the user is kicked
 	void Authenticate(int a_ClientID, const AString & a_UserName, const AString & a_ServerHash);
 
 	/// Starts the authenticator thread. The thread may be started and stopped repeatedly
-	void Start(cIniFile IniFile);
+	void Start(cIniFile & IniFile);
 	
 	/// Stops the authenticator thread. The thread may be started and stopped repeatedly
 	void Stop(void);

--- a/source/Root.cpp
+++ b/source/Root.cpp
@@ -245,7 +245,7 @@ void cRoot::LoadGlobalSettings()
 
 
 
-void cRoot::LoadWorlds(cIniFile IniFile)
+void cRoot::LoadWorlds(cIniFile & IniFile)
 {
 	// First get the default world
 	AString DefaultWorldName = IniFile.GetValueSet("Worlds", "DefaultWorld", "world");

--- a/source/Root.h
+++ b/source/Root.h
@@ -162,7 +162,7 @@ private:
 	void LoadGlobalSettings();
 
 	/// Loads the worlds from settings.ini, creates the worldmap
-	void LoadWorlds(cIniFile IniFile);
+	void LoadWorlds(cIniFile & IniFile);
 	
 	/// Starts each world's life
 	void StartWorlds(void);


### PR DESCRIPTION
fix for #290. I hope I did it properly. I usualy don't do C++ stuff.
