### PR TITLE
Fix clang compile error

### DIFF
--- a/src/Generating/CompoGen.cpp
+++ b/src/Generating/CompoGen.cpp
@@ -377,7 +377,7 @@ void cCompoGenCache::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc::
 	if (((m_NumHits + m_NumMisses) % 1024) == 10)
 	{
 		LOGD("CompoGenCache: %d hits, %d misses, saved %.2f %%", m_NumHits, m_NumMisses, 100.0 * m_NumHits / (m_NumHits + m_NumMisses));
-		LOGD("CompoGenCache: Avg cache chain length: %.2f", (float)m_TotalChain / m_NumHits);
+		LOGD("CompoGenCache: Avg cache chain length: %.2f", static_cast<float>(m_TotalChain) / m_NumHits);
 	}
 	#endif  // _DEBUG
 	


### PR DESCRIPTION
Fixes a bug where Clang 3.6 would fail due to warnings on debug builds due to the use of an old-style cast.
```
[ 81%] Built target Entities
[ 81%] Building CXX object src/Generating/CMakeFiles/Generating.dir/CompoGen.cpp.o
/home/theo/src/cuberite/src/Generating/CompoGen.cpp:380:55: error: use of old-style cast [-Werror,-Wold-style-cast]
                LOGD("CompoGenCache: Avg cache chain length: %.2f", (float)m_TotalChain / m_NumHits);
                                                                    ^      ~~~~~~~~~~~~
1 error generated.
                                                                         ^
1 error generated.
```

OS: Arch Linux x86_64
Compiler:
```
clang version 3.6.2 (tags/RELEASE_362/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
```