### PR TITLE
Api dump check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ players
 world
 world_nether
 
-#cmake stuff
+# cmake stuff
 CMakeFiles/
 cmake_install.cmake
 CMakeCache.txt
@@ -79,7 +79,7 @@ src/Bindings/BindingDependencies.txt
 Cuberite.dir/
 src/AllFiles.lst
 
-#win32 cmake stuff
+# win32 cmake stuff
 *.vcxproj
 *.vcproj
 *.vcxproj.filters
@@ -88,10 +88,16 @@ src/AllFiles.lst
 *.sln
 *.idb
 
-#cmake output folders
+# cmake output folders
 ZERO_CHECK.dir/
 Debug/
 DebugProfile/
 Release/
 ReleaseProfile/
 *.dir/
+
+# APIDump-generated status files:
+Server/cuberite_api.lua
+Server/official_undocumented.lua
+Server/NewlyUndocumented.lua
+

--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -21,8 +21,19 @@ cd ..
 echo "Building..."
 make -j 2;
 make -j 2 test ARGS="-V";
+
+echo "Testing..."
 cd Server/;
 if [ "$TRAVIS_CUBERITE_BUILD_TYPE" != "COVERAGE" ]; then
-	echo restart | $CUBERITE_PATH;
-	echo stop | $CUBERITE_PATH;
+	$CUBERITE_PATH << EOF
+load APIDump
+apicheck
+restart
+stop
+EOF
+	if [ -f ./NewlyUndocumented.lua ]; then
+		echo "ERROR: Newly undocumented API symbols found:"
+		cat ./NewlyUndocumented.lua
+		exit 1
+	fi
 fi

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3029,6 +3029,7 @@ end
 		"cFurnaceEntity.__cBlockEntityWindowOwner__",
 		"cHopperEntity.__cBlockEntityWindowOwner__",
 		"cLuaWindow.__cItemGrid__cListener__",
+		"Globals._CuberiteInternal_.*",  -- Ignore all internal Cuberite constants
 	},
 
 	IgnoreVariables =


### PR DESCRIPTION
This allows the CI builds to check for newly exported API symbols without documentation.