### PR TITLE
Fixes #2458

### DIFF
--- a/src/BlockEntities/JukeboxEntity.cpp
+++ b/src/BlockEntities/JukeboxEntity.cpp
@@ -21,7 +21,6 @@ cJukeboxEntity::cJukeboxEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld 
 
 cJukeboxEntity::~cJukeboxEntity()
 {
-	EjectRecord();
 }
 
 


### PR DESCRIPTION
* Simplified entity adding

@jammet, so what happened was.
1. I fixed a typo where chunk unloading would only happen once every 5 minutes. It was intended to be once every 10 seconds.
2. In your world, at (148 77 103) and (103 90 120) you have jukeboxes with discs in them.
3. These happened to be in chunks that got unloaded at the end of this 10 second interval.
4. Jukeboxes eject their discs on unload, so this queued a new entity to be added to the unloading chunk
5. The server gets round to adding the queued entity, and promptly finds the chunk unloaded. It consequently tries to load the chunk again, and thus the jukebox, which saved with the disc still inside, since saving happens before the disc is ejected.
6. This loaded chunk is the unloaded 10 seconds later, and thus repeat *ad infinitum*, spamming those 'cPickup spawned in non-existent chunk' messages.

~~Now the pickup entities are added immediately to the [still alive](https://www.youtube.com/watch?v=Y6ljFaKRTrI) chunk, and are destroyed when it is [nullified](https://www.youtube.com/watch?v=uqH_Y1TupoQ). There is still the issue that jukeboxes eject a disc, effectively into the ether, when they unload, since everything's discarded afterwards, but oh well.~~

Okay, as suspected the above has concurrency issues. New fix is to fix the bug reported in the second part of the above. Jukeboxes don't throw a disc into the air when they're about to ~~die~~ be unloaded.