### PR TITLE
Use .travis.yml to whitelist coverity_scan for push builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,7 @@ notifications:
   email:
     on_success: change
     on_failure: always
-
+branches:
+  only:
+    - coverity_scan
+    - master


### PR DESCRIPTION
Travis will only run coverity on a push build, but we want to disable push builds for most of the project. This whitelist should be a good compromise.