### PR TITLE
Improved spawn location calculations.

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1343,7 +1343,7 @@ bool cEntity::DetectPortal()
 					TargetPos.x *= 8.0;
 					TargetPos.z *= 8.0;
 
-					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedOverworldName(), dimNether, GetWorld()->GetName(), false);
+					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedOverworldName(), dimNether, GetWorld()->GetName(), true);
 					LOGD("Jumping nether -> overworld");
 					new cNetherPortalScanner(this, TargetWorld, TargetPos, 256);
 					return true;
@@ -1367,7 +1367,7 @@ bool cEntity::DetectPortal()
 					TargetPos.x /= 8.0;
 					TargetPos.z /= 8.0;
 
-					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedNetherWorldName(), dimNether, GetWorld()->GetName(), false);
+					cWorld * TargetWorld = cRoot::Get()->CreateAndInitializeWorld(GetWorld()->GetLinkedNetherWorldName(), dimNether, GetWorld()->GetName(), true);
 					LOGD("Jumping overworld -> nether");
 					new cNetherPortalScanner(this, TargetWorld, TargetPos, 128);
 					return true;

--- a/src/World.h
+++ b/src/World.h
@@ -1042,7 +1042,11 @@ private:
 	void UpdateSkyDarkness(void);
 
 	/** Generates a random spawnpoint on solid land by walking chunks and finding their biomes */
-	void GenerateRandomSpawn(void);
+	void GenerateRandomSpawn(int a_MaxSpawnRadius);
+
+	/** Can the specified coordinates be used as a spawn point?
+	Returns true if spawn position is valid and sets a_Y to the valid spawn height */
+	bool CanSpawnAt(double a_X, double & a_Y, double a_Z);
 
 	/** Check if player starting point is acceptable */
 	bool CheckPlayerSpawnPoint(int a_PosX, int a_PosY, int a_PosZ);


### PR DESCRIPTION
Note: Sorry for messing up the other PR. I rebased my fork, pushed and it auto-closed the other PR :(

 - Supports Overworld and Nether spawns.
 - Supports spawning under objects, but still above ground (e.g. under the leaves of a tree).
 - Protects against spawning in oceans.
 - Protects against spawning in water.
 - Uses a radial search about the origin, rather than a linear.
 - Correctly calculates Nether spawn on spawn world generation (fixes: https://github.com/cuberite/cuberite/issues/2548)
 - Fixes a bug in CheckPlayerSpawnPoint() where the X offset was used in both the X and Z coordinates (BLOCKTYPE BlockType = GetBlock(a_PosX + Coords[i].x, a_PosY, a_PosZ + Coords[i].x);)