### PR TITLE
Fixed glowstone drop count

### DIFF
--- a/src/Blocks/BlockGlowstone.h
+++ b/src/Blocks/BlockGlowstone.h
@@ -20,8 +20,8 @@ public:
 	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta) override
 	{
 		// Reset meta to 0
-		// TODO: More drops?
-		a_Pickups.push_back(cItem(E_ITEM_GLOWSTONE_DUST, 1, 0));
+		MTRand r1;
+		a_Pickups.push_back(cItem(E_ITEM_GLOWSTONE_DUST, (char)(2 + r1.randInt(2)), 0));
 	}
 } ;
 


### PR DESCRIPTION
Copied the pattern used in other block handlers.

On a side note, I believe it is a waste of both (stack) memory and time to construct and initialize a full mersenne twister context for each ConvertToPickups() call (unless I missed something). Shall I try to improve it?
