### PR TITLE
Creeper fixes

### DIFF
--- a/src/Mobs/Creeper.h
+++ b/src/Mobs/Creeper.h
@@ -21,13 +21,14 @@ public:
 	virtual void DoTakeDamage(TakeDamageInfo & a_TDI) override;
 	virtual void Attack(float a_Dt) override;
 	virtual void Tick(float a_Dt, cChunk & a_Chunk) override;
+	virtual void OnRightClicked(cPlayer & a_Player) override;
 
 	bool IsBlowing(void) const {return m_bIsBlowing; }
 	bool IsCharged(void) const {return m_bIsCharged; }
 
 private:
 
-	bool m_bIsBlowing, m_bIsCharged;
+	bool m_bIsBlowing, m_bIsCharged, m_BurnedWithFlintAndSteel;
 	int m_ExplodingTimer;
 
 } ;


### PR DESCRIPTION
- Fixed explosion time (1.5s, according to minecraftwiki)
- Creeper explodes if right clicked with flint and steel
