### PR TITLE
Fixed stupid mistake in conditional

### DIFF
--- a/src/Items/ItemBoat.h
+++ b/src/Items/ItemBoat.h
@@ -1,4 +1,3 @@
-
 // ItemBoat.h
 
 // Declares the various boat ItemHandlers
@@ -31,7 +30,7 @@ public:
 	
 	virtual bool OnItemUse(cWorld * a_World, cPlayer * a_Player, const cItem & a_Item, int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_Dir) override
 	{
-		if (a_Dir != BLOCK_FACE_YM && a_Dir != BLOCK_FACE_NONE)
+		if ((a_Dir != BLOCK_FACE_YM) && (a_Dir != BLOCK_FACE_NONE))
 		{
 			return false;
 		}


### PR DESCRIPTION
boats can't be placed if the face is not block_face_none and not block_face_YM, not if it is only not one.
