### PR TITLE
Work on NetherPortalScanner. Setup portal scanner to reset PortalCool…

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1269,11 +1269,12 @@ void cEntity::DetectCacti(void)
 
 
 
-void cEntity::ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition)
+void cEntity::ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_SetPortalCooldown)
 {
 	m_NewWorld = a_World;
 	m_NewWorldPosition = a_NewPosition;
 	m_IsWorldChangeScheduled = true;
+	m_WorldChangeSetPortalCooldown = a_SetPortalCooldown;
 }
 
 
@@ -1285,6 +1286,14 @@ bool cEntity::DetectPortal()
 	if (m_IsWorldChangeScheduled)
 	{
 		m_IsWorldChangeScheduled = false;
+
+		if (m_WorldChangeSetPortalCooldown)
+		{
+			// Delay the portal check.
+			m_PortalCooldownData.m_TicksDelayed = 0;
+			m_PortalCooldownData.m_ShouldPreventTeleportation = true;
+		}
+
 		MoveToWorld(m_NewWorld, false, m_NewWorldPosition);
 		return true;
 	}
@@ -1343,10 +1352,10 @@ bool cEntity::DetectPortal()
 					TargetPos.x *= 8.0;
 					TargetPos.z *= 8.0;
 
-					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedOverworldName(), dimNether, GetWorld()->GetName());
+					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedOverworldName(), dimNether, GetWorld()->GetName(), false);
 					LOGD("Jumping nether -> overworld");
 					new cNetherPortalScanner(this, TargetWorld, TargetPos, 256);
-					return false;
+					return true;
 				}
 				else
 				{
@@ -1367,10 +1376,10 @@ bool cEntity::DetectPortal()
 					TargetPos.x /= 8.0;
 					TargetPos.z /= 8.0;
 
-					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedNetherWorldName(), dimNether, GetWorld()->GetName());
+					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedNetherWorldName(), dimNether, GetWorld()->GetName(), false);
 					LOGD("Jumping overworld -> nether");
 					new cNetherPortalScanner(this, TargetWorld, TargetPos, 128);
-					return false;
+					return true;
 				}
 			}
 			case E_BLOCK_END_PORTAL:

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -350,31 +350,31 @@ public:
 	*/
 	virtual bool DetectPortal(void);
 	
-	/// Handles when the entity is in the void
+	/** Handles when the entity is in the void */
 	virtual void TickInVoid(cChunk & a_Chunk);
 
-	/// Called when the entity starts burning
+	/** Called when the entity starts burning */
 	virtual void OnStartedBurning(void);
 	
-	/// Called when the entity finishes burning
+	/** Called when the entity finishes burning */
 	virtual void OnFinishedBurning(void);
 	
 	// tolua_begin
 	
-	/// Sets the maximum value for the health
+	/** Sets the maximum value for the health */
 	void SetMaxHealth(int a_MaxHealth);
 
 	int GetMaxHealth(void) const { return m_MaxHealth; }
 	
-	/// Sets whether the entity is fireproof
+	/** Sets whether the entity is fireproof */
 	void SetIsFireproof(bool a_IsFireproof);
 	
 	bool IsFireproof(void) const { return m_IsFireproof; }
 	
-	/// Puts the entity on fire for the specified amount of ticks
+	/** Puts the entity on fire for the specified amount of ticks */
 	void StartBurning(int a_TicksLeftBurning);
 	
-	/// Stops the entity from burning, resets all burning timers
+	/** Stops the entity from burning, resets all burning timers */
 	void StopBurning(void);
 	
 	// tolua_end
@@ -386,14 +386,14 @@ public:
 
 	// tolua_begin
 	
-	/// Teleports to the entity specified
+	/** Teleports to the entity specified */
 	virtual void TeleportToEntity(cEntity & a_Entity);
 	
-	/// Teleports to the coordinates specified
+	/** Teleports to the coordinates specified */
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
 
-	/// Schedules a MoveToWorld call to occur on the next Tick of the entity
-	void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition);
+	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
+	void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_SetPortalCooldown = false);
 
 	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition) { return DoMoveToWorld(a_World, a_ShouldSendRespawn, a_NewPosition); }
 
@@ -538,6 +538,7 @@ protected:
 
 	/** State variables for ScheduleMoveToWorld. */
 	bool m_IsWorldChangeScheduled;
+	bool m_WorldChangeSetPortalCooldown;
 	cWorld * m_NewWorld;
 	Vector3d m_NewWorldPosition;
 	

--- a/src/NetherPortalScanner.cpp
+++ b/src/NetherPortalScanner.cpp
@@ -49,6 +49,12 @@ void cNetherPortalScanner::OnChunkAvailable(int a_ChunkX, int a_ChunkZ)
 		if (blocks[i] == E_BLOCK_NETHER_PORTAL)
 		{
 			Vector3i Coordinate = cChunkDef::IndexToCoordinate(i);
+			if (Coordinate.y >= m_MaxY)
+			{
+				// This is above the map, don't consider it.
+				continue;
+			}
+
 			Vector3d PortalLoc = Vector3d(Coordinate.x + a_ChunkX * cChunkDef::Width, Coordinate.y, Coordinate.z + a_ChunkZ * cChunkDef::Width);
 			if (!m_FoundPortal)
 			{
@@ -284,7 +290,7 @@ void cNetherPortalScanner::OnDisabled(void)
 	}
 
 	LOGD("Placing player at {%f, %f, %f}", Position.x, Position.y, Position.z);
-	m_Entity->ScheduleMoveToWorld(m_World, Position);
+	m_Entity->ScheduleMoveToWorld(m_World, Position, true);
 	delete this;
 }
 

--- a/src/NetherPortalScanner.h
+++ b/src/NetherPortalScanner.h
@@ -40,7 +40,7 @@ private:
 	static const int SearchSolidBaseWidth = 3;
 
 	/** Where to place the player out from the face and across the face */
-	const double OutOffset = 1.5;
+	const double OutOffset = 0.5;
 	const double AcrossOffset = 0.5;
 
 	/** Builds a portal. */

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -342,7 +342,7 @@ void cRoot::LoadWorlds(cSettingsRepositoryInterface & a_Settings)
 
 
 
-cWorld * cRoot::CreateAndInitializeWorld(const AString & a_WorldName, eDimension a_Dimension, const AString & a_OverworldName)
+cWorld * cRoot::CreateAndInitializeWorld(const AString & a_WorldName, eDimension a_Dimension, const AString & a_OverworldName, bool a_InitSpawn)
 {
 	cWorld * World = m_WorldsByName[a_WorldName];
 	if (World != nullptr)
@@ -353,7 +353,10 @@ cWorld * cRoot::CreateAndInitializeWorld(const AString & a_WorldName, eDimension
 	cWorld * NewWorld = new cWorld(a_WorldName.c_str(), a_Dimension, a_OverworldName);
 	m_WorldsByName[a_WorldName] = NewWorld;
 	NewWorld->Start();
-	NewWorld->InitializeSpawn();
+	if (a_InitSpawn)
+	{
+		NewWorld->InitializeSpawn();
+	}
 	m_PluginManager->CallHookWorldStarted(*NewWorld);
 	return NewWorld;
 }

--- a/src/Root.h
+++ b/src/Root.h
@@ -69,7 +69,7 @@ public:
 	The dimension parameter is used to create a world with a specific dimension
 	a_OverworldName should be set for non-overworld dimensions if one wishes that world to link back to an overworld via portals
 	*/
-	cWorld * CreateAndInitializeWorld(const AString & a_WorldName, eDimension a_Dimension = dimOverworld, const AString & a_OverworldName = "");
+	cWorld * CreateAndInitializeWorld(const AString & a_WorldName, eDimension a_Dimension = dimOverworld, const AString & a_OverworldName = "", bool a_InitSpawn = true);
 
 	/** Returns the up time of the server in seconds */
 	int GetServerUpTime(void)


### PR DESCRIPTION
…down. Changed where player is spawned. Added a_InitSpawn flag to CreateAndInitializeWorld.

The CreateAndInitializeWorld flag was created because as far as I know, the Nether does not require a spawn area (**correct me if I'm wrong, this seems like a big but valid assumption to me**). DetectPortal sends a player respawn packet, but this packet is not actually sent until DetectPortal returns, which is after CreateAndInitializeWorld is called. Creating a spawn area is time-consuming, so sometimes the packet can be delayed for a while (many seconds).

This PR also contains minor stylistic changes to some comments I found. Also ScheduleMoveToWorld can set the PortalCooldown. Also actually checks the MaxY limit.
