### PR TITLE
Fixing how village doors are generated in 1.8.

### DIFF
--- a/src/Blocks/BlockDoor.h
+++ b/src/Blocks/BlockDoor.h
@@ -242,7 +242,7 @@ public:
 		if ((Meta & 0x08) != 0)
 		{
 			// The coords are pointing at the top part of the door
-			if (a_BlockX > 0)
+			if (a_BlockY > 0)
 			{
 				NIBBLETYPE DownMeta = a_ChunkInterface.GetBlockMeta(a_BlockX, a_BlockY - 1, a_BlockZ);
 				return static_cast<NIBBLETYPE>((DownMeta & 0x07) | 0x08 | (Meta << 4));


### PR DESCRIPTION
Fix for #1661 in Minecraft 1.8 (removed bit 3 in the door's upper block and fixed typo in BlockDoor.h).

I'm not sure if manually applying the fix to the prefab files is the proper way to do this, since they're apparently generated, but they were committed so I changed them in a commit.
