### PR TITLE
Fix FreeBSD build by including signal.h

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -25,13 +25,15 @@
 
 #include <iostream>
 
-#ifdef _WIN32
+#if defined(_WIN32)
 	#include <psapi.h>
-#elif defined(__linux__)
-	#include <fstream>
+#elif defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 	#include <signal.h>
-#elif defined(__APPLE__)
-	#include <mach/mach.h>
+	#if defined(__linux__)
+		#include <fstream>
+	#elif defined(__APPLE__)
+		#include <mach/mach.h>
+	#endif
 #endif
 
 


### PR DESCRIPTION
On FreeBSD the build dies due to missing `signal.h`:

    [ 97%] Building CXX object src/CMakeFiles/MCServer.dir/Root.cpp.o
    /home/matti/cuberite/src/Root.cpp:301:51: error: use of undeclared identifier 'SIGKILL'
                    if (pthread_kill(m_InputThread.native_handle(), SIGKILL) != 0)

Dependency on `signal.h` was introduced by #2427.

This PR fixes the build. However I wonder whether these POSIX headers should be included in less a case-by-case manner. I'm not a pro on that front so I couldn't tell.