### PR TITLE
Call Neighbour changed handlers when a melon is created

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1035,6 +1035,9 @@ void cChunk::GrowMelonPumpkin(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Bl
 				Meta
 			);
 			VERIFY(UnboundedRelFastSetBlock(a_RelX + x, a_RelY, a_RelZ + z, ProduceType, Meta));
+			auto Absolute = RelativeToAbsolute(Vector3i{a_RelX + x, a_RelY, a_RelZ + z}, m_PosX, m_PosZ);
+			cChunkInterface ChunkInterface(this->GetWorld()->GetChunkMap());
+			cBlockHandler::NeighborChanged(ChunkInterface, Absolute.x, Absolute.y, Absolute.z);
 			break;
 		}
 	}


### PR DESCRIPTION
This is a partial fix for #2213, which should prevent the conditions which cause the crash from being created.