### PR TITLE
Use an unreserved qualifier for thread local storage

### DIFF
--- a/src/FastRandom.cpp
+++ b/src/FastRandom.cpp
@@ -8,17 +8,19 @@
 
 #include <random>
 
-#ifdef _WIN32
-	#define thread_local static __declspec(thread)
-#elif defined __APPLE__
-	#define thread_local static __thread
+#if defined (__GNUC__)
+	#define ATTRIBUTE_TLS static __thread
+#elif defined (_MSC_VER)
+	#define ATTRIBUTE_TLS static __declspec(thread)
+#else
+	#error "Unknown thread local storage qualifier"
 #endif
 
 static unsigned int GetRandomSeed()
 {
-	thread_local bool SeedCounterInitialized = 0;
-	thread_local unsigned int SeedCounter = 0;
-	
+	ATTRIBUTE_TLS bool SeedCounterInitialized = 0;
+	ATTRIBUTE_TLS unsigned int SeedCounter = 0;
+
 	if (!SeedCounterInitialized)
 	{
 		std::random_device rd;
@@ -47,8 +49,8 @@ public:
 		TestInts();
 		TestFloats();
 	}
-	
-	
+
+
 	void TestInts(void)
 	{
 		printf("Testing ints...\n");


### PR DESCRIPTION
Fixes #1906 

This was never fixed in master branch and it was FTC 

First I tried using `thread_local` directly but apparently it's not supported by Apple clang out of the box. 

```
Apple LLVM version 7.0.0 (clang-700.1.76)
Target: x86_64-apple-darwin15.0.0
Thread model: posix
```

Fixed compiler error:
```
/Users/canc/Code/cpp/cuberite/src/FastRandom.cpp:14:10: error: keyword is hidden by macro definition [-Werror,-Wkeyword-macro]
        #define thread_local static __thread
                ^
```

Although it's not supported, it's still a valid reserved keyword in clang. That was causing this.