### PR TITLE
Fixed clang autodetection.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -88,7 +88,7 @@ CXX_OPTIONS += -Wall
 ###################################################
 # Fix Crypto++ warnings in clang
 
-ifeq ($(shell $(CXX) --version 2>&1 | grep -i -c "clang version"),1)
+ifeq ($(shell $(CXX) --version 2>&1 | grep -i -c "clang"),1)
 CC_OPTIONS += -DCRYPTOPP_DISABLE_ASM
 CXX_OPTIONS += -DCRYPTOPP_DISABLE_ASM
 endif


### PR DESCRIPTION
Wouldn't compile on Mac OS 10.9 due to change in clang output when calling 'clang --version'.

See http://forum.mc-server.org/showthread.php?tid=1281&pid=10842#pid10842 for the entire conversation.
