### PR TITLE
Now Horses spawn with correct data values.

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1073,9 +1073,9 @@ cMonster * cMonster::NewMonsterFromType(eMonsterType a_MobType)
 		case mtHorse:
 		{
 			// Horses take a type (species), a colour, and a style (dots, stripes, etc.)
-			int HorseType = Random.NextInt(7);
-			int HorseColor = Random.NextInt(6);
-			int HorseStyle = Random.NextInt(6);
+			int HorseType = Random.NextInt(8);
+			int HorseColor = Random.NextInt(7);
+			int HorseStyle = Random.NextInt(5);
 			int HorseTameTimes = Random.NextInt(6) + 1;
 
 			if ((HorseType == 5) || (HorseType == 6) || (HorseType == 7))


### PR DESCRIPTION
The max-value of style is 4, of color is 6.
See http://wiki.vg/Entities#Horse
Also based on the if, the max value of HorseType is 7.
Bugfix #2259 

This doesn't fix wrong values in existing Worlds, because invisible horses could be a "feature", so I didn't checked the values on Horse-Creation.