### PR TITLE
Added weather intervals to world.ini settings.

### DIFF
--- a/src/World.h
+++ b/src/World.h
@@ -921,6 +921,9 @@ private:
 
 	eWeather m_Weather;
 	int m_WeatherInterval;
+	int m_MaxSunnyTicks, m_MinSunnyTicks;
+	int m_MaxRainTicks,  m_MinRainTicks;
+	int m_MaxThunderStormTicks, m_MinThunderStormTicks;
 	
 	int  m_MaxCactusHeight;
 	int  m_MaxSugarcaneHeight;


### PR DESCRIPTION
Made world's weather intervals settable through world.ini.
Changed the interval defaults to match Vanilla.

Also fixed MSVC warnings from over-zealous clang fixes in the weather functions.

Fixes #2499