### PR TITLE
fixed potions being used up in creative mode

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -628,8 +628,14 @@ void cPlayer::FinishEating(void)
 	}
 	ItemHandler->OnFoodEaten(m_World, this, &Item);
 
-	GetInventory().RemoveOneEquippedItem();
+	// Stop potions from being removed in creative mode
+	// TODO: Review item removal locations
+	if (!IsGameModeCreative())
+	{
+		GetInventory().RemoveOneEquippedItem();
+	}
 
+	// TODO: Discuss if this should be moved to its own item like milk
 	// if the food is mushroom soup, return a bowl to the inventory
 	if (Item.m_ItemType == E_ITEM_MUSHROOM_SOUP)
 	{

--- a/src/Items/ItemPotion.h
+++ b/src/Items/ItemPotion.h
@@ -68,8 +68,14 @@ public:
 			cEntityEffect::GetPotionEffectDuration(PotionDamage),
 			cEntityEffect::GetPotionEffectIntensity(PotionDamage)
 		);
-		a_Player->GetInventory().RemoveOneEquippedItem();
-		a_Player->GetInventory().AddItem(E_ITEM_GLASS_BOTTLE);
+
+		// Stop potions from being removed in creative mode
+		// TODO: Review item removal locations
+		if (!a_Player->IsGameModeCreative())
+		{
+			a_Player->GetInventory().RemoveOneEquippedItem();
+			a_Player->GetInventory().AddItem(E_ITEM_GLASS_BOTTLE);
+		}
 		return true;
 	}
 };


### PR DESCRIPTION
we should only remove the item from one location, i have a feeling this will remove the empty bottle too if you have a full inventory, but i was not sure about how we wished to approach that.
