### PR TITLE
Add handling of water bottle

### DIFF
--- a/src/Items/CMakeLists.txt
+++ b/src/Items/CMakeLists.txt
@@ -13,6 +13,7 @@ SET (HDRS
 	ItemBed.h
 	ItemBigFlower.h
 	ItemBoat.h
+	ItemBottle.h
 	ItemBow.h
 	ItemBrewingStand.h
 	ItemBucket.h

--- a/src/Items/ItemBottle.h
+++ b/src/Items/ItemBottle.h
@@ -1,0 +1,95 @@
+
+#pragma once
+
+#include "ItemHandler.h"
+#include "../World.h"
+
+
+
+
+
+class cItemBottleHandler :
+	public cItemHandler
+{
+public:
+	cItemBottleHandler() :
+		cItemHandler(E_ITEM_GLASS_BOTTLE)
+	{
+	}
+
+
+	bool GetBlockFromTrace(cWorld * a_World, cPlayer * a_Player, Vector3i & a_BlockPos)
+	{
+		class cCallbacks :
+			public cBlockTracer::cCallbacks
+		{
+		public:
+			Vector3i m_Pos;
+			bool     m_HasHitFluid;
+
+
+			cCallbacks(void) :
+				m_HasHitFluid(false)
+			{
+			}
+
+			virtual bool OnNextBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, char a_EntryFace) override
+			{
+				if (IsBlockWater(a_BlockType))
+				{
+					if (a_BlockMeta != 0)  // we're only looking for source blocks
+					{
+						return false;
+					}
+					m_HasHitFluid = true;
+					m_Pos.Set(a_BlockX, a_BlockY, a_BlockZ);
+					return true;
+				}
+				return false;
+			}
+		} Callbacks;
+
+		cLineBlockTracer Tracer(*a_World, Callbacks);
+		Vector3d Start(a_Player->GetEyePosition() + a_Player->GetLookVector());
+		Vector3d End(a_Player->GetEyePosition() + a_Player->GetLookVector() * 5);
+
+		Tracer.Trace(Start.x, Start.y, Start.z, End.x, End.y, End.z);
+
+		if (!Callbacks.m_HasHitFluid)
+		{
+			return false;
+		}
+
+
+		a_BlockPos = Callbacks.m_Pos;
+		return true;
+	}
+
+
+
+	virtual bool OnItemUse(
+		cWorld * a_World, cPlayer * a_Player, cBlockPluginInterface & a_PluginInterface, const cItem & a_Item,
+		int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace
+		) override
+	{
+		if (a_BlockFace != BLOCK_FACE_NONE)
+		{
+			return false;
+		}
+
+		Vector3i BlockPos;
+		if (!GetBlockFromTrace(a_World, a_Player, BlockPos))
+		{
+			return false;  // Nothing in range.
+		}
+
+		a_Player->GetInventory().RemoveOneEquippedItem();
+		cItem NewItem(E_ITEM_POTION, 1, 0);
+		a_Player->GetInventory().AddItem(NewItem);
+		return true;
+	}
+} ;
+
+
+
+

--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -13,6 +13,7 @@
 #include "ItemBed.h"
 #include "ItemBigFlower.h"
 #include "ItemBoat.h"
+#include "ItemBottle.h"
 #include "ItemBow.h"
 #include "ItemBrewingStand.h"
 #include "ItemBucket.h"
@@ -134,6 +135,7 @@ cItemHandler * cItemHandler::CreateItemHandler(int a_ItemType)
 		case E_ITEM_FISHING_ROD:         return new cItemFishingRodHandler(a_ItemType);
 		case E_ITEM_FLINT_AND_STEEL:     return new cItemLighterHandler(a_ItemType);
 		case E_ITEM_FLOWER_POT:          return new cItemFlowerPotHandler(a_ItemType);
+		case E_ITEM_GLASS_BOTTLE:        return new cItemBottleHandler();
 		case E_ITEM_GOLDEN_APPLE:        return new cItemGoldenAppleHandler();
 		case E_ITEM_MAP:                 return new cItemMapHandler();
 		case E_ITEM_MILK:                return new cItemMilkHandler();


### PR DESCRIPTION
Currently using an empty bottle on a water source block creates a phantom water bottle that disappears on inventory sync.

I copied the ```GetBlockFromTrace``` function from ```ItemBucket.h``` - probably should refactor it out into a ```World``` function or somewhere else.