### PR TITLE
"Special blocks" handling

### DIFF
--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -22,9 +22,9 @@ cAggressiveMonster::cAggressiveMonster(const AString & a_ConfigName, eMonsterTyp
 
 
 // What to do if in Chasing State
-void cAggressiveMonster::InStateChasing(std::chrono::milliseconds a_Dt)
+void cAggressiveMonster::InStateChasing(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
-	super::InStateChasing(a_Dt);
+	super::InStateChasing(a_Dt, a_Chunk);
 
 	if (m_Target != nullptr)
 	{

--- a/src/Mobs/AggressiveMonster.h
+++ b/src/Mobs/AggressiveMonster.h
@@ -11,16 +11,16 @@ class cAggressiveMonster :
 	public cMonster
 {
 	typedef cMonster super;
-	
+
 public:
 
 	cAggressiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, double a_Width, double a_Height);
 
 	virtual void Tick          (std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
-	virtual void InStateChasing(std::chrono::milliseconds a_Dt) override;
-	
+	virtual void InStateChasing(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
+
 	virtual void EventSeePlayer(cEntity *) override;
-	
+
 	/** Try to perform attack
 	returns true if attack was deemed successful (hit player, fired projectile, creeper exploded, etc.) even if it didn't actually do damage
 	return false if e.g. the mob is still in cooldown from a previous attack */

--- a/src/Mobs/Horse.cpp
+++ b/src/Mobs/Horse.cpp
@@ -72,7 +72,7 @@ void cHorse::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			m_bIsTame = true;
 		}
 	}
-	
+
 	if (m_bIsRearing)
 	{
 		if (m_RearTickCount == 20)
@@ -161,12 +161,12 @@ void cHorse::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 
 
 
-void cHorse::InStateIdle(std::chrono::milliseconds a_Dt)
+void cHorse::InStateIdle(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	// If horse is tame and someone is sitting on it, don't walk around
 	if ((!m_bIsTame) || (m_Attachee == nullptr))
 	{
-		super::InStateIdle(a_Dt);
+		super::InStateIdle(a_Dt, a_Chunk);
 	}
 }
 

--- a/src/Mobs/Horse.h
+++ b/src/Mobs/Horse.h
@@ -11,14 +11,14 @@ class cHorse :
 	public cPassiveMonster
 {
 	typedef cPassiveMonster super;
-	
+
 public:
 	cHorse(int Type, int Color, int Style, int TameTimes);
 
 	CLASS_PROTODEF(cHorse)
-	
+
 	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
-	virtual void InStateIdle(std::chrono::milliseconds a_Dt) override;
+	virtual void InStateIdle(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void OnRightClicked(cPlayer & a_Player) override;

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -79,9 +79,9 @@ public:
 	virtual void EventLosePlayer(void);
 	virtual void CheckEventLostPlayer(void);
 
-	virtual void InStateIdle    (std::chrono::milliseconds a_Dt);
-	virtual void InStateChasing (std::chrono::milliseconds a_Dt);
-	virtual void InStateEscaping(std::chrono::milliseconds a_Dt);
+	virtual void InStateIdle    (std::chrono::milliseconds a_Dt, cChunk & a_Chunk);
+	virtual void InStateChasing (std::chrono::milliseconds a_Dt, cChunk & a_Chunk);
+	virtual void InStateEscaping(std::chrono::milliseconds a_Dt, cChunk & a_Chunk);
 
 	int GetAttackRate() { return static_cast<int>(m_AttackRate); }
 	void SetAttackRate(float a_AttackRate) { m_AttackRate = a_AttackRate; }
@@ -193,7 +193,7 @@ protected:
 	/** Returns if a monster can reach a given height by jumping. */
 	inline bool DoesPosYRequireJump(int a_PosY)
 	{
-		return ((a_PosY > POSY_TOINT) && (a_PosY == POSY_TOINT + 1));
+		return ((a_PosY > POSY_TOINT));
 	}
 
 	/** Move in a straight line to the next waypoint in the path, will jump if needed. */

--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -7,6 +7,7 @@ enum class ePathFinderStatus;
 class cPath;
 */
 
+
 #include "../FastRandom.h"
 #ifdef COMPILING_PATHFIND_DEBUGGER
 	/* Note: the COMPILING_PATHFIND_DEBUGGER flag is used by Native / WiseOldMan95 to debug
@@ -19,18 +20,36 @@ class cPath;
 //fwd: ../Chunk.h
 class cChunk;
 
+
 /* Various little structs and classes */
 enum class ePathFinderStatus {CALCULATING,  PATH_FOUND,  PATH_NOT_FOUND, NEARBY_FOUND};
 enum class eCellStatus {OPENLIST,  CLOSEDLIST,  NOLIST};
+/** The pathfinder has 3 types of cells (cPathCell).
+1 - empty. m_IsSolid is false, m_IsSpecial is false.  Air cells are always traversable by A*.
+2 - occupied / solid. m_IsSolid is true, m_IsSpecial is false.  Air cells are never traversable by A*.
+3 - Special. m_IsSolid is true, m_IsSpecial is true. These cells are special: They may either behave as empty
+or as occupied / solid, depending on the mob's direction of movement. For instance, an airblock above a fence is a special cell,
+because when mobs attempt to travel to it by jumping, it acts as a solid. But when mobs fall and land on top of a fence,
+it acts as air. Special cells include: Doors, ladders, trapdoors, water, gates.
+
+The main function which handles special blocks is SpecialIsSolidFromThisDirection.
+This function receives a BlockType, a meta, and a direction of travel,
+then it uses those 3 parameters to decide whether the special block should behave as a solid or as air in this
+particular direction of travel.
+
+Currently, only fences and water are handled properly. The function always returns "true" (meaning: treat as occuiped/solid) for
+the rest of the blocks. This will be fixed once the physics engine issues are fixed. */
 struct cPathCell
 {
 	Vector3i m_Location;   // Location of the cell in the world.
 	int m_F, m_G, m_H;  // F, G, H as defined in regular A*.
 	eCellStatus m_Status;  // Which list is the cell in? Either non, open, or closed.
 	cPathCell * m_Parent;  // Cell's parent, as defined in regular A*.
-	bool m_IsSolid;	   // Is the cell an air or a solid? Partial solids are currently considered solids.
+	bool m_IsSolid;	   // Is the cell an air or a solid? Partial solids are considered solids. If m_IsSpecial is true, this is always true.
+	bool m_IsSpecial;  // The cell is special - it acts as "solid" or "air" depending on direction, e.g. door or top of fence.
+	BLOCKTYPE m_BlockType;
+	NIBBLETYPE m_BlockMeta;
 };
-
 
 
 
@@ -48,32 +67,22 @@ public:
 class cPath
 {
 public:
-	/** Creates a pathfinder instance. A Mob will probably need a single pathfinder instance for its entire life.
+	/** Creates a pathfinder instance.
+	After calling this, you are expected to call CalculationStep() once per tick or once per several ticks
+	until it returns something other than CALCULATING.
 
-	Note that if you have a man-sized mob (1x1x2, zombies, etc), you are advised to call this function without parameters
-	because the declaration might change in later version of the pathFinder, and a parameter-less call always assumes a man-sized mob.
-
-	If your mob is not man-sized, you are advised to use cPath(width, height), this would be compatible with future versions,
-	but please be aware that as of now those parameters will be ignored and your mob will be assumed to be man sized.
-
-	@param a_BoundingBoxWidth the character's boundingbox width in blocks. Currently the parameter is ignored and 1 is assumed.
-	@param a_BoundingBoxHeight the character's boundingbox width in blocks. Currently the parameter is ignored and 2 is assumed.
-	@param a_MaxUp the character's max jump height in blocks. Currently the parameter is ignored and 1 is assumed.
-	@param a_MaxDown How far is the character willing to fall? Currently the parameter is ignored and 1 is assumed. */
-	/** Attempts to find a path starting from source to destination.
-	After calling this, you are expected to call Step() once per tick or once per several ticks until it returns true. You should then call getPath() to obtain the path.
-	Calling this before a path is found resets the current path and starts another search.
 	@param a_StartingPoint The function expects this position to be the lowest block the mob is in, a rule of thumb: "The block where the Zombie's knees are at".
 	@param a_EndingPoint "The block where the Zombie's knees want to be".
-	@param a_MaxSteps The maximum steps before giving up. */
+	@param a_MaxSteps The maximum steps before giving up.
+	@param a_BoundingBoxWidth the character's boundingbox width in blocks. Currently the parameter is ignored and 1 is assumed.
+	@param a_BoundingBoxHeight the character's boundingbox width in blocks. Currently the parameter is ignored and 2 is assumed. */
 	cPath(
 		cChunk & a_Chunk,
 		const Vector3d & a_StartingPoint, const Vector3d & a_EndingPoint, int a_MaxSteps,
-		double a_BoundingBoxWidth, double a_BoundingBoxHeight,
-		int a_MaxUp = 1, int a_MaxDown = 1
+		double a_BoundingBoxWidth, double a_BoundingBoxHeight
 	);
 
-	/** Creates a dummy path which does nothing except returning false when isValid is called. */
+	/** Creates an invalid path which is not usable. You shouldn't call any method other than isValid on such a path. */
 	cPath();
 
 	/** delete default constructors */
@@ -84,9 +93,11 @@ public:
 	cPath & operator=(cPath && a_other) = delete;
 
 	/** Performs part of the path calculation and returns the appropriate status.
+	If PATH_FOUND is returned, the path was found, and you can call query the instance for waypoints via GetNextWayPoint, etc.
 	If NEARBY_FOUND is returned, it means that the destination is not reachable, but a nearby destination
 	is reachable. If the user likes the alternative destination, they can call AcceptNearbyPath to treat the path as found,
-	and to make consequent calls to step return PATH_FOUND */
+	and to make consequent calls to step return PATH_FOUND
+	If PATH_NOT_FOUND is returned, then no path was found. */
 	ePathFinderStatus CalculationStep(cChunk & a_Chunk);
 
 	/** Called after the PathFinder's step returns NEARBY_FOUND.
@@ -142,7 +153,6 @@ public:
 private:
 
 	/* General */
-	bool IsSolid(const Vector3i & a_Location);  // Query our hosting world and ask it if there's a solid at a_location.
 	bool StepOnce();  // The public version just calls this version * CALCULATIONS_PER_CALL times.
 	void FinishCalculation();  // Clears the memory used for calculating the path.
 	void FinishCalculation(ePathFinderStatus a_NewStatus);  // Clears the memory used for calculating the path and changes the status.
@@ -152,7 +162,7 @@ private:
 	/* Openlist and closedlist management */
 	void OpenListAdd(cPathCell * a_Cell);
 	cPathCell * OpenListPop();
-	bool ProcessIfWalkable(const Vector3i &a_Location, cPathCell * a_Parent, int a_Cost);
+	bool ProcessIfWalkable(const Vector3i & a_Location, cPathCell * a_Source, int a_Cost);
 
 	/* Map management */
 	void ProcessCell(cPathCell * a_Cell,  cPathCell * a_Caller,  int a_GDelta);
@@ -179,12 +189,16 @@ private:
 	std::vector<Vector3i> m_PathPoints;
 
 	/* Interfacing with the world */
+	void FillCellAttributes(cPathCell & a_Cell);  // Query our hosting world and fill the cell with info
 	cChunk * m_Chunk;  // Only valid inside Step()!
 	bool m_BadChunkFound;
 
 	/* High level world queries */
-	bool IsWalkable(const Vector3i & a_Location);
-	bool BodyFitsIn(const Vector3i & a_Location);
+	bool IsWalkable(const Vector3i & a_Location, const Vector3i & a_Source);
+	bool BodyFitsIn(const Vector3i & a_Location, const Vector3i & a_Source);
+	bool BlockTypeIsSpecial(BLOCKTYPE a_Type);
+	bool BlockTypeIsFence(BLOCKTYPE a_Type);  // TODO Perhaps this should be moved to cBlockInfo
+	bool SpecialIsSolidFromThisDirection(BLOCKTYPE a_Type, NIBBLETYPE a_Meta,  const Vector3i & a_Direction);
 	bool HasSolidBelow(const Vector3i & a_Location);
 	#ifdef COMPILING_PATHFIND_DEBUGGER
 	#include "../path_irrlicht.cpp"

--- a/src/Mobs/PathFinder.h
+++ b/src/Mobs/PathFinder.h
@@ -3,16 +3,11 @@
 #include "Path.h"
 
 #define WAYPOINT_RADIUS 0.5
-/*
-TODO DOXY style
 
-This class wraps cPath.
+/** This class wraps cPath.
 cPath is a "dumb device" - You give it point A and point B, and it returns a full path path.
 cPathFinder - You give it a constant stream of point A (where you are) and point B (where you want to go),
-and it tells you where to go next. It manages path recalculation internally, and is much more efficient that calling cPath every step.
-
-*/
-
+and it tells you where to go next. It manages path recalculation internally, and is much more efficient that calling cPath every step. */
 class cPathFinder
 {
 
@@ -80,16 +75,17 @@ private:
 	/** When a path is not found, this cooldown prevents any recalculations for several ticks. */
 	int m_NotFoundCooldown;
 
-	/** Ensures the destination is not buried underground or under water. Also ensures the destination is not in the air.
-	Only the Y coordinate of m_FinalDestination might be changed by this call.
-	1. If m_FinalDestination is the position of a water block, m_FinalDestination's Y will be modified to point to the heighest water block in the pool in the current column.
-	2. If m_FinalDestination is the position of a solid, m_FinalDestination's Y will be modified to point to the first airblock above the solid in the current column.
-	3. If m_FinalDestination is the position of an air block, Y will keep decreasing until hitting either a solid or water.
-	Now either 1 or 2 is performed. */
-	bool EnsureProperDestination(cChunk & a_Chunk);
+	/** Ensures the location is not in the air or under water.
+	May change the Y coordinate of the given vector.
+	1. If a_Vector is the position of water, a_Vector's Y will be modified to point to the first air block above it.
+	2. If a_Vector is the position of air, a_Vector's Y will be modified to point to the first airblock below it which has solid or water beneath. */
+	bool EnsureProperPoint(Vector3d & a_Vector, cChunk & a_Chunk);
 
 	/** Resets a pathfinding task, typically because m_FinalDestination has deviated too much from m_DeviationOrigin. */
 	void ResetPathFinding(cChunk &a_Chunk);
+
+	/** Return true the the blocktype is either water or solid */
+	bool IsWaterOrSolid(BLOCKTYPE a_BlockType);
 
 	/** Is the path too old and should be recalculated? When this is true ResetPathFinding() is called. */
 	bool PathIsTooOld() const;

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneLampHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneLampHandler.h
@@ -33,7 +33,7 @@ public:
 
 	virtual cVector3iArray Update(const Vector3i & a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta, PoweringData a_PoweringData) override
 	{
-		LOGD("Evaluating lamp (%i %i %i)", a_Position.x, a_Position.y, a_Position.z);
+		// LOGD("Evaluating lamp (%i %i %i)", a_Position.x, a_Position.y, a_Position.z);
 
 		if (a_PoweringData.PowerLevel > 0)
 		{

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneTorchHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneTorchHandler.h
@@ -58,7 +58,7 @@ public:
 
 	virtual cVector3iArray Update(const Vector3i & a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta, PoweringData a_PoweringData) override
 	{
-		LOGD("Evaluating torchy the redstone torch (%i %i %i)", a_Position.x, a_Position.y, a_Position.z);
+		// LOGD("Evaluating torchy the redstone torch (%i %i %i)", a_Position.x, a_Position.y, a_Position.z);
 
 		auto Data = static_cast<cIncrementalRedstoneSimulator *>(m_World.GetRedstoneSimulator())->GetChunkData();
 		auto DelayInfo = Data->GetMechanismDelayInfo(a_Position);

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -113,7 +113,7 @@ public:
 	virtual cVector3iArray Update(const Vector3i & a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta, PoweringData a_PoweringData) override
 	{
 		UNUSED(a_BlockType);
-		LOGD("Evaluating dusty the wire (%d %d %d) %i", a_Position.x, a_Position.y, a_Position.z, a_PoweringData.PowerLevel);
+		// LOGD("Evaluating dusty the wire (%d %d %d) %i", a_Position.x, a_Position.y, a_Position.z, a_PoweringData.PowerLevel);
 
 		if (a_Meta != a_PoweringData.PowerLevel)
 		{

--- a/src/Simulator/IncrementalRedstoneSimulator/SolidBlockHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/SolidBlockHandler.h
@@ -38,7 +38,7 @@ public:
 	{
 		UNUSED(a_BlockType);
 		UNUSED(a_Meta);
-		LOGD("Evaluating blocky the generic block (%d %d %d)", a_Position.x, a_Position.y, a_Position.z);
+		// LOGD("Evaluating blocky the generic block (%d %d %d)", a_Position.x, a_Position.y, a_Position.z);
 
 		auto PreviousPower = static_cast<cIncrementalRedstoneSimulator *>(m_World.GetRedstoneSimulator())->GetChunkData()->ExchangeUpdateOncePowerData(a_Position, a_PoweringData);
 		if ((a_PoweringData != PreviousPower) || (a_PoweringData.PoweringBlock != PreviousPower.PoweringBlock))


### PR DESCRIPTION
This is a rewrite of some of the pathfinding code. I've devised a nice way of handling "Special Blocks" - Blocks that behave either as solid or as air, depending on cirumstances. This should allow incorprating ladder / door / trapdoor handling with ease.

This PR implements / fixes / improves:
 - `Path.cpp` code should be cleaner now and adding features should be easier. Dealing with special blocks is no longer "ad-hoc".
 - Sets the stage for dealing with #2062.
 - Sets the stage for dealing with ladders.
 - Sets the stage for having several PathFinding modes (Discussed in #2775)
 - Implements mob swimming. 
 - Mobs can jump out of water.
 - Proper fence handling.
 - Idle mobs will now spend far less time in water.
 - Mobs heads are more natural, less jiggles and looking the wrong way.

Closes #2773
Closes #2276
Closes #2792
Resolves part of #2043 