### PR TITLE
Added a forgotten break in cHangingEntity constructor.

### DIFF
--- a/src/Entities/HangingEntity.h
+++ b/src/Entities/HangingEntity.h
@@ -103,6 +103,7 @@ protected:
 				// ASSERT(!"Tried to convert a bad facing!");
 
 				Dir = cHangingEntity::BlockFaceToProtocolFace(BLOCK_FACE_XP);
+				break;
 			}
 			#if !defined(__clang__)
 			default:


### PR DESCRIPTION
This had caused loading the cHangingEntity to fail in debug builds.