### PR TITLE
Removed check for enqueuing a chunk that is already enqueued to be loaded

### DIFF
--- a/src/WorldStorage/WorldStorage.cpp
+++ b/src/WorldStorage/WorldStorage.cpp
@@ -150,7 +150,7 @@ size_t cWorldStorage::GetSaveQueueLength(void)
 
 void cWorldStorage::QueueLoadChunk(int a_ChunkX, int a_ChunkY, int a_ChunkZ, bool a_Generate)
 {
-	m_LoadQueue.EnqueueItemIfNotPresent(sChunkLoad(a_ChunkX, a_ChunkY, a_ChunkZ, a_Generate));
+	m_LoadQueue.EnqueueItem(sChunkLoad(a_ChunkX, a_ChunkY, a_ChunkZ, a_Generate));
 	m_Event.Set();
 }
 


### PR DESCRIPTION
This removal is safe as cWorldStorage checks for duplicate chunks when dequeuing
and removes an expensive iteration whilst holding the queue lock
