### PR TITLE
Fix compilation warnings related to implicit and old-style casts

### DIFF
--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -146,6 +146,7 @@ set_source_files_properties(${BINDING_OUTPUTS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/Bindings/Bindings.cpp PROPERTIES COMPILE_FLAGS -Wno-error)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+	set_source_files_properties(${CMAKE_SOURCE_DIR}/src/Bindings/Bindings.cpp PROPERTIES COMPILE_FLAGS ${COMPILE_FLAGS} "-Wno-old-style-cast -Wno-missing-prototypes")
 	set_source_files_properties(LuaWindow.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=switch-enum")
 endif()
 

--- a/src/Bindings/LuaFunctions.h
+++ b/src/Bindings/LuaFunctions.h
@@ -2,11 +2,13 @@
 
 #include "Logger.h"
 #include <time.h>
+#include <chrono>
 // tolua_begin
 
 inline unsigned int GetTime()
 {
-	return (unsigned int)time(0);
+	// NB: For caveats, please see http://stackoverflow.com/a/14505248
+	return static_cast<unsigned int>(std::chrono::seconds(time(0)).count());
 }
 
 inline std::string GetChar( std::string & a_Str, unsigned int a_Idx)

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1668,7 +1668,7 @@ void cClientHandle::HandleRespawn(void)
 
 
 
-void cClientHandle::HandleKeepAlive(int a_KeepAliveID)
+void cClientHandle::HandleKeepAlive(UInt32 a_KeepAliveID)
 {
 	if (a_KeepAliveID == m_PingID)
 	{

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -310,7 +310,7 @@ public:  // tolua_export
 	*/
 	bool HandleHandshake        (const AString & a_Username);
 	
-	void HandleKeepAlive        (int a_KeepAliveID);
+	void HandleKeepAlive        (UInt32 a_KeepAliveID);
 	void HandleLeftClick        (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, UInt8 a_Status);
 	
 	/** Called when the protocol receives a MC|TrSel packet, indicating that the player used a trade in
@@ -413,7 +413,7 @@ private:
 	std::chrono::steady_clock::duration m_Ping;
 
 	/** ID of the last ping request sent to the client. */
-	int m_PingID;
+	UInt32 m_PingID;
 
 	/** Time of the last ping request sent to the client. */
 	std::chrono::steady_clock::time_point m_PingStartTime;

--- a/src/Generating/ComposableGenerator.cpp
+++ b/src/Generating/ComposableGenerator.cpp
@@ -336,7 +336,7 @@ void cComposableGenerator::InitFinishGens(cIniFile & a_IniFile)
 		}
 		else if (NoCaseCompare(*itr, "DualRidgeCaves") == 0)
 		{
-			float Threshold = (float)a_IniFile.GetValueSetF("Generator", "DualRidgeCavesThreshold", 0.3);
+			float Threshold = static_cast<float>(a_IniFile.GetValueSetF("Generator", "DualRidgeCavesThreshold", 0.3));
 			m_FinishGens.push_back(cFinishGenPtr(new cStructGenDualRidgeCaves(Seed, Threshold)));
 		}
 		else if (NoCaseCompare(*itr, "DungeonRooms") == 0)
@@ -569,12 +569,18 @@ void cComposableGenerator::InitFinishGens(cIniFile & a_IniFile)
 			double MinCeilingHeightCenter = a_IniFile.GetValueSetF("Generator", "RoughRavinesMinCeilingHeightCenter", 36);
 			m_FinishGens.push_back(cFinishGenPtr(new cRoughRavines(
 				Seed, MaxSize, MinSize,
-				(float)MaxCenterWidth,         (float)MinCenterWidth,
-				(float)MaxRoughness,           (float)MinRoughness,
-				(float)MaxFloorHeightEdge,     (float)MinFloorHeightEdge,
-				(float)MaxFloorHeightCenter,   (float)MinFloorHeightCenter,
-				(float)MaxCeilingHeightEdge,   (float)MinCeilingHeightEdge,
-				(float)MaxCeilingHeightCenter, (float)MinCeilingHeightCenter,
+				static_cast<float>(MaxCenterWidth),
+				static_cast<float>(MinCenterWidth),
+				static_cast<float>(MaxRoughness),
+				static_cast<float>(MinRoughness),
+				static_cast<float>(MaxFloorHeightEdge),
+				static_cast<float>(MinFloorHeightEdge),
+				static_cast<float>(MaxFloorHeightCenter),
+				static_cast<float>(MinFloorHeightCenter),
+				static_cast<float>(MaxCeilingHeightEdge),
+				static_cast<float>(MinCeilingHeightEdge),
+				static_cast<float>(MaxCeilingHeightCenter),
+				static_cast<float>(MinCeilingHeightCenter),
 				GridSize, MaxOffset
 			)));
 		}

--- a/src/Generating/DistortedHeightmap.cpp
+++ b/src/Generating/DistortedHeightmap.cpp
@@ -129,13 +129,13 @@ cDistortedHeightmap::cDistortedHeightmap(int a_Seed, cBiomeGenPtr a_BiomeGen) :
 	m_HeightGen(m_UnderlyingHeiGen, 64),
 	m_IsInitialized(false)
 {
-	m_NoiseDistortX.AddOctave((NOISE_DATATYPE)1,    (NOISE_DATATYPE)0.5);
-	m_NoiseDistortX.AddOctave((NOISE_DATATYPE)0.5,  (NOISE_DATATYPE)1);
-	m_NoiseDistortX.AddOctave((NOISE_DATATYPE)0.25, (NOISE_DATATYPE)2);
+	m_NoiseDistortX.AddOctave(static_cast<NOISE_DATATYPE>(1),    static_cast<NOISE_DATATYPE>(0.5));
+	m_NoiseDistortX.AddOctave(static_cast<NOISE_DATATYPE>(0.5),  static_cast<NOISE_DATATYPE>(1));
+	m_NoiseDistortX.AddOctave(static_cast<NOISE_DATATYPE>(0.25), static_cast<NOISE_DATATYPE>(2));
 
-	m_NoiseDistortZ.AddOctave((NOISE_DATATYPE)1,    (NOISE_DATATYPE)0.5);
-	m_NoiseDistortZ.AddOctave((NOISE_DATATYPE)0.5,  (NOISE_DATATYPE)1);
-	m_NoiseDistortZ.AddOctave((NOISE_DATATYPE)0.25, (NOISE_DATATYPE)2);
+	m_NoiseDistortZ.AddOctave(static_cast<NOISE_DATATYPE>(1),    static_cast<NOISE_DATATYPE>(0.5));
+	m_NoiseDistortZ.AddOctave(static_cast<NOISE_DATATYPE>(0.5),  static_cast<NOISE_DATATYPE>(1));
+	m_NoiseDistortZ.AddOctave(static_cast<NOISE_DATATYPE>(0.25), static_cast<NOISE_DATATYPE>(2));
 }
 
 
@@ -151,9 +151,9 @@ void cDistortedHeightmap::Initialize(cIniFile & a_IniFile)
 
 	// Read the params from the INI file:
 	m_SeaLevel   =                 a_IniFile.GetValueSetI("Generator", "SeaLevel",                     62);
-	m_FrequencyX = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "DistortedHeightmapFrequencyX", 10);
-	m_FrequencyY = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "DistortedHeightmapFrequencyY", 10);
-	m_FrequencyZ = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "DistortedHeightmapFrequencyZ", 10);
+	m_FrequencyX = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "DistortedHeightmapFrequencyX", 10));
+	m_FrequencyY = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "DistortedHeightmapFrequencyY", 10));
+	m_FrequencyZ = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "DistortedHeightmapFrequencyZ", 10));
 
 	m_IsInitialized = true;
 }
@@ -187,12 +187,12 @@ void cDistortedHeightmap::GenerateHeightArray(void)
 	NOISE_DATATYPE DistortNoiseX[DIM_X * DIM_Y * DIM_Z];
 	NOISE_DATATYPE DistortNoiseZ[DIM_X * DIM_Y * DIM_Z];
 	NOISE_DATATYPE Workspace[DIM_X * DIM_Y * DIM_Z];
-	NOISE_DATATYPE StartX = ((NOISE_DATATYPE)(m_CurChunkX * cChunkDef::Width)) / m_FrequencyX;
-	NOISE_DATATYPE EndX   = ((NOISE_DATATYPE)((m_CurChunkX + 1) * cChunkDef::Width - 1)) / m_FrequencyX;
+	NOISE_DATATYPE StartX = static_cast<NOISE_DATATYPE>(m_CurChunkX * cChunkDef::Width) / m_FrequencyX;
+	NOISE_DATATYPE EndX   = static_cast<NOISE_DATATYPE>((m_CurChunkX + 1) * cChunkDef::Width - 1) / m_FrequencyX;
 	NOISE_DATATYPE StartY = 0;
-	NOISE_DATATYPE EndY   = ((NOISE_DATATYPE)(257)) / m_FrequencyY;
-	NOISE_DATATYPE StartZ = ((NOISE_DATATYPE)(m_CurChunkZ * cChunkDef::Width)) / m_FrequencyZ;
-	NOISE_DATATYPE EndZ   = ((NOISE_DATATYPE)((m_CurChunkZ + 1) * cChunkDef::Width - 1)) / m_FrequencyZ;
+	NOISE_DATATYPE EndY   = static_cast<NOISE_DATATYPE>(257) / m_FrequencyY;
+	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(m_CurChunkZ * cChunkDef::Width) / m_FrequencyZ;
+	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>((m_CurChunkZ + 1) * cChunkDef::Width - 1) / m_FrequencyZ;
 
 	m_NoiseDistortX.Generate3D(DistortNoiseX, DIM_X, DIM_Y, DIM_Z, StartX, EndX, StartY, EndY, StartZ, EndZ, Workspace);
 	m_NoiseDistortZ.Generate3D(DistortNoiseZ, DIM_X, DIM_Y, DIM_Z, StartX, EndX, StartY, EndY, StartZ, EndZ, Workspace);
@@ -211,10 +211,10 @@ void cDistortedHeightmap::GenerateHeightArray(void)
 			{
 				NOISE_DATATYPE DistX = DistortNoiseX[NoiseArrayIdx + x] * m_DistortAmpX[AmpIdx + x];
 				NOISE_DATATYPE DistZ = DistortNoiseZ[NoiseArrayIdx + x] * m_DistortAmpZ[AmpIdx + x];
-				DistX += (NOISE_DATATYPE)(m_CurChunkX * cChunkDef::Width + x * INTERPOL_X);
-				DistZ += (NOISE_DATATYPE)(m_CurChunkZ * cChunkDef::Width + z * INTERPOL_Z);
+				DistX += static_cast<NOISE_DATATYPE>(m_CurChunkX * cChunkDef::Width + x * INTERPOL_X);
+				DistZ += static_cast<NOISE_DATATYPE>(m_CurChunkZ * cChunkDef::Width + z * INTERPOL_Z);
 				// Adding 0.5 helps alleviate the interpolation artifacts
-				DistHei[NoiseArrayIdx + x] = (NOISE_DATATYPE)GetHeightmapAt(DistX, DistZ) + (NOISE_DATATYPE)0.5;
+				DistHei[NoiseArrayIdx + x] = static_cast<NOISE_DATATYPE>(GetHeightmapAt(DistX, DistZ)) + static_cast<NOISE_DATATYPE>(0.5);
 			}
 		}
 	}
@@ -263,9 +263,9 @@ void cDistortedHeightmap::InitializeShapeGen(cIniFile & a_IniFile)
 
 int cDistortedHeightmap::GetHeightmapAt(NOISE_DATATYPE a_X, NOISE_DATATYPE a_Z)
 {
-	int RelX = (int)std::floor(a_X);
+	int RelX = FloorC(a_X);
 	int RelY = 0;
-	int RelZ = (int)std::floor(a_Z);
+	int RelZ = FloorC(a_Z);
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(RelX, RelY, RelZ, ChunkX, ChunkZ);
 

--- a/src/Generating/EndGen.cpp
+++ b/src/Generating/EndGen.cpp
@@ -62,9 +62,9 @@ void cEndGen::InitializeCompoGen(cIniFile & a_IniFile)
 	m_IslandSizeY = a_IniFile.GetValueSetI("Generator", "EndGenIslandSizeY", m_IslandSizeY);
 	m_IslandSizeZ = a_IniFile.GetValueSetI("Generator", "EndGenIslandSizeZ", m_IslandSizeZ);
 
-	m_FrequencyX = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "EndGenFrequencyX", m_FrequencyX);
-	m_FrequencyY = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "EndGenFrequencyY", m_FrequencyY);
-	m_FrequencyZ = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "EndGenFrequencyZ", m_FrequencyZ);
+	m_FrequencyX = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "EndGenFrequencyX", m_FrequencyX));
+	m_FrequencyY = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "EndGenFrequencyY", m_FrequencyY));
+	m_FrequencyZ = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "EndGenFrequencyZ", m_FrequencyZ));
 
 	// Recalculate the min and max chunk coords of the island
 	m_MaxChunkX = (m_IslandSizeX + cChunkDef::Width - 1) / cChunkDef::Width;
@@ -102,28 +102,28 @@ void cEndGen::GenerateNoiseArray(void)
 	NOISE_DATATYPE Workspace[DIM_X * DIM_Y * DIM_Z];  // [x + DIM_X * z + DIM_X * DIM_Z * y]
 
 	// Generate the downscaled noise:
-	NOISE_DATATYPE StartX = ((NOISE_DATATYPE)(m_LastChunkX       * cChunkDef::Width)) / m_FrequencyX;
-	NOISE_DATATYPE EndX   = ((NOISE_DATATYPE)((m_LastChunkX + 1) * cChunkDef::Width)) / m_FrequencyX;
-	NOISE_DATATYPE StartZ = ((NOISE_DATATYPE)(m_LastChunkZ       * cChunkDef::Width)) / m_FrequencyZ;
-	NOISE_DATATYPE EndZ   = ((NOISE_DATATYPE)((m_LastChunkZ + 1) * cChunkDef::Width)) / m_FrequencyZ;
+	NOISE_DATATYPE StartX = static_cast<NOISE_DATATYPE>(m_LastChunkX       * cChunkDef::Width) / m_FrequencyX;
+	NOISE_DATATYPE EndX   = static_cast<NOISE_DATATYPE>((m_LastChunkX + 1) * cChunkDef::Width) / m_FrequencyX;
+	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(m_LastChunkZ       * cChunkDef::Width) / m_FrequencyZ;
+	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>((m_LastChunkZ + 1) * cChunkDef::Width) / m_FrequencyZ;
 	NOISE_DATATYPE StartY = 0;
-	NOISE_DATATYPE EndY   = ((NOISE_DATATYPE)257) / m_FrequencyY;
+	NOISE_DATATYPE EndY   = static_cast<NOISE_DATATYPE>(257) / m_FrequencyY;
 	m_Perlin.Generate3D(NoiseData, DIM_X, DIM_Z, DIM_Y, StartX, EndX, StartZ, EndZ, StartY, EndY, Workspace);
 
 	// Add distance:
 	int idx = 0;
 	for (int y = 0; y < DIM_Y; y++)
 	{
-		NOISE_DATATYPE ValY = (NOISE_DATATYPE)(2 * INTERPOL_Y * y - m_IslandSizeY) / m_IslandSizeY;
+		NOISE_DATATYPE ValY = static_cast<NOISE_DATATYPE>(2 * INTERPOL_Y * y - m_IslandSizeY) / m_IslandSizeY;
 		ValY = ValY * ValY;
 		for (int z = 0; z < DIM_Z; z++)
 		{
-			NOISE_DATATYPE ValZ = (NOISE_DATATYPE)(m_LastChunkZ * cChunkDef::Width + (z * cChunkDef::Width / (DIM_Z - 1))) / m_IslandSizeZ;
+			NOISE_DATATYPE ValZ = static_cast<NOISE_DATATYPE>(m_LastChunkZ * cChunkDef::Width + (z * cChunkDef::Width / (DIM_Z - 1))) / m_IslandSizeZ;
 			ValZ = ValZ * ValZ;
 			for (int x = 0; x < DIM_X; x++)
 			{
 				// NOISE_DATATYPE ValX = StartX + (EndX - StartX) * x / (DIM_X - 1);
-				NOISE_DATATYPE ValX = (NOISE_DATATYPE)(m_LastChunkX * cChunkDef::Width + (x * cChunkDef::Width / (DIM_X - 1))) / m_IslandSizeX;
+				NOISE_DATATYPE ValX = static_cast<NOISE_DATATYPE>(m_LastChunkX * cChunkDef::Width + (x * cChunkDef::Width / (DIM_X - 1))) / m_IslandSizeX;
 				ValX = ValX * ValX;
 				NoiseData[idx++] += ValX + ValZ + ValY;
 			}  // for x
@@ -164,7 +164,7 @@ void cEndGen::GenShape(int a_ChunkX, int a_ChunkZ, cChunkDesc::Shape & a_Shape)
 
 	PrepareState(a_ChunkX, a_ChunkZ);
 
-	int MaxY = std::min((int)(1.75 * m_IslandSizeY + 1), cChunkDef::Height - 1);
+	int MaxY = std::min(static_cast<int>(1.75 * m_IslandSizeY + 1), cChunkDef::Height - 1);
 	for (int z = 0; z < cChunkDef::Width; z++)
 	{
 		for (int x = 0; x < cChunkDef::Width; x++)

--- a/src/Generating/HeiGen.cpp
+++ b/src/Generating/HeiGen.cpp
@@ -230,7 +230,7 @@ cHeiGenMultiCache::cHeiGenMultiCache(cTerrainHeightGenPtr a_HeiGenToCache, size_
 void cHeiGenMultiCache::GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::HeightMap & a_HeightMap)
 {
 	// Get the subcache responsible for this chunk:
-	const size_t cacheIdx = ((size_t)a_ChunkX + m_CoeffZ * (size_t)a_ChunkZ) % m_NumSubCaches;
+	const size_t cacheIdx = (static_cast<size_t>(a_ChunkX) + m_CoeffZ * static_cast<size_t>(a_ChunkZ)) % m_NumSubCaches;
 
 	// Ask the subcache:
 	m_SubCaches[cacheIdx]->GenHeightMap(a_ChunkX, a_ChunkZ, a_HeightMap);
@@ -243,7 +243,7 @@ void cHeiGenMultiCache::GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::Heig
 bool cHeiGenMultiCache::GetHeightAt(int a_ChunkX, int a_ChunkZ, int a_RelX, int a_RelZ, HEIGHTTYPE & a_Height)
 {
 	// Get the subcache responsible for this chunk:
-	const size_t cacheIdx = ((size_t)a_ChunkX + m_CoeffZ * (size_t)a_ChunkZ) % m_NumSubCaches;
+	const size_t cacheIdx = (static_cast<size_t>(a_ChunkX) + m_CoeffZ * static_cast<size_t>(a_ChunkZ)) % m_NumSubCaches;
 
 	// Ask the subcache:
 	return m_SubCaches[cacheIdx]->GetHeightAt(a_ChunkX, a_ChunkZ, a_RelX, a_RelZ, a_Height);
@@ -295,10 +295,10 @@ void cHeiGenClassic::GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::HeightM
 {
 	for (int z = 0; z < cChunkDef::Width; z++)
 	{
-		const float zz = (float)(a_ChunkZ * cChunkDef::Width + z);
+		const float zz = static_cast<float>(a_ChunkZ * cChunkDef::Width + z);
 		for (int x = 0; x < cChunkDef::Width; x++)
 		{
-			const float xx = (float)(a_ChunkX * cChunkDef::Width + x);
+			const float xx = static_cast<float>(a_ChunkX * cChunkDef::Width + x);
 			
 			HEIGHTTYPE hei = static_cast<HEIGHTTYPE>(Clamp(static_cast<int>(64 + (GetNoise(xx * 0.05f, zz * 0.05f) * 16)), 10, 250));
 			cChunkDef::SetHeight(a_HeightMap, x, z, hei);
@@ -312,12 +312,12 @@ void cHeiGenClassic::GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::HeightM
 
 void cHeiGenClassic::InitializeHeightGen(cIniFile & a_IniFile)
 {
-	m_HeightFreq1 = (float)a_IniFile.GetValueSetF("Generator", "ClassicHeightFreq1", 0.1);
-	m_HeightFreq2 = (float)a_IniFile.GetValueSetF("Generator", "ClassicHeightFreq2", 1.0);
-	m_HeightFreq3 = (float)a_IniFile.GetValueSetF("Generator", "ClassicHeightFreq3", 2.0);
-	m_HeightAmp1  = (float)a_IniFile.GetValueSetF("Generator", "ClassicHeightAmp1",  1.0);
-	m_HeightAmp2  = (float)a_IniFile.GetValueSetF("Generator", "ClassicHeightAmp2",  0.5);
-	m_HeightAmp3  = (float)a_IniFile.GetValueSetF("Generator", "ClassicHeightAmp3",  0.5);
+	m_HeightFreq1 = static_cast<float>(a_IniFile.GetValueSetF("Generator", "ClassicHeightFreq1", 0.1));
+	m_HeightFreq2 = static_cast<float>(a_IniFile.GetValueSetF("Generator", "ClassicHeightFreq2", 1.0));
+	m_HeightFreq3 = static_cast<float>(a_IniFile.GetValueSetF("Generator", "ClassicHeightFreq3", 2.0));
+	m_HeightAmp1  = static_cast<float>(a_IniFile.GetValueSetF("Generator", "ClassicHeightAmp1",  1.0));
+	m_HeightAmp2  = static_cast<float>(a_IniFile.GetValueSetF("Generator", "ClassicHeightAmp2",  0.5));
+	m_HeightAmp3  = static_cast<float>(a_IniFile.GetValueSetF("Generator", "ClassicHeightAmp3",  0.5));
 }
 
 
@@ -341,10 +341,10 @@ cHeiGenMountains::cHeiGenMountains(int a_Seed) :
 
 void cHeiGenMountains::GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::HeightMap & a_HeightMap)
 {
-	NOISE_DATATYPE StartX = (NOISE_DATATYPE)(a_ChunkX * cChunkDef::Width);
-	NOISE_DATATYPE EndX   = (NOISE_DATATYPE)(a_ChunkX * cChunkDef::Width + cChunkDef::Width - 1);
-	NOISE_DATATYPE StartZ = (NOISE_DATATYPE)(a_ChunkZ * cChunkDef::Width);
-	NOISE_DATATYPE EndZ   = (NOISE_DATATYPE)(a_ChunkZ * cChunkDef::Width + cChunkDef::Width - 1);
+	NOISE_DATATYPE StartX = static_cast<NOISE_DATATYPE>(a_ChunkX * cChunkDef::Width);
+	NOISE_DATATYPE EndX   = static_cast<NOISE_DATATYPE>(a_ChunkX * cChunkDef::Width + cChunkDef::Width - 1);
+	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(a_ChunkZ * cChunkDef::Width);
+	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>(a_ChunkZ * cChunkDef::Width + cChunkDef::Width - 1);
 	NOISE_DATATYPE Workspace[16 * 16];
 	NOISE_DATATYPE MountainNoise[16 * 16];
 	NOISE_DATATYPE DitchNoise[16 * 16];
@@ -603,7 +603,7 @@ NOISE_DATATYPE cHeiGenBiomal::GetHeightAt(int a_RelX, int a_RelZ, int a_ChunkX, 
 			Height += BiomeCounts[i] * (m_GenParam[i].m_BaseHeight + oct1 + oct2 + oct3);
 		}
 		NOISE_DATATYPE res = Height / Sum;
-		return std::min((NOISE_DATATYPE)250, std::max(res, (NOISE_DATATYPE)5));
+		return std::min(static_cast<NOISE_DATATYPE>(250), std::max(res, static_cast<NOISE_DATATYPE>(5)));
 	}
 	
 	// No known biome around? Weird. Return a bogus value:

--- a/src/Generating/Noise3DGenerator.cpp
+++ b/src/Generating/Noise3DGenerator.cpp
@@ -184,12 +184,12 @@ void cNoise3DGenerator::Initialize(cIniFile & a_IniFile)
 {
 	// Params:
 	m_SeaLevel            =                 a_IniFile.GetValueSetI("Generator", "SeaLevel", 62);
-	m_HeightAmplification = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DHeightAmplification", 0.1);
-	m_MidPoint            = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DMidPoint", 68);
-	m_FrequencyX          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyX", 8);
-	m_FrequencyY          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyY", 8);
-	m_FrequencyZ          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyZ", 8);
-	m_AirThreshold        = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DAirThreshold", 0.5);
+	m_HeightAmplification = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DHeightAmplification", 0.1));
+	m_MidPoint            = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DMidPoint", 68));
+	m_FrequencyX          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyX", 8));
+	m_FrequencyY          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyY", 8));
+	m_FrequencyZ          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyZ", 8));
+	m_AirThreshold        = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DAirThreshold", 0.5));
 }
 
 
@@ -250,12 +250,12 @@ void cNoise3DGenerator::GenerateNoiseArray(int a_ChunkX, int a_ChunkZ, NOISE_DAT
 	NOISE_DATATYPE NoiseW[DIM_X * DIM_Y * DIM_Z];  // Workspace that the noise calculation can use and trash
 
 	// Our noise array has different layout, XZY, instead of regular chunk's XYZ, that's why the coords are "renamed"
-	NOISE_DATATYPE StartX = ((NOISE_DATATYPE)(a_ChunkX       * cChunkDef::Width)) / m_FrequencyX;
-	NOISE_DATATYPE EndX   = ((NOISE_DATATYPE)((a_ChunkX + 1) * cChunkDef::Width)) / m_FrequencyX;
-	NOISE_DATATYPE StartZ = ((NOISE_DATATYPE)(a_ChunkZ       * cChunkDef::Width)) / m_FrequencyZ;
-	NOISE_DATATYPE EndZ   = ((NOISE_DATATYPE)((a_ChunkZ + 1) * cChunkDef::Width)) / m_FrequencyZ;
+	NOISE_DATATYPE StartX = static_cast<NOISE_DATATYPE>(a_ChunkX       * cChunkDef::Width) / m_FrequencyX;
+	NOISE_DATATYPE EndX   = static_cast<NOISE_DATATYPE>((a_ChunkX + 1) * cChunkDef::Width) / m_FrequencyX;
+	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(a_ChunkZ       * cChunkDef::Width) / m_FrequencyZ;
+	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>((a_ChunkZ + 1) * cChunkDef::Width) / m_FrequencyZ;
 	NOISE_DATATYPE StartY = 0;
-	NOISE_DATATYPE EndY   = ((NOISE_DATATYPE)256) / m_FrequencyY;
+	NOISE_DATATYPE EndY   = static_cast<NOISE_DATATYPE>(256) / m_FrequencyY;
 
 	m_Perlin.Generate3D(NoiseO, DIM_X, DIM_Y, DIM_Z, StartX, EndX, StartY, EndY, StartZ, EndZ, NoiseW);
 
@@ -404,21 +404,21 @@ void cNoise3DComposable::Initialize(cIniFile & a_IniFile)
 {
 	// Params:
 	// The defaults generate extreme hills terrain
-	m_HeightAmplification = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DHeightAmplification", 0.045);
-	m_MidPoint            = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DMidPoint", 75);
-	m_FrequencyX          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyX", 40);
-	m_FrequencyY          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyY", 40);
-	m_FrequencyZ          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyZ", 40);
-	m_BaseFrequencyX      = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DBaseFrequencyX", 40);
-	m_BaseFrequencyZ      = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DBaseFrequencyZ", 40);
-	m_ChoiceFrequencyX    = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DChoiceFrequencyX", 40);
-	m_ChoiceFrequencyY    = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DChoiceFrequencyY", 80);
-	m_ChoiceFrequencyZ    = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DChoiceFrequencyZ", 40);
-	m_AirThreshold        = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DAirThreshold", 0);
+	m_HeightAmplification = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DHeightAmplification", 0.045));
+	m_MidPoint            = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DMidPoint", 75));
+	m_FrequencyX          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyX", 40));
+	m_FrequencyY          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyY", 40));
+	m_FrequencyZ          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DFrequencyZ", 40));
+	m_BaseFrequencyX      = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DBaseFrequencyX", 40));
+	m_BaseFrequencyZ      = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DBaseFrequencyZ", 40));
+	m_ChoiceFrequencyX    = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DChoiceFrequencyX", 40));
+	m_ChoiceFrequencyY    = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DChoiceFrequencyY", 80));
+	m_ChoiceFrequencyZ    = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DChoiceFrequencyZ", 40));
+	m_AirThreshold        = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DAirThreshold", 0));
 	int NumChoiceOctaves  = a_IniFile.GetValueSetI("Generator", "Noise3DNumChoiceOctaves",  4);
 	int NumDensityOctaves = a_IniFile.GetValueSetI("Generator", "Noise3DNumDensityOctaves", 6);
 	int NumBaseOctaves    = a_IniFile.GetValueSetI("Generator", "Noise3DNumBaseOctaves",    6);
-	NOISE_DATATYPE BaseNoiseAmplitude = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "Noise3DBaseAmplitude", 1);
+	NOISE_DATATYPE BaseNoiseAmplitude = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "Noise3DBaseAmplitude", 1));
 
 	// Add octaves for the choice noise:
 	NOISE_DATATYPE wavlen = 1, ampl = 0.5;
@@ -566,19 +566,19 @@ void cBiomalNoise3DComposable::Initialize(cIniFile & a_IniFile)
 	// Params:
 	// The defaults generate extreme hills terrain
 	m_SeaLevel            =                 a_IniFile.GetValueSetI("Generator", "SeaLevel", 62);
-	m_FrequencyX          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DFrequencyX", 40);
-	m_FrequencyY          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DFrequencyY", 40);
-	m_FrequencyZ          = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DFrequencyZ", 40);
-	m_BaseFrequencyX      = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DBaseFrequencyX", 40);
-	m_BaseFrequencyZ      = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DBaseFrequencyZ", 40);
-	m_ChoiceFrequencyX    = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DChoiceFrequencyX", 40);
-	m_ChoiceFrequencyY    = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DChoiceFrequencyY", 80);
-	m_ChoiceFrequencyZ    = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DChoiceFrequencyZ", 40);
-	m_AirThreshold        = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DAirThreshold", 0);
+	m_FrequencyX          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DFrequencyX", 40));
+	m_FrequencyY          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DFrequencyY", 40));
+	m_FrequencyZ          = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DFrequencyZ", 40));
+	m_BaseFrequencyX      = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DBaseFrequencyX", 40));
+	m_BaseFrequencyZ      = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DBaseFrequencyZ", 40));
+	m_ChoiceFrequencyX    = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DChoiceFrequencyX", 40));
+	m_ChoiceFrequencyY    = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DChoiceFrequencyY", 80));
+	m_ChoiceFrequencyZ    = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DChoiceFrequencyZ", 40));
+	m_AirThreshold        = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DAirThreshold", 0));
 	int NumChoiceOctaves  = a_IniFile.GetValueSetI("Generator", "BiomalNoise3DNumChoiceOctaves",  4);
 	int NumDensityOctaves = a_IniFile.GetValueSetI("Generator", "BiomalNoise3DNumDensityOctaves", 6);
 	int NumBaseOctaves    = a_IniFile.GetValueSetI("Generator", "BiomalNoise3DNumBaseOctaves",    6);
-	NOISE_DATATYPE BaseNoiseAmplitude = (NOISE_DATATYPE)a_IniFile.GetValueSetF("Generator", "BiomalNoise3DBaseAmplitude", 1);
+	NOISE_DATATYPE BaseNoiseAmplitude = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "BiomalNoise3DBaseAmplitude", 1));
 
 	// Add octaves for the choice noise:
 	NOISE_DATATYPE wavlen = 1, ampl = 0.5;

--- a/src/Generating/Ravines.cpp
+++ b/src/Generating/Ravines.cpp
@@ -134,34 +134,34 @@ void cStructGenRavines::cRavine::GenerateBaseDefPoints(int a_BlockX, int a_Block
 	int CenterZ = a_BlockZ + OffsetZ;
 	
 	// Get the base angle in which the ravine "axis" goes:
-	float Angle = (float)(((float)((a_Noise.IntNoise3DInt(20 * a_BlockX, 70 * a_BlockZ, 6000) / 9) % 16384)) / 16384.0 * M_PI);
+	float Angle = static_cast<float>((static_cast<float>((a_Noise.IntNoise3DInt(20 * a_BlockX, 70 * a_BlockZ, 6000) / 9) % 16384)) / 16384.0 * M_PI);
 	float xc = sinf(Angle);
 	float zc = cosf(Angle);
 	
 	// Calculate the definition points and radii:
-	int MaxRadius = (int)(sqrt(12.0 + ((a_Noise.IntNoise2DInt(61 * a_BlockX, 97 * a_BlockZ) / 13) % a_Size) / 16));
+	int MaxRadius = static_cast<int>(sqrt(12.0 + ((a_Noise.IntNoise2DInt(61 * a_BlockX, 97 * a_BlockZ) / 13) % a_Size) / 16));
 	int Top       = 32 + ((a_Noise.IntNoise2DInt(13 * a_BlockX, 17 * a_BlockZ) / 23) % 32);
 	int Bottom    = 5 + ((a_Noise.IntNoise2DInt(17 * a_BlockX, 29 * a_BlockZ) / 13) % 32);
 	int Mid = (Top + Bottom) / 2;
-	int DefinitionPointX = CenterX - (int)(xc * a_Size / 2);
-	int DefinitionPointZ = CenterZ - (int)(zc * a_Size / 2);
+	int DefinitionPointX = CenterX - static_cast<int>(xc * a_Size / 2);
+	int DefinitionPointZ = CenterZ - static_cast<int>(zc * a_Size / 2);
 	m_Points.push_back(cRavDefPoint(DefinitionPointX, DefinitionPointZ, 0, (Mid + Top) / 2, (Mid + Bottom) / 2));
 	for (int i = 1; i < NUM_RAVINE_POINTS - 1; i++)
 	{
-		int LineX = CenterX + (int)(xc * a_Size * (i - NUM_RAVINE_POINTS / 2) / NUM_RAVINE_POINTS);
-		int LineZ = CenterZ + (int)(zc * a_Size * (i - NUM_RAVINE_POINTS / 2) / NUM_RAVINE_POINTS);
+		int LineX = CenterX + static_cast<int>(xc * a_Size * (i - NUM_RAVINE_POINTS / 2) / NUM_RAVINE_POINTS);
+		int LineZ = CenterZ + static_cast<int>(zc * a_Size * (i - NUM_RAVINE_POINTS / 2) / NUM_RAVINE_POINTS);
 		// Amplitude is the amount of blocks that this point is away from the ravine "axis"
 		int Amplitude = (a_Noise.IntNoise3DInt(70 * a_BlockX, 20 * a_BlockZ + 31 * i, 10000 * i) / 9) % a_Size;
 		Amplitude = Amplitude / 4 - a_Size / 8;  // Amplitude is in interval [-a_Size / 4, a_Size / 4]
-		int PointX = LineX + (int)(zc * Amplitude);
-		int PointZ = LineZ - (int)(xc * Amplitude);
+		int PointX = LineX + static_cast<int>(zc * Amplitude);
+		int PointZ = LineZ - static_cast<int>(xc * Amplitude);
 		int Radius = MaxRadius - abs(i - NUM_RAVINE_POINTS / 2);  // TODO: better radius function
 		int ThisTop    = Top    + ((a_Noise.IntNoise3DInt(7 *  a_BlockX, 19 * a_BlockZ, i * 31) / 13) % 8) - 4;
 		int ThisBottom = Bottom + ((a_Noise.IntNoise3DInt(19 * a_BlockX, 7 *  a_BlockZ, i * 31) / 13) % 8) - 4;
 		m_Points.push_back(cRavDefPoint(PointX, PointZ, Radius, ThisTop, ThisBottom));
 	}  // for i - m_Points[]
-	DefinitionPointX = CenterX + (int)(xc * a_Size / 2);
-	DefinitionPointZ = CenterZ + (int)(zc * a_Size / 2);
+	DefinitionPointX = CenterX + static_cast<int>(xc * a_Size / 2);
+	DefinitionPointZ = CenterZ + static_cast<int>(zc * a_Size / 2);
 	m_Points.push_back(cRavDefPoint(DefinitionPointX, DefinitionPointZ, 0, Mid, Mid));
 }
 
@@ -362,7 +362,7 @@ void cStructGenRavines::cRavine::DrawIntoChunk(cChunkDesc & a_ChunkDesc)
 			int DistSq = (DifX + x) * (DifX + x) + (DifZ + z) * (DifZ + z);
 			if (DistSq <= RadiusSq)
 			{
-				int Top = std::min(itr->m_Top, (int)(cChunkDef::Height));  // Stupid gcc needs int cast
+				int Top = std::min(itr->m_Top, static_cast<int>(cChunkDef::Height));  // Stupid gcc needs int cast
 				for (int y = std::max(itr->m_Bottom, 1); y <= Top; y++)
 				{
 					switch (a_ChunkDesc.GetBlockType(x, y, z))

--- a/src/Generating/RoughRavines.cpp
+++ b/src/Generating/RoughRavines.cpp
@@ -37,12 +37,12 @@ public:
 		size_t Half = a_Size;  // m_DefPoints[Half] will be the centerpoint
 		m_DefPoints.resize(Max + 1);
 		int rnd = m_Noise.IntNoise2DInt(a_OriginX, a_OriginZ) / 7;
-		float Len = (float)a_Size;
-		float Angle = (float)rnd;  // Angle is in radians, will be wrapped in the "sin" and "cos" operations
+		float Len = static_cast<float>(a_Size);
+		float Angle = static_cast<float>(rnd);  // Angle is in radians, will be wrapped in the "sin" and "cos" operations
 		float OfsX = sinf(Angle) * Len;
 		float OfsZ = cosf(Angle) * Len;
 		m_DefPoints[0].Set   (a_OriginX - OfsX, a_OriginZ - OfsZ, 1,             a_CeilingHeightEdge1,  a_FloorHeightEdge1);
-		m_DefPoints[Half].Set((float)a_OriginX, (float)a_OriginZ, a_CenterWidth, a_CeilingHeightCenter, a_FloorHeightCenter);
+		m_DefPoints[Half].Set(static_cast<float>(a_OriginX), static_cast<float>(a_OriginZ), a_CenterWidth, a_CeilingHeightCenter, a_FloorHeightCenter);
 		m_DefPoints[Max].Set (a_OriginX + OfsX, a_OriginZ + OfsZ, 1,             a_CeilingHeightEdge2,  a_FloorHeightEdge2);
 		
 		// Calculate the points in between, recursively:
@@ -104,7 +104,7 @@ protected:
 		// Adjust the midpoint by a small amount of perpendicular vector in a random one of its two directions:
 		float dx = p2.m_X - p1.m_X;
 		float dz = p2.m_Z - p1.m_Z;
-		if ((m_Noise.IntNoise2DInt((int)MidX, (int)MidZ) / 11) % 2 == 0)
+		if ((m_Noise.IntNoise2DInt(static_cast<int>(MidX), static_cast<int>(MidZ)) / 11) % 2 == 0)
 		{
 			MidX += dz * m_Roughness;
 			MidZ -= dx * m_Roughness;
@@ -138,7 +138,7 @@ protected:
 			int rnd = m_Noise.IntNoise2DInt(a_GridX, a_GridZ) / 13;
 			int NumBlocks = (rnd % 3) + 2;
 			rnd = rnd / 4;
-			float Val = (float)(rnd % 256) / 128 - 1;  // Random float in range [-1, +1]
+			float Val = static_cast<float>(rnd % 256) / 128.0f - 1.0f;  // Random float in range [-1, +1]
 			if (h + NumBlocks > cChunkDef::Height)
 			{
 				NumBlocks = cChunkDef::Height - h;
@@ -194,8 +194,8 @@ protected:
 					continue;
 				}
 				
-				int Top = std::min((int)ceilf(itr->m_Top), +cChunkDef::Height);
-				for (int y = std::max((int)floorf(itr->m_Bottom), 1); y <= Top; y++)
+				int Top = std::min(static_cast<int>(ceilf(itr->m_Top)), +cChunkDef::Height);
+				for (int y = std::max(static_cast<int>(floorf(itr->m_Bottom)), 1); y <= Top; y++)
 				{
 					if ((itr->m_Radius + m_PerHeightRadius[y]) * (itr->m_Radius + m_PerHeightRadius[y]) < DistSq)
 					{

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -624,23 +624,23 @@ cStructGenDistortedMembraneOverhangs::cStructGenDistortedMembraneOverhangs(int a
 
 void cStructGenDistortedMembraneOverhangs::GenFinish(cChunkDesc & a_ChunkDesc)
 {
-	const NOISE_DATATYPE Frequency = (NOISE_DATATYPE)16;
-	const NOISE_DATATYPE Amount = (NOISE_DATATYPE)1;
+	const NOISE_DATATYPE Frequency = static_cast<NOISE_DATATYPE>(16);
+	const NOISE_DATATYPE Amount = static_cast<NOISE_DATATYPE>(1);
 	for (int y = 50; y < 128; y++)
 	{
-		NOISE_DATATYPE NoiseY = (NOISE_DATATYPE)y / 32;
+		NOISE_DATATYPE NoiseY = static_cast<NOISE_DATATYPE>(y) / 32;
 		// TODO: proper water level - where to get?
 		BLOCKTYPE ReplacementBlock = (y > 62) ? E_BLOCK_AIR : E_BLOCK_STATIONARY_WATER;
 		for (int z = 0; z < cChunkDef::Width; z++)
 		{
-			NOISE_DATATYPE NoiseZ = ((NOISE_DATATYPE)(a_ChunkDesc.GetChunkZ() * cChunkDef::Width + z)) / Frequency;
+			NOISE_DATATYPE NoiseZ = static_cast<NOISE_DATATYPE>(a_ChunkDesc.GetChunkZ() * cChunkDef::Width + z) / Frequency;
 			for (int x = 0; x < cChunkDef::Width; x++)
 			{
-				NOISE_DATATYPE NoiseX = ((NOISE_DATATYPE)(a_ChunkDesc.GetChunkX() * cChunkDef::Width + x)) / Frequency;
+				NOISE_DATATYPE NoiseX = static_cast<NOISE_DATATYPE>(a_ChunkDesc.GetChunkX() * cChunkDef::Width + x) / Frequency;
 				NOISE_DATATYPE DistortX = m_NoiseX.CubicNoise3D(NoiseX, NoiseY, NoiseZ) * Amount;
 				NOISE_DATATYPE DistortY = m_NoiseY.CubicNoise3D(NoiseX, NoiseY, NoiseZ) * Amount;
 				NOISE_DATATYPE DistortZ = m_NoiseZ.CubicNoise3D(NoiseX, NoiseY, NoiseZ) * Amount;
-				int MembraneHeight = 96 - (int)((DistortY + m_NoiseH.CubicNoise2D(NoiseX + DistortX, NoiseZ + DistortZ)) * 30);
+				int MembraneHeight = 96 - static_cast<int>((DistortY + m_NoiseH.CubicNoise2D(NoiseX + DistortX, NoiseZ + DistortZ)) * 30);
 				if (MembraneHeight < y)
 				{
 					a_ChunkDesc.SetBlockType(x, y, z, ReplacementBlock);

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -724,7 +724,7 @@ void cInventory::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 	if ((a_ItemGrid == &m_ArmorSlots) && (World != nullptr))
 	{
 		World->BroadcastEntityEquipment(
-			m_Owner, static_cast<short>(ArmorSlotNumToEntityEquipmentID(a_SlotNum)),
+			m_Owner, static_cast<short>(ArmorSlotNumToEntityEquipmentID(static_cast<short>(a_SlotNum))),
 			m_ArmorSlots.GetSlot(a_SlotNum), m_Owner.GetClientHandle()
 		);
 	}

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -67,20 +67,20 @@ void cMap::Tick()
 
 void cMap::UpdateRadius(int a_PixelX, int a_PixelZ, unsigned int a_Radius)
 {
-	int PixelRadius = a_Radius / GetPixelWidth();
+	int PixelRadius = static_cast<int>(a_Radius / GetPixelWidth());
 
-	unsigned int StartX = Clamp(a_PixelX - PixelRadius, 0, (int)m_Width);
-	unsigned int StartZ = Clamp(a_PixelZ - PixelRadius, 0, (int)m_Height);
+	unsigned int StartX = static_cast<unsigned int>(Clamp(a_PixelX - PixelRadius, 0, static_cast<int>(m_Width)));
+	unsigned int StartZ = static_cast<unsigned int>(Clamp(a_PixelZ - PixelRadius, 0, static_cast<int>(m_Height)));
 
-	unsigned int EndX   = Clamp(a_PixelX + PixelRadius, 0, (int)m_Width);
-	unsigned int EndZ   = Clamp(a_PixelZ + PixelRadius, 0, (int)m_Height);
+	unsigned int EndX   = static_cast<unsigned int>(Clamp(a_PixelX + PixelRadius, 0, static_cast<int>(m_Width)));
+	unsigned int EndZ   = static_cast<unsigned int>(Clamp(a_PixelZ + PixelRadius, 0, static_cast<int>(m_Height)));
 
 	for (unsigned int X = StartX; X < EndX; ++X)
 	{
 		for (unsigned int Z = StartZ; Z < EndZ; ++Z)
 		{
-			int dX = X - a_PixelX;
-			int dZ = Z - a_PixelZ;
+			int dX = static_cast<int>(X) - a_PixelX;
+			int dZ = static_cast<int>(Z) - a_PixelZ;
 
 			if ((dX * dX) + (dZ * dZ) < (PixelRadius * PixelRadius))
 			{
@@ -96,10 +96,10 @@ void cMap::UpdateRadius(int a_PixelX, int a_PixelZ, unsigned int a_Radius)
 
 void cMap::UpdateRadius(cPlayer & a_Player, unsigned int a_Radius)
 {
-	unsigned int PixelWidth = GetPixelWidth();
+	int PixelWidth = static_cast<int>(GetPixelWidth());
 
-	int PixelX = (int) (a_Player.GetPosX() - m_CenterX) / PixelWidth + (m_Width  / 2);
-	int PixelZ = (int) (a_Player.GetPosZ() - m_CenterZ) / PixelWidth + (m_Height / 2);
+	int PixelX = static_cast<int>(a_Player.GetPosX() - m_CenterX) / PixelWidth + static_cast<int>(m_Width  / 2);
+	int PixelZ = static_cast<int>(a_Player.GetPosZ() - m_CenterZ) / PixelWidth + static_cast<int>(m_Height / 2);
 
 	UpdateRadius(PixelX, PixelZ, a_Radius);
 }
@@ -110,10 +110,8 @@ void cMap::UpdateRadius(cPlayer & a_Player, unsigned int a_Radius)
 
 bool cMap::UpdatePixel(unsigned int a_X, unsigned int a_Z)
 {
-	unsigned int PixelWidth = GetPixelWidth();
-
-	int BlockX = m_CenterX + ((a_X - (m_Width  / 2)) * PixelWidth);
-	int BlockZ = m_CenterZ + ((a_Z - (m_Height / 2)) * PixelWidth);
+	int BlockX = m_CenterX + static_cast<int>((a_X - m_Width  / 2) * GetPixelWidth());
+	int BlockZ = m_CenterZ + static_cast<int>((a_Z - m_Height / 2) * GetPixelWidth());
 
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(BlockX, BlockZ, ChunkX, ChunkZ);
@@ -174,7 +172,8 @@ bool cMap::UpdatePixel(unsigned int a_X, unsigned int a_Z)
 			}
 
 			// Multiply base color ID by 4 and add brightness ID
-			m_PixelData = ColourID * 4 + BrightnessID[Clamp<size_t>(static_cast<size_t>(Height / (ChunkHeight / BrightnessID.size())), 0, BrightnessID.size() - 1)];
+			const int BrightnessIDSize = static_cast<int>(BrightnessID.size());
+			m_PixelData = ColourID * 4 + BrightnessID[static_cast<size_t>(Clamp<int>((BrightnessIDSize * Height) / ChunkHeight, 0, BrightnessIDSize - 1))];
 			return false;
 		}
 
@@ -294,8 +293,8 @@ const cMapDecorator cMap::CreateDecorator(const cEntity * a_TrackedEntity)
 	int InsideHeight = (GetHeight() / 2) - 1;
 	
 	// Center of pixel
-	int PixelX = (int)(a_TrackedEntity->GetPosX() - GetCenterX()) / GetPixelWidth();
-	int PixelZ = (int)(a_TrackedEntity->GetPosZ() - GetCenterZ()) / GetPixelWidth();
+	int PixelX = static_cast<int>(a_TrackedEntity->GetPosX() - GetCenterX()) / static_cast<int>(GetPixelWidth());
+	int PixelZ = static_cast<int>(a_TrackedEntity->GetPosZ() - GetCenterZ()) / static_cast<int>(GetPixelWidth());
 
 	cMapDecorator::eType Type;
 	int Rot;
@@ -347,7 +346,7 @@ const cMapDecorator cMap::CreateDecorator(const cEntity * a_TrackedEntity)
 		}
 	}
 
-	return {Type, (unsigned)(2 * PixelX + 1), (unsigned)(2 * PixelZ + 1), Rot};
+	return {Type, static_cast<unsigned>(2 * PixelX + 1), static_cast<unsigned>(2 * PixelZ + 1), Rot};
 }
 
 
@@ -355,7 +354,7 @@ const cMapDecorator cMap::CreateDecorator(const cEntity * a_TrackedEntity)
 
 unsigned int cMap::GetPixelWidth(void) const
 {
-	return (int) pow(2.0, (double) m_Scale);
+	return static_cast<unsigned int>(pow(2.0, static_cast<double>(m_Scale)));
 }
 
 

--- a/src/PolarSSL++/RsaPrivateKey.cpp
+++ b/src/PolarSSL++/RsaPrivateKey.cpp
@@ -100,7 +100,7 @@ AString cRsaPrivateKey::GetPubKeyDER(void)
 	{
 		return AString();
 	}
-	return AString((const char *)(buf + sizeof(buf) - res), (size_t)res);
+	return AString(reinterpret_cast<const char *>(buf + sizeof(buf) - res), static_cast<size_t>(res));
 }
 
 
@@ -134,7 +134,7 @@ int cRsaPrivateKey::Decrypt(const Byte * a_EncryptedData, size_t a_EncryptedLeng
 	{
 		return -1;
 	}
-	return (int)DecryptedLength;
+	return static_cast<int>(DecryptedLength);
 }
 
 
@@ -167,7 +167,7 @@ int cRsaPrivateKey::Encrypt(const Byte * a_PlainData, size_t a_PlainLength, Byte
 	{
 		return -1;
 	}
-	return (int)m_Rsa.len;
+	return static_cast<int>(m_Rsa.len);
 }
 
 

--- a/src/Protocol/Protocol17x.cpp
+++ b/src/Protocol/Protocol17x.cpp
@@ -652,7 +652,7 @@ void cProtocol172::SendKeepAlive(UInt32 a_PingID)
 	}
 	
 	cPacketizer Pkt(*this, 0x00);  // Keep Alive packet
-	Pkt.WriteBEInt32(static_cast<Int32>(a_PingID));
+	Pkt.WriteBEUInt32(a_PingID);
 }
 
 
@@ -2144,7 +2144,7 @@ void cProtocol172::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 
 void cProtocol172::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
 {
-	HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, KeepAliveID);
+	HANDLE_READ(a_ByteBuffer, ReadBEUInt32, UInt32, KeepAliveID);
 	m_Client->HandleKeepAlive(KeepAliveID);
 }
 

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -649,7 +649,7 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 		Pkt.WriteBEUInt8(static_cast<UInt8>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
 		Pkt.WriteBEInt8(static_cast<Int8>(a_World.GetDimension()));
 		Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
-		Pkt.WriteBEUInt8(Clamp<UInt8>(Server->GetMaxPlayers(), 0, 255));
+		Pkt.WriteBEUInt8(static_cast<UInt8>(Clamp<int>(Server->GetMaxPlayers(), 0, 255)));
 		Pkt.WriteString("default");  // Level type - wtf?
 		Pkt.WriteBool(false);  // Reduced Debug Info - wtf?
 	}
@@ -2197,7 +2197,7 @@ void cProtocol180::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffe
 		m_Client->Kick("Hacked client");
 		return;
 	}
-	if (ntohl(DecryptedNonce[0]) != (unsigned)(uintptr_t)this)  // Cannot convert to c++ casts
+	if (ntohl(DecryptedNonce[0]) != static_cast<unsigned>(reinterpret_cast<uintptr_t>(this)))
 	{
 		LOGD("Bad nonce value");
 		m_Client->Kick("Hacked client");
@@ -2247,7 +2247,7 @@ void cProtocol180::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 		Pkt.WriteVarInt32(static_cast<UInt32>(PubKeyDer.size()));
 		Pkt.WriteBuf(PubKeyDer.data(), PubKeyDer.size());
 		Pkt.WriteVarInt32(4);
-		Pkt.WriteBEInt32((int)(intptr_t)this);  // Using 'this' as the cryptographic nonce, so that we don't have to generate one each time :) Cannot convert to c++ casts
+		Pkt.WriteBEInt32(static_cast<int>(reinterpret_cast<intptr_t>(this)));  // Using 'this' as the cryptographic nonce, so that we don't have to generate one each time :)
 		m_Client->SetUsername(Username);
 		return;
 	}
@@ -2406,7 +2406,7 @@ void cProtocol180::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 void cProtocol180::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, KeepAliveID);
-	m_Client->HandleKeepAlive(static_cast<Int32>(KeepAliveID));
+	m_Client->HandleKeepAlive(KeepAliveID);
 }
 
 

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -756,7 +756,7 @@ int cRoot::GetVirtualRAMUsage(void)
 		if (KERN_SUCCESS == task_info(
 			mach_task_self(),
 			TASK_BASIC_INFO,
-			(task_info_t)&t_info,
+			reinterpret_cast<task_info_t>(&t_info),
 			&t_info_count
 		))
 		{
@@ -808,7 +808,7 @@ int cRoot::GetPhysicalRAMUsage(void)
 		if (KERN_SUCCESS == task_info(
 			mach_task_self(),
 			TASK_BASIC_INFO,
-			(task_info_t)&t_info,
+			reinterpret_cast<task_info_t>(&t_info),
 			&t_info_count
 		))
 		{


### PR DESCRIPTION
The compilation output on OS X is rather noisy. This PR tackles some of this by fixing old-style casts and changing some implicit casts into explicit ones.