### PR TITLE
Fix being set on fire while directly being under lava

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1119,7 +1119,7 @@ void cEntity::TickBurning(cChunk & a_Chunk)
 	int MinRelZ = FloorC(GetPosZ() - m_Width / 2) - a_Chunk.GetPosZ() * cChunkDef::Width;
 	int MaxRelZ = FloorC(GetPosZ() + m_Width / 2) - a_Chunk.GetPosZ() * cChunkDef::Width;
 	int MinY = Clamp(POSY_TOINT, 0, cChunkDef::Height - 1);
-	int MaxY = Clamp(CeilC(GetPosY() + m_Height), 0, cChunkDef::Height - 1);
+	int MaxY = Clamp(FloorC(GetPosY() + m_Height), 0, cChunkDef::Height - 1);
 	bool HasWater = false;
 	bool HasLava = false;
 	bool HasFire = false;


### PR DESCRIPTION
Right now you will be on fire if there is a block of lava right above you, even if it doesn't pour down.

Simulation:
- Player is on Y=0, Lava is on Y=2.
- Player is 1.8 tall
- MinY = floor(PosY) = 0
- MaxY = ceil(PosY + 1.8) = ceil(1.8) = 2
- The loop runs MinY->MaxY inclusive -> tests 0 to 2 -> tests lava block that the player is not in actual contact with.

Either my solution, or change the loop to be exclusive to MaxY.