### PR TITLE
Removed the particles when a mob spawns.

### DIFF
--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2766,9 +2766,6 @@ int cWorld::SpawnMob(double a_PosX, double a_PosY, double a_PosZ, cMonster::eTyp
 	{
 		Monster->SetPosition(a_PosX, a_PosY, a_PosZ);
 	}
-
-	// Because it's logical that ALL mob spawns need spawn effects, not just spawners
-	BroadcastSoundParticleEffect(2004, (int)a_PosX, (int)a_PosY, (int)a_PosZ, 0);
 	
 	return SpawnMobFinalize(Monster);
 }


### PR DESCRIPTION
Currently when a mob spawns the server also spawns particles. 
If a plugin doesn't want those particles then there is no way to get rid of them.
Since vanilla only spawns particles on a mob spawn when it comes from a spawner it makes sense to remove the particle effect in the function and only generate them when a spawner spawns a mob.
