### PR TITLE
Added better check for xxd existance

### DIFF
--- a/lib/tolua++/CMakeLists.txt
+++ b/lib/tolua++/CMakeLists.txt
@@ -7,25 +7,28 @@ include_directories ("${PROJECT_SOURCE_DIR}/include/")
 include_directories ("${PROJECT_SOURCE_DIR}/../")
 include_directories ("${PROJECT_SOURCE_DIR}")
 
-if(UNIX)
+find_program(XXD_EXECUTABLE xxd)
+
+if(NOT XXD_EXECUTABLE STREQUAL "xxd-NOTFOUND")
 	add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/src/bin/basic_lua.h
-					COMMAND xxd -i lua/basic.lua | sed 's/unsigned char/static const unsigned char/g' >basic_lua.h
+					COMMAND ${XXD_EXECUTABLE} -i lua/basic.lua | sed 's/unsigned char/static const unsigned char/g' >basic_lua.h
 					WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/bin/
 					DEPENDS ${PROJECT_SOURCE_DIR}/src/bin/lua/basic.lua)
 	add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/src/bin/enumerate_lua.h
-					COMMAND xxd -i lua/enumerate.lua | sed 's/unsigned char/static const unsigned char/g' >enumerate_lua.h
+					COMMAND ${XXD_EXECUTABLE} -i lua/enumerate.lua | sed 's/unsigned char/static const unsigned char/g' >enumerate_lua.h
 					WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/bin/
 					DEPENDS ${PROJECT_SOURCE_DIR}/src/bin/lua/enumerate.lua)
 	add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/src/bin/function_lua.h
-					COMMAND xxd -i lua/function.lua | sed 's/unsigned char/static const unsigned char/g' >function_lua.h
+					COMMAND ${XXD_EXECUTABLE} -i lua/function.lua | sed 's/unsigned char/static const unsigned char/g' >function_lua.h
 					WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/bin/
 					DEPENDS ${PROJECT_SOURCE_DIR}/src/bin/lua/function.lua)
 	add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/src/bin/declaration_lua.h
-					COMMAND xxd -i lua/declaration.lua | sed 's/unsigned char/static const unsigned char/g' >declaration_lua.h
+					COMMAND ${XXD_EXECUTABLE} -i lua/declaration.lua | sed 's/unsigned char/static const unsigned char/g' >declaration_lua.h
 					WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/bin/
 					DEPENDS ${PROJECT_SOURCE_DIR}/src/bin/lua/declaration.lua)
 	set_property(SOURCE src/bin/toluabind.c APPEND PROPERTY OBJECT_DEPENDS ${PROJECT_SOURCE_DIR}/src/bin/enumerate_lua.h ${PROJECT_SOURCE_DIR}/src/bin/basic_lua.h ${PROJECT_SOURCE_DIR}/src/bin/function_lua.h ${PROJECT_SOURCE_DIR}/src/bin/declaration_lua.h)
-	message(hello)
+else()
+	message("xxd not found, changes to tolua scripts will be ignored")
 endif()
 
 


### PR DESCRIPTION
Now uses find_program to check for xxds existence rather than assuming it will exist on all unix machines. Fixes #825.
