### PR TITLE
Vector3 warning fixes

### DIFF
--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -175,14 +175,6 @@ public:
 		return *this;
 	}
 
-	template <typename T2> inline Vector3<T> & operator = (const Vector3<T2> & a_Rhs)
-	{
-		x = (T)a_Rhs.x;
-		y = (T)a_Rhs.y;
-		z = (T)a_Rhs.z;
-		return *this;
-	}
-
 	// tolua_begin
 	
 	inline Vector3<T> operator + (const Vector3<T>& a_Rhs) const


### PR DESCRIPTION
This fixes all clang warnings within the `Vector3` template.
