### PR TITLE
PF - Improved mob jumping

### DIFF
--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -79,7 +79,7 @@ public:
 	/** delete default constructors */
 	cPath(const cPath & a_other) = delete;
 	cPath(cPath && a_other) = delete;
-	
+
 	cPath & operator=(const cPath & a_other) = delete;
 	cPath & operator=(cPath && a_other) = delete;
 
@@ -152,7 +152,7 @@ private:
 	/* Openlist and closedlist management */
 	void OpenListAdd(cPathCell * a_Cell);
 	cPathCell * OpenListPop();
-	void ProcessIfWalkable(const Vector3i &a_Location, cPathCell * a_Parent, int a_Cost);
+	bool ProcessIfWalkable(const Vector3i &a_Location, cPathCell * a_Parent, int a_Cost);
 
 	/* Map management */
 	void ProcessCell(cPathCell * a_Cell,  cPathCell * a_Caller,  int a_GDelta);
@@ -181,6 +181,11 @@ private:
 	/* Interfacing with the world */
 	cChunk * m_Chunk;  // Only valid inside Step()!
 	bool m_BadChunkFound;
+
+	/* High level world queries */
+	bool IsWalkable(const Vector3i & a_Location);
+	bool BodyFitsIn(const Vector3i & a_Location);
+	bool HasSolidBelow(const Vector3i & a_Location);
 	#ifdef COMPILING_PATHFIND_DEBUGGER
 	#include "../path_irrlicht.cpp"
 	#endif

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -107,8 +107,12 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk & a_Chunk, const Vector3d 
 				}
 			}
 
+			Vector3d Waypoint(m_WayPoint);
+			Vector3d Source(m_Source);
+			Waypoint.y = 0;
+			Source.y = 0;
 
-			if (m_Path->IsFirstPoint() || ((m_WayPoint - m_Source).SqrLength() < WAYPOINT_RADIUS))
+			if (m_Path->IsFirstPoint() || (((Waypoint - Source).SqrLength() < WAYPOINT_RADIUS) && (m_Source.y >= m_WayPoint.y)))
 			{
 				// if the mob has just started or if the mob reached a waypoint, give them a new waypoint.
 				m_WayPoint = m_Path->GetNextPoint();


### PR DESCRIPTION
This PR drastically improves mob jumping.
Fixes #2787.
Closes #2646.

Makes the problems discussed in #2771 less severe. Specifically, chickens flight is now better handled, and zombies will not weirdly look back after going down a block.

Mobs no longer act weird when the player jumps.

`StepOnce` is now more readable.