### PR TITLE
Prevent fall damage, when falling on slimeblocks

### DIFF
--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -93,20 +93,30 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 void cPawn::HandleFalling()
 {
-	if (m_bTouchGround)
+	if (!m_bTouchGround)
 	{
-		int Damage = (m_LastGroundHeight - POSY_TOINT) - 3;
+		// Just update the ground height to have the highest position of the player
+		m_LastGroundHeight = std::max(m_LastGroundHeight, POSY_TOINT);
+		return;
+	}
+	
+	int Damage = (m_LastGroundHeight - POSY_TOINT) - 3;
+	m_LastGroundHeight = POSY_TOINT;
+	
+	if (
+		(GetWorld()->GetBlock(POSX_TOINT, POSY_TOINT - 1, POSZ_TOINT) == E_BLOCK_SLIME_BLOCK)    // Falling on slimeblocks does not inflict fall damage
+		// TODO !((GetEntityType() == eEntityType::etPlayer) && static_cast<cPlayer*>(this)->IsCrouched())  // Except the player is sneaking
+	)
+	{
+		return;
+	}
 
-		if (Damage > 0)
-		{
-			TakeDamage(dtFalling, nullptr, Damage, Damage, 0);
-
+	if (Damage > 0)
+	{
+		TakeDamage(dtFalling, nullptr, Damage, Damage, 0);
 			
-			// Fall particles
-			GetWorld()->BroadcastSoundParticleEffect(2006, POSX_TOINT, POSY_TOINT - 1, POSZ_TOINT, Damage /* Used as particle effect speed modifier */);
-		}
-
-		m_LastGroundHeight = POSY_TOINT;
+		// Fall particles
+		GetWorld()->BroadcastSoundParticleEffect(2006, POSX_TOINT, POSY_TOINT - 1, POSZ_TOINT, Damage /* Used as particle effect speed modifier */);
 	}
 	
 	/* Player.cpp old code

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -55,6 +55,11 @@ public:
 protected:
 	typedef std::map<cEntityEffect::eType, cEntityEffect *> tEffectMap;
 	tEffectMap m_EntityEffects;
+	
+	bool m_bTouchGround;
+	int m_LastGroundHeight;
+	
+	virtual void HandleFalling(void);
 } ;  // tolua_export
 
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -55,8 +55,6 @@ cPlayer::cPlayer(cClientHandlePtr a_Client, const AString & a_PlayerName) :
 	m_FoodSaturationLevel(5.0),
 	m_FoodTickTimer(0),
 	m_FoodExhaustionLevel(0.0),
-	m_LastGroundHeight(0),
-	m_bTouchGround(false),
 	m_Stance(0.0),
 	m_Inventory(*this),
 	m_EnderChestContents(9, 3),
@@ -497,26 +495,7 @@ void cPlayer::SetTouchGround(bool a_bTouchGround)
 		)
 	)
 	{
-		auto Damage = static_cast<int>(m_LastGroundHeight - GetPosY() - 3.0);
-		if (Damage > 0)
-		{
-			// cPlayer makes sure damage isn't applied in creative, no need to check here
-			TakeDamage(dtFalling, nullptr, Damage, Damage, 0);
-
-			// Fall particles
-			Damage = std::min(15, Damage);
-			GetClientHandle()->SendParticleEffect(
-				"blockdust",
-				GetPosition(),
-				{ 0, 0, 0 },
-				(Damage - 1.f) * ((0.3f - 0.1f) / (15.f - 1.f)) + 0.1f,  // Map damage (1 - 15) to particle speed (0.1 - 0.3)
-				static_cast<int>((Damage - 1.f) * ((50.f - 20.f) / (15.f - 1.f)) + 20.f),  // Map damage (1 - 15) to particle quantity (20 - 50)
-				{ { GetWorld()->GetBlock(POS_TOINT - Vector3i(0, 1, 0)), 0 } }
-			);
-		}
-
 		m_bTouchGround = true;
-		m_LastGroundHeight = GetPosY();
 	}
 	else
 	{

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -550,8 +550,6 @@ protected:
 	/** A "buffer" which adds up hunger before it is substracted from m_FoodSaturationLevel or m_FoodLevel. Each action adds a little */
 	double m_FoodExhaustionLevel;
 
-	double m_LastGroundHeight;
-	bool m_bTouchGround;
 	double m_Stance;
 
 	/** Stores the player's inventory, consisting of crafting grid, hotbar, and main slots */

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -79,7 +79,6 @@ cMonster::cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const A
 	, m_PathfinderActivated(false)
 	, m_GiveUpCounter(0)
 	, m_TicksSinceLastPathReset(1000)
-	, m_LastGroundHeight(POSY_TOINT)
 	, m_JumpCoolDown(0)
 	, m_IdleInterval(0)
 	, m_DestroyTimer(0)
@@ -479,7 +478,6 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	}
 
 	SetPitchAndYawFromDestination();
-	HandleFalling();
 
 	switch (m_EMState)
 	{
@@ -504,6 +502,16 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	}  // switch (m_EMState)
 
 	BroadcastMovementUpdate();
+}
+
+
+
+
+
+void cMonster::HandleFalling(void)
+{
+	m_bTouchGround = IsOnGround();
+	super::HandleFalling();
 }
 
 
@@ -555,28 +563,6 @@ void cMonster::SetPitchAndYawFromDestination()
 			SetHeadYaw(BodyRotation);
 			SetPitch(-BodyPitch);
 		}
-	}
-}
-
-
-
-
-
-void cMonster::HandleFalling()
-{
-	if (m_bOnGround)
-	{
-		int Damage = (m_LastGroundHeight - POSY_TOINT) - 3;
-
-		if (Damage > 0)
-		{
-			TakeDamage(dtFalling, nullptr, Damage, Damage, 0);
-
-			// Fall particles
-			GetWorld()->BroadcastSoundParticleEffect(2006, POSX_TOINT, POSY_TOINT - 1, POSZ_TOINT, Damage /* Used as particle effect speed modifier */);
-		}
-
-		m_LastGroundHeight = POSY_TOINT;
 	}
 }
 

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -246,8 +246,7 @@ protected:
 	/** Sets the body yaw and head yaw / pitch based on next / ultimate destinations */
 	void SetPitchAndYawFromDestination(void);
 
-	virtual void HandleFalling(void);
-	int m_LastGroundHeight;
+	virtual void HandleFalling(void) override;
 	int m_JumpCoolDown;
 
 	std::chrono::milliseconds m_IdleInterval;


### PR DESCRIPTION
**NOT COMPLETE YET**
See: http://minecraft.gamepedia.com/Slimeblock#Usage

This is interesting for #1404.
I've merged the HandleFalling method from cMonster into cPawn to reduce code duplication.
But I have no idea, how to implement the fall damage, when sneaking and falling on slimeblocks.