### PR TITLE
Fixed String Parsing crash bug

### DIFF
--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -91,11 +91,7 @@ bool cParsedNBT::ReadString(size_t & a_StringStart, size_t & a_StringLen)
 	NEEDBYTES(2);
 	a_StringStart = m_Pos + 2;
 	a_StringLen = static_cast<size_t>(GetBEShort(m_Data + m_Pos));
-	if (a_StringLen > 0xffff)
-	{
-		// Suspicious string length
-		return false;
-	}
+	NEEDBYTES(a_StringLen);
 	m_Pos += 2 + a_StringLen;
 	return true;
 }


### PR DESCRIPTION
Check string length against actual remaining data, not an arbitrary constant