### PR TITLE
Removed the BasicStyleCheck from Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
-    - lua5.1
 
 script: ./CIbuild.sh
 

--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -13,11 +13,6 @@ if [ "$CXX" == "g++" ]; then
 fi
 cmake . -DBUILD_TOOLS=1 -DSELF_TEST=1;
 
-echo "Checking basic style..."
-cd src
-lua CheckBasicStyle.lua
-cd ..
-
 echo "Building..."
 make -j 2;
 make -j 2 test ARGS="-V";


### PR DESCRIPTION
The check is being done on dedicated CircleCI "build" now.