### PR TITLE
Vector floor fix

### DIFF
--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -316,7 +316,7 @@ protected:
 
 
 
-template <> Vector3<int> Vector3<int>::Floor(void) const
+template <> inline Vector3<int> Vector3<int>::Floor(void) const
 {
 	return *this;
 }


### PR DESCRIPTION
MSVC2008 complains that it doesn't know which `floor` function to choose for the `<int>` version of the class. Provided a specific override for that (and one that has better performance, as no flooring is needed for ints).
