### PR TITLE
Slimeblock implementation

### DIFF
--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -305,6 +305,7 @@ void cBlockInfo::Initialize(cBlockInfoArray & a_Info)
 	a_Info[E_BLOCK_RED_MUSHROOM        ].m_OneHitDig = true;
 	a_Info[E_BLOCK_REEDS               ].m_OneHitDig = true;
 	a_Info[E_BLOCK_SAPLING             ].m_OneHitDig = true;
+	a_Info[E_BLOCK_SLIME_BLOCK         ].m_OneHitDig = true;
 	a_Info[E_BLOCK_TNT                 ].m_OneHitDig = true;
 	a_Info[E_BLOCK_TALL_GRASS          ].m_OneHitDig = true;
 	a_Info[E_BLOCK_TORCH               ].m_OneHitDig = true;

--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -72,6 +72,7 @@
 #include "BlockSideways.h"
 #include "BlockSignPost.h"
 #include "BlockSlab.h"
+#include "BlockSlime.h"
 #include "BlockSnow.h"
 #include "BlockStairs.h"
 #include "BlockStems.h"
@@ -297,6 +298,7 @@ cBlockHandler * cBlockHandler::CreateBlockHandler(BLOCKTYPE a_BlockType)
 		case E_BLOCK_SEA_LANTERN:           return new cBlockSeaLanternHandler      (a_BlockType);
 		case E_BLOCK_SIGN_POST:             return new cBlockSignPostHandler        (a_BlockType);
 		case E_BLOCK_SNOW:                  return new cBlockSnowHandler            (a_BlockType);
+		case E_BLOCK_SLIME_BLOCK:           return new cBlockSlimeHandler           (a_BlockType);
 		case E_BLOCK_SPRUCE_DOOR:           return new cBlockDoorHandler            (a_BlockType);
 		case E_BLOCK_SPRUCE_FENCE_GATE:     return new cBlockFenceGateHandler       (a_BlockType);
 		case E_BLOCK_SPRUCE_WOOD_STAIRS:    return new cBlockStairsHandler          (a_BlockType);

--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -32,7 +32,7 @@ void cBlockPistonHandler::OnDestroyed(cChunkInterface & a_ChunkInterface, cWorld
 {
 	NIBBLETYPE OldMeta = a_ChunkInterface.GetBlockMeta(a_BlockX, a_BlockY, a_BlockZ);
 
-	const Vector3i pushDir = GetDirectionVec(OldMeta);
+	const Vector3i pushDir = VectorFromMetaData(OldMeta);
 	int newX = a_BlockX + pushDir.x;
 	int newY = a_BlockY + pushDir.y;
 	int newZ = a_BlockZ + pushDir.z;
@@ -73,7 +73,7 @@ bool cBlockPistonHandler::GetPlacementBlockTypeMeta(
 
 
 
-Vector3i cBlockPistonHandler::GetDirectionVec(int a_PistonMeta)
+Vector3i cBlockPistonHandler::VectorFromMetaData(int a_PistonMeta)
 {
 	switch (a_PistonMeta & 0x07)
 	{
@@ -214,7 +214,7 @@ void cBlockPistonHandler::ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ,
 		return;
 	}
 
-	Vector3i pushDir = GetDirectionVec(pistonMeta);
+	Vector3i pushDir = VectorFromMetaData(pistonMeta);
 
 	std::unordered_set<Vector3i, VectorHasher<int>> blocksPushed;
 	if (!CanPushBlock(a_BlockX + pushDir.x, a_BlockY + pushDir.y, a_BlockZ + pushDir.z,
@@ -253,7 +253,7 @@ void cBlockPistonHandler::RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ
 		return;
 	}
 
-	Vector3i pushDir = GetDirectionVec(pistonMeta);
+	Vector3i pushDir = VectorFromMetaData(pistonMeta);
 
 	// Check the extension:
 	if (a_World->GetBlock(a_BlockX + pushDir.x, a_BlockY + pushDir.y, a_BlockZ + pushDir.z) != E_BLOCK_PISTON_EXTENSION)
@@ -312,7 +312,7 @@ void cBlockPistonHeadHandler::OnDestroyedByPlayer(cChunkInterface & a_ChunkInter
 {
 	NIBBLETYPE OldMeta = a_ChunkInterface.GetBlockMeta(a_BlockX, a_BlockY, a_BlockZ);
 
-	Vector3i pushDir = cBlockPistonHandler::GetDirectionVec(OldMeta);
+	Vector3i pushDir = cBlockPistonHandler::VectorFromMetaData(OldMeta);
 	int newX = a_BlockX - pushDir.x;
 	int newY = a_BlockY - pushDir.y;
 	int newZ = a_BlockZ - pushDir.z;

--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -14,22 +14,6 @@
 
 
 
-#define AddPistonDir(x, y, z, dir, amount) \
-	switch (dir & 0x07) \
-	{ \
-		case 0: (y) -= (amount); break; \
-		case 1: (y) += (amount); break; \
-		case 2: (z) -= (amount); break; \
-		case 3: (z) += (amount); break; \
-		case 4: (x) -= (amount); break; \
-		case 5: (x) += (amount); break; \
-		default: \
-		{ \
-			LOGWARNING("%s: invalid direction %d, ignoring", __FUNCTION__, dir & 0x07); \
-			break; \
-		} \
-	}
-
 #define PISTON_MAX_PUSH_DISTANCE 12
 
 
@@ -48,10 +32,10 @@ void cBlockPistonHandler::OnDestroyed(cChunkInterface & a_ChunkInterface, cWorld
 {
 	NIBBLETYPE OldMeta = a_ChunkInterface.GetBlockMeta(a_BlockX, a_BlockY, a_BlockZ);
 
-	int newX = a_BlockX;
-	int newY = a_BlockY;
-	int newZ = a_BlockZ;
-	AddPistonDir(newX, newY, newZ, OldMeta, 1);
+	const Vector3i pushDir = GetDirectionVec(OldMeta);
+	int newX = a_BlockX + pushDir.x;
+	int newY = a_BlockY + pushDir.y;
+	int newZ = a_BlockZ + pushDir.z;
 
 	if (a_ChunkInterface.GetBlock(newX, newY, newZ) == E_BLOCK_PISTON_EXTENSION)
 	{
@@ -89,9 +73,31 @@ bool cBlockPistonHandler::GetPlacementBlockTypeMeta(
 
 
 
+Vector3i cBlockPistonHandler::GetDirectionVec(int a_PistonMeta)
+{
+	switch (a_PistonMeta & 0x07)
+	{
+		case 0: return Vector3i( 0, -1,  0);
+		case 1: return Vector3i( 0,  1,  0);
+		case 2: return Vector3i( 0,  0, -1);
+		case 3: return Vector3i( 0,  0,  1);
+		case 4: return Vector3i(-1,  0,  0);
+		case 5: return Vector3i( 1,  0,  0);
+		default:
+		{
+			LOGWARNING("%s: invalid direction %d, ignoring", __FUNCTION__, a_PistonMeta & 0x07);
+			return Vector3i();
+		}
+	}
+}
+
+
+
+
+
 bool cBlockPistonHandler::CanPushBlock(
 	int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, bool a_RequirePushable,
-	std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, NIBBLETYPE a_PistonMeta
+	std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, const Vector3i & a_PushDir
 )
 {
 	const static std::array<Vector3i, 6> pushingDirs = {{ Vector3i(-1, 0, 0), Vector3i(1, 0, 0), Vector3i(0, -1, 0), Vector3i(0, 1, 0),
@@ -133,15 +139,14 @@ bool cBlockPistonHandler::CanPushBlock(
 		// Try to push the other directions
 		for(const Vector3i & testDir : pushingDirs)
 		{
-			if(!CanPushBlock(a_BlockX + testDir.x, a_BlockY + testDir.y, a_BlockZ + testDir.z, a_World, false, a_BlocksPushed, a_PistonMeta))
+			if(!CanPushBlock(a_BlockX + testDir.x, a_BlockY + testDir.y, a_BlockZ + testDir.z, a_World, false, a_BlocksPushed, a_PushDir))
 			{
 				return false;
 			}
 		}
 	}
 
-	AddPistonDir(a_BlockX, a_BlockY, a_BlockZ, a_PistonMeta, 1);
-	return CanPushBlock(a_BlockX, a_BlockY, a_BlockZ, a_World, true, a_BlocksPushed, a_PistonMeta);
+	return CanPushBlock(a_BlockX + a_PushDir.x, a_BlockY + a_PushDir.y, a_BlockZ + a_PushDir.z, a_World, true, a_BlocksPushed, a_PushDir);
 }
 
 
@@ -160,24 +165,22 @@ void cBlockPistonHandler::ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ,
 		return;
 	}
 
-	int moveX = a_BlockX;
-	int moveY = a_BlockY;
-	int moveZ = a_BlockZ;
+	Vector3i pushDir = GetDirectionVec(pistonMeta);
+	int moveX = a_BlockX + pushDir.x;
+	int moveY = a_BlockY + pushDir.y;
+	int moveZ = a_BlockZ + pushDir.z;
 
-	AddPistonDir(moveX, moveY, moveZ, pistonMeta, 1);
 	std::unordered_set<Vector3i, VectorHasher<int>> blocksPushed;
-	if (!CanPushBlock(moveX, moveY, moveZ, a_World, true, blocksPushed, pistonMeta))
+	if (!CanPushBlock(moveX, moveY, moveZ, a_World, true, blocksPushed, pushDir))
 	{
 		// Can't push anything, bail out
 		return;
 	}
 
-	Vector3i pistonMoveVec;
-	AddPistonDir(pistonMoveVec.x, pistonMoveVec.y, pistonMoveVec.z, pistonMeta, 1);
 	std::vector<Vector3i> sortedBlocks(blocksPushed.begin(), blocksPushed.end());
-	std::sort(sortedBlocks.begin(), sortedBlocks.end(), [pistonMoveVec](const Vector3i & a, const Vector3i & b)
+	std::sort(sortedBlocks.begin(), sortedBlocks.end(), [pushDir](const Vector3i & a, const Vector3i & b)
 	{
-		return a.Dot(pistonMoveVec) > b.Dot(pistonMoveVec);
+		return a.Dot(pushDir) > b.Dot(pushDir);
 	});
 
 	a_World->BroadcastBlockAction(a_BlockX, a_BlockY, a_BlockZ, 0, pistonMeta, pistonBlock);
@@ -193,7 +196,9 @@ void cBlockPistonHandler::ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ,
 		a_World->GetBlockTypeMeta(moveX, moveY, moveZ, moveBlock, moveMeta);
 		a_World->SetBlock(moveX, moveY, moveZ, E_BLOCK_AIR, 0);
 
-		AddPistonDir(moveX, moveY, moveZ, pistonMeta, 1);
+		moveX += pushDir.x;
+		moveY += pushDir.y;
+		moveZ += pushDir.z;
 
 		if (cBlockInfo::IsPistonBreakable(moveBlock))
 		{
@@ -211,7 +216,9 @@ void cBlockPistonHandler::ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ,
 	}
 
 	a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, pistonBlock, pistonMeta | 0x8);
-	AddPistonDir(a_BlockX, a_BlockY, a_BlockZ, pistonMeta, 1);
+	a_BlockX += pushDir.x;
+	a_BlockY += pushDir.y;
+	a_BlockZ += pushDir.z;
 	a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, E_BLOCK_PISTON_EXTENSION, pistonMeta | (IsSticky(pistonBlock) ? 8 : 0));
 }
 
@@ -231,18 +238,18 @@ void cBlockPistonHandler::RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ
 		return;
 	}
 
+	Vector3i pushDir = GetDirectionVec(pistonMeta);
+
 	// Check the extension:
-	AddPistonDir(a_BlockX, a_BlockY, a_BlockZ, pistonMeta, 1);
-	if (a_World->GetBlock(a_BlockX, a_BlockY, a_BlockZ) != E_BLOCK_PISTON_EXTENSION)
+	if (a_World->GetBlock(a_BlockX + pushDir.x, a_BlockY + pushDir.y, a_BlockZ + pushDir.z) != E_BLOCK_PISTON_EXTENSION)
 	{
 		LOGD("%s: Piston without an extension - still extending, or just in an invalid state?", __FUNCTION__);
 		return;
 	}
 
 	// Remove Extension
-	a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, E_BLOCK_AIR, 0);
+	a_World->SetBlock(a_BlockX + pushDir.x, a_BlockY + pushDir.y, a_BlockZ + pushDir.z, E_BLOCK_AIR, 0);
 
-	AddPistonDir(a_BlockX, a_BlockY, a_BlockZ, pistonMeta, -1);
 	a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, pistonBlock, pistonMeta & ~(8));
 	a_World->BroadcastBlockAction(a_BlockX, a_BlockY, a_BlockZ, 1, pistonMeta & ~(8), pistonBlock);
 	a_World->BroadcastSoundEffect("tile.piston.in", static_cast<double>(a_BlockX), static_cast<double>(a_BlockY), static_cast<double>(a_BlockZ), 0.5f, 0.7f);
@@ -253,44 +260,23 @@ void cBlockPistonHandler::RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ
 		return;
 	}
 
-	AddPistonDir(a_BlockX, a_BlockY, a_BlockZ, pistonMeta, 2);
+	a_BlockX += 2 * pushDir.x;
+	a_BlockY += 2 * pushDir.y;
+	a_BlockZ += 2 * pushDir.z;
 	// Try to "push" the pulling block in the opposite direction
-	switch(pistonMeta & 0x07)
-	{
-		case 0:
-		case 1:
-			pistonMeta = 1 - pistonMeta;
-			break;
-		case 2:
-		case 3:
-			pistonMeta = 5 - pistonMeta;
-			break;
-
-		case 4:
-		case 5:
-			pistonMeta = 9 - pistonMeta;
-			break;
-
-		default:
-			{
-				LOGWARNING("%s: invalid direction %d, ignoring", __FUNCTION__, pistonMeta & 0x07); \
-				break;
-			}
-	}
+	pushDir *= -1;
 
 	std::unordered_set<Vector3i, VectorHasher<int>> pushedBlocks;
-	if (!CanPushBlock(a_BlockX, a_BlockY, a_BlockZ, a_World, false, pushedBlocks, pistonMeta))
+	if (!CanPushBlock(a_BlockX, a_BlockY, a_BlockZ, a_World, false, pushedBlocks, pushDir))
 	{
 		// Not pushable, bail out
 		return;
 	}
 
-	Vector3i pistonMoveVec;
-	AddPistonDir(pistonMoveVec.x, pistonMoveVec.y, pistonMoveVec.z, pistonMeta, 1);
 	std::vector<Vector3i> sortedBlocks(pushedBlocks.begin(), pushedBlocks.end());
-	std::sort(sortedBlocks.begin(), sortedBlocks.end(), [pistonMoveVec](const Vector3i & a, const Vector3i & b)
+	std::sort(sortedBlocks.begin(), sortedBlocks.end(), [pushDir](const Vector3i & a, const Vector3i & b)
 	{
-		return a.Dot(pistonMoveVec) > b.Dot(pistonMoveVec);
+		return a.Dot(pushDir) > b.Dot(pushDir);
 	});
 
 	int moveX, moveY, moveZ;
@@ -304,7 +290,9 @@ void cBlockPistonHandler::RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ
 		a_World->GetBlockTypeMeta(moveX, moveY, moveZ, moveBlock, moveMeta);
 		a_World->SetBlock(moveX, moveY, moveZ, E_BLOCK_AIR, 0);
 
-		AddPistonDir(moveX, moveY, moveZ, pistonMeta, 1);
+		moveX += pushDir.x;
+		moveY += pushDir.y;
+		moveZ += pushDir.z;
 
 		if (cBlockInfo::IsPistonBreakable(moveBlock))
 		{
@@ -342,10 +330,10 @@ void cBlockPistonHeadHandler::OnDestroyedByPlayer(cChunkInterface & a_ChunkInter
 {
 	NIBBLETYPE OldMeta = a_ChunkInterface.GetBlockMeta(a_BlockX, a_BlockY, a_BlockZ);
 
-	int newX = a_BlockX;
-	int newY = a_BlockY;
-	int newZ = a_BlockZ;
-	AddPistonDir(newX, newY, newZ, OldMeta, -1);
+	Vector3i pushDir = cBlockPistonHandler::GetDirectionVec(OldMeta);
+	int newX = a_BlockX - pushDir.x;
+	int newY = a_BlockY - pushDir.y;
+	int newZ = a_BlockZ - pushDir.z;
 
 	BLOCKTYPE Block = a_ChunkInterface.GetBlock(newX, newY, newZ);
 	if ((Block == E_BLOCK_STICKY_PISTON) || (Block == E_BLOCK_PISTON))

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -84,8 +84,8 @@ public:
 	/** Converts piston block's metadata into a unit vector representing the direction in which the piston will extend. */
 	static Vector3i MetadataToOffset(NIBBLETYPE a_PistonMeta);
 
-	static void ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
-	static void RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	static void ExtendPiston(Vector3i a_BlockPos, cWorld * a_World);
+	static void RetractPiston(Vector3i a_BlockPos, cWorld * a_World);
 
 	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) override
 	{
@@ -150,7 +150,7 @@ private:
 
 	/** Tries to push a block and increases the pushed blocks variable. Returns true if the block is pushable */
 	static bool CanPushBlock(
-		int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, bool a_RequirePushable,
+		const Vector3i & a_BlockPos, cWorld * a_World, bool a_RequirePushable,
 		Vector3iSet & a_BlocksPushed, const Vector3i & a_PushDir
 	);
 	

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -81,6 +81,9 @@ public:
 		}
 	}
 
+	/** This method converts the magic piston metadata into a direction vector.
+		This vector has a length of 1 and points into the direction, in which the piston will extend.
+	*/
 	static Vector3i GetDirectionVec(int a_PistonMeta);
 
 	static void ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -81,10 +81,8 @@ public:
 		}
 	}
 
-	/** This method converts the magic piston metadata into a direction vector.
-		This vector has a length of 1 and points into the direction, in which the piston will extend.
-	*/
-	static Vector3i VectorFromMetaData(int a_PistonMeta);
+	/** Converts piston block's metadata into a unit vector representing the direction in which the piston will extend. */
+	static Vector3i MetadataToOffset(NIBBLETYPE a_PistonMeta);
 
 	static void ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
 	static void RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
@@ -96,6 +94,8 @@ public:
 	}
 
 private:
+	
+	typedef std::unordered_set<Vector3i, VectorHasher<int>> Vector3iSet;
 
 	/** Returns true if the piston (specified by blocktype) is a sticky piston */
 	static inline bool IsSticky(BLOCKTYPE a_BlockType) { return (a_BlockType == E_BLOCK_STICKY_PISTON); }
@@ -151,11 +151,11 @@ private:
 	/** Tries to push a block and increases the pushed blocks variable. Returns true if the block is pushable */
 	static bool CanPushBlock(
 		int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, bool a_RequirePushable,
-		std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, const Vector3i & a_PushDir
+		Vector3iSet & a_BlocksPushed, const Vector3i & a_PushDir
 	);
 	
 	/** Moves a list of blocks in a specific direction */
-	static void PushBlocks(const std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksToPush,
+	static void PushBlocks(const Vector3iSet & a_BlocksToPush,
 		cWorld * a_World, const Vector3i & a_PushDir
 	);
 } ;

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -151,6 +151,7 @@ private:
 		std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, const Vector3i & a_PushDir
 	);
 	
+	/** Moves a list of blocks in a specific direction */
 	static void PushBlocks(const std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksToPush,
 		cWorld * a_World, const Vector3i & a_PushDir
 	);

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -161,6 +161,10 @@ private:
 		int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, bool a_RequirePushable,
 		std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, const Vector3i & a_PushDir
 	);
+	
+	static void PushBlocks(const std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksToPush,
+		cWorld * a_World, const Vector3i & a_PushDir
+	);
 } ;
 
 

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -81,6 +81,8 @@ public:
 		}
 	}
 
+	static Vector3i GetDirectionVec(int a_PistonMeta);
+
 	static void ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
 	static void RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
 
@@ -157,7 +159,7 @@ private:
 	/** Tries to push a block and increases the pushed blocks variable. Returns true if the block is pushable */
 	static bool CanPushBlock(
 		int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, bool a_RequirePushable,
-		std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, NIBBLETYPE a_PistonMeta
+		std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, const Vector3i & a_PushDir
 	);
 } ;
 

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -145,17 +145,6 @@ private:
 		return true;
 	}
 
-	/** Returns true if the specified block can be pulled by a sticky piston */
-	static inline bool CanPull(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
-	{
-		if (cBlockInfo::IsPistonBreakable(a_BlockType))
-		{
-			return false;  // CanBreakPush returns true, but we need false to prevent pulling
-		}
-		
-		return CanPush(a_BlockType, a_BlockMeta);
-	}
-
 	/** Tries to push a block and increases the pushed blocks variable. Returns true if the block is pushable */
 	static bool CanPushBlock(
 		int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, bool a_RequirePushable,

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -3,6 +3,8 @@
 
 #include "BlockHandler.h"
 
+#include <unordered_set>
+
 
 class cWorld;
 
@@ -152,8 +154,11 @@ private:
 		return CanPush(a_BlockType, a_BlockMeta);
 	}
 
-	/** Returns how many blocks the piston has to push (where the first free space is); < 0 when unpushable */
-	static int FirstPassthroughBlock(int a_PistonX, int a_PistonY, int a_PistonZ, NIBBLETYPE a_PistonMeta, cWorld * a_World);
+	/** Tries to push a block and increases the pushed blocks variable. Returns true if the block is pushable */
+	static bool CanPushBlock(
+		int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, bool a_RequirePushable,
+		std::unordered_set<Vector3i, VectorHasher<int>> & a_BlocksPushed, NIBBLETYPE a_PistonMeta
+	);
 } ;
 
 

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -84,7 +84,7 @@ public:
 	/** This method converts the magic piston metadata into a direction vector.
 		This vector has a length of 1 and points into the direction, in which the piston will extend.
 	*/
-	static Vector3i GetDirectionVec(int a_PistonMeta);
+	static Vector3i VectorFromMetaData(int a_PistonMeta);
 
 	static void ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
 	static void RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);

--- a/src/Blocks/BlockSlime.h
+++ b/src/Blocks/BlockSlime.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "BlockHandler.h"
+
+
+
+
+
+class cBlockSlimeHandler :
+	public cBlockHandler
+{
+public:
+	cBlockSlimeHandler(BLOCKTYPE a_BlockType)
+		: cBlockHandler(a_BlockType)
+	{
+	}
+	
+	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta) override
+	{
+		a_Pickups.push_back(cItem(m_BlockType, 1, 0));
+	}
+
+	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) override
+	{
+		UNUSED(a_Meta);
+		return 1;
+	}
+};
+
+
+
+

--- a/src/Simulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator.cpp
@@ -882,11 +882,11 @@ void cIncrementalRedstoneSimulator::HandlePiston(int a_RelBlockX, int a_RelBlock
 
 	if (IsPistonPowered(a_RelBlockX, a_RelBlockY, a_RelBlockZ, m_Chunk->GetMeta(a_RelBlockX, a_RelBlockY, a_RelBlockZ) & 0x7))  // We only want the bottom three bits (4th controls extended-ness)
 	{
-		GetHandlerCompileTime<E_BLOCK_PISTON>::type::ExtendPiston(BlockX, a_RelBlockY, BlockZ, &this->m_World);
+		GetHandlerCompileTime<E_BLOCK_PISTON>::type::ExtendPiston(Vector3i(BlockX, a_RelBlockY, BlockZ), &this->m_World);
 	}
 	else
 	{
-		GetHandlerCompileTime<E_BLOCK_PISTON>::type::RetractPiston(BlockX, a_RelBlockY, BlockZ, &this->m_World);
+		GetHandlerCompileTime<E_BLOCK_PISTON>::type::RetractPiston(Vector3i(BlockX, a_RelBlockY, BlockZ), &this->m_World);
 	}
 }
 


### PR DESCRIPTION
This PR implements the slimeblocks and the piston mechanics with them.
This fixes #2530, but not fully #1404, because the bouncing/item mechanics are not implemented.

Please be aware, that the client does the piston calculation client side, so that you should relog to check, if it really worked.