### PR TITLE
Add entry for bat in monsters.ini

### DIFF
--- a/MCServer/monsters.ini
+++ b/MCServer/monsters.ini
@@ -185,4 +185,10 @@ AttackDamage=6.0
 SightDistance=25.0
 MaxHealth=100
 
+[Bat]
+AttackRange=2.0
+AttackRate=1
+AttackDamage=0.0
+SightDistance=25.0
+MaxHealth=6
 


### PR DESCRIPTION
The max health of bats is now 6 as described in the minecraft wiki. Resolving issue #1281
