### PR TITLE
Fix duplicate commands added to README.md

### DIFF
--- a/MCServer/Plugins/InfoDump.lua
+++ b/MCServer/Plugins/InfoDump.lua
@@ -444,7 +444,18 @@ local function BuildPermissions(a_PluginInfo)
 				Permissions[info.Permission] = Permission
 				-- Add the command to the list of commands using this permission:
 				Permission.CommandsAffected = Permission.CommandsAffected or {}
-				table.insert(Permission.CommandsAffected, CommandString)
+				-- First, make sure that we don't already have this command in the list,
+				-- it may have already been present in a_PluginInfo
+				local NewCommand = true
+				for _, existCmd in ipairs(Permission.CommandsAffected) do
+					if CommandString == existCmd then
+						NewCommand = false
+						break
+					end
+				end
+				if NewCommand then
+					table.insert(Permission.CommandsAffected, CommandString)
+				end
 			end
 			
 			-- Process the command param combinations for permissions:


### PR DESCRIPTION
When a `Permissions` section exists in an `Info.lua` file, commands are added twice to the `Permissions` section of the `README.md` file. 

What is happening is that in the assignment statement (on line 437): `local Permissions = a_PluginInfo.Permissions or {}`,  `a_PluginInfo.Permissions` already exists on the first pass through for the generation of `forum_info.txt` (when a `Permissions` section exists in `Info.lua`). This causes the reference to that table to be assigned to the variable `Permissions` (rather then a brand new blank table - which, in this case, would be unwanted since we would lose the already added permission node descriptions and recommended groups) and thus all the commands are added directly to `a_PluginInfo.Permissions` on the first pass through. Then on the second pass through to generate the `README.md` file, the `Permissions` variable is again assigned the same reference to `a_PluginInfo.Permissions` and the loop re-adds the already added commands to the permission nodes in the table all over again, resulting in duplicated commands in the `Permissions` section of the `README.md` file.

This change will probably slow down `InfoDump.lua` slightly, but it beats de-duping the files after the fact.
