### PR TITLE
clearing CheckBasicStyle.lua messages

### DIFF
--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -233,8 +233,8 @@ static int tolua_AllToLua_StringToMobType00(lua_State* tolua_S)
 	#ifndef TOLUA_RELEASE
 	tolua_Error tolua_err;
 	if (
-		!tolua_iscppstring(tolua_S,1,0,&tolua_err) ||
-		!tolua_isnoobj(tolua_S,2,&tolua_err)
+		!tolua_iscppstring(tolua_S, 1, 0, &tolua_err) ||
+		!tolua_isnoobj(tolua_S, 2, &tolua_err)
 		)
 		goto tolua_lerror;
 	else

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -65,7 +65,7 @@ void cFinishGenNetherClumpFoliage::GenFinish(cChunkDesc & a_ChunkDesc)
 		{
 			continue;
 		}
-		
+
 		// Choose what block to use.
 		NOISE_DATATYPE BlockType = m_Noise.IntNoise3D((int) ChunkX, y, (int) ChunkZ);
 		if (BlockType < -0.7)
@@ -195,10 +195,10 @@ void cFinishGenTallGrass::GenFinish(cChunkDesc & a_ChunkDesc)
 			{
 				continue;
 			}
-			
+
 			// Get the top block + 1. This is the place where the grass would finaly be placed:
 			int y = a_ChunkDesc.GetHeight(x, z) + 1;
-			
+
 			if (y >= 255)
 			{
 				continue;
@@ -281,7 +281,7 @@ bool cFinishGenSprinkleFoliage::TryAddSugarcane(cChunkDesc & a_ChunkDesc, int a_
 	{
 		return false;
 	}
-	
+
 	// All conditions met, place a sugarcane here:
 	a_ChunkDesc.SetBlockType(a_RelX, a_RelY + 1, a_RelZ, E_BLOCK_SUGARCANE);
 	return true;
@@ -294,7 +294,7 @@ bool cFinishGenSprinkleFoliage::TryAddSugarcane(cChunkDesc & a_ChunkDesc, int a_
 void cFinishGenSprinkleFoliage::GenFinish(cChunkDesc & a_ChunkDesc)
 {
 	// Generate small foliage (1-block):
-	
+
 	// TODO: Update heightmap with 1-block-tall foliage
 	for (int z = 0; z < cChunkDef::Width; z++)
 	{
@@ -319,7 +319,7 @@ void cFinishGenSprinkleFoliage::GenFinish(cChunkDesc & a_ChunkDesc)
 				// WEIRD, since we're using heightmap, so there should NOT be anything above it
 				continue;
 			}
-			
+
 			const float xx = (float)BlockX;
 			float val1 = m_Noise.CubicNoise2D(xx * 0.1f,  zz * 0.1f);
 			float val2 = m_Noise.CubicNoise2D(xx * 0.01f, zz * 0.01f);
@@ -359,7 +359,7 @@ void cFinishGenSprinkleFoliage::GenFinish(cChunkDesc & a_ChunkDesc)
 					}
 					break;
 				}  // case E_BLOCK_GRASS
-				
+
 				case E_BLOCK_SAND:
 				{
 					int y = Top + 1;
@@ -400,7 +400,7 @@ void cFinishGenSoulsandRims::GenFinish(cChunkDesc & a_ChunkDesc)
 	int ChunkZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;
 	HEIGHTTYPE MaxHeight = a_ChunkDesc.GetMaxHeight();
 
-	for (int x = 0; x < 16; x++) 
+	for (int x = 0; x < 16; x++)
 	{
 		int xx = ChunkX + x;
 		for (int z = 0; z < 16; z++)
@@ -768,7 +768,7 @@ void cFinishGenPreSimulator::StationarizeFluid(
 			}  // for y
 		}  // for x
 	}  // for z
-	
+
 	// Turn fluid at the chunk edges into non-stationary fluid:
 	for (int y = 0; y < cChunkDef::Height; y++)
 	{
@@ -860,12 +860,12 @@ void cFinishGenFluidSprings::GenFinish(cChunkDesc & a_ChunkDesc)
 		// Not in this chunk
 		return;
 	}
-	
+
 	// Get the height at which to try:
 	int Height = m_Noise.IntNoise3DInt(128 * a_ChunkDesc.GetChunkX(), 1024, 256 * a_ChunkDesc.GetChunkZ()) / 11;
 	Height %= m_HeightDistribution.GetSum();
 	Height = m_HeightDistribution.MapValue(Height);
-	
+
 	// Try adding the spring at the height, if unsuccessful, move lower:
 	for (int y = Height; y > 1; y--)
 	{
@@ -903,7 +903,7 @@ bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int
 	{
 		return false;
 	}
-	
+
 	static const struct
 	{
 		int x, y, z;
@@ -934,7 +934,7 @@ bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int
 	{
 		return false;
 	}
-	
+
 	// Has exactly one air neighbor, place a spring:
 	a_ChunkDesc.SetBlockTypeMeta(x, y, z, m_Fluid, 0);
 	return true;

--- a/src/Generating/FinishGen.h
+++ b/src/Generating/FinishGen.h
@@ -121,7 +121,7 @@ class cFinishGenSoulsandRims :
 	public cFinishGen
 {
 public:
-	cFinishGenSoulsandRims(int a_Seed) : 
+	cFinishGenSoulsandRims(int a_Seed) :
 		m_Noise(a_Seed)
 	{
 	}
@@ -141,14 +141,14 @@ class cFinishGenSprinkleFoliage :
 {
 public:
 	cFinishGenSprinkleFoliage(int a_Seed) : m_Noise(a_Seed), m_Seed(a_Seed) {}
-	
+
 protected:
 	cNoise m_Noise;
 	int    m_Seed;
-	
+
 	/// Tries to place sugarcane at the coords specified, returns true if successful
 	bool TryAddSugarcane(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ);
-	
+
 	// cFinishGen override:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 } ;
@@ -186,31 +186,31 @@ public:
 		{
 			m_IsAllowedBelow[idx] = false;
 		}
-		
+
 		// Load the allowed blocks into m_IsAllowedBelow
 		for (BlockList::iterator itr = a_AllowedBelow.begin(); itr != a_AllowedBelow.end(); ++itr)
 		{
 			m_IsAllowedBelow[*itr] = true;
 		}
-		
+
 		// Initialize all the biome types.
 		for (size_t idx = 0; idx < ARRAYCOUNT(m_IsBiomeAllowed); ++idx)
 		{
 			m_IsBiomeAllowed[idx] = false;
 		}
-		
+
 		// Load the allowed biomes into m_IsBiomeAllowed
 		for (BiomeList::iterator itr = a_Biomes.begin(); itr != a_Biomes.end(); ++itr)
 		{
 			m_IsBiomeAllowed[*itr] = true;
 		}
 	}
-	
+
 protected:
 	cNoise m_Noise;
 	BLOCKTYPE m_BlockType;
 	int       m_Amount;         ///< Relative amount of blocks to try adding. 1 = one block per 256 biome columns.
-	
+
 	int GetNumToGen(const cChunkDef::BiomeMap & a_BiomeMap);
 
 	// Returns true if the given biome is a biome that is allowed.
@@ -225,7 +225,7 @@ protected:
 		return m_IsAllowedBelow[a_BlockBelow];
 	}
 
-	
+
 	// cFinishGen override:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 } ;
@@ -242,11 +242,11 @@ public:
 		m_Level(a_Level)
 	{
 	}
-	
+
 	int GetLevel(void) const { return m_Level; }
 protected:
 	int m_Level;
-	
+
 	// cFinishGen override:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 } ;
@@ -260,7 +260,7 @@ class cFinishGenPreSimulator :
 {
 public:
 	cFinishGenPreSimulator(bool a_PreSimulateFallingBlocks, bool a_PreSimulateWater, bool a_PreSimulateLava);
-	
+
 protected:
 
 	bool m_PreSimulateFallingBlocks;
@@ -272,7 +272,7 @@ protected:
 		cChunkDef::BlockTypes & a_BlockTypes,    // Block types to read and change
 		cChunkDef::HeightMap & a_HeightMap       // Height map to update by the current data
 	);
-	
+
 	/** For each fluid block:
 	- if all surroundings are of the same fluid, makes it stationary; otherwise makes it flowing (excl. top)
 	- all fluid on the chunk's edge is made flowing
@@ -297,7 +297,7 @@ class cFinishGenFluidSprings :
 {
 public:
 	cFinishGenFluidSprings(int a_Seed, BLOCKTYPE a_Fluid, cIniFile & a_IniFile, eDimension a_Dimension);
-	
+
 protected:
 
 	cNoise         m_Noise;

--- a/src/Mobs/Pig.cpp
+++ b/src/Mobs/Pig.cpp
@@ -49,17 +49,17 @@ void cPig::OnRightClicked(cPlayer & a_Player)
 				a_Player.Detach();
 				return;
 			}
-		
+
 			if (m_Attachee->IsPlayer())
 			{
 				// Another player is already sitting in here, cannot attach
 				return;
 			}
-		
+
 			// Detach whatever is sitting in this pig now:
 			m_Attachee->Detach();
 		}
-	
+
 		// Attach the player to this pig
 		a_Player.AttachTo(this);
 	}
@@ -100,7 +100,7 @@ void cPig::Tick(float a_Dt, cChunk & a_Chunk)
 
 
 bool cPig::DoTakeDamage(TakeDamageInfo & a_TDI)
-{	
+{
 	if (!super::DoTakeDamage(a_TDI))
 	{
 		return false;


### PR DESCRIPTION
just clears the large amount of errors from CheckBasicStyle.lua. 

Replaces lines containing only whitespace with newlines, replace CRLF with LF, some spacing fixes after commas, removes trailing whitespace.

Not sure if other people had the issue with CRLF at end of line, but I was getting a few thousand messages from checkstyle.
EDIT:
I think I just had my autocrlf config wrong
