### PR TITLE
Tilling dirt should send block update

### DIFF
--- a/src/Items/ItemHoe.h
+++ b/src/Items/ItemHoe.h
@@ -57,7 +57,7 @@ public:
 				}
 			}
 
-			a_World->FastSetBlock(a_BlockX, a_BlockY, a_BlockZ, NewBlock, 0);
+			a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, NewBlock, 0);
 			a_World->BroadcastSoundEffect("dig.gravel", a_BlockX + 0.5, a_BlockY + 0.5, a_BlockZ + 0.5, 1.0f, 0.8f);
 			a_Player->UseEquippedItem();
 			return true;


### PR DESCRIPTION
There are BUD switches that are built on this (https://www.youtube.com/watch?v=Bk_ChvmtCNY) but more prominently, torches placed on dirt blocks should pop off when the dirt block is tilled.