### PR TITLE
Update COMPILING.md

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -27,7 +27,7 @@ To contribute your changes to the source back to the repository, you need a Git 
 
 Alternatively, if you want only to compile the source, without contributing, you can [download the sources in a ZIP file directly from GitHub](https://github.com/cuberite/cuberite/archive/master.zip).
 
-If you're using Git to get the source, use the following set of commands to set up the local workspace correctly:
+If you're using Git to get the source, use the following command to set up the local workspace correctly:
 
 ```
 git clone --recursive https://github.com/cuberite/cuberite.git
@@ -87,9 +87,17 @@ git clone --recursive https://github.com/cuberite/cuberite.git
 
 ### Building ###
 
-Follow the instructions at [CMake on Unix-based platforms](#cmake-on-unix-based-platforms).
+Run the following commands to build Cuberite:
 
-After doing so, run the command `make` in the build directory, and Cuberite will build.
+```
+mkdir Release
+cd Release
+cmake -DCMAKE_BUILD_TYPE=RELEASE ..
+make -j`nproc`
+```
+
+This will build Cuberite in release mode, which is better for almost all cases. For more `cmake` options, or for building in debug mode, see the section below.
+
 
 CMake on Unix-based platforms
 -----------------------------
@@ -143,3 +151,24 @@ When cross-compiling for another computer it is important to set cross compiling
 to your cmake command.
 
 Note that real cross-compilation is hard at this moment, because an executable generated during the build process is required for later stages, so if your computer cannot run executables it generates the build will not work.
+
+### List of all build flags ###
+
+Cuberite's build process supports a large number of flags for customising the builds. Use these flags by adding `-DFlag_name=Value` to the cmake configuration command. For example to enable test generation using the `SELF_TEST` flag add: `-DSELF_TEST=ON`
+
+###### BUILD_TOOLS
+Adds the Cuberite tools to the build. At the moment only MCADefrag and ProtoProxy are added. Define as ON to enable. Define as OFF to disable. 
+
+###### BUILD_UNSTABLE_TOOLS
+Adds tools that are not working yet to the build. Currently this is only the Generator Performance Test. Used for developing these tools. Define as ON to enable. Define as OFF to disable. 
+
+###### SELF_TEST
+Enables generation of tests and self-test startup code. Tests can be run with ctest and with makefiles make test. Define as ON to enable. Define as OFF to disable. 
+
+###### FORCE_32
+Forces the build to use 32 bit builds on *nix systems. Define as ON to enable. Define as OFF to disable.
+ 
+###### CROSSCOMPILE
+Disables optimizations for the build host. This is important when building on a different machine from the one you will run Cuberite on as the build machine may support instructions the final machine does not. This flag only has any effect on linux. Define as ON to enable. Define as OFF to disable. 
+
+

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This Linux script will download the correct binary from the project site.
 
 #### Compiling
  - You can compile automatically for Linux with the `compile.sh` script. The script is described below.
- - You can also compile manually.
+ - You can also compile manually. See [COMPILING.md](https://github.com/cuberite/cuberite/blob/master/COMPILING.md).
 
-Compiling may provide better performance performance (1.5-3x as fast) and it supports more operating systems. See the [COMPILING.md](https://github.com/cuberite/cuberite/blob/master/COMPILING.md) file for more details.
+Compiling may provide better performance performance (1.5-3x as fast) and it supports more operating systems. 
 
 ##### The compile.sh script
 This script downloads the source code and compiles it. The script is smart enough to notify you of missing dependencies and instructing you on how to install them. The script doesn't work for Windows.


### PR DESCRIPTION
 - ~~Replaced `apt-get clang` with `apt-get gcc`, because beginners are better off with GCC, because it's more widely used in Linux and is more likely to be installed already. Advanced users know what they're doing.~~
 - Copied over the build flag list from the book.
 - Several minor changes.