### PR TITLE
Chickens shouldn't take fall damage [re-pull]

### DIFF
--- a/src/Mobs/Chicken.cpp
+++ b/src/Mobs/Chicken.cpp
@@ -61,6 +61,10 @@ void cChicken::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 
 
 
+void cChicken::HandleFalling(void)
+{
+	// empty - chickens don't take fall damage
+}
 
 
 

--- a/src/Mobs/Chicken.h
+++ b/src/Mobs/Chicken.h
@@ -21,6 +21,8 @@ public:
 
 	virtual const cItem GetFollowedItem(void) const override { return cItem(E_ITEM_SEEDS); }
 
+	virtual void HandleFalling(void) override;
+
 private:
 
 	int m_EggDropTimer;


### PR DESCRIPTION
(from https://github.com/cuberite/cuberite/pull/2602 but with proper repo)

Also needs an exception at https://github.com/cuberite/cuberite/blob/master/src/Entities/Entity.cpp#L931 for the falling speed to be exempted from gravity, but I don't know the actual numbers.