### PR TITLE
Cmake generated projects for IDEs include headers in project files.

### DIFF
--- a/src/BlockEntities/CMakeLists.txt
+++ b/src/BlockEntities/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(BlockEntities ${SOURCE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,7 @@ if (NOT MSVC)
 
 	file(GLOB SOURCE
 		"*.cpp"
+		"*.h"
 	)
 
 	list(REMOVE_ITEM SOURCE "${PROJECT_SOURCE_DIR}/StackWalker.cpp" "${PROJECT_SOURCE_DIR}/LeakFinder.cpp")

--- a/src/Entities/CMakeLists.txt
+++ b/src/Entities/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(Entities ${SOURCE})

--- a/src/Generating/CMakeLists.txt
+++ b/src/Generating/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(Generating ${SOURCE})

--- a/src/Generating/Prefabs/CMakeLists.txt
+++ b/src/Generating/Prefabs/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(Generating_Prefabs ${SOURCE})

--- a/src/HTTPServer/CMakeLists.txt
+++ b/src/HTTPServer/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(HTTPServer ${SOURCE})

--- a/src/Mobs/CMakeLists.txt
+++ b/src/Mobs/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(Mobs ${SOURCE})

--- a/src/OSSupport/CMakeLists.txt
+++ b/src/OSSupport/CMakeLists.txt
@@ -5,6 +5,7 @@ project (MCServer)
 include_directories ("${PROJECT_SOURCE_DIR}/../")
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(OSSupport ${SOURCE})

--- a/src/Protocol/CMakeLists.txt
+++ b/src/Protocol/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(Protocol ${SOURCE})

--- a/src/Simulator/CMakeLists.txt
+++ b/src/Simulator/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(Simulator ${SOURCE})

--- a/src/UI/CMakeLists.txt
+++ b/src/UI/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(UI ${SOURCE})

--- a/src/WorldStorage/CMakeLists.txt
+++ b/src/WorldStorage/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/../")
 
 file(GLOB SOURCE
     "*.cpp"
+    "*.h"
 )
 
 add_library(WorldStorage ${SOURCE})


### PR DESCRIPTION
When Cmake generates projects for XCode (and, if my sources are correct, Visual Studio as well), it does not put _any_ header files in the project. Adding them to the glob fixes that on my configuration, but needs testing on Windows. 

Confirmed working in XCode 5, Eclipse. 
