### PR TITLE
Revised the explosion-related Lua API and docs.

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -2858,6 +2858,18 @@ end
 				TrimString = {Params = "string", Return = "string", Notes = "Trims whitespace at both ends of the string"},
 				md5 = {Params = "string", Return = "string", Notes = "<b>OBSOLETE</b>, use the {{cCryptoHash}} functions instead.<br>Converts a string to a raw binary md5 hash."},
 			},
+			Constants =
+			{
+				esBed = { Notes = "A bed explosion. The SourceData param is the {{Vector3i|position}} of the bed." },
+				esEnderCrystal = { Notes = "An ender crystal entity explosion. The SourceData param is the {{cEntity|ender crystal entity}} object." },
+				esGhastFireball = { Notes = "A ghast fireball explosion. The SourceData param is the {{cGhastFireballEntity|ghast fireball entity}} object." },
+				esMonster = { Notes = "A monster explosion (creeper). The SourceData param is the {{cMonster|monster entity}} object." },
+				esOther = { Notes = "Any other explosion. The SourceData param is unused." },
+				esPlugin = { Notes = "An explosion started by a plugin, without any further information. The SourceData param is unused. "},
+				esPrimedTNT = { Notes = "A TNT explosion. The SourceData param is the {{cTNTEntity|TNT entity}} object."},
+				esWitherBirth = { Notes = "An explosion at a wither's birth. The SourceData param is the {{cMonster|wither entity}} object." },
+				esWitherSkull = { Notes = "A wither skull explosion. The SourceData param is the {{cWitherSkullEntity|wither skull entity}} object." },
+			},
 			ConstantGroups =
 			{
 				BlockTypes =
@@ -2961,7 +2973,7 @@ end
 						These constants are used to differentiate the various sources of explosions. They are used in
 						the {{OnExploded|HOOK_EXPLODED}} hook, {{OnExploding|HOOK_EXPLODING}} hook and in the
 						{{cWorld}}:DoExplosionAt() function. These constants also dictate the type of the additional
-						data provided with the explosions, such as the exploding {{cCreeper|creeper}} entity or the
+						data provided with the explosions, such as the exploding creeper {{cEntity|entity}} or the
 						{{Vector3i|coords}} of the exploding bed.
 					]],
 				},
@@ -3037,6 +3049,7 @@ end
 		"cHopperEntity.__cBlockEntityWindowOwner__",
 		"cLuaWindow.__cItemGrid__cListener__",
 		"Globals._CuberiteInternal_.*",  -- Ignore all internal Cuberite constants
+		"Globals.esMax",
 	},
 
 	IgnoreVariables =

--- a/Server/Plugins/APIDump/Hooks/OnExploded.lua
+++ b/Server/Plugins/APIDump/Hooks/OnExploded.lua
@@ -11,20 +11,7 @@ return
 			<p>
 			The explosion carries with it the type of its source - whether it's a creeper exploding, or TNT,
 			etc. It also carries the identification of the actual source. The exact type of the identification
-			depends on the source kind:
-			<table>
-			<tr><th>Source</th><th>SourceData Type</th><th>Notes</th></tr>
-			<tr><td>esPrimedTNT</td><td>{{cTNTEntity}}</td><td>An exploding primed TNT entity</td></tr>
-			<tr><td>esCreeper</td><td>{{cCreeper}}</td><td>An exploding creeper or charged creeper</td></tr>
-			<tr><td>esBed</td><td>{{Vector3i}}</td><td>A bed exploding in the Nether or in the End. The bed coords are given.</td></tr>
-			<tr><td>esEnderCrystal</td><td>{{Vector3i}}</td><td>An ender crystal exploding upon hit. The block coords are given.</td></tr>
-			<tr><td>esGhastFireball</td><td>{{cGhastFireballEntity}}</td><td>A ghast fireball hitting ground or an {{cEntity|entity}}.</td></tr>
-			<tr><td>esWitherSkullBlack</td><td><i>TBD</i></td><td>A black wither skull hitting ground or an {{cEntity|entity}}.</td></tr>
-			<tr><td>esWitherSkullBlue</td><td><i>TBD</i></td><td>A blue wither skull hitting ground or an {{cEntity|entity}}.</td></tr>
-			<tr><td>esWitherBirth</td><td><i>TBD</i></td><td>A wither boss being created</td></tr>
-			<tr><td>esOther</td><td><i>TBD</i></td><td>Any other previously unspecified type.</td></tr>
-			<tr><td>esPlugin</td><td>object</td><td>An explosion created by a plugin. The plugin may specify any kind of data.</td></tr>
-			</table></p>
+			depends on the source kind, see the {{Globals#ExplosionSource|esXXX}} constants' descriptions for details.
 		]],
 		Params =
 		{
@@ -35,7 +22,7 @@ return
 			{ Name = "Y", Type = "number", Notes = "Y-coord of the explosion center" },
 			{ Name = "Z", Type = "number", Notes = "Z-coord of the explosion center" },
 			{ Name = "Source", Type = "eExplosionSource", Notes = "Source of the explosion. See the table above." },
-			{ Name = "SourceData", Type = "varies", Notes = "Additional data for the source. The exact type varies by the source. See the table above." },
+			{ Name = "SourceData", Type = "varies", Notes = "Additional data for the source. The exact type varies by the source. See the {{Globals#ExplosionSource|esXXX}} constants' descriptions." },
 		},
 		Returns = [[
 			If the function returns false or no value, the next plugin's callback is called. If the function

--- a/Server/Plugins/APIDump/Hooks/OnExploding.lua
+++ b/Server/Plugins/APIDump/Hooks/OnExploding.lua
@@ -11,20 +11,7 @@ return
 			<p>
 			The explosion carries with it the type of its source - whether it's a creeper exploding, or TNT,
 			etc. It also carries the identification of the actual source. The exact type of the identification
-			depends on the source kind:
-			<table>
-			<tr><th>Source</th><th>SourceData Type</th><th>Notes</th></tr>
-			<tr><td>esPrimedTNT</td><td>{{cTNTEntity}}</td><td>An exploding primed TNT entity</td></tr>
-			<tr><td>esCreeper</td><td>{{cCreeper}}</td><td>An exploding creeper or charged creeper</td></tr>
-			<tr><td>esBed</td><td>{{Vector3i}}</td><td>A bed exploding in the Nether or in the End. The bed coords are given.</td></tr>
-			<tr><td>esEnderCrystal</td><td>{{Vector3i}}</td><td>An ender crystal exploding upon hit. The block coords are given.</td></tr>
-			<tr><td>esGhastFireball</td><td>{{cGhastFireballEntity}}</td><td>A ghast fireball hitting ground or an {{cEntity|entity}}.</td></tr>
-			<tr><td>esWitherSkullBlack</td><td><i>TBD</i></td><td>A black wither skull hitting ground or an {{cEntity|entity}}.</td></tr>
-			<tr><td>esWitherSkullBlue</td><td><i>TBD</i></td><td>A blue wither skull hitting ground or an {{cEntity|entity}}.</td></tr>
-			<tr><td>esWitherBirth</td><td><i>TBD</i></td><td>A wither boss being created</td></tr>
-			<tr><td>esOther</td><td><i>TBD</i></td><td>Any other previously unspecified type.</td></tr>
-			<tr><td>esPlugin</td><td>object</td><td>An explosion created by a plugin. The plugin may specify any kind of data.</td></tr>
-			</table></p>
+			depends on the source kind, see the {{Globals#ExplosionSource|esXXX}} constants' descriptions for details
 		]],
 		Params =
 		{
@@ -35,12 +22,16 @@ return
 			{ Name = "Y", Type = "number", Notes = "Y-coord of the explosion center" },
 			{ Name = "Z", Type = "number", Notes = "Z-coord of the explosion center" },
 			{ Name = "Source", Type = "eExplosionSource", Notes = "Source of the explosion. See the table above." },
-			{ Name = "SourceData", Type = "varies", Notes = "Additional data for the source. The exact type varies by the source. See the table above." },
+			{ Name = "SourceData", Type = "varies", Notes = "Additional data for the source. The exact type varies by the source. See the {{Globals#ExplosionSource|esXXX}} constants' description." },
 		},
 		Returns = [[
 			If the function returns false or no value, the next plugin's callback is called, and finally
 			Cuberite will process the explosion - destroy blocks and push + hurt entities. If the function
-			returns true, no other callback is called for this event and the explosion will not occur.
+			returns true, no other callback is called for this event and the explosion will not occur.</p>
+			<p>
+			The hook handler may return up to two more values after the initial bool. The second returned value
+			overrides the CanCauseFire parameter for subsequent hook calls and the final explosion, the third
+			returned value overrides the ExplosionSize parameter for subsequent hook calls and the final explosion.
 		]],
 	},  -- HOOK_EXPLODING
 }

--- a/Server/Plugins/APIDump/Writing-a-Cuberite-plugin.html
+++ b/Server/Plugins/APIDump/Writing-a-Cuberite-plugin.html
@@ -209,10 +209,11 @@ function Explode(Split, Player)
 	-- Create a callback ExplodePlayer with parameter Explodee, which Cuberite calls for every player on the server
 	local HasExploded = false
 	local ExplodePlayer = function(Explodee)
-		-- If the player we are currently at is the one we specified as the parameter
+		-- If the player name matches exactly
 		if (Explodee:GetName() == Split[2]) then
-			-- Create an explosion at the same position as they are; see <a href="cWorld.html">API docs</a> for further details of this function
-			Player:GetWorld():DoExplosionAt(Explodee:GetPosX(), Explodee:GetPosY(), Explodee:GetPosZ(), false, esPlugin)
+			-- Create an explosion of force level 2 at the same position as they are
+			-- see <a href="cWorld.html">API docs</a> for further details of this function
+			Player:GetWorld():DoExplosionAt(2, Explodee:GetPosX(), Explodee:GetPosY(), Explodee:GetPosZ(), false, esPlugin)
 			Player:SendMessageSuccess(Split[2] .. " was successfully exploded")
 			HasExploded = true;
 			return true -- Signalize to Cuberite that we do not need to call this callback for any more players

--- a/Server/Plugins/APIDump/main_APIDump.lua
+++ b/Server/Plugins/APIDump/main_APIDump.lua
@@ -786,7 +786,7 @@ local function WriteHtmlClass(a_ClassAPI, a_ClassMenu)
 				cf:write("<a name='", group.Name, "'><p>");
 				cf:write(LinkifyString(group.TextBefore or "", Source));
 				WriteConstantTable(group.Constants, a_InheritedName or a_ClassAPI.Name);
-				cf:write(LinkifyString(group.TextAfter or "", Source), "</a></p>");
+				cf:write(LinkifyString(group.TextAfter or "", Source), "</a></p><hr/>");
 			end
 		end
 	end

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -807,25 +807,6 @@ void cLuaState::Push(UInt32 a_Value)
 
 
 
-void cLuaState::Push(void * a_Ptr)
-{
-	UNUSED(a_Ptr);
-	ASSERT(IsValid());
-
-	// Investigate the cause of this - what is the callstack?
-	// One code path leading here is the OnHookExploding / OnHookExploded with exotic parameters. Need to decide what to do with them
-	LOGWARNING("Lua engine: attempting to push a plain pointer, pushing nil instead.");
-	LOGWARNING("This indicates an unimplemented part of MCS bindings");
-	LogStackTrace();
-	
-	lua_pushnil(m_LuaState);
-	m_NumCurrentFunctionArgs += 1;
-}
-
-
-
-
-
 void cLuaState::Push(std::chrono::milliseconds a_Value)
 {
 	ASSERT(IsValid());
@@ -833,20 +814,6 @@ void cLuaState::Push(std::chrono::milliseconds a_Value)
 	tolua_pushnumber(m_LuaState, static_cast<lua_Number>(a_Value.count()));
 	m_NumCurrentFunctionArgs += 1;
 }
-
-
-
-
-
-/*
-void cLuaState::PushUserType(void * a_Object, const char * a_Type)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, a_Object, a_Type);
-	m_NumCurrentFunctionArgs += 1;
-}
-*/
 
 
 
@@ -1177,6 +1144,39 @@ bool cLuaState::CheckParamNumber(int a_StartParam, int a_EndParam)
 	for (int i = a_StartParam; i <= a_EndParam; i++)
 	{
 		if (tolua_isnumber(m_LuaState, i, 0, &tolua_err))
+		{
+			continue;
+		}
+		// Not the correct parameter
+		lua_Debug entry;
+		VERIFY(lua_getstack(m_LuaState, 0,   &entry));
+		VERIFY(lua_getinfo (m_LuaState, "n", &entry));
+		AString ErrMsg = Printf("#ferror in function '%s'.", (entry.name != nullptr) ? entry.name : "?");
+		tolua_error(m_LuaState, ErrMsg.c_str(), &tolua_err);
+		return false;
+	}  // for i - Param
+	
+	// All params checked ok
+	return true;
+}
+
+
+
+
+
+bool cLuaState::CheckParamBool(int a_StartParam, int a_EndParam)
+{
+	ASSERT(IsValid());
+	
+	if (a_EndParam < 0)
+	{
+		a_EndParam = a_StartParam;
+	}
+	
+	tolua_Error tolua_err;
+	for (int i = a_StartParam; i <= a_EndParam; i++)
+	{
+		if (tolua_isboolean(m_LuaState, i, 0, &tolua_err))
 		{
 			continue;
 		}

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -259,7 +259,6 @@ public:
 	void Push(int a_Value);
 	void Push(long a_Value);
 	void Push(const UInt32 a_Value);
-	void Push(void * a_Ptr);
 	void Push(std::chrono::milliseconds a_time);
 	
 	// GetStackValue() retrieves the value at a_StackPos, if it is a valid type. If not, a_Value is unchanged.
@@ -374,6 +373,9 @@ public:
 	
 	/** Returns true if the specified parameters on the stack are numbers; also logs warning if not */
 	bool CheckParamNumber(int a_StartParam, int a_EndParam = -1);
+	
+	/** Returns true if the specified parameters on the stack are bools; also logs warning if not */
+	bool CheckParamBool(int a_StartParam, int a_EndParam = -1);
 	
 	/** Returns true if the specified parameters on the stack are strings; also logs warning if not */
 	bool CheckParamString(int a_StartParam, int a_EndParam = -1);

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -667,16 +667,20 @@ bool cPluginLua::OnExploded(cWorld & a_World, double a_ExplosionSize, bool a_Can
 	{
 		switch (a_Source)
 		{
-			case esOther:            m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData, cLuaState::Return, res); break;
-			case esPrimedTNT:        m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cTNTEntity *>(a_SourceData), cLuaState::Return, res); break;
-			case esMonster:          m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>(a_SourceData), cLuaState::Return, res); break;
-			case esBed:              m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>(a_SourceData), cLuaState::Return, res); break;
-			case esEnderCrystal:     m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>(a_SourceData), cLuaState::Return, res); break;
-			case esGhastFireball:    m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData, cLuaState::Return, res); break;
-			case esWitherSkullBlack:
-			case esWitherSkullBlue:  m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData, cLuaState::Return, res); break;
-			case esWitherBirth:      m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData, cLuaState::Return, res); break;
-			case esPlugin:           m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData, cLuaState::Return, res); break;
+			case esBed:           m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>            (a_SourceData), cLuaState::Return, res); break;
+			case esEnderCrystal:  m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cEntity *>             (a_SourceData), cLuaState::Return, res); break;
+			case esGhastFireball: m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cGhastFireballEntity *>(a_SourceData), cLuaState::Return, res); break;
+			case esMonster:       m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res); break;
+			case esOther:         m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, cLuaState::Return, res); break;
+			case esPlugin:        m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, cLuaState::Return, res); break;
+			case esPrimedTNT:     m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cTNTEntity *>          (a_SourceData), cLuaState::Return, res); break;
+			case esWitherBirth:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res); break;
+			case esWitherSkull:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cWitherSkullEntity *>  (a_SourceData), cLuaState::Return, res); break;
+			case esMax:
+			{
+				ASSERT(!"Invalid explosion source");
+				return false;
+			}
 		}
 		if (res)
 		{
@@ -703,16 +707,20 @@ bool cPluginLua::OnExploding(cWorld & a_World, double & a_ExplosionSize, bool & 
 	{
 		switch (a_Source)
 		{
-			case esOther:            m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData,               cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esPrimedTNT:        m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cTNTEntity *>(a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esMonster:          m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>(a_SourceData),   cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esBed:              m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>(a_SourceData),   cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esEnderCrystal:     m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>(a_SourceData),   cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esGhastFireball:    m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData,               cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esWitherSkullBlack:
-			case esWitherSkullBlue:  m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData,               cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esWitherBirth:      m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData,               cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esPlugin:           m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData,               cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esBed:           m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>            (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esEnderCrystal:  m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cEntity *>             (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esGhastFireball: m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cGhastFireballEntity *>(a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esMonster:       m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esOther:         m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source,                                                         cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esPlugin:        m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source,                                                         cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esPrimedTNT:     m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cTNTEntity *>          (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esWitherBirth:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esWitherSkull:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cWitherSkullEntity *>  (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esMax:
+			{
+				ASSERT(!"Invalid explosion source");
+				return false;
+			}
 		}
 		if (res)
 		{

--- a/src/BlockID.h
+++ b/src/BlockID.h
@@ -1051,18 +1051,30 @@ enum eDamageType
 
 
 
+/** The source of an explosion.
+Also dictates the type of the additional data passed to the explosion handlers:
+| esBed           | Vector3i *             | Bed exploding in the Nether or in the End
+| esEnderCrystal  | cEnderCrystal *        |
+| esGhastFireball | cGhastFireballEntity * |
+| esMonster       | cMonster *             |
+| esOther         | nullptr                | Any other explosion unaccounted for
+| esPlugin        | nullptr                | Explosion primarily attributed to a plugin
+| esPrimedTNT     | cTNTEntity *           |
+| esWitherBirth   | cMonster *             |
+| esWitherSkull   | cProjectileEntity *    |
+*/
 enum eExplosionSource
 {
-	esOther,
-	esPrimedTNT,
-	esMonster,
 	esBed,
 	esEnderCrystal,
 	esGhastFireball,
-	esWitherSkullBlack,
-	esWitherSkullBlue,
-	esWitherBirth,
+	esMonster,
+	esOther,
 	esPlugin,
+	esPrimedTNT,
+	esWitherBirth,
+	esWitherSkull,
+	esMax,
 } ;
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -517,20 +517,11 @@ public:
 	/** Calls the callback for each furnace in the specified chunk; returns true if all furnaces processed, false if the callback aborted by returning true */
 	bool ForEachFurnaceInChunk(int a_ChunkX, int a_ChunkZ, cFurnaceCallback & a_Callback);  // Exported in ManualBindings.cpp
 	
-	/** Does an explosion with the specified strength at the specified coordinate
-	a_SourceData exact type depends on the a_Source:
-	| esOther            | void *           |
-	| esPrimedTNT        | cTNTEntity *     |
-	| esMonster          | cMonster *       |
-	| esBed              | cVector3i *      |
-	| esEnderCrystal     | Vector3i *       |
-	| esGhastFireball    | cGhastFireball * |
-	| esWitherSkullBlack | TBD              |
-	| esWitherSkullBlue  | TBD              |
-	| esWitherBirth      | cMonster *       |
-	| esPlugin           | void *           |
-	*/
-	virtual void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, eExplosionSource a_Source, void * a_SourceData) override;  // tolua_export
+	/** Does an explosion with the specified strength at the specified coordinates.
+	Executes the HOOK_EXPLODING and HOOK_EXPLODED hooks as part of the processing.
+	a_SourceData exact type depends on the a_Source, see the declaration of the esXXX constants in BlockID.h for details.
+	Exported to Lua manually in ManualBindings_World.cpp in order to support the variable a_SourceData param. */
+	virtual void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, eExplosionSource a_Source, void * a_SourceData) override;
 
 	/** Calls the callback for the block entity at the specified coords; returns false if there's no block entity at those coords, true if found */
 	virtual bool DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBlockEntityCallback & a_Callback) override;  // Exported in ManualBindings.cpp


### PR DESCRIPTION
Unified the various sources of `esXXX` type information.
Fixed wrong datatypes passed into the explosion hooks.
Centralized the explosion-related LuaAPI documentation.
Fixed example Lua plugin calling explosions.
Removed unneeded `cLuaState::Push(void *)`.

Fixes #2746.