### PR TITLE
Stop creepers from exploding even if they just died

### DIFF
--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -43,7 +43,7 @@ void cCreeper::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			m_ExplodingTimer += 1;
 		}
 
-		if (m_ExplodingTimer == 30)
+		if ((m_ExplodingTimer == 30) && (GetHealth() > 0.0))  // only explode when not already dead
 		{
 			m_World->DoExplosionAt((m_bIsCharged ? 5 : 3), GetPosX(), GetPosY(), GetPosZ(), false, esMonster, this);
 			Destroy();  // Just in case we aren't killed by the explosion


### PR DESCRIPTION
Should mobs even ```Tick()``` once they died?