### PR TITLE
Decoupled cMonster and path recalculation logic, created cPathFinder

### DIFF
--- a/src/Mobs/CMakeLists.txt
+++ b/src/Mobs/CMakeLists.txt
@@ -25,6 +25,7 @@ SET (SRCS
 	PassiveAggressiveMonster.cpp
 	PassiveMonster.cpp
 	Path.cpp
+	PathFinder.cpp
 	Pig.cpp
 	Rabbit.cpp
 	Sheep.cpp
@@ -64,6 +65,7 @@ SET (HDRS
 	PassiveAggressiveMonster.h
 	PassiveMonster.h
 	Path.h
+	PathFinder.h
 	Pig.h
 	Rabbit.h
 	Sheep.h

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -239,6 +239,7 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		{
 			case ePathFinderStatus::PATH_FOUND:
 			case ePathFinderStatus::NEARBY_FOUND:
+			{
 				/* If I burn in daylight, and I won't burn where I'm standing, and I'll burn in my next position, and at least one of those is true:
 				1. I am idle
 				2. I was not hurt by a player recently.
@@ -258,7 +259,7 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 					a_IsFollowingPath = true;  // Used for proper body / head orientation only.
 					MoveToWayPoint(*Chunk);
 				}
-				break;
+			}
 			default:
 			{
 

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -13,7 +13,7 @@
 #include "../Chunk.h"
 #include "../FastRandom.h"
 
-#include "Path.h"
+#include "PathFinder.h"
 
 
 
@@ -74,11 +74,8 @@ cMonster::cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const A
 	, m_EMState(IDLE)
 	, m_EMPersonality(AGGRESSIVE)
 	, m_Target(nullptr)
-	, m_Path(nullptr)
-	, m_IsFollowingPath(false)
+	, m_PathFinder(a_Width, a_Height)
 	, m_PathfinderActivated(false)
-	, m_GiveUpCounter(0)
-	, m_TicksSinceLastPathReset(1000)
 	, m_LastGroundHeight(POSY_TOINT)
 	, m_JumpCoolDown(0)
 	, m_IdleInterval(0)
@@ -123,118 +120,6 @@ void cMonster::SpawnOn(cClientHandle & a_Client)
 
 
 
-bool cMonster::TickPathFinding(cChunk & a_Chunk)
-{
-	if (!m_PathfinderActivated)
-	{
-		return false;
-	}
-	if (m_TicksSinceLastPathReset < 1000)
-	{
-		// No need to count beyond 1000. 1000 is arbitary here.
-		++m_TicksSinceLastPathReset;
-	}
-
-	if (ReachedFinalDestination())
-	{
-		StopMovingToPosition();
-		return false;
-	}
-
-	if ((m_FinalDestination - m_PathFinderDestination).Length() > 0.25)  // if the distance between where we're going and where we should go is too big.
-	{
-		/* If we reached the last path waypoint,
-		Or if we haven't re-calculated for too long.
-		Interval is proportional to distance squared, and its minimum is 10.
-		(Recalculate lots when close, calculate rarely when far) */
-		if (
-			((GetPosition() - m_PathFinderDestination).Length() < 0.25) ||
-			((m_TicksSinceLastPathReset > 10) && (m_TicksSinceLastPathReset > (0.4 * (m_FinalDestination - GetPosition()).SqrLength())))
-		)
-		{
-			/* Re-calculating is expensive when there's no path to target, and it results in mobs freezing very often as a result of always recalculating.
-			This is a workaround till we get better path recalculation. */
-			if (!m_NoPathToTarget)
-			{
-				ResetPathFinding();
-			}
-		}
-	}
-
-	if (m_Path == nullptr)
-	{
-		if (!EnsureProperDestination(a_Chunk))
-		{
-			StopMovingToPosition();  // Invalid chunks, probably world is loading or something, cancel movement.
-			return false;
-		}
-		m_GiveUpCounter = 40;
-		m_NoPathToTarget = false;
-		m_NoMoreWayPoints = false;
-		m_PathFinderDestination = m_FinalDestination;
-		m_Path = new cPath(a_Chunk, GetPosition(), m_PathFinderDestination, 20, GetWidth(), GetHeight());
-	}
-
-	switch (m_Path->Step(a_Chunk))
-	{
-		case ePathFinderStatus::NEARBY_FOUND:
-		{
-			m_NoPathToTarget = true;
-			m_PathFinderDestination = m_Path->AcceptNearbyPath();
-			break;
-		}
-
-		case ePathFinderStatus::PATH_NOT_FOUND:
-		{
-			StopMovingToPosition();  // Try to calculate a path again.
-			// Note that the next time may succeed, e.g. if a player breaks a barrier.
-			break;
-		}
-		case ePathFinderStatus::CALCULATING:
-		{
-			// Pathfinder needs more time
-			break;
-		}
-		case ePathFinderStatus::PATH_FOUND:
-		{
-			if (m_NoMoreWayPoints || (--m_GiveUpCounter == 0))
-			{
-				if (m_EMState == ATTACKING)
-				{
-					ResetPathFinding();  // Try to calculate a path again.
-					// This results in mobs hanging around an unreachable target (player).
-				}
-				else
-				{
-					StopMovingToPosition();  // Find a different place to go to.
-				}
-				return false;
-			}
-			else if (!m_Path->IsLastPoint())  // Have we arrived at the next cell, as denoted by m_NextWayPointPosition?
-			{
-				if ((m_Path->IsFirstPoint() || ReachedNextWaypoint()))
-				{
-					m_NextWayPointPosition = m_Path->GetNextPoint();
-					m_GiveUpCounter = 40;  // Give up after 40 ticks (2 seconds) if failed to reach m_NextWayPointPosition.
-				}
-			}
-			else
-			{
-				m_NoMoreWayPoints = true;
-			}
-
-			m_IsFollowingPath = true;
-			return true;
-		}
-	}
-
-	return false;
-}
-
-
-
-
-
 void cMonster::MoveToWayPoint(cChunk & a_Chunk)
 {
 	if (m_JumpCoolDown == 0)
@@ -242,8 +127,7 @@ void cMonster::MoveToWayPoint(cChunk & a_Chunk)
 		if (DoesPosYRequireJump(FloorC(m_NextWayPointPosition.y)))
 		{
 			if (
-				(IsOnGround() && (GetSpeedX() == 0.0f) && (GetSpeedY() == 0.0f)) ||
-				(IsSwimming() && (m_GiveUpCounter < 15))
+				(IsOnGround() && (GetSpeedX() == 0.0f) && (GetSpeedY() == 0.0f))  // TODO water handling?
 			)
 			{
 				m_bOnGround = false;
@@ -294,98 +178,7 @@ void cMonster::MoveToWayPoint(cChunk & a_Chunk)
 
 
 
-bool cMonster::EnsureProperDestination(cChunk & a_Chunk)
-{
-	cChunk * Chunk = a_Chunk.GetNeighborChunk(FloorC(m_FinalDestination.x), FloorC(m_FinalDestination.z));
-	BLOCKTYPE BlockType;
-	NIBBLETYPE BlockMeta;
 
-	if ((Chunk == nullptr) || !Chunk->IsValid())
-	{
-		return false;
-	}
-
-	int RelX = FloorC(m_FinalDestination.x) - Chunk->GetPosX() * cChunkDef::Width;
-	int RelZ = FloorC(m_FinalDestination.z) - Chunk->GetPosZ() * cChunkDef::Width;
-
-	// If destination in the air, first try to go 1 block north, or east, or west.
-	// This fixes the player leaning issue.
-	// If that failed, we instead go down to the lowest air block.
-	Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y) - 1, RelZ, BlockType, BlockMeta);
-	if (!cBlockInfo::IsSolid(BlockType))
-	{
-		bool InTheAir = true;
-		int x, z;
-		for (z = -1; z <= 1; ++z)
-		{
-			for (x = -1; x <= 1; ++x)
-			{
-				if ((x==0) && (z==0))
-				{
-					continue;
-				}
-				Chunk = a_Chunk.GetNeighborChunk(FloorC(m_FinalDestination.x+x), FloorC(m_FinalDestination.z+z));
-				if ((Chunk == nullptr) || !Chunk->IsValid())
-				{
-					return false;
-				}
-				RelX = FloorC(m_FinalDestination.x+x) - Chunk->GetPosX() * cChunkDef::Width;
-				RelZ = FloorC(m_FinalDestination.z+z) - Chunk->GetPosZ() * cChunkDef::Width;
-				Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y) - 1, RelZ, BlockType, BlockMeta);
-				if (cBlockInfo::IsSolid(BlockType))
-				{
-					m_FinalDestination.x += x;
-					m_FinalDestination.z += z;
-					InTheAir = false;
-					goto breakBothLoops;
-				}
-			}
-		}
-		breakBothLoops:
-
-		// Go down to the lowest air block.
-		if (InTheAir)
-		{
-			while (m_FinalDestination.y > 0)
-			{
-				Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y) - 1, RelZ, BlockType, BlockMeta);
-				if (cBlockInfo::IsSolid(BlockType))
-				{
-					break;
-				}
-				m_FinalDestination.y -= 1;
-			}
-		}
-	}
-
-	// If destination in water, go up to the highest water block.
-	// If destination in solid, go up to first air block.
-	bool InWater = false;
-	while (m_FinalDestination.y < cChunkDef::Height)
-	{
-		Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y), RelZ, BlockType, BlockMeta);
-		if (BlockType == E_BLOCK_STATIONARY_WATER)
-		{
-			InWater = true;
-		}
-		else if (cBlockInfo::IsSolid(BlockType))
-		{
-			InWater = false;
-		}
-		else
-		{
-			break;
-		}
-		m_FinalDestination.y += 1;
-	}
-	if (InWater)
-	{
-		m_FinalDestination.y -= 1;
-	}
-
-
-	return true;
-}
 
 
 
@@ -404,22 +197,6 @@ void cMonster::MoveToPosition(const Vector3d & a_Position)
 void cMonster::StopMovingToPosition()
 {
 	m_PathfinderActivated = false;
-	ResetPathFinding();
-}
-
-
-
-
-
-void cMonster::ResetPathFinding(void)
-{
-	m_TicksSinceLastPathReset = 0;
-	m_IsFollowingPath = false;
-	if (m_Path != nullptr)
-	{
-		delete m_Path;
-		m_Path = nullptr;
-	}
 }
 
 
@@ -453,29 +230,43 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 	// Process the undead burning in daylight.
 	HandleDaylightBurning(*Chunk, WouldBurnAt(GetPosition(), *Chunk));
-	if (TickPathFinding(*Chunk))
+
+	bool a_IsFollowingPath = false;
+	if (m_PathfinderActivated)
 	{
-		/* If I burn in daylight, and I won't burn where I'm standing, and I'll burn in my next position, and at least one of those is true:
-		1. I am idle
-		2. I was not hurt by a player recently.
-		Then STOP. */
-		if (
-			m_BurnsInDaylight && ((m_TicksSinceLastDamaged >= 100) || (m_EMState == IDLE)) &&
-			WouldBurnAt(m_NextWayPointPosition, *Chunk) &&
-			!WouldBurnAt(GetPosition(), *Chunk)
-		)
+		// Note that m_NextWayPointPosition is actually returned by GetNextWayPoint)
+		switch (m_PathFinder.GetNextWayPoint(*Chunk, GetPosition(), m_FinalDestination, m_NextWayPointPosition))
 		{
-			// If we burn in daylight, and we would burn at the next step, and we won't burn where we are right now, and we weren't provoked recently:
-			StopMovingToPosition();
-			m_GiveUpCounter = 40;  // This doesn't count as giving up, keep the giveup timer as is.
-		}
-		else
-		{
-			MoveToWayPoint(*Chunk);
+			case ePathFinderStatus::PATH_FOUND:
+			case ePathFinderStatus::NEARBY_FOUND:
+				/* If I burn in daylight, and I won't burn where I'm standing, and I'll burn in my next position, and at least one of those is true:
+				1. I am idle
+				2. I was not hurt by a player recently.
+				Then STOP. */
+				if (
+					m_BurnsInDaylight && ((m_TicksSinceLastDamaged >= 100) || (m_EMState == IDLE)) &&
+					WouldBurnAt(m_NextWayPointPosition, *Chunk) &&
+					!WouldBurnAt(GetPosition(), *Chunk)
+				)
+				{
+					// If we burn in daylight, and we would burn at the next step, and we won't burn where we are right now, and we weren't provoked recently:
+					StopMovingToPosition();
+					//  TODO m_GiveUpCounter = 40;  // This doesn't count as giving up, keep the giveup timer as is.
+				}
+				else
+				{
+					a_IsFollowingPath = true;  // Used for proper body / head orientation only.
+					MoveToWayPoint(*Chunk);
+				}
+				break;
+			default:
+			{
+
+			}
 		}
 	}
 
-	SetPitchAndYawFromDestination();
+	SetPitchAndYawFromDestination(a_IsFollowingPath);
 	HandleFalling();
 
 	switch (m_EMState)
@@ -507,7 +298,7 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 
 
-void cMonster::SetPitchAndYawFromDestination()
+void cMonster::SetPitchAndYawFromDestination(bool a_IsFollowingPath)
 {
 	Vector3d FinalDestination = m_FinalDestination;
 	if (m_Target != nullptr)
@@ -522,9 +313,8 @@ void cMonster::SetPitchAndYawFromDestination()
 		}
 	}
 
-
 	Vector3d BodyDistance;
-	if (!m_IsFollowingPath && (m_Target != nullptr))
+	if (!a_IsFollowingPath && (m_Target != nullptr))
 	{
 		BodyDistance = m_Target->GetPosition() - GetPosition();
 	}
@@ -547,7 +337,7 @@ void cMonster::SetPitchAndYawFromDestination()
 			SetHeadYaw(HeadRotation);
 			SetPitch(-HeadPitch);
 		}
-		else  // We're not an owl. If it's more than 120, don't look behind and instead look at where you're walking.
+		else  // We're not an owl. If it's more than 90, don't look behind and instead look at where you're walking.
 		{
 			SetHeadYaw(BodyRotation);
 			SetPitch(-BodyPitch);
@@ -791,7 +581,7 @@ void cMonster::EventLosePlayer(void)
 
 void cMonster::InStateIdle(std::chrono::milliseconds a_Dt)
 {
-	if (m_IsFollowingPath)
+	if (m_PathfinderActivated)
 	{
 		return;  // Still getting there
 	}

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -25,14 +25,6 @@ bool compareHeuristics::operator()(cPathCell * & a_Cell1, cPathCell * & a_Cell2)
 
 
 
-cPath::cPath()
-{
-
-}
-
-
-
-
 
 /* cPath implementation */
 cPath::cPath(
@@ -42,6 +34,7 @@ cPath::cPath(
 	int a_MaxUp, int a_MaxDown
 ) :
 	m_StepsLeft(a_MaxSteps),
+	m_IsValid(true),
 	m_CurrentPoint(0),  // GetNextPoint increments this to 1, but that's fine, since the first cell is always a_StartingPoint
 	m_Chunk(&a_Chunk),
 	m_BadChunkFound(false)
@@ -74,6 +67,21 @@ cPath::cPath(
 	m_Status = ePathFinderStatus::CALCULATING;
 
 	ProcessCell(GetCell(m_Source), nullptr, 0);
+}
+
+
+
+
+
+cPath::cPath() : m_IsValid(false) { }
+
+
+
+
+
+bool cPath::IsValid()
+{
+	return m_IsValid;
 }
 
 

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -25,6 +25,14 @@ bool compareHeuristics::operator()(cPathCell * & a_Cell1, cPathCell * & a_Cell2)
 
 
 
+cPath::cPath()
+{
+
+}
+
+
+
+
 
 /* cPath implementation */
 cPath::cPath(

--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -77,6 +77,9 @@ public:
 	/** Constructs a dummy cPath that shouldn't be used. */
 	cPath();
 
+	/** Returns false if this cPath was constructed with an empty constructor and shouldn't be used. */
+	bool IsValid();
+
 	/** Performs part of the path calculation and returns the appropriate status.
 	If NEARBY_FOUND is returned, it means that the destination is not reachable, but a nearby destination
 	is reachable. If the user likes the alternative destination, they can call AcceptNearbyPath to treat the path as found,
@@ -149,7 +152,7 @@ private:
 
 	/* Control fields */
 	ePathFinderStatus m_Status;
-
+	bool m_IsValid;
 	/* Final path fields */
 	size_t m_CurrentPoint;
 	std::vector<Vector3i> m_PathPoints;

--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -72,7 +72,7 @@ public:
 		double a_BoundingBoxWidth, double a_BoundingBoxHeight,
 		int a_MaxUp = 1, int a_MaxDown = 1
 	);
-	
+
 	/** Performs part of the path calculation and returns the appropriate status.
 	If NEARBY_FOUND is returned, it means that the destination is not reachable, but a nearby destination
 	is reachable. If the user likes the alternative destination, they can call AcceptNearbyPath to treat the path as found,

--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -73,6 +73,10 @@ public:
 		int a_MaxUp = 1, int a_MaxDown = 1
 	);
 
+
+	/** Constructs a dummy cPath that shouldn't be used. */
+	cPath();
+
 	/** Performs part of the path calculation and returns the appropriate status.
 	If NEARBY_FOUND is returned, it means that the destination is not reachable, but a nearby destination
 	is reachable. If the user likes the alternative destination, they can call AcceptNearbyPath to treat the path as found,

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -1,0 +1,226 @@
+
+
+#include "Globals.h"
+#include "PathFinder.h"
+#include "../Chunk.h"
+
+cPathFinder::cPathFinder(double a_MobWidth, double a_MobHeight)
+	: m_Path(nullptr)
+	, m_IsFollowingPath(false)
+	, m_GiveUpCounter(0)
+	, m_TicksSinceLastPathReset(1000)
+{
+	m_Width = a_MobWidth;
+	m_Height = a_MobHeight;
+
+}
+
+
+
+ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Source, Vector3d a_Destination, Vector3d &a_OutputWaypoint)
+{
+	m_FinalDestination = a_Destination;
+	m_Source = a_Source;
+
+	if (m_TicksSinceLastPathReset < 1000)
+	{
+		// No need to count beyond 1000. 1000 is arbitary here.
+		++m_TicksSinceLastPathReset;
+	}
+
+	/* if (ReachedFinalDestination())
+	{
+		StopMovingToPosition();
+		return false;
+	} */
+
+	if ((m_FinalDestination - m_PathFinderDestination).Length() > 0.25)  // if the distance between where we're going and where we should go is too big.
+	{
+		/* If we reached the last path waypoint,
+		Or if we haven't re-calculated for too long.
+		Interval is proportional to distance squared, and its minimum is 10.
+		(Recalculate lots when close, calculate rarely when far) */
+		if (
+			((m_Source - m_PathFinderDestination).Length() < 0.25) ||
+			((m_TicksSinceLastPathReset > 10) && (m_TicksSinceLastPathReset > (0.4 * (m_FinalDestination - m_Source).SqrLength())))
+		)
+		{
+			/* Re-calculating is expensive when there's no path to target, and it results in mobs freezing very often as a result of always recalculating.
+			This is a workaround till we get better path recalculation. */
+			if (!m_NoPathToTarget)
+			{
+				ResetPathFinding();
+			}
+		}
+	}
+
+	if (m_Path == nullptr)
+	{
+		if (!EnsureProperDestination(a_Chunk))
+		{
+			return ePathFinderStatus::PATH_NOT_FOUND;
+		}
+
+		m_GiveUpCounter = 40;
+		m_NoPathToTarget = false;
+		m_NoMoreWayPoints = false;
+		m_PathFinderDestination = m_FinalDestination;
+		m_Path = new cPath(a_Chunk, m_Source, m_PathFinderDestination, 20, m_Width, m_Height);
+	}
+
+	switch (m_Path->Step(a_Chunk))
+	{
+		case ePathFinderStatus::NEARBY_FOUND:
+		{
+			m_NoPathToTarget = true;
+			m_PathFinderDestination = m_Path->AcceptNearbyPath();
+			return ePathFinderStatus::PATH_FOUND;
+			break;
+		}
+
+		case ePathFinderStatus::PATH_NOT_FOUND:
+		{
+			return ePathFinderStatus::PATH_NOT_FOUND;
+		}
+		case ePathFinderStatus::CALCULATING:
+		{
+			m_TicksSinceLastPathReset = 0;  // Start ticking only after a path is found.
+			return ePathFinderStatus::CALCULATING;
+		}
+		case ePathFinderStatus::PATH_FOUND:
+		{
+			if (m_NoMoreWayPoints || (--m_GiveUpCounter == 0))
+			{
+				ResetPathFinding();  // Try to calculate a path again.
+				return ePathFinderStatus::CALCULATING;
+			}
+			else if (!m_Path->IsLastPoint())  // Have we arrived at the next cell, as denoted by m_NextWayPointPosition?
+			{
+				if ((m_Path->IsFirstPoint() || (m_NextWayPointPosition - m_Source).SqrLength() < 0.25))
+				{
+					m_NextWayPointPosition = m_Path->GetNextPoint();
+					a_OutputWaypoint = m_NextWayPointPosition;
+					m_GiveUpCounter = 40;  // Give up after 40 ticks (2 seconds) if failed to reach m_NextWayPointPosition.
+				}
+			}
+			else
+			{
+				m_NoMoreWayPoints = true;
+			}
+
+			m_IsFollowingPath = true;
+			return ePathFinderStatus::PATH_FOUND;
+		}
+
+	default:  // Dummy to get rid of compiler warning.
+		return ePathFinderStatus::PATH_FOUND;
+		break;
+	}
+}
+
+
+void cPathFinder::ResetPathFinding(void)
+{
+	m_TicksSinceLastPathReset = 0;
+	m_IsFollowingPath = false;
+	m_NoMoreWayPoints = false;
+	if (m_Path != nullptr)
+	{
+		delete m_Path;
+		m_Path = nullptr;
+	}
+}
+
+
+bool cPathFinder::EnsureProperDestination(cChunk & a_Chunk)
+{
+	cChunk * Chunk = a_Chunk.GetNeighborChunk(FloorC(m_FinalDestination.x), FloorC(m_FinalDestination.z));
+	BLOCKTYPE BlockType;
+	NIBBLETYPE BlockMeta;
+
+	if ((Chunk == nullptr) || !Chunk->IsValid())
+	{
+		return false;
+	}
+
+	int RelX = FloorC(m_FinalDestination.x) - Chunk->GetPosX() * cChunkDef::Width;
+	int RelZ = FloorC(m_FinalDestination.z) - Chunk->GetPosZ() * cChunkDef::Width;
+
+	// If destination in the air, first try to go 1 block north, or east, or west.
+	// This fixes the player leaning issue.
+	// If that failed, we instead go down to the lowest air block.
+	Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y) - 1, RelZ, BlockType, BlockMeta);
+	if (!cBlockInfo::IsSolid(BlockType))
+	{
+		bool InTheAir = true;
+		int x, z;
+		for (z = -1; z <= 1; ++z)
+		{
+			for (x = -1; x <= 1; ++x)
+			{
+				if ((x==0) && (z==0))
+				{
+					continue;
+				}
+				Chunk = a_Chunk.GetNeighborChunk(FloorC(m_FinalDestination.x+x), FloorC(m_FinalDestination.z+z));
+				if ((Chunk == nullptr) || !Chunk->IsValid())
+				{
+					return false;
+				}
+				RelX = FloorC(m_FinalDestination.x+x) - Chunk->GetPosX() * cChunkDef::Width;
+				RelZ = FloorC(m_FinalDestination.z+z) - Chunk->GetPosZ() * cChunkDef::Width;
+				Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y) - 1, RelZ, BlockType, BlockMeta);
+				if (cBlockInfo::IsSolid(BlockType))
+				{
+					m_FinalDestination.x += x;
+					m_FinalDestination.z += z;
+					InTheAir = false;
+					goto breakBothLoops;
+				}
+			}
+		}
+		breakBothLoops:
+
+		// Go down to the lowest air block.
+		if (InTheAir)
+		{
+			while (m_FinalDestination.y > 0)
+			{
+				Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y) - 1, RelZ, BlockType, BlockMeta);
+				if (cBlockInfo::IsSolid(BlockType))
+				{
+					break;
+				}
+				m_FinalDestination.y -= 1;
+			}
+		}
+	}
+
+	// If destination in water, go up to the highest water block.
+	// If destination in solid, go up to first air block.
+	bool InWater = false;
+	while (m_FinalDestination.y < cChunkDef::Height)
+	{
+		Chunk->GetBlockTypeMeta(RelX, FloorC(m_FinalDestination.y), RelZ, BlockType, BlockMeta);
+		if (BlockType == E_BLOCK_STATIONARY_WATER)
+		{
+			InWater = true;
+		}
+		else if (cBlockInfo::IsSolid(BlockType))
+		{
+			InWater = false;
+		}
+		else
+		{
+			break;
+		}
+		m_FinalDestination.y += 1;
+	}
+	if (InWater)
+	{
+		m_FinalDestination.y -= 1;
+	}
+
+
+	return true;
+}

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -35,14 +35,14 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 		return false;
 	} */
 
-	if ((m_FinalDestination - m_PathDestination).Length() > 0.25)  // if the distance between where we're going and where we should go is too big.
+	if ((m_FinalDestination - m_PathDestination).SqrLength() > 0.25 * 0.25)  // if the distance between where we're going and where we should go is too big.
 	{
 		/* If we reached the last path waypoint,
 		Or if we haven't re-calculated for too long.
 		Interval is proportional to distance squared, and its minimum is 10.
 		(Recalculate lots when close, calculate rarely when far) */
 		if (
-			((m_Source - m_PathDestination).Length() < 0.25) ||
+			((m_Source - m_PathDestination).SqrLength() > 0.25 * 0.25) ||
 			((m_TicksSinceLastPathReset > 10) && (m_TicksSinceLastPathReset > (0.4 * (m_FinalDestination - m_Source).SqrLength())))
 		)
 		{
@@ -114,7 +114,7 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 		default:
 		{
 			return ePathFinderStatus::PATH_FOUND;
-			// Fixes GCC warning: PathFinder.cpp:114: warning: control reaches end of non-void function.
+			// Fixes GCC warning: "control reaches end of non-void function".
 		}
 		#endif
 	}

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -158,7 +158,7 @@ bool cPathFinder::EnsureProperDestination(cChunk & a_Chunk)
 		{
 			for (x = -1; x <= 1; ++x)
 			{
-				if ((x==0) && (z==0))
+				if ((x == 0) && (z == 0))
 				{
 					continue;
 				}

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -75,7 +75,6 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 			m_NoPathToTarget = true;
 			m_PathFinderDestination = m_Path->AcceptNearbyPath();
 			return ePathFinderStatus::PATH_FOUND;
-			break;
 		}
 
 		case ePathFinderStatus::PATH_NOT_FOUND:
@@ -111,10 +110,6 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 			m_IsFollowingPath = true;
 			return ePathFinderStatus::PATH_FOUND;
 		}
-
-	default:  // Dummy to get rid of compiler warning.
-		return ePathFinderStatus::PATH_FOUND;
-		break;
 	}
 }
 

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -6,7 +6,6 @@
 
 cPathFinder::cPathFinder(double a_MobWidth, double a_MobHeight)
 	: m_Path(nullptr)
-	, m_IsFollowingPath(false)
 	, m_GiveUpCounter(0)
 	, m_TicksSinceLastPathReset(1000)
 {
@@ -109,7 +108,6 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 				m_NoMoreWayPoints = true;
 			}
 
-			m_IsFollowingPath = true;
 			return ePathFinderStatus::PATH_FOUND;
 		}
 	}
@@ -122,7 +120,6 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 void cPathFinder::ResetPathFinding(void)
 {
 	m_TicksSinceLastPathReset = 0;
-	m_IsFollowingPath = false;
 	m_NoMoreWayPoints = false;
 	if (m_Path != nullptr)
 	{

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -6,7 +6,6 @@
 
 cPathFinder::cPathFinder(double a_MobWidth, double a_MobHeight) :
 	m_Path(),
-	m_PathIsvalid(false),
 	m_GiveUpCounter(0),
 	m_TicksSinceLastPathReset(1000)
 {
@@ -55,7 +54,7 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 		}
 	}
 
-	if (m_PathIsvalid == false)
+	if (m_Path.IsValid() == false)
 	{
 		if (!EnsureProperDestination(a_Chunk))
 		{
@@ -67,7 +66,6 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 		m_NoMoreWayPoints = false;
 		m_PathDestination = m_FinalDestination;
 		m_Path = cPath(a_Chunk, m_Source, m_PathDestination, 20, m_Width, m_Height);
-		m_PathIsvalid = true;
 	}
 
 	switch (m_Path.Step(a_Chunk))
@@ -129,7 +127,7 @@ void cPathFinder::ResetPathFinding(void)
 {
 	m_TicksSinceLastPathReset = 0;
 	m_NoMoreWayPoints = false;
-	m_PathIsvalid = false;
+	m_Path = cPath();  // "Destroy" our path.
 }
 
 

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -17,6 +17,8 @@ cPathFinder::cPathFinder(double a_MobWidth, double a_MobHeight)
 
 
 
+
+
 ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Source, Vector3d a_Destination, Vector3d &a_OutputWaypoint)
 {
 	m_FinalDestination = a_Destination;
@@ -34,14 +36,14 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 		return false;
 	} */
 
-	if ((m_FinalDestination - m_PathFinderDestination).Length() > 0.25)  // if the distance between where we're going and where we should go is too big.
+	if ((m_FinalDestination - m_PathDestination).Length() > 0.25)  // if the distance between where we're going and where we should go is too big.
 	{
 		/* If we reached the last path waypoint,
 		Or if we haven't re-calculated for too long.
 		Interval is proportional to distance squared, and its minimum is 10.
 		(Recalculate lots when close, calculate rarely when far) */
 		if (
-			((m_Source - m_PathFinderDestination).Length() < 0.25) ||
+			((m_Source - m_PathDestination).Length() < 0.25) ||
 			((m_TicksSinceLastPathReset > 10) && (m_TicksSinceLastPathReset > (0.4 * (m_FinalDestination - m_Source).SqrLength())))
 		)
 		{
@@ -64,8 +66,8 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 		m_GiveUpCounter = 40;
 		m_NoPathToTarget = false;
 		m_NoMoreWayPoints = false;
-		m_PathFinderDestination = m_FinalDestination;
-		m_Path = new cPath(a_Chunk, m_Source, m_PathFinderDestination, 20, m_Width, m_Height);
+		m_PathDestination = m_FinalDestination;
+		m_Path = new cPath(a_Chunk, m_Source, m_PathDestination, 20, m_Width, m_Height);
 	}
 
 	switch (m_Path->Step(a_Chunk))
@@ -73,7 +75,7 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 		case ePathFinderStatus::NEARBY_FOUND:
 		{
 			m_NoPathToTarget = true;
-			m_PathFinderDestination = m_Path->AcceptNearbyPath();
+			m_PathDestination = m_Path->AcceptNearbyPath();
 			return ePathFinderStatus::PATH_FOUND;
 		}
 
@@ -114,6 +116,9 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 }
 
 
+
+
+
 void cPathFinder::ResetPathFinding(void)
 {
 	m_TicksSinceLastPathReset = 0;
@@ -125,6 +130,9 @@ void cPathFinder::ResetPathFinding(void)
 		m_Path = nullptr;
 	}
 }
+
+
+
 
 
 bool cPathFinder::EnsureProperDestination(cChunk & a_Chunk)

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -110,6 +110,13 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk &a_Chunk, Vector3d a_Sourc
 
 			return ePathFinderStatus::PATH_FOUND;
 		}
+		#ifndef __clang__
+		default:
+		{
+			return ePathFinderStatus::PATH_FOUND;
+			// Fixes GCC warning: PathFinder.cpp:114: warning: control reaches end of non-void function.
+		}
+		#endif
 	}
 }
 

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -11,7 +11,6 @@ cPathFinder::cPathFinder(double a_MobWidth, double a_MobHeight)
 {
 	m_Width = a_MobWidth;
 	m_Height = a_MobHeight;
-
 }
 
 

--- a/src/Mobs/PathFinder.h
+++ b/src/Mobs/PathFinder.h
@@ -33,7 +33,6 @@ private:
 	/* If 0, will give up reaching the next m_NextWayPointPosition and will re-compute path. */
 	int m_GiveUpCounter;
 	int m_TicksSinceLastPathReset;
-	int m_JumpCoolDown;
 
 	/** Coordinates of the next position that should be reached */
 	Vector3d m_NextWayPointPosition;

--- a/src/Mobs/PathFinder.h
+++ b/src/Mobs/PathFinder.h
@@ -51,9 +51,6 @@ private:
 	/** The current cPath instance we have. This is discarded and recreated when a path recalculation is needed. */
 	cPath m_Path;
 
-	/** If false, it means that m_Path should be initialized using m_Path = cPath(...) before use. */
-	bool m_PathIsvalid;
-
 	/** If 0, will give up reaching the next m_NextWayPointPosition and will recalculate path. */
 	int m_GiveUpCounter;
 

--- a/src/Mobs/PathFinder.h
+++ b/src/Mobs/PathFinder.h
@@ -49,7 +49,10 @@ private:
 	double m_Height;
 
 	/** The current cPath instance we have. This is discarded and recreated when a path recalculation is needed. */
-	cPath *  m_Path;  // TODO unique ptr
+	cPath m_Path;
+
+	/** If false, it means that m_Path should be initialized using m_Path = cPath(...) before use. */
+	bool m_PathIsvalid;
 
 	/** If 0, will give up reaching the next m_NextWayPointPosition and will recalculate path. */
 	int m_GiveUpCounter;

--- a/src/Mobs/PathFinder.h
+++ b/src/Mobs/PathFinder.h
@@ -17,33 +17,56 @@ class cPathFinder
 {
 
 public:
+	/** Creates a cPathFinder instance. Each mob should have one cPathFinder throughout its lifetime.
+	@param a_MobWidth The mob width.
+	@param a_MobWidth The mob height.
+	*/
 	cPathFinder(double a_MobWidth, double a_MobHeight);
+
+	/** Updates the PathFinder's internal state and returns a waypoint.
+	A waypoint is a coordinate which the mob can safely move to from its current position in a straight line.
+	The mob is expected to call this function tick as long as it is following a path.
+	@param a_Chunk The chunk in which the mob is currently at.
+	@param a_Source The mob's position. a_Source's coordinates are expected to be within the chunk given in a_Chunk.
+	@param a_Destination The position the mob would like to reach,
+	@param a_OutputWaypoint An output parameter: The next waypoint to go to.
+
+	Returns an ePathFinderStatus.
+	ePathFinderStatus:CALCULATING - The PathFinder is still processing a path. Nothing was written to a_OutputWaypoint. The mob should probably not move.
+	ePathFinderStatus:PATH_FOUND - The PathFinder has found a path to the target. The next waypoint was written a_OutputWaypoint. The mob should probably move to a_OutputWaypoint.
+	ePathFinderStatus:NEARBY_FOUND - The PathFinder did not find a destination to the target but did find a nearby spot. The next waypoint was written a_OutputWaypoint. The mob should probably move to a_OutputWaypoint.
+	ePathFinderStatus:PATH_NOT_FOUND - The PathFinder did not find a destination to the target. Nothing was written to a_OutputWaypoint. The mob should probably not move.
+
+	Note: Once NEARBY_FOUND is returned once, subsequent calls return PATH_FOUND. This may be changed in the future. */
 	ePathFinderStatus GetNextWayPoint(cChunk & a_Chunk, Vector3d a_Source, Vector3d a_Destination, Vector3d & a_OutputWaypoint);
 
 private:
 
+	/** The width of the Mob which owns this PathFinder. */
 	double m_Width;
+
+	/** The height of the Mob which owns this PathFinder. */
 	double m_Height;
 
+	/** The current cPath instance we have. This is discarded and recreated when a path recalculation is needed. */
 	cPath *  m_Path;  // TODO unique ptr
 
-	/** Stores if mobile is currently moving towards the ultimate, final destination */
-	bool m_IsFollowingPath;
-
-	/* If 0, will give up reaching the next m_NextWayPointPosition and will re-compute path. */
+	/** If 0, will give up reaching the next m_NextWayPointPosition and will recalculate path. */
 	int m_GiveUpCounter;
+
+	/** The ticks since the last recalculation was completed. */
 	int m_TicksSinceLastPathReset;
 
-	/** Coordinates of the next position that should be reached */
+	/** Coordinates of the next position that should be reached. */
 	Vector3d m_NextWayPointPosition;
 
 	/** Coordinates for the ultimate, final destination. */
 	Vector3d m_FinalDestination;
 
-	/** Coordinates for the ultimate, final destination last given to the pathfinder. */
-	Vector3d m_PathFinderDestination;
+	/** Coordinates for the destination last given to cPath. */
+	Vector3d m_PathDestination;
 
-	/** */
+	/** Coordinates for where the mob is currently at. */
 	Vector3d m_Source;
 
 	/** True if there's no path to target and we're walking to an approximated location. */

--- a/src/Mobs/PathFinder.h
+++ b/src/Mobs/PathFinder.h
@@ -1,0 +1,70 @@
+
+#pragma once
+
+#include "Path.h"
+
+/*
+TODO DOXY style
+
+This class wraps cPath.
+cPath is a "dumb device" - You give it point A and point B, and it returns a full path path.
+cPathFinder - You give it a constant stream of point A (where you are) and point B (where you want to go),
+and it tells you where to go next. It manages path recalculation internally, and is much more efficient that calling cPath every step.
+
+*/
+
+class cPathFinder
+{
+
+public:
+	cPathFinder(double a_MobWidth, double a_MobHeight);
+	ePathFinderStatus GetNextWayPoint(cChunk & a_Chunk, Vector3d a_Source, Vector3d a_Destination, Vector3d & a_OutputWaypoint);
+
+private:
+
+	double m_Width;
+	double m_Height;
+
+	cPath *  m_Path;  // TODO unique ptr
+
+	/** Stores if mobile is currently moving towards the ultimate, final destination */
+	bool m_IsFollowingPath;
+
+	/* If 0, will give up reaching the next m_NextWayPointPosition and will re-compute path. */
+	int m_GiveUpCounter;
+	int m_TicksSinceLastPathReset;
+	int m_JumpCoolDown;
+
+	/** Coordinates of the next position that should be reached */
+	Vector3d m_NextWayPointPosition;
+
+	/** Coordinates for the ultimate, final destination. */
+	Vector3d m_FinalDestination;
+
+	/** Coordinates for the ultimate, final destination last given to the pathfinder. */
+	Vector3d m_PathFinderDestination;
+
+	/** */
+	Vector3d m_Source;
+
+	/** True if there's no path to target and we're walking to an approximated location. */
+	bool m_NoPathToTarget;
+
+	/** Whether The mob has finished their path, note that this does not imply reaching the destination,
+	the destination may sometimes differ from the current path. */
+	bool m_NoMoreWayPoints;
+
+	/** Ensures the destination is not buried underground or under water. Also ensures the destination is not in the air.
+	Only the Y coordinate of m_FinalDestination might be changed.
+	1. If m_FinalDestination is the position of a water block, m_FinalDestination's Y will be modified to point to the heighest water block in the pool in the current column.
+	2. If m_FinalDestination is the position of a solid, m_FinalDestination's Y will be modified to point to the first airblock above the solid in the current column.
+	3. If m_FinalDestination is the position of an air block, Y will keep decreasing until hitting either a solid or water.
+	Now either 1 or 2 is performed. */
+	bool EnsureProperDestination(cChunk & a_Chunk);
+
+	/** Resets a pathfinding task, be it due to failure or something else
+	Resets the pathfinder. If m_IsFollowingPath is true, TickPathFinding starts a brand new path.
+	Should only be called by the pathfinder, cMonster::Tick or StopMovingToPosition. */
+	void ResetPathFinding(void);
+
+};

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -158,7 +158,7 @@ void cVillager::HandleFarmerPrepareFarmCrops()
 void cVillager::HandleFarmerTryHarvestCrops()
 {
 	// Harvest the crops if the villager isn't moving and if the crops are closer then 2 blocks.
-	if (!m_IsFollowingPath && (GetPosition() - m_CropsPos).Length() < 2)
+	if (!m_PathfinderActivated && (GetPosition() - m_CropsPos).Length() < 2)
 	{
 		// Check if the blocks didn't change while the villager was walking to the coordinates.
 		BLOCKTYPE CropBlock = m_World->GetBlock(m_CropsPos.x, m_CropsPos.y, m_CropsPos.z);

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -158,7 +158,7 @@ void cVillager::HandleFarmerPrepareFarmCrops()
 void cVillager::HandleFarmerTryHarvestCrops()
 {
 	// Harvest the crops if the villager isn't moving and if the crops are closer then 2 blocks.
-	if (!m_PathfinderActivated && (GetPosition() - m_CropsPos).Length() < 2)
+	if (!m_PathfinderActivated && (GetPosition() - m_CropsPos).SqrLength() < 2 * 2)
 	{
 		// Check if the blocks didn't change while the villager was walking to the coordinates.
 		BLOCKTYPE CropBlock = m_World->GetBlock(m_CropsPos.x, m_CropsPos.y, m_CropsPos.z);


### PR DESCRIPTION
cMonster had too much path-finding code. I've moved the path recalculation logic into a new class called cPathFinder.

Advantages:
 - Cleaner cMonster, seperation of concerns.
 - The path recalculation algorithm can be swapped without having to edit the AI code simply by reimplementing by  `cPathFinder`.


**Some background**

**cPath**: A device which takes two points as an input, and returns a path.

The most accurate pathfinding would be calling cPath every single step. But that's very resource-intensive. A saner approach would be calling cPath less often, but that's a delicate task: If we call cPath too little, the mob would move along stalled paths and it ends going to where the player had been long ago. Until now,  cMonster had this path recalculation logic, but that made it too tightly coupled with pathfinding and too messy. This commit moves that recalculation logic to a new class called cPathFinder.

**cPathFinder**: Wraps cPath, takes two points as an input each tick, returns the next way point the mob should move to. It internally decides whether to use an old cPath or to recalculate. That decision is based on both the time since the last recalculation and the distance to the target.

In most cases, no one should use cPath directly. The only exception I can think of is when one needs to pre-calculate static paths, but perhaps that should also be wrapped in some class like `cStaticPathFinder`.