### PR TITLE
Stop pathfinding over cobble walls

### DIFF
--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -148,6 +148,7 @@ bool cPath::IsSolid(const Vector3i & a_Location)
 			(BlockType == E_BLOCK_FENCE) ||
 			(BlockType == E_BLOCK_OAK_FENCE_GATE) ||
 			(BlockType == E_BLOCK_NETHER_BRICK_FENCE) ||
+			(BlockType == E_BLOCK_COBBLESTONE_WALL) ||
 			((BlockType >= E_BLOCK_SPRUCE_FENCE_GATE) && (BlockType <= E_BLOCK_ACACIA_FENCE))
 	)
 	{


### PR DESCRIPTION
Also 1.5 blocks high, shouldn't pathfind over it.