### PR TITLE
Fixed redstone issue

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator.cpp
@@ -645,7 +645,8 @@ void cIncrementalRedstoneSimulator::FindAndPowerBorderingWires(std::vector<std::
 
 		if (
 			(Neighbour->GetBlock(AdjustedPos) == E_BLOCK_REDSTONE_WIRE) &&
-			(!cBlockInfo::FullyOccupiesVoxel(a_EntryChunk->GetBlock(a_EntryRelBlockPosition.x, a_EntryRelBlockPosition.y + 1, a_EntryRelBlockPosition.z))) &&
+			(!cBlockInfo::FullyOccupiesVoxel(a_EntryChunk->GetBlock(a_EntryRelBlockPosition.x, a_EntryRelBlockPosition.y + 1, a_EntryRelBlockPosition.z)) ||
+			(a_EntryChunk->GetBlock(a_EntryRelBlockPosition.x, a_EntryRelBlockPosition.y + 1, a_EntryRelBlockPosition.z) == E_BLOCK_GLOWSTONE)) &&
 			(MyPower > 1) && (MyPower > IsWirePowered(AdjustedPos, Neighbour)))
 		{
 			PowerBorderingWires(a_PotentialWireList, a_EntryRelBlockPosition, a_EntryChunk, AdjustedPos, Neighbour, MyPower);
@@ -665,7 +666,8 @@ void cIncrementalRedstoneSimulator::FindAndPowerBorderingWires(std::vector<std::
 
 		if (
 			(Neighbour->GetBlock(AdjustedPos) == E_BLOCK_REDSTONE_WIRE) &&
-			(!cBlockInfo::FullyOccupiesVoxel(Neighbour->GetBlock(AdjustedPos.x, AdjustedPos.y + 1, AdjustedPos.z))) &&
+			(!cBlockInfo::FullyOccupiesVoxel(Neighbour->GetBlock(AdjustedPos.x, AdjustedPos.y + 1, AdjustedPos.z)) ||
+			(Neighbour->GetBlock(AdjustedPos.x, AdjustedPos.y + 1, AdjustedPos.z) == E_BLOCK_GLOWSTONE)) &&
 			(MyPower > 1) && (MyPower > IsWirePowered(AdjustedPos, Neighbour)))
 		{
 			PowerBorderingWires(a_PotentialWireList, a_EntryRelBlockPosition, a_EntryChunk, AdjustedPos, Neighbour, MyPower);


### PR DESCRIPTION
Fixed issue where glowstone blocks would block power transmission.

Glowstone is a transparent material according to the [wiki](http://minecraft.gamepedia.com/Glowstone#In_redstone_circuits) as well as in MC's source code (probably because it is a glass based block).