### PR TITLE
Fix for potion color after tossing

### DIFF
--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -76,12 +76,12 @@ cSplashPotionEntity::cSplashPotionEntity(
 	const Vector3d & a_Speed,
 	cEntityEffect::eType a_EntityEffectType,
 	cEntityEffect a_EntityEffect,
-	int a_PotionParticleType
+	int a_PotionColor
 ) :
 	super(pkSplashPotion, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25),
 	m_EntityEffectType(a_EntityEffectType),
 	m_EntityEffect(a_EntityEffect),
-	m_PotionParticleType(a_PotionParticleType)
+	m_PotionColor(a_PotionColor)
 {
 	SetSpeed(a_Speed);
 }
@@ -116,7 +116,7 @@ void cSplashPotionEntity::Splash(const Vector3d & a_HitPos)
 	cSplashPotionCallback Callback(a_HitPos, m_EntityEffectType, m_EntityEffect);
 	m_World->ForEachEntity(Callback);
 	
-	m_World->BroadcastSoundParticleEffect(2002, (int)a_HitPos.x, (int)a_HitPos.y, (int)a_HitPos.z, m_PotionParticleType);
+	m_World->BroadcastSoundParticleEffect(2002, (int)a_HitPos.x, (int)a_HitPos.y, (int)a_HitPos.z, m_PotionColor);
 }
 
 
@@ -125,7 +125,7 @@ void cSplashPotionEntity::Splash(const Vector3d & a_HitPos)
 
 void cSplashPotionEntity::SpawnOn(cClientHandle & a_Client)
 {
-	a_Client.SendSpawnObject(*this, 73, m_PotionParticleType, ANGLE_TO_PROTO(GetYaw()), ANGLE_TO_PROTO(GetPitch()));
+	a_Client.SendSpawnObject(*this, 73, m_PotionColor, ANGLE_TO_PROTO(GetYaw()), ANGLE_TO_PROTO(GetPitch()));
 	a_Client.SendEntityMetadata(*this);
 }
 

--- a/src/Entities/SplashPotionEntity.h
+++ b/src/Entities/SplashPotionEntity.h
@@ -31,22 +31,22 @@ public:
 		const Vector3d & a_Speed,
 		cEntityEffect::eType a_EntityEffectType,
 		cEntityEffect a_EntityEffect,
-		int a_PotionParticleType
+		int a_PotionColor
 	);
 	
-	cEntityEffect::eType GetEntityEffectType  (void) const { return m_EntityEffectType; }
-	cEntityEffect        GetEntityEffect      (void) const { return m_EntityEffect; }
-	int                  GetPotionParticleType(void) const { return m_PotionParticleType; }
+	cEntityEffect::eType GetEntityEffectType(void) const { return m_EntityEffectType; }
+	cEntityEffect        GetEntityEffect(void)     const { return m_EntityEffect; }
+	int                  GetPotionColor(void)      const { return m_PotionColor; }
 	
 	void SetEntityEffectType(cEntityEffect::eType a_EntityEffectType) { m_EntityEffectType = a_EntityEffectType; }
 	void SetEntityEffect(cEntityEffect a_EntityEffect) { m_EntityEffect = a_EntityEffect; }
-	void SetPotionParticleType(int a_PotionParticleType) { m_PotionParticleType = a_PotionParticleType; }
+	void SetPotionColor(int a_PotionColor) { m_PotionColor = a_PotionColor; }
 	
 protected:
 	
 	cEntityEffect::eType m_EntityEffectType;
 	cEntityEffect m_EntityEffect;
-	int m_PotionParticleType;
+	int m_PotionColor;
 	
 
 	// cProjectileEntity overrides:

--- a/src/Items/ItemPotion.h
+++ b/src/Items/ItemPotion.h
@@ -17,8 +17,8 @@ public:
 	}
 	
 
-	/** Returns the potion particle type (used by the client for visuals), based on the potion's damage value */
-	static int GetPotionParticleType(short a_ItemDamage)
+	/** Returns the potion color (used by the client for visuals), based on the potion's damage value */
+	static int GetPotionColor(short a_ItemDamage)
 	{
 		// Lowest six bits
 		return (a_ItemDamage & 0x3f);
@@ -156,7 +156,7 @@ public:
 		cSplashPotionEntity * Projectile = new cSplashPotionEntity(
 			a_Player, Pos.x, Pos.y, Pos.z, Speed,
 			GetEntityEffectType(PotionDamage), cEntityEffect(GetEntityEffectDuration(PotionDamage),
-			GetEntityEffectIntensity(PotionDamage)), GetPotionParticleType(PotionDamage)
+			GetEntityEffectIntensity(PotionDamage)), GetPotionColor(PotionDamage)
 		);
 		if (Projectile == NULL)
 		{

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -613,7 +613,7 @@ void cNBTChunkSerializer::AddProjectileEntity(cProjectileEntity * a_Projectile)
 				m_Writer.AddInt("EffectDuration",           (Int16)Potion->GetEntityEffect().GetDuration());
 				m_Writer.AddShort("EffectIntensity",         Potion->GetEntityEffect().GetIntensity());
 				m_Writer.AddDouble("EffectDistanceModifier", Potion->GetEntityEffect().GetDistanceModifier());
-				m_Writer.AddInt("PotionName",                Potion->GetPotionParticleType());
+				m_Writer.AddInt("PotionName",                Potion->GetPotionColor());
 			}
 			case cProjectileEntity::pkGhastFireball:
 			{

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -1681,7 +1681,7 @@ void cWSSAnvil::LoadSplashPotionFromNBT(cEntityList & a_Entities, const cParsedN
 	
 	SplashPotion->SetEntityEffectType((cEntityEffect::eType) a_NBT.FindChildByName(a_TagIdx, "EffectType"));
 	SplashPotion->SetEntityEffect(cEntityEffect(EffectDuration, EffectIntensity, EffectDistanceModifier));
-	SplashPotion->SetPotionParticleType(a_NBT.FindChildByName(a_TagIdx, "PotionName"));
+	SplashPotion->SetPotionColor(a_NBT.FindChildByName(a_TagIdx, "PotionName"));
 	
 	// Store the new splash potion in the entities list:
 	a_Entities.push_back(SplashPotion.release());


### PR DESCRIPTION
Previously, all potions would be red after being tossed. The correct color now shows. 

I also renamed PotionParticleType to PotionColor, because the variable is now being used for general color instead of just particle colors. 
