### PR TITLE
Decoupled cChunkGenerator from cWorld and cRoot.

### DIFF
--- a/src/Generating/ComposableGenerator.cpp
+++ b/src/Generating/ComposableGenerator.cpp
@@ -157,9 +157,9 @@ cComposableGenerator::~cComposableGenerator()
 
 
 
-void cComposableGenerator::Initialize(cWorld * a_World, cIniFile & a_IniFile)
+void cComposableGenerator::Initialize(cIniFile & a_IniFile)
 {
-	super::Initialize(a_World, a_IniFile);
+	super::Initialize(a_IniFile);
 	
 	InitBiomeGen(a_IniFile);
 	InitHeightGen(a_IniFile);
@@ -369,13 +369,14 @@ void cComposableGenerator::InitFinishGens(cIniFile & a_IniFile)
 	int Seed = m_ChunkGenerator.GetSeed();
 	AString Structures = a_IniFile.GetValueSet("Generator", "Finishers", "SprinkleFoliage,Ice,Snow,Lilypads,BottomLava,DeadBushes,PreSimulator");
 
+	eDimension Dimension = StringToDimension(a_IniFile.GetValue("General", "Dimension", "Overworld"));
 	AStringVector Str = StringSplitAndTrim(Structures, ",");
 	for (AStringVector::const_iterator itr = Str.begin(); itr != Str.end(); ++itr)
 	{
 		// Finishers, alpha-sorted:
 		if (NoCaseCompare(*itr, "BottomLava") == 0)
 		{
-			int DefaultBottomLavaLevel = (m_World->GetDimension() == dimNether) ? 30 : 10;
+			int DefaultBottomLavaLevel = (Dimension == dimNether) ? 30 : 10;
 			int BottomLavaLevel = a_IniFile.GetValueSetI("Generator", "BottomLavaLevel", DefaultBottomLavaLevel);
 			m_FinishGens.push_back(new cFinishGenBottomLava(BottomLavaLevel));
 		}
@@ -389,7 +390,7 @@ void cComposableGenerator::InitFinishGens(cIniFile & a_IniFile)
 		}
 		else if (NoCaseCompare(*itr, "LavaSprings") == 0)
 		{
-			m_FinishGens.push_back(new cFinishGenFluidSprings(Seed, E_BLOCK_LAVA, a_IniFile, *m_World));
+			m_FinishGens.push_back(new cFinishGenFluidSprings(Seed, E_BLOCK_LAVA, a_IniFile, Dimension));
 		}
 		else if (NoCaseCompare(*itr, "Lilypads") == 0)
 		{
@@ -409,7 +410,7 @@ void cComposableGenerator::InitFinishGens(cIniFile & a_IniFile)
 		}
 		else if (NoCaseCompare(*itr, "WaterSprings") == 0)
 		{
-			m_FinishGens.push_back(new cFinishGenFluidSprings(Seed, E_BLOCK_WATER, a_IniFile, *m_World));
+			m_FinishGens.push_back(new cFinishGenFluidSprings(Seed, E_BLOCK_WATER, a_IniFile, Dimension));
 		}
 	}  // for itr - Str[]
 }

--- a/src/Generating/ComposableGenerator.h
+++ b/src/Generating/ComposableGenerator.h
@@ -162,7 +162,7 @@ public:
 	cComposableGenerator(cChunkGenerator & a_ChunkGenerator);
 	virtual ~cComposableGenerator();
 	
-	virtual void Initialize(cWorld * a_World, cIniFile & a_IniFile) override;
+	virtual void Initialize(cIniFile & a_IniFile) override;
 	virtual void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap) override;
 	virtual void DoGenerate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) override;
 

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -520,7 +520,7 @@ void cFinishGenPreSimulator::StationarizeFluid(
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // cFinishGenFluidSprings:
 
-cFinishGenFluidSprings::cFinishGenFluidSprings(int a_Seed, BLOCKTYPE a_Fluid, cIniFile & a_IniFile, const cWorld & a_World) :
+cFinishGenFluidSprings::cFinishGenFluidSprings(int a_Seed, BLOCKTYPE a_Fluid, cIniFile & a_IniFile, eDimension a_Dimension) :
 	m_Noise(a_Seed + a_Fluid * 100),  // Need to take fluid into account, otherwise water and lava springs generate next to each other
 	m_HeightDistribution(255),
 	m_Fluid(a_Fluid)
@@ -529,7 +529,7 @@ cFinishGenFluidSprings::cFinishGenFluidSprings(int a_Seed, BLOCKTYPE a_Fluid, cI
 	AString SectionName = IsWater ? "WaterSprings" : "LavaSprings";
 	AString DefaultHeightDistribution;
 	int DefaultChance = 0;
-	switch (a_World.GetDimension())
+	switch (a_Dimension)
 	{
 		case dimNether:
 		{

--- a/src/Generating/FinishGen.h
+++ b/src/Generating/FinishGen.h
@@ -164,7 +164,7 @@ class cFinishGenFluidSprings :
 	public cFinishGen
 {
 public:
-	cFinishGenFluidSprings(int a_Seed, BLOCKTYPE a_Fluid, cIniFile & a_IniFile, const cWorld & a_World);
+	cFinishGenFluidSprings(int a_Seed, BLOCKTYPE a_Fluid, cIniFile & a_IniFile, eDimension a_Dimension);
 	
 protected:
 

--- a/src/Generating/Noise3DGenerator.cpp
+++ b/src/Generating/Noise3DGenerator.cpp
@@ -150,10 +150,8 @@ cNoise3DGenerator::~cNoise3DGenerator()
 
 
 
-void cNoise3DGenerator::Initialize(cWorld * a_World, cIniFile & a_IniFile)
+void cNoise3DGenerator::Initialize(cIniFile & a_IniFile)
 {
-	m_World = a_World;
-
 	// Params:
 	m_SeaLevel            =                 a_IniFile.GetValueSetI("Generator", "Noise3DSeaLevel", 62);
 	m_HeightAmplification = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DHeightAmplification", 0);

--- a/src/Generating/Noise3DGenerator.h
+++ b/src/Generating/Noise3DGenerator.h
@@ -24,7 +24,7 @@ public:
 	cNoise3DGenerator(cChunkGenerator & a_ChunkGenerator);
 	virtual ~cNoise3DGenerator();
 	
-	virtual void Initialize(cWorld * a_World, cIniFile & a_IniFile) override;
+	virtual void Initialize(cIniFile & a_IniFile) override;
 	virtual void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap) override;
 	virtual void DoGenerate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) override;
 	

--- a/src/World.h
+++ b/src/World.h
@@ -636,6 +636,27 @@ private:
 		virtual void Execute(void) override;
 	} ;
 	
+	
+	/** Implementation of the callbacks that the ChunkGenerator uses to store new chunks and interface to plugins */
+	class cChunkGeneratorCallbacks :
+		public cChunkGenerator::cChunkSink,
+		public cChunkGenerator::cPluginInterface
+	{
+		cWorld * m_World;
+		
+		// cChunkSink overrides:
+		virtual void OnChunkGenerated  (cChunkDesc & a_ChunkDesc) override;
+		virtual bool IsChunkValid      (int a_ChunkX, int a_ChunkZ) override;
+		virtual bool HasChunkAnyClients(int a_ChunkX, int a_ChunkZ) override;
+		
+		// cPluginInterface overrides:
+		virtual void CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) override;
+		virtual void CallHookChunkGenerated (cChunkDesc & a_ChunkDesc) override;
+		
+	public:
+		cChunkGeneratorCallbacks(cWorld & a_World);
+	} ;
+	
 
 	AString m_WorldName;
 	AString m_IniFileName;
@@ -713,6 +734,9 @@ private:
 	sSetBlockList    m_FastSetBlockQueue;
 
 	cChunkGenerator  m_Generator;
+	
+	/** The callbacks that the ChunkGenerator uses to store new chunks and interface to plugins */
+	cChunkGeneratorCallbacks m_GeneratorCallbacks;
 	
 	cChunkSender     m_ChunkSender;
 	cLightingThread  m_Lighting;


### PR DESCRIPTION
Now the chunk generator can be used by other projects without depending on the two hugest structures in MCS. This will allow us to later create a ChunkGenerator server or a generator speed comparator, as separate projects.
