### PR TITLE
Added -march=native to linux targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,15 @@ else()
 	add_flags_cxx("-pthread")
 endif()
 
-# Allow for a forced 32-bit build under 32-bit OS:
+# Allow for a forced 32-bit build under 64-bit OS:
 if (FORCE_32)
 	add_flags_cxx("-m32")
 	add_flags_lnk("-m32")
+endif()
+
+#have the compiler generate code spercificly targeted at the current machine on Linux
+if(LINUX AND NOT CROSSCOMPILE)
+	add_flags_cxx("-march=native")
 endif()
 
 # Set lower warnings-level for the libraries:


### PR DESCRIPTION
Added -march=native option to compilation on linux. This tells the compiler to generate code for the current processor allowing it to make full use of any extensions. It can cause the compiler to generate code that doesn't work on other machines so there is an override option, CROSSCOMPILE. It is only set on linux as OS X has an buggy version of gcc where it doesn't work on some versions. It can add hugely to performance, a brief test with ChunkWorx showed a 4 times improvement in generation rate on a sandy bridge.
