### PR TITLE
Grass Growth Fix

### DIFF
--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -86,7 +86,7 @@ void cBlockInfo::Initialize(cBlockInfoArray & a_Info)
 	a_Info[E_BLOCK_ENDER_CHEST         ].m_SpreadLightFalloff = 1;
 	a_Info[E_BLOCK_END_PORTAL          ].m_SpreadLightFalloff = 1;
 	a_Info[E_BLOCK_END_PORTAL_FRAME    ].m_SpreadLightFalloff = 1;
-	a_Info[E_BLOCK_FARMLAND            ].m_SpreadLightFalloff = 1;
+	a_Info[E_BLOCK_FARMLAND            ].m_SpreadLightFalloff = 15;
 	a_Info[E_BLOCK_FENCE               ].m_SpreadLightFalloff = 1;
 	a_Info[E_BLOCK_FENCE_GATE          ].m_SpreadLightFalloff = 1;
 	a_Info[E_BLOCK_FIRE                ].m_SpreadLightFalloff = 1;

--- a/src/Blocks/BlockBed.h
+++ b/src/Blocks/BlockBed.h
@@ -36,11 +36,6 @@ public:
 		a_Pickups.push_back(cItem(E_ITEM_BED, 1, 0));
 	}
 
-	virtual bool CanDirtGrowGrass(NIBBLETYPE a_Meta) override
-	{
-		return true;
-	}
-
 
 	// Bed specific helper functions
 	static NIBBLETYPE RotationToMetaData(double a_Rotation)

--- a/src/Blocks/BlockDirt.h
+++ b/src/Blocks/BlockDirt.h
@@ -94,10 +94,9 @@ public:
 				continue;
 			}
 
-			BLOCKTYPE AboveDest;
-			NIBBLETYPE AboveMeta;
-			Chunk->GetBlockTypeMeta(BlockX, BlockY + 1, BlockZ, AboveDest, AboveMeta);
-			if (cBlockInfo::GetHandler(AboveDest)->CanDirtGrowGrass(AboveMeta))
+			NIBBLETYPE light = std::max(a_Chunk.GetBlockLight(BlockX, BlockY + 1, BlockZ), a_Chunk.GetTimeAlteredLight(a_Chunk.GetSkyLight(BlockX, BlockY + 1, BlockZ)));
+			// Grass does not spread to blocks with a light level less than 5
+			if (light > 4)
 			{
 				if (!cRoot::Get()->GetPluginManager()->CallHookBlockSpread(*Chunk->GetWorld(), Chunk->GetPosX() * cChunkDef::Width + BlockX, BlockY, Chunk->GetPosZ() * cChunkDef::Width + BlockZ, ssGrassSpread))
 				{

--- a/src/Blocks/BlockDirt.h
+++ b/src/Blocks/BlockDirt.h
@@ -48,15 +48,15 @@ public:
 		}
 		else if ((a_RelY < cChunkDef::Height - 1))
 		{
-			NIBBLETYPE block_light = a_Chunk.GetBlockLight(a_RelX, a_RelY + 1, a_RelZ);
+			NIBBLETYPE light = std::max(a_Chunk.GetBlockLight(a_RelX, a_RelY + 1, a_RelZ), a_Chunk.GetTimeAlteredLight(a_Chunk.GetSkyLight(a_RelX, a_RelY + 1, a_RelZ)));
 			// Grass turns back to dirt when light levels are below 5
-			if (block_light < 5)
+			if (light < 5)
 			{
 				a_Chunk.FastSetBlock(a_RelX, a_RelY, a_RelZ, E_BLOCK_DIRT, E_META_DIRT_NORMAL);
 				return;
 			}
 			// Source block is not bright enough to spread
-			if (std::max(block_light, a_Chunk.GetTimeAlteredLight(a_Chunk.GetSkyLight(a_RelX, a_RelY + 1, a_RelZ))) < 9)
+			if (light < 9)
 			{
 				return;
 			}

--- a/src/Blocks/BlockDirt.h
+++ b/src/Blocks/BlockDirt.h
@@ -39,19 +39,6 @@ public:
 		{
 			return;
 		}
-		
-		// Grass becomes dirt if there is something on top of it:
-		if (a_RelY < cChunkDef::Height - 1)
-		{
-			BLOCKTYPE Above;
-			NIBBLETYPE AboveMeta;
-			a_Chunk.GetBlockTypeMeta(a_RelX, a_RelY + 1, a_RelZ, Above, AboveMeta);
-			if (!cBlockInfo::GetHandler(Above)->CanDirtGrowGrass(AboveMeta))
-			{
-				a_Chunk.FastSetBlock(a_RelX, a_RelY, a_RelZ, E_BLOCK_DIRT, E_META_DIRT_NORMAL);
-				return;
-			}
-		}
 
 		// Make sure that there is enough light at the source block to spread
 		if (!a_Chunk.GetWorld()->IsChunkLighted(a_Chunk.GetPosX(), a_Chunk.GetPosZ()))
@@ -59,10 +46,21 @@ public:
 			a_Chunk.GetWorld()->QueueLightChunk(a_Chunk.GetPosX(), a_Chunk.GetPosZ());
 			return;
 		}
-		else if ((a_RelY < cChunkDef::Height - 1) && std::max(a_Chunk.GetBlockLight(a_RelX, a_RelY + 1, a_RelZ), a_Chunk.GetTimeAlteredLight(a_Chunk.GetSkyLight(a_RelX, a_RelY + 1, a_RelZ))) < 9)
+		else if ((a_RelY < cChunkDef::Height - 1))
 		{
+			NIBBLETYPE block_light = a_Chunk.GetBlockLight(a_RelX, a_RelY + 1, a_RelZ);
+			// Grass turns back to dirt when light levels are below 5
+			if (block_light < 5)
+			{
+				a_Chunk.FastSetBlock(a_RelX, a_RelY, a_RelZ, E_BLOCK_DIRT, E_META_DIRT_NORMAL);
+				return;
+			}
 			// Source block is not bright enough to spread
-			return;
+			if (std::max(block_light, a_Chunk.GetTimeAlteredLight(a_Chunk.GetSkyLight(a_RelX, a_RelY + 1, a_RelZ))) < 9)
+			{
+				return;
+			}
+			
 		}
 
 		// Grass spreads to adjacent dirt blocks:

--- a/src/Blocks/BlockFluid.h
+++ b/src/Blocks/BlockFluid.h
@@ -49,12 +49,6 @@ public:
 		}
 		super::Check(a_ChunkInterface, a_PluginInterface, a_RelX, a_RelY, a_RelZ, a_Chunk);
 	}
-
-
-	virtual bool CanDirtGrowGrass(NIBBLETYPE a_Meta) override
-	{
-		return false;
-	}
 } ;
 
 

--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -512,15 +512,6 @@ bool cBlockHandler::CanBeAt(cChunkInterface & a_ChunkInterface, int a_BlockX, in
 
 
 
-bool cBlockHandler::CanDirtGrowGrass(NIBBLETYPE a_Meta)
-{
-	return ((cBlockInfo::IsTransparent(m_BlockType)) || (cBlockInfo::IsOneHitDig(m_BlockType)));
-}
-
-
-
-
-
 bool cBlockHandler::IsUseable()
 {
 	return false;

--- a/src/Blocks/BlockHandler.h
+++ b/src/Blocks/BlockHandler.h
@@ -83,9 +83,6 @@ public:
 	
 	/// Checks if the block can stay at the specified relative coords in the chunk
 	virtual bool CanBeAt(cChunkInterface & a_ChunkInterface, int a_RelX, int a_RelY, int a_RelZ, const cChunk & a_Chunk);
-
-	/** Can the dirt under this block grow to grass? */
-	virtual bool CanDirtGrowGrass(NIBBLETYPE a_Meta);
 	
 	/** Checks if the block can be placed at this point.
 	Default: CanBeAt(...)

--- a/src/Blocks/BlockSlab.h
+++ b/src/Blocks/BlockSlab.h
@@ -88,12 +88,6 @@ public:
 		return true;
 	}
 
-
-	virtual bool CanDirtGrowGrass(NIBBLETYPE a_Meta) override
-	{
-		return ((a_Meta & 0x8) != 0);
-	}
-
 	
 	/// Returns true if the specified blocktype is one of the slabs handled by this handler
 	static bool IsAnySlabType(BLOCKTYPE a_BlockType)

--- a/src/Blocks/BlockStairs.h
+++ b/src/Blocks/BlockStairs.h
@@ -62,12 +62,6 @@ public:
 	}
 
 
-	virtual bool CanDirtGrowGrass(NIBBLETYPE a_Meta) override
-	{
-		return true;
-	}
-
-
 	static NIBBLETYPE RotationToMetaData(double a_Rotation)
 	{
 		a_Rotation += 90 + 45;  // So its not aligned with axis

--- a/src/Simulator/FloodyFluidSimulator.cpp
+++ b/src/Simulator/FloodyFluidSimulator.cpp
@@ -113,7 +113,7 @@ void cFloodyFluidSimulator::SimulateBlock(cChunk * a_Chunk, int a_RelX, int a_Re
 		if (
 			(m_NumNeighborsForSource > 0) &&  // Source creation is on
 			(MyMeta == m_Falloff) &&          // Only exactly one block away from a source (fast bail-out)
-			!IsPassableForFluid(Below) &&     // Only exactly 1 block deep
+			(!IsPassableForFluid(Below) || Below == E_BLOCK_STATIONARY_WATER) &&     // Exactly one block deep or above water source
 			CheckNeighborsForSource(a_Chunk, a_RelX, a_RelY, a_RelZ)  // Did we create a source?
 		)
 		{

--- a/src/Simulator/FloodyFluidSimulator.cpp
+++ b/src/Simulator/FloodyFluidSimulator.cpp
@@ -113,7 +113,7 @@ void cFloodyFluidSimulator::SimulateBlock(cChunk * a_Chunk, int a_RelX, int a_Re
 		if (
 			(m_NumNeighborsForSource > 0) &&  // Source creation is on
 			(MyMeta == m_Falloff) &&          // Only exactly one block away from a source (fast bail-out)
-			(!IsPassableForFluid(Below) || Below == E_BLOCK_STATIONARY_WATER) &&     // Exactly one block deep or above water source
+			!IsPassableForFluid(Below) &&     // Exactly one block deep or above water source
 			CheckNeighborsForSource(a_Chunk, a_RelX, a_RelY, a_RelZ)  // Did we create a source?
 		)
 		{


### PR DESCRIPTION
Grass now turns to dirt when light levels are below 5.
Grass will not spread to blocks where the light level is below 5.
Grass no longer grows under farmland.