### PR TITLE
MCS sockets can be rebound immediately

### DIFF
--- a/src/HTTPServer/HTTPServer.cpp
+++ b/src/HTTPServer/HTTPServer.cpp
@@ -179,6 +179,8 @@ bool cHTTPServer::Initialize(const AString & a_PortsIPv4, const AString & a_Port
 	
 	// Open up requested ports:
 	bool HasAnyPort;
+	m_ListenThreadIPv4.SetReuseAddr(true);
+	m_ListenThreadIPv6.SetReuseAddr(true);
 	HasAnyPort = m_ListenThreadIPv4.Initialize(a_PortsIPv4);
 	HasAnyPort = m_ListenThreadIPv6.Initialize(a_PortsIPv6) || HasAnyPort;
 	if (!HasAnyPort)


### PR DESCRIPTION
- Fixes #1150
- Fixes #272 

Could someone on the Linux and Macintosh OSes test this out? I was unable to reproduce these problems, but StackOverflow answers indicated that this was the right thing to do.
