### PR TITLE
Enabled -ffast-math

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -184,8 +184,13 @@ macro(set_exe_flags)
 		string(REPLACE "-w" "" CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG}")
 		add_flags_cxx("-Wall -Wextra")
 		
-		#we support non-IEEE 754 fpus so can make no guarentees about error
+		# we support non-IEEE 754 fpus so can make no guarentees about error
 		add_flags_cxx("-ffast-math")
+		
+		# clang does not provide the __extern_always_inline macro and a part of libm depends on this when using fast-math
+		if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+			add_flags_cxx("-D__extern_always_inline=inline")
+		endif()
 	endif()
 
 endmacro()


### PR DESCRIPTION
We support non-IEEE 754 fpu's (I'm looking at you intel x87 fpu's :smile:) so we can't make any guarantees about floating point error. As such we should be able to handle fast-math optimizations that are algebraical equivalent but with different error.
