### PR TITLE
Fixed potential crash in Player.cpp

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -906,7 +906,7 @@ void cPlayer::KilledBy(TakeDamageInfo & a_TDI)
 		}
 		GetWorld()->BroadcastChatDeath(Printf("%s %s", GetName().c_str(), DamageText.c_str()));
 	}
-	else if (a_TDI.Attacker == NULL) // && !m_World->ShouldBroadcastDeathMessages() by fallthrough
+	else if (a_TDI.Attacker == NULL)  // && !m_World->ShouldBroadcastDeathMessages() by fallthrough
 	{
 		// no-op
 	}


### PR DESCRIPTION
Fixes CID 71780
If ShouldBroadcastDeathMessages is false the pointer would fall through to a check agaist it being a player
