### PR TITLE
Fix FreeBSD build

### DIFF
--- a/src/HTTPServer/CMakeLists.txt
+++ b/src/HTTPServer/CMakeLists.txt
@@ -27,6 +27,7 @@ SET (HDRS
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	set_source_files_properties(HTTPServer.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=global-constructors -Wno-error=old-style-cast")
 	set_source_files_properties(HTTPConnection.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=switch-enum")
+	set_source_files_properties(HTTPMessage.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=tautological-compare")
 endif()
 
 if(NOT MSVC)


### PR DESCRIPTION
Fix the FreeBSD build that was broken by a too strict compiler check. Downgraded the offending error to warning.

This PR may give a merge conflict with #2371 although there is no real conflict.