### PR TITLE
Fixed Middle-Click Button in the ClickWindow-Packet.

### DIFF
--- a/src/Protocol/Protocol17x.cpp
+++ b/src/Protocol/Protocol17x.cpp
@@ -2374,7 +2374,7 @@ void cProtocol172::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 		case 0x0206: Action = caNumber7;         break;
 		case 0x0207: Action = caNumber8;         break;
 		case 0x0208: Action = caNumber9;         break;
-		case 0x0300: Action = caMiddleClick;     break;
+		case 0x0302: Action = caMiddleClick;     break;
 		case 0x0400: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caLeftClickOutsideHoldNothing  : caDropKey;     break;
 		case 0x0401: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caRightClickOutsideHoldNothing : caCtrlDropKey; break;
 		case 0x0500: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caLeftPaintBegin               : caUnknown;     break;

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -2692,7 +2692,7 @@ void cProtocol180::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 		case 0x0206: Action = caNumber7;         break;
 		case 0x0207: Action = caNumber8;         break;
 		case 0x0208: Action = caNumber9;         break;
-		case 0x0300: Action = caMiddleClick;     break;
+		case 0x0302: Action = caMiddleClick;     break;
 		case 0x0400: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caLeftClickOutsideHoldNothing  : caDropKey;     break;
 		case 0x0401: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caRightClickOutsideHoldNothing : caCtrlDropKey; break;
 		case 0x0500: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caLeftPaintBegin               : caUnknown;     break;


### PR DESCRIPTION
See http://wiki.vg/Protocol#Click_Window
The MiddleClick has the button 2 and not 0.
Fixes #2260  

The middle mouse button is already implemented in `cSlotArea::MiddleClicked` (line 256), but was not read correctly from the packet.