### PR TITLE
Lilypads drop when not on source water.

### DIFF
--- a/src/Blocks/BlockLilypad.h
+++ b/src/Blocks/BlockLilypad.h
@@ -23,6 +23,22 @@ public:
 		UNUSED(a_Meta);
 		return 7;
 	}
+
+
+	virtual bool CanBeAt(cChunkInterface & a_ChunkInterface, int a_RelX, int a_RelY, int a_RelZ, const cChunk & a_Chunk) override
+	{
+		if ((a_RelY < 1) || (a_RelY >= cChunkDef::Height))
+		{
+			return false;
+		}
+		BLOCKTYPE UnderType;
+		NIBBLETYPE UnderMeta;
+		a_Chunk.GetBlockTypeMeta(a_RelX, a_RelY - 1, a_RelZ, UnderType, UnderMeta);
+		return (
+			((UnderType == E_BLOCK_STATIONARY_WATER) || (UnderType == E_BLOCK_WATER)) &&  // Water is below...
+			(UnderMeta == 0)                                                              // ... and it's a source
+		);
+	}
 };
 
 


### PR DESCRIPTION
Lilypad blocks now break and drop as items when the block below them changes to non-water or non-source water.

Fixes #2404.
Closes #2411.