### PR TITLE
Update JsonCPP

### DIFF
--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -14,7 +14,7 @@ fi
 cmake . -DBUILD_TOOLS=1 -DSELF_TEST=1;
 
 echo "Building..."
-make -j 2;
+VERBOSE=1 make -j 2;
 make -j 2 test ARGS="-V";
 
 echo "Testing..."


### PR DESCRIPTION
This updates JsonCpp to latest version. The version we currently using has a problem that crashes cmake 3.4 under windows. Updating JsonCpp  fixes the problem.
I had to fix a few errors from JsonCpp. Please look at them and if they are okay then it can be merged.

Edit: Not worth struggling with this anymore.
If someone has an error from CMake under windows. You can install CMake 3.4.0-rc2, that contains the fix for the JsonCpp problem.