### PR TITLE
Moved CodeCoverage into a separate cmake condition.

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -27,10 +27,12 @@ endmacro()
 
 macro(set_flags)
 	# Add coverage processing, if requested:
-	if (${CMAKE_BUILD_TYPE} STREQUAL "COVERAGE")
-		message("Including CodeCoverage")
-		set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/lib/cmake-coverage/")
-		include(CodeCoverage)
+	if (NOT MSVC)
+		if (${CMAKE_BUILD_TYPE} STREQUAL "COVERAGE")
+			message("Including CodeCoverage")
+			set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/lib/cmake-coverage/")
+			include(CodeCoverage)
+		endif()
 	endif()
 
 	# Add the preprocessor macros used for distinguishing between debug and release builds (CMake does this automatically for MSVC):


### PR DESCRIPTION
This mainly allows non-MSVC windows builds.
