### PR TITLE
Namechange to Cuberite

### DIFF
--- a/src/Bindings/PluginLua.h
+++ b/src/Bindings/PluginLua.h
@@ -14,8 +14,8 @@
 #include "LuaState.h"
 
 // Names for the global variables through which the plugin is identified in its LuaState
-#define LUA_PLUGIN_NAME_VAR_NAME     "_MCServerInternal_PluginName"
-#define LUA_PLUGIN_INSTANCE_VAR_NAME "_MCServerInternal_PluginInstance"
+#define LUA_PLUGIN_NAME_VAR_NAME     "_CuberiteInternal_PluginName"
+#define LUA_PLUGIN_INSTANCE_VAR_NAME "_CuberiteInternal_PluginInstance"
 
 
 

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -1742,7 +1742,7 @@ bool cPluginManager::BindConsoleCommand(const AString & a_Command, cPlugin * a_P
 	{
 		if (cmd->second.m_Plugin == nullptr)
 		{
-			LOGWARNING("Console command \"%s\" is already bound internally by MCServer, cannot bind in plugin \"%s\".", a_Command.c_str(), a_Plugin->GetName().c_str());
+			LOGWARNING("Console command \"%s\" is already bound internally by Cuberite, cannot bind in plugin \"%s\".", a_Command.c_str(), a_Plugin->GetName().c_str());
 		}
 		else
 		{

--- a/src/BiomeDef.h
+++ b/src/BiomeDef.h
@@ -16,7 +16,7 @@
 // tolua_begin
 /** Biome IDs
 The first batch corresponds to the clientside biomes, used by MineCraft.
-BiomeIDs over 255 are used by MCServer internally and are translated to MC biomes before sending them to client
+BiomeIDs over 255 are used by Cuberite internally and are translated to MC biomes before sending them to client
 */
 enum EMCSBiome
 {

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -67,8 +67,8 @@ public:
 	/// The type used for any heightmap operations and storage; idx = x + Width * z; Height points to the highest non-air block in the column
 	typedef HEIGHTTYPE HeightMap[Width * Width];
 
-	/** The type used for any biomemap operations and storage inside MCServer,
-	using MCServer biomes (need not correspond to client representation!)
+	/** The type used for any biomemap operations and storage inside Cuberite,
+	using Cuberite biomes (need not correspond to client representation!)
 	idx = x + Width * z  // Need to verify this with the protocol spec, currently unknown!
 	*/
 	typedef EMCSBiome BiomeMap[Width * Width];

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -225,7 +225,7 @@ template class SizeChecker<UInt8,  1>;
 #endif
 
 #if defined(ANDROID_NDK)
-	#define FILE_IO_PREFIX "/sdcard/mcserver/"
+	#define FILE_IO_PREFIX "/sdcard/Cuberite/"
 #else
 	#define FILE_IO_PREFIX ""
 #endif

--- a/src/HTTPServer/HTTPServer.cpp
+++ b/src/HTTPServer/HTTPServer.cpp
@@ -83,7 +83,7 @@ class cDebugCallbacks :
 			{
 				if (!a_Request.HasAuth() || (a_Request.GetAuthUsername() != "a") || (a_Request.GetAuthPassword() != "b"))
 				{
-					a_Connection.SendNeedAuth("MCServer WebAdmin");
+					a_Connection.SendNeedAuth("Cuberite WebAdmin");
 					return;
 				}
 			}

--- a/src/LoggerListeners.cpp
+++ b/src/LoggerListeners.cpp
@@ -190,7 +190,7 @@
 					break;
 				}
 			}
-			__android_log_print(AndroidLogLevel, "MCServer", "%s", a_Message.c_str());
+			__android_log_print(AndroidLogLevel, "Cuberite", "%s", a_Message.c_str());
 		}
 	};
 	

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -941,7 +941,7 @@ eMonsterType cMonster::StringToMobType(const AString & a_Name)
 {
 	AString lcName = StrToLower(a_Name);
 
-	// Search MCServer name:
+	// Search Cuberite name:
 	for (size_t i = 0; i < ARRAYCOUNT(g_MobTypeNames); i++)
 	{
 		if (strcmp(g_MobTypeNames[i].m_lcName, lcName.c_str()) == 0)

--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -10,7 +10,7 @@ class cPath;
 #include "../FastRandom.h"
 #ifdef COMPILING_PATHFIND_DEBUGGER
 	/* Note: the COMPILING_PATHFIND_DEBUGGER flag is used by Native / WiseOldMan95 to debug
-	this class outside of MCServer. This preprocessor flag is never set when compiling MCServer. */
+	this class outside of Cuberite. This preprocessor flag is never set when compiling Cuberite. */
 	#include "PathFinderIrrlicht_Head.h"
 #endif
 

--- a/src/PolarSSL++/SslContext.cpp
+++ b/src/PolarSSL++/SslContext.cpp
@@ -50,7 +50,7 @@ int cSslContext::Initialize(bool a_IsClient, const SharedPtr<cCtrDrbgContext> & 
 	if (m_CtrDrbg.get() == nullptr)
 	{
 		m_CtrDrbg.reset(new cCtrDrbgContext);
-		m_CtrDrbg->Initialize("MCServer", 8);
+		m_CtrDrbg->Initialize("Cuberite", 8);
 	}
 	
 	// Initialize PolarSSL's structures:

--- a/src/Protocol/Authenticator.cpp
+++ b/src/Protocol/Authenticator.cpp
@@ -149,7 +149,7 @@ bool cAuthenticator::AuthWithYggdrasil(AString & a_UserName, const AString & a_S
 	AString Request;
 	Request += "GET " + ActualAddress + " HTTP/1.0\r\n";
 	Request += "Host: " + m_Server + "\r\n";
-	Request += "User-Agent: MCServer\r\n";
+	Request += "User-Agent: Cuberite\r\n";
 	Request += "Connection: close\r\n";
 	Request += "\r\n";
 
@@ -223,7 +223,7 @@ bool cAuthenticator::GetPlayerProperties(const AString & a_UUID, Json::Value & a
 	AString Request;
 	Request += "GET " + ActualAddress + " HTTP/1.0\r\n";
 	Request += "Host: " + m_Server + "\r\n";
-	Request += "User-Agent: MCServer\r\n";
+	Request += "User-Agent: Cuberite\r\n";
 	Request += "Connection: close\r\n";
 	Request += "\r\n";
 

--- a/src/Protocol/Authenticator.h
+++ b/src/Protocol/Authenticator.h
@@ -1,7 +1,7 @@
 
 // cAuthenticator.h
 
-// Interfaces to the cAuthenticator class representing the thread that authenticates users against the official MC server
+// Interfaces to the cAuthenticator class representing the thread that authenticates users against the official Cuberite
 // Authentication prevents "hackers" from joining with an arbitrary username (possibly impersonating the server admins)
 // For more info, see http://wiki.vg/Session#Server_operation
 // In MCS, authentication is implemented as a single thread that receives queued auth requests and dispatches them one by one.

--- a/src/Protocol/MojangAPI.cpp
+++ b/src/Protocol/MojangAPI.cpp
@@ -688,7 +688,7 @@ void cMojangAPI::QueryNamesToUUIDs(AStringVector & a_NamesToQuery)
 		AString Request;
 		Request += "POST " + m_NameToUUIDAddress + " HTTP/1.0\r\n";  // We need to use HTTP 1.0 because we don't handle Chunked transfer encoding
 		Request += "Host: " + m_NameToUUIDServer + "\r\n";
-		Request += "User-Agent: MCServer\r\n";
+		Request += "User-Agent: Cuberite\r\n";
 		Request += "Connection: close\r\n";
 		Request += "Content-Type: application/json\r\n";
 		Request += Printf("Content-Length: %u\r\n", static_cast<unsigned>(RequestBody.length()));
@@ -802,7 +802,7 @@ void cMojangAPI::QueryUUIDToProfile(const AString & a_UUID)
 	AString Request;
 	Request += "GET " + Address + " HTTP/1.0\r\n";  // We need to use HTTP 1.0 because we don't handle Chunked transfer encoding
 	Request += "Host: " + m_UUIDToProfileServer + "\r\n";
-	Request += "User-Agent: MCServer\r\n";
+	Request += "User-Agent: Cuberite\r\n";
 	Request += "Connection: close\r\n";
 	Request += "Content-Length: 0\r\n";
 	Request += "\r\n";

--- a/src/Protocol/Protocol17x.cpp
+++ b/src/Protocol/Protocol17x.cpp
@@ -1865,7 +1865,7 @@ void cProtocol172::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 	// Version:
 	Json::Value Version;
-	Version["name"] = "MCServer 1.7.2";
+	Version["name"] = "Cuberite 1.7.2";
 	Version["protocol"] = 4;
 
 	// Players:
@@ -2459,7 +2459,7 @@ void cProtocol172::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 		}
 		
 		// Send back our brand:
-		SendPluginMessage("MC|Brand", "MCServer");
+		SendPluginMessage("MC|Brand", "Cuberite");
 		return;
 	}
 	else if (a_Channel == "MC|Beacon")
@@ -3307,7 +3307,7 @@ void cProtocol176::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 	// Version:
 	Json::Value Version;
-	Version["name"] = "MCServer 1.7.6";
+	Version["name"] = "Cuberite 1.7.6";
 	Version["protocol"] = 5;
 
 	// Players:

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -2154,7 +2154,7 @@ void cProtocol180::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 	// Version:
 	Json::Value Version;
-	Version["name"] = "MCServer 1.8";
+	Version["name"] = "Cuberite 1.8";
 	Version["protocol"] = 47;
 
 	// Players:
@@ -2759,7 +2759,7 @@ void cProtocol180::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Brand);
 		m_Client->SetClientBrand(Brand);
 		// Send back our brand, including the length:
-		SendPluginMessage("MC|Brand", "\x08MCServer");
+		SendPluginMessage("MC|Brand", "\x08Cuberite");
 		return;
 	}
 	else if (a_Channel == "MC|Beacon")

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -114,7 +114,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> overridesRepo)
 	LOG("--- Started Log ---\n");
 
 	#ifdef BUILD_ID
-	LOG("MCServer " BUILD_SERIES_NAME " build id: " BUILD_ID);
+	LOG("Cuberite " BUILD_SERIES_NAME " build id: " BUILD_ID);
 	LOG("from commit id: " BUILD_COMMIT_ID " built at: " BUILD_DATETIME);
 	#endif
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -187,7 +187,7 @@ void cServer::PlayerDestroying(const cPlayer * a_Player)
 
 bool cServer::InitServer(cSettingsRepositoryInterface & a_Settings, bool a_ShouldAuth)
 {
-	m_Description = a_Settings.GetValueSet("Server", "Description", "MCServer - in C++!");
+	m_Description = a_Settings.GetValueSet("Server", "Description", "Cuberite - in C++!");
 	m_MaxPlayers  = a_Settings.GetValueSetI("Server", "MaxPlayers", 100);
 	m_bIsHardcore = a_Settings.GetValueSetB("Server", "HardcoreEnabled", false);
 	m_bAllowMultiLogin = a_Settings.GetValueSetB("Server", "AllowMultiLogin", false);

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -96,7 +96,7 @@ bool cWebAdmin::Init(void)
 	if (!m_IniFile.ReadFile("webadmin.ini"))
 	{
 		LOGWARN("Regenerating webadmin.ini, all settings will be reset");
-		m_IniFile.AddHeaderComment(" This file controls the webadmin feature of MCServer");
+		m_IniFile.AddHeaderComment(" This file controls the webadmin feature of Cuberite");
 		m_IniFile.AddHeaderComment(" Username format: [User:*username*]");
 		m_IniFile.AddHeaderComment(" Password format: Password=*password*; for example:");
 		m_IniFile.AddHeaderComment(" [User:admin]");
@@ -131,7 +131,7 @@ bool cWebAdmin::Init(void)
 
 		// Sets the fallback template:
 		m_LoginTemplate = \
-		"<h1>MCServer WebAdmin</h1>" \
+		"<h1>Cuberite WebAdmin</h1>" \
 		"<center>" \
 		"<form method='get' action='webadmin/'>" \
 		"<input type='submit' value='Log in'>" \
@@ -216,7 +216,7 @@ void cWebAdmin::HandleWebadminRequest(cHTTPConnection & a_Connection, cHTTPReque
 {
 	if (!a_Request.HasAuth())
 	{
-		a_Connection.SendNeedAuth("MCServer WebAdmin");
+		a_Connection.SendNeedAuth("Cuberite WebAdmin");
 		return;
 	}
 
@@ -224,7 +224,7 @@ void cWebAdmin::HandleWebadminRequest(cHTTPConnection & a_Connection, cHTTPReque
 	AString UserPassword = m_IniFile.GetValue("User:" + a_Request.GetAuthUsername(), "Password", "");
 	if ((UserPassword == "") || (a_Request.GetAuthPassword() != UserPassword))
 	{
-		a_Connection.SendNeedAuth("MCServer WebAdmin - bad username or password");
+		a_Connection.SendNeedAuth("Cuberite WebAdmin - bad username or password");
 		return;
 	}
 
@@ -333,7 +333,7 @@ void cWebAdmin::HandleWebadminRequest(cHTTPConnection & a_Connection, cHTTPReque
 	ReplaceString(Template, "{MENU}",        Menu);
 	ReplaceString(Template, "{PLUGIN_NAME}", FoundPlugin);
 	ReplaceString(Template, "{CONTENT}",     Content);
-	ReplaceString(Template, "{TITLE}",       "MCServer");
+	ReplaceString(Template, "{TITLE}",       "Cuberite");
 
 	AString NumChunks;
 	Printf(NumChunks, "%d", cRoot::Get()->GetTotalChunkCount());

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -415,7 +415,7 @@ void cNBTChunkSerializer::AddFallingBlockEntity(cFallingBlock * a_FallingBlock)
 		AddBasicEntity(a_FallingBlock, "FallingSand");
 		m_Writer.AddInt("TileID", a_FallingBlock->GetBlockType());
 		m_Writer.AddByte("Data", a_FallingBlock->GetBlockMeta());
-		m_Writer.AddByte("Time", 1);  // Unused in MCServer, Vanilla said to need nonzero
+		m_Writer.AddByte("Time", 1);  // Unused in Cuberite, Vanilla said to need nonzero
 		m_Writer.AddByte("DropItem", 1);
 		m_Writer.AddByte("HurtEntities", a_FallingBlock->GetBlockType() == E_BLOCK_ANVIL);
 	m_Writer.EndCompound();

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -898,7 +898,7 @@ cBlockEntity * cWSSAnvil::LoadChestFromNBT(const cParsedNBT & a_NBT, int a_TagId
 	// Check if the data has a proper type:
 	// TODO: Does vanilla use "TrappedChest" or not? MCWiki says no, but previous code says yes
 	// Ref.: http://minecraft.gamepedia.com/Trapped_Chest
-	//       https://github.com/mc-server/MCServer/blob/d0551e2e0a98a28f31a88d489d17b408e4a7d38d/src/WorldStorage/WSSAnvil.cpp#L637
+	//       https://github.com/mc-server/Cuberite/blob/d0551e2e0a98a28f31a88d489d17b408e4a7d38d/src/WorldStorage/WSSAnvil.cpp#L637
 	if (!CheckBlockEntityType(a_NBT, a_TagIdx, "Chest") && !CheckBlockEntityType(a_NBT, a_TagIdx, "TrappedChest"))
 	{
 		return nullptr;
@@ -1106,7 +1106,7 @@ cBlockEntity * cWSSAnvil::LoadMobSpawnerFromNBT(const cParsedNBT & a_NBT, int a_
 
 	std::unique_ptr<cMobSpawnerEntity> MobSpawner(new cMobSpawnerEntity(a_BlockX, a_BlockY, a_BlockZ, m_World));
 
-	// Load entity (MCServer worlds):
+	// Load entity (Cuberite worlds):
 	int Type = a_NBT.FindChildByName(a_TagIdx, "Entity");
 	if ((Type >= 0) && (a_NBT.GetType(Type) == TAG_Short))
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ bool cRoot::m_RunAsService = false;
 #if defined(_WIN32)
 	SERVICE_STATUS_HANDLE g_StatusHandle  = nullptr;
 	HANDLE                g_ServiceThread = INVALID_HANDLE_VALUE;
-	#define               SERVICE_NAME      "MCServerService"
+	#define               SERVICE_NAME      "CuberiteService"
 #endif
 
 
@@ -78,10 +78,10 @@ void NonCtrlHandler(int a_Signal)
 		case SIGSEGV:
 		{
 			std::signal(SIGSEGV, SIG_DFL);
-			LOGERROR("  D:    | MCServer has encountered an error and needs to close");
+			LOGERROR("  D:    | Cuberite has encountered an error and needs to close");
 			LOGERROR("Details | SIGSEGV: Segmentation fault");
 			#ifdef BUILD_ID
-			LOGERROR("MCServer " BUILD_SERIES_NAME " build id: " BUILD_ID);
+			LOGERROR("Cuberite " BUILD_SERIES_NAME " build id: " BUILD_ID);
 			LOGERROR("from commit id: " BUILD_COMMIT_ID " built at: " BUILD_DATETIME);
 			#endif
 			PrintStackTrace();
@@ -93,10 +93,10 @@ void NonCtrlHandler(int a_Signal)
 		#endif
 		{
 			std::signal(a_Signal, SIG_DFL);
-			LOGERROR("  D:    | MCServer has encountered an error and needs to close");
+			LOGERROR("  D:    | Cuberite has encountered an error and needs to close");
 			LOGERROR("Details | SIGABRT: Server self-terminated due to an internal fault");
 			#ifdef BUILD_ID
-			LOGERROR("MCServer " BUILD_SERIES_NAME " build id: " BUILD_ID);
+			LOGERROR("Cuberite " BUILD_SERIES_NAME " build id: " BUILD_ID);
 			LOGERROR("from commit id: " BUILD_COMMIT_ID " built at: " BUILD_DATETIME);
 			#endif
 			PrintStackTrace();
@@ -369,7 +369,7 @@ std::unique_ptr<cMemorySettingsRepository> parseArguments(int argc, char **argv)
 	try
 	{
 		// Parse the comand line args:
-		TCLAP::CmdLine cmd("MCServer");
+		TCLAP::CmdLine cmd("Cuberite");
 		TCLAP::ValueArg<int> slotsArg    ("s", "max-players",         "Maximum number of slots for the server to use, overrides setting in setting.ini", false, -1, "number", cmd);
 		TCLAP::MultiArg<int> portsArg    ("p", "port",                "The port number the server should listen to", false, "port", cmd);
 		TCLAP::SwitchArg commLogArg      ("",  "log-comm",            "Log server client communications to file", cmd);


### PR DESCRIPTION
Do not merge yet. I changed the occurrences of MCServer to Cuberite using a regex. It caught a low amount of occurrences, so please double-check my regex. Also, since this is an automatic change, all changed lines should be manually inspected.
The new code compiles and runs fine.
Here are the used bash commands:

```
#Directory is MCServer/src
find . -type f | grep .cpp | while read line; do perl -pe 's/(mc ?server)/Cuberite/gi' -i $line; done
find . -type f | grep .h | while read line; do perl -pe 's/(mc ?server)/Cuberite/gi' -i $line; done
```

~~Edit: Now I also executed the same command, but with this regex:
`s/(mc\-server)/Cuberite/gi`~~ Edit2: This was reverted.
