### PR TITLE
Made Lua API check strings strictly.

### DIFF
--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -1065,7 +1065,7 @@ bool cLuaState::CheckParamString(int a_StartParam, int a_EndParam)
 	tolua_Error tolua_err;
 	for (int i = a_StartParam; i <= a_EndParam; i++)
 	{
-		if (tolua_isstring(m_LuaState, i, 0, &tolua_err))
+		if (lua_isstring(m_LuaState, i))
 		{
 			continue;
 		}
@@ -1073,6 +1073,9 @@ bool cLuaState::CheckParamString(int a_StartParam, int a_EndParam)
 		lua_Debug entry;
 		VERIFY(lua_getstack(m_LuaState, 0,   &entry));
 		VERIFY(lua_getinfo (m_LuaState, "n", &entry));
+		tolua_err.array = 0;
+		tolua_err.type = "string";
+		tolua_err.index = i;
 		AString ErrMsg = Printf("#ferror in function '%s'.", (entry.name != nullptr) ? entry.name : "?");
 		tolua_error(m_LuaState, ErrMsg.c_str(), &tolua_err);
 		return false;


### PR DESCRIPTION
Previously nil was accepted as a string in cLuaState::CheckParamString(), now it's reported as an error.

This is a follow-up of the `cFile` API extension. That API was the first to use `ASSERT`s for checking that the values were actually read from the Lua state, and the asserts failed in the cases such as:
```lua
cFile:IsFile(nil)
```
because the `CheckParamString` check succeeded, while the `GetStackValues` call failed then.