### PR TITLE
Changed server description to "Cuberite - Minecraft in C++!"

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -189,7 +189,7 @@ void cServer::PlayerDestroying(const cPlayer * a_Player)
 
 bool cServer::InitServer(cSettingsRepositoryInterface & a_Settings, bool a_ShouldAuth)
 {
-	m_Description = a_Settings.GetValueSet("Server", "Description", "Cuberite - in C++!");
+	m_Description = a_Settings.GetValueSet("Server", "Description", "Cuberite - Minecraft in C++!");
 	m_MaxPlayers  = a_Settings.GetValueSetI("Server", "MaxPlayers", 100);
 	m_bIsHardcore = a_Settings.GetValueSetB("Server", "HardcoreEnabled", false);
 	m_bAllowMultiLogin = a_Settings.GetValueSetB("Server", "AllowMultiLogin", false);


### PR DESCRIPTION
Currently the server description is `Cuberite - in C++!` Which is probably an automatic regex change of `Minecraft - in C++!`.