### PR TITLE
Use static casts instead of C casts, add floor-cast functions

### DIFF
--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -27,9 +27,9 @@
 		return super::GetClass(); \
 	}
 
-#define POSX_TOINT FloorD(GetPosX())
-#define POSY_TOINT FloorD(GetPosY())
-#define POSZ_TOINT FloorD(GetPosZ())
+#define POSX_TOINT FloorC(GetPosX())
+#define POSY_TOINT FloorC(GetPosY())
+#define POSZ_TOINT FloorC(GetPosZ())
 #define POS_TOINT  Vector3i(POSXTOINT, POSYTOINT, POSZTOINT)
 
 #define GET_AND_VERIFY_CURRENT_CHUNK(ChunkVarName, X, Z) cChunk * ChunkVarName = a_Chunk.GetNeighborChunk(X, Z); if ((ChunkVarName == NULL) || !ChunkVarName->IsValid()) { return; }

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -400,32 +400,18 @@ T Clamp(T a_Value, T a_Min, T a_Max)
 
 
 
-/** Floors a_Value, then casts it to C (an int by default) */
-template <typename C = int>
-C FloorD(double a_Value)
+/** Floors a value, then casts it to C (an int by default) */
+template <typename C = int, typename T>
+typename std::enable_if<std::is_arithmetic<T>::value, C>::type FloorC(T a_Value)
 {
 	return static_cast<C>(std::floor(a_Value));
 }
 
-/** Floors a_Value, then casts it to C (an int by default) */
-template <typename C = int>
-C FloorF(double a_Value)
-{
-	return static_cast<C>(std::floorf(a_Value));
-}
-
-/** Ciels a_Value, then casts it to C (an int by default) */
-template <typename C = int>
-C CeilD(double a_Value)
+/** Ceils a value, then casts it to C (an int by default) */
+template <typename C = int, typename T>
+typename std::enable_if<std::is_arithmetic<T>::value, C>::type CeilC(T a_Value)
 {
 	return static_cast<C>(std::ceil(a_Value));
-}
-
-/** Ciels a_Value, then casts it to C (an int by default) */
-template <typename C = int>
-C CeilF(double a_Value)
-{
-	return static_cast<C>(std::ceilf(a_Value));
 }
 
 

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -137,9 +137,9 @@ public:
 	inline Vector3<int> Floor(void) const
 	{
 		return Vector3<int>(
-			static_cast<int>(floor(x)),
-			static_cast<int>(floor(y)),
-			static_cast<int>(floor(z))
+			FloorC(x),
+			FloorC(y),
+			FloorC(z)
 		);
 	}
 


### PR DESCRIPTION
Makes use of C++11 features, so I guess this can't be merged quite yet. 

@madmaxoft when will we be able to use these again?
