### PR TITLE
Add missing plugin error

### DIFF
--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -103,13 +103,14 @@ bool cPluginLua::Initialize(void)
 		{
 			Close();
 			return false;
-		} else 
+		} 
+		else 
 		{
 			numFiles++;
 		}
 	}  // for itr - Files[]
 
-	if (numFiles == 0) // no lua files found
+	if (numFiles == 0)
 	{
 		LOGWARNING("No lua files found: plugin %s is missing.", GetName().c_str());
 		Close();


### PR DESCRIPTION
Previously, if a plugin was included but the folder had no lua files,
the error given was ambiguous. Now, it explicitly describes lack of lua
files.

See issue #512

P.S. This probably isn't the best way, but this is where the fix can be
made.
