### PR TITLE
Doors now get placed on the server-side.

### DIFF
--- a/src/Items/ItemDoor.h
+++ b/src/Items/ItemDoor.h
@@ -32,7 +32,6 @@ public:
 		{
 			return false;
 		}
-		AddFaceDirection(a_BlockX, a_BlockY, a_BlockZ, a_BlockFace);
 
 		// Door (bottom block) can be placed in Y range of [1, 254]:
 		if ((a_BlockY < 1) || (a_BlockY >= cChunkDef::Height - 2))


### PR DESCRIPTION
The Y-Value is already the lower door block(From ItemHandler.cpp:346).
Increasing it once again, places the door into the air, which is blocked by Cuberite.
Bugfix #2279 