### PR TITLE
Fix mobs firing when already dead

### DIFF
--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -80,7 +80,7 @@ void cAggressiveMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	Vector3d AttackDirection(m_Target->GetPosition() + Vector3d(0, m_Target->GetHeight(), 0) - MyHeadPosition);
 
 
-	if (TargetIsInRange() && !LineOfSight.Trace(MyHeadPosition, AttackDirection, static_cast<int>(AttackDirection.Length())))
+	if (TargetIsInRange() && !LineOfSight.Trace(MyHeadPosition, AttackDirection, static_cast<int>(AttackDirection.Length())) && (GetHealth() > 0.0))
 	{
 		// Attack if reached destination, target isn't null, and have a clear line of sight to target (so won't attack through walls)
 		StopMovingToPosition();


### PR DESCRIPTION
The dying animation keeps mobs as valid (see https://github.com/cuberite/cuberite/blob/master/src/Mobs/Monster.cpp#L434) so the tick/attack logic still runs even after they've fallen over. This can result in e.g. dead skeletons still shooting arrows.