### PR TITLE
Fix block placement over fire

### DIFF
--- a/src/Blocks/BlockFire.h
+++ b/src/Blocks/BlockFire.h
@@ -217,6 +217,11 @@ public:
 
 		return (FoundFrameZP && FoundFrameZM);
 	}
+
+	virtual bool DoesIgnoreBuildCollision(cPlayer * a_Player, NIBBLETYPE a_Meta) override
+	{
+		return true;
+	}
 };
 
 


### PR DESCRIPTION
Fix for any block to be placed successfully on top of fire 