### PR TITLE
Changed the deadlock detector interval to 120 seconds.Closes #2550

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -193,7 +193,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 	if (settingsRepo->GetValueSetB("DeadlockDetect", "Enabled", true))
 	{
 		LOGD("Starting deadlock detector...");
-		dd.Start(settingsRepo->GetValueSetI("DeadlockDetect", "IntervalSec", 20));
+		dd.Start(settingsRepo->GetValueSetI("DeadlockDetect", "IntervalSec", 120));
 	}
 
 	settingsRepo->Flush();


### PR DESCRIPTION
Changed the default deadlock detector interval to 120 seconds.