### PR TITLE
Removed the explicit copy constructor for cItem.

### DIFF
--- a/src/Item.h
+++ b/src/Item.h
@@ -73,6 +73,10 @@ public:
 	}
 	
 	
+	// The constructor is disabled in code, because the compiler generates it anyway,
+	// but it needs to stay because ToLua needs to generate the binding for it
+	#if 0
+	
 	/** Creates an exact copy of the item */
 	cItem(const cItem & a_CopyFrom) :
 		m_ItemType    (a_CopyFrom.m_ItemType),
@@ -84,6 +88,8 @@ public:
 		m_FireworkItem(a_CopyFrom.m_FireworkItem)
 	{
 	}
+	
+	#endif
 	
 	
 	void Empty(void)


### PR DESCRIPTION
The compiler generates an implicit one with the same contents and warns about it. The function was left in for ToLua to generate the binding for it.
