### PR TITLE
added spawning rule to mooshroom

### DIFF
--- a/src/MobSpawner.cpp
+++ b/src/MobSpawner.cpp
@@ -291,7 +291,7 @@ bool cMobSpawner::CanSpawnHere(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_R
 				return (
 					(TargetBlock == E_BLOCK_AIR) &&
 					(BlockAbove == E_BLOCK_AIR) &&
-					(!cBlockInfo::IsTransparent(BlockBelow)) &&
+					(BlockBelow == E_BLOCK_MYCELIUM) &&
 					(
 						(a_Biome == biMushroomShore) ||
 						(a_Biome == biMushroomIsland)


### PR DESCRIPTION
add a rule for mooshrooms to spawn on mushroom islands.

mushroom island spawn seed: -213275449
