### PR TITLE
Neutral mobs should be neutral

### DIFF
--- a/src/Mobs/Enderman.cpp
+++ b/src/Mobs/Enderman.cpp
@@ -126,7 +126,7 @@ void cEnderman::CheckEventSeePlayer()
 
 	if (!Callback.GetPlayer()->IsGameModeCreative())
 	{
-		super::EventSeePlayer(Callback.GetPlayer());
+		cMonster::EventSeePlayer(Callback.GetPlayer());
 		m_EMState = CHASING;
 		m_bIsScreaming = true;
 		GetWorld()->BroadcastEntityMetadata(*this);

--- a/src/Mobs/PassiveAggressiveMonster.cpp
+++ b/src/Mobs/PassiveAggressiveMonster.cpp
@@ -39,3 +39,9 @@ bool cPassiveAggressiveMonster::DoTakeDamage(TakeDamageInfo & a_TDI)
 
 
 
+void cPassiveAggressiveMonster::EventSeePlayer(cEntity *)
+{
+	// don't do anything, neutral mobs don't react to just seeing the player
+}
+
+

--- a/src/Mobs/PassiveAggressiveMonster.h
+++ b/src/Mobs/PassiveAggressiveMonster.h
@@ -16,6 +16,7 @@ public:
 	cPassiveAggressiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, double a_Width, double a_Height);
 
 	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
+	virtual void EventSeePlayer(cEntity *) override;
 } ;
 
 


### PR DESCRIPTION
Right now endermen / pigmen attack immediately because they inherited ```cAggressiveMonster::EventSeePlayer```. (Wolves are an exception because ```cWolf::Tick```.)