### PR TITLE
Added LuaState tracker and memory stats logging.

### DIFF
--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -210,6 +210,9 @@ public:
 	
 	/** Returns true if the m_LuaState is valid */
 	bool IsValid(void) const { return (m_LuaState != nullptr); }
+
+	/** Returns the name of the subsystem, as specified when the instance was created. */
+	AString GetSubsystemName(void) const { return m_SubsystemName; }
 	
 	/** Adds the specified path to package.<a_PathVariable> */
 	void AddPackagePath(const AString & a_PathVariable, const AString & a_Path);
@@ -517,6 +520,40 @@ protected:
 	/** Tries to break into the MobDebug debugger, if it is installed. */
 	static int BreakIntoDebugger(lua_State * a_LuaState);
 } ;
+
+
+
+
+
+/** Keeps track of all create cLuaState instances.
+Can query each for the amount of currently used memory. */
+class cLuaStateTracker
+{
+public:
+	/** Adds the specified Lua state to the internal list of LuaStates. */
+	static void Add(cLuaState & a_LuaState);
+
+	/** Deletes the specified Lua state from the internal list of LuaStates. */
+	static void Del(cLuaState & a_LuaState);
+
+	/** Returns the statistics for all the registered LuaStates. */
+	static AString GetStats(void);
+
+protected:
+	typedef cLuaState * cLuaStatePtr;
+	typedef std::vector<cLuaStatePtr> cLuaStatePtrs;
+
+	/** The internal list of LuaStates.
+	Protected against multithreaded access by m_CSLuaStates. */
+	cLuaStatePtrs m_LuaStates;
+
+	/** Protects m_LuaStates against multithreaded access. */
+	cCriticalSection m_CSLuaStates;
+
+
+	/** Returns the single instance of this class. */
+	static cLuaStateTracker & Get(void);
+};
 
 
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -145,6 +145,8 @@ cServer::cServer(void) :
 	m_ShouldLoadOfflinePlayerData(false),
 	m_ShouldLoadNamedPlayerData(true)
 {
+	// Initialize the LuaStateTracker singleton before the app goes multithreaded:
+	cLuaStateTracker::GetStats();
 }
 
 
@@ -519,6 +521,13 @@ void cServer::ExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallbac
 	else if (split[0].compare("chunkstats") == 0)
 	{
 		cRoot::Get()->LogChunkStats(a_Output);
+		a_Output.Finished();
+		return;
+	}
+
+	else if (split[0].compare("luastats") == 0)
+	{
+		a_Output.Out(cLuaStateTracker::GetStats());
 		a_Output.Finished();
 		return;
 	}


### PR DESCRIPTION
Added a new built-in command `luastats` that lists the memory used by each `cLuaState` instance currently active:
```
[6fcee5d7|21:29:14] Executing console command: "luastats"
[6fcee5d7|21:29:14] State "<webadmin_template>" is using 653 KiB of memory
[6fcee5d7|21:29:14] State "plugin APIDump" is using 1238 KiB of memory
[6fcee5d7|21:29:14] State "plugin ChunkWorx" is using 592 KiB of memory
[6fcee5d7|21:29:14] State "plugin Core" is using 1272 KiB of memory
[6fcee5d7|21:29:14] State "plugin GalExport" is using 889 KiB of memory
[6fcee5d7|21:29:14] State "plugin Gallery" is using 850 KiB of memory
[6fcee5d7|21:29:14] State "plugin LastSeen" is using 597 KiB of memory
[6fcee5d7|21:29:14] State "plugin NetworkTest" is using 625 KiB of memory
[6fcee5d7|21:29:14] State "plugin PluginMemory" is using 1452 KiB of memory
[6fcee5d7|21:29:14] State "plugin ProtectionAreas" is using 680 KiB of memory
[6fcee5d7|21:29:14] State "plugin WorldEdit" is using 815 KiB of memory
[6fcee5d7|21:29:14] Total memory used by Lua: 9663 KiB
```

This will allow us to see if increased memory usage reported in Linux is due to Lua or our memory leaks. Also, is cool :)