### PR TITLE
Revert Clang compiler flag that breaks OS X build

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -277,7 +277,6 @@ macro(set_exe_flags)
 					# Ignore another problem in sqlite
 					add_flags_cxx("-Wno-documentation-unknown-command")
 				endif()
-				add_flags_cxx("-Wno-format-pedantic")
 			endif()
 		endif()
 	endif()


### PR DESCRIPTION
This is probably not the right way to fix the problem reported in #2440 but let's OS X people to build the software in the interim. 