### PR TITLE
Qualify abs with namespace, use explicit cast

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2124,7 +2124,7 @@ void cPlayer::UpdateMovementStats(const Vector3d & a_DeltaPos, bool a_PreviousIs
 			else if (a_DeltaPos.y < 0.0)
 			{
 				// Increment statistic
-				m_Stats.AddValue(statDistFallen, (StatValue)(abs(a_DeltaPos.y) * 100 + 0.5));
+				m_Stats.AddValue(statDistFallen, static_cast<StatValue>(std::abs(a_DeltaPos.y) * 100 + 0.5));
 			}
 			// TODO: good opportunity to detect illegal flight (check for falling tho)
 		}


### PR DESCRIPTION
Fix #2442 by:
- Qualifying the call to `std::abs` function explicitly with namespace
- Using static cast instead of old-style implicit cast