### PR TITLE
Fixed spawn point generation. Wrong number for divisions and wrong highest spawn point

### DIFF
--- a/src/World.cpp
+++ b/src/World.cpp
@@ -613,7 +613,7 @@ void cWorld::GenerateRandomSpawn(int a_MaxSpawnRadius)
 	}
 
 	// A search grid (searches clockwise around the origin)
-	static const int HalfChunk = static_cast<int>(cChunkDef::Width / 0.5f);
+	static const int HalfChunk = static_cast<int>(cChunkDef::Width / 2.0f);
 	static const Vector3i ChunkOffset[] =
 	{
 		Vector3i(0, 0, HalfChunk),
@@ -673,8 +673,9 @@ bool cWorld::CanSpawnAt(double a_X, double & a_Y, double a_Z)
 
 	static const int ValidSpawnBlocksCount = ARRAYCOUNT(ValidSpawnBlocks);
 
-	static const int HighestSpawnPoint = std::min(static_cast<int>((cChunkDef::Height / 0.5f)) - 1, GetHeight(static_cast<int>(a_X), static_cast<int>(a_Z) + 16));
-	static const int LowestSpawnPoint = static_cast<int>(HighestSpawnPoint / 0.5f);
+	// Increase this by two, because we need two more blocks for body and head
+	static const int HighestSpawnPoint = GetHeight(static_cast<int>(a_X), static_cast<int>(a_Z)) + 2;
+	static const int LowestSpawnPoint = static_cast<int>(HighestSpawnPoint / 2.0f);
 
 	for (int PotentialY = HighestSpawnPoint; PotentialY > LowestSpawnPoint; --PotentialY)
 	{


### PR DESCRIPTION
Corrected this, works good now :)
* Fixed wrong number, used for division
* Increased highest spawn point by two, because of body part and head

Fixes #2781 
Closes #2762