### PR TITLE
Fixed Clang warnings.

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -264,6 +264,7 @@ macro(set_exe_flags)
 			add_flags_cxx("-D__extern_always_inline=inline")
 			add_flags_cxx("-Weverything -Werror -Wno-c++98-compat-pedantic -Wno-string-conversion")
 			add_flags_cxx("-Wno-exit-time-destructors -Wno-padded -Wno-weak-vtables")
+			add_flags_cxx("-Wno-switch-enum")  # This is a pretty useless warning, we've already got -Wswitch which is what we need
 			if ("${CLANG_VERSION}" VERSION_GREATER 3.0)
 				# flags that are not present in 3.0
 				add_flags_cxx("-Wno-implicit-fallthrough")

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1896,10 +1896,10 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 		public cEntityCallback
 	{
 	public:
-		cTNTDamageCallback(cBoundingBox & a_bbTNT, Vector3d a_ExplosionPos, int a_ExplosionSize) :
-			m_bbTNT(a_bbTNT),
-			m_ExplosionPos(a_ExplosionPos),
-			m_ExplosionSize(a_ExplosionSize)
+		cTNTDamageCallback(cBoundingBox & a_CBBBTNT, Vector3d a_CBExplosionPos, int a_CBExplosionSize) :
+			m_bbTNT(a_CBBBTNT),
+			m_ExplosionPos(a_CBExplosionPos),
+			m_ExplosionSize(a_CBExplosionSize)
 		{
 		}
 
@@ -2364,10 +2364,10 @@ bool cChunkMap::GenerateChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * 
 		class cPrepareLoadCallback: public cChunkCoordCallback
 		{
 		public:
-			cPrepareLoadCallback(cWorld & a_World, cChunkMap & a_ChunkMap, cChunkCoordCallback * a_Callback):
-				m_World(a_World),
-				m_ChunkMap(a_ChunkMap),
-				m_Callback(a_Callback)
+			cPrepareLoadCallback(cWorld & a_CBWorld, cChunkMap & a_CBChunkMap, cChunkCoordCallback * a_CBCallback):
+				m_World(a_CBWorld),
+				m_ChunkMap(a_CBChunkMap),
+				m_Callback(a_CBCallback)
 			{
 			}
 
@@ -2385,7 +2385,7 @@ bool cChunkMap::GenerateChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * 
 				}
 
 				// The chunk failed to load, generate it:
-				cCSLock Lock(m_ChunkMap.m_CSLayers);
+				cCSLock CBLock(m_ChunkMap.m_CSLayers);
 				cChunkPtr CBChunk = m_ChunkMap.GetChunkNoLoad(a_CBChunkX, a_CBChunkZ);
 
 				if (CBChunk == nullptr)

--- a/src/Entities/CMakeLists.txt
+++ b/src/Entities/CMakeLists.txt
@@ -61,10 +61,7 @@ SET (HDRS
 	WitherSkullEntity.h)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	set_source_files_properties(Entity.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=sign-conversion -Wno-error=global-constructors -Wno-error=switch-enum ")
-	set_source_files_properties(EntityEffect.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=switch-enum ")
-	set_source_files_properties(Floater.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=sign-conversion ")
-	set_source_files_properties(Player.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=sign-conversion -Wno-error=switch-enum -Wno-error=conversion ")
+	set_source_files_properties(Entity.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=global-constructors")
 endif()
 
 if(NOT MSVC)

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -908,7 +908,15 @@ void cPlayer::KilledBy(TakeDamageInfo & a_TDI)
 			case dtEnderPearl: DamageText = "misused an ender pearl"; break;
 			case dtAdmin: DamageText = "was administrator'd"; break;
 			case dtExplosion: DamageText = "blew up"; break;
-			default: DamageText = "died, somehow; we've no idea how though"; break;
+			case dtAttack: DamageText = "was attacked by thin air"; break;
+			#ifndef __clang__
+			default:
+			{
+				ASSERT(!"Unknown damage type");
+				DamageText = "died, somehow; we've no idea how though";
+				break;
+			}
+			#endif  // __clang__
 		}
 		AString DeathMessage = Printf("%s %s", GetName().c_str(), DamageText.c_str());
 		PluginManager->CallHookKilled(*this, a_TDI, DeathMessage);

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -1916,7 +1916,7 @@ void cProtocol180::AddReceivedData(const char * a_Data, size_t a_Size)
 				bb.ReadAll(Packet);
 				Packet.resize(Packet.size() - 1);  // Drop the final NUL pushed there for over-read detection
 				AString Out;
-				CreateHexDump(Out, Packet.data(), (int)Packet.size(), 24);
+				CreateHexDump(Out, Packet.data(), Packet.size(), 24);
 				LOGD("Packet contents:\n%s", Out.c_str());
 			#endif  // _DEBUG
 			
@@ -2145,7 +2145,7 @@ void cProtocol180::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffe
 
 	// Decrypt EncNonce using privkey
 	cRsaPrivateKey & rsaDecryptor = cRoot::Get()->GetServer()->GetPrivateKey();
-	Int32 DecryptedNonce[MAX_ENC_LEN / sizeof(Int32)];
+	UInt32 DecryptedNonce[MAX_ENC_LEN / sizeof(Int32)];
 	int res = rsaDecryptor.Decrypt(reinterpret_cast<const Byte *>(EncNonce.data()), EncNonce.size(), reinterpret_cast<Byte *>(DecryptedNonce), sizeof(DecryptedNonce));
 	if (res != 4)
 	{

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -706,10 +706,10 @@ bool cRoot::FindAndDoWithPlayer(const AString & a_PlayerName, cPlayerListCallbac
 		}
 
 	public:
-		cCallback (const AString & a_PlayerName) :
+		cCallback (const AString & a_CBPlayerName) :
 			m_BestRating(0),
-			m_NameLength(a_PlayerName.length()),
-			m_PlayerName(a_PlayerName),
+			m_NameLength(a_CBPlayerName.length()),
+			m_PlayerName(a_CBPlayerName),
 			m_BestMatch(),
 			m_NumMatches(0)
 		{}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,15 @@
 
 
 
+
+// Forward declarations to satisfy Clang's -Wmissing-variable-declarations:
+extern bool g_ShouldLogCommIn;
+extern bool g_ShouldLogCommOut;
+
+
+
+
+
 /** If something has told the server to stop; checked periodically in cRoot */
 bool cRoot::m_TerminateEventRaised = false;
 
@@ -67,7 +76,8 @@ Synchronize this with Server.cpp to enable the "dumpmem" console command. */
 
 
 
-void NonCtrlHandler(int a_Signal)
+#ifndef _DEBUG
+static void NonCtrlHandler(int a_Signal)
 {
 	LOGD("Terminate event raised from std::signal");
 	cRoot::Get()->QueueExecuteConsoleCommand("stop");
@@ -110,6 +120,7 @@ void NonCtrlHandler(int a_Signal)
 		default: break;
 	}
 }
+#endif  // _DEBUG
 
 
 
@@ -129,11 +140,11 @@ typedef BOOL  (WINAPI *pMiniDumpWriteDump)(
 	PMINIDUMP_CALLBACK_INFORMATION CallbackParam
 );
 
-pMiniDumpWriteDump g_WriteMiniDump;  // The function in dbghlp DLL that creates dump files
+static pMiniDumpWriteDump g_WriteMiniDump;  // The function in dbghlp DLL that creates dump files
 
-wchar_t g_DumpFileName[MAX_PATH];  // Filename of the dump file; hes to be created before the dump handler kicks in
-char g_ExceptionStack[128 * 1024];  // Substitute stack, just in case the handler kicks in because of "insufficient stack space"
-MINIDUMP_TYPE g_DumpFlags = MiniDumpNormal;  // By default dump only the stack and some helpers
+static wchar_t g_DumpFileName[MAX_PATH];  // Filename of the dump file; hes to be created before the dump handler kicks in
+static char g_ExceptionStack[128 * 1024];  // Substitute stack, just in case the handler kicks in because of "insufficient stack space"
+static MINIDUMP_TYPE g_DumpFlags = MiniDumpNormal;  // By default dump only the stack and some helpers
 
 
 
@@ -142,7 +153,7 @@ MINIDUMP_TYPE g_DumpFlags = MiniDumpNormal;  // By default dump only the stack a
 /** This function gets called just before the "program executed an illegal instruction and will be terminated" or similar.
 Its purpose is to create the crashdump using the dbghlp DLLs
 */
-LONG WINAPI LastChanceExceptionFilter(__in struct _EXCEPTION_POINTERS * a_ExceptionInfo)
+static LONG WINAPI LastChanceExceptionFilter(__in struct _EXCEPTION_POINTERS * a_ExceptionInfo)
 {
 	char * newStack = &g_ExceptionStack[sizeof(g_ExceptionStack) - 1];
 	char * oldStack;
@@ -185,7 +196,7 @@ LONG WINAPI LastChanceExceptionFilter(__in struct _EXCEPTION_POINTERS * a_Except
 
 #ifdef _WIN32
 // Handle CTRL events in windows, including console window close
-BOOL CtrlHandler(DWORD fdwCtrlType)
+static BOOL CtrlHandler(DWORD fdwCtrlType)
 {
 	cRoot::Get()->QueueExecuteConsoleCommand("stop");
 	LOGD("Terminate event raised from the Windows CtrlHandler");
@@ -204,7 +215,7 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 ////////////////////////////////////////////////////////////////////////////////
 // UniversalMain - Main startup logic for both standard running and as a service
 
-void UniversalMain(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
+static void UniversalMain(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 {
 	// Initialize logging subsystem:
 	cLogger::InitiateMultithreading();
@@ -242,7 +253,7 @@ void UniversalMain(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo
 ////////////////////////////////////////////////////////////////////////////////
 // serviceWorkerThread: Keep the service alive
 
-DWORD WINAPI serviceWorkerThread(LPVOID lpParam)
+static DWORD WINAPI serviceWorkerThread(LPVOID lpParam)
 {
 	UNREFERENCED_PARAMETER(lpParam);
 
@@ -262,7 +273,7 @@ DWORD WINAPI serviceWorkerThread(LPVOID lpParam)
 ////////////////////////////////////////////////////////////////////////////////
 // serviceSetState: Set the internal status of the service
 
-void serviceSetState(DWORD acceptedControls, DWORD newState, DWORD exitCode)
+static void serviceSetState(DWORD acceptedControls, DWORD newState, DWORD exitCode)
 {
 	SERVICE_STATUS serviceStatus = {};
 	serviceStatus.dwCheckPoint = 0;
@@ -285,7 +296,7 @@ void serviceSetState(DWORD acceptedControls, DWORD newState, DWORD exitCode)
 ////////////////////////////////////////////////////////////////////////////////
 // serviceCtrlHandler: Handle stop events from the Service Control Manager
 
-void WINAPI serviceCtrlHandler(DWORD CtrlCode)
+static void WINAPI serviceCtrlHandler(DWORD CtrlCode)
 {
 	switch (CtrlCode)
 	{
@@ -308,7 +319,7 @@ void WINAPI serviceCtrlHandler(DWORD CtrlCode)
 ////////////////////////////////////////////////////////////////////////////////
 // serviceMain: Startup logic for running as a service
 
-void WINAPI serviceMain(DWORD argc, TCHAR *argv[])
+static void WINAPI serviceMain(DWORD argc, TCHAR *argv[])
 {
 	wchar_t applicationFilename[MAX_PATH];
 	wchar_t applicationDirectory[MAX_PATH];
@@ -353,7 +364,7 @@ void WINAPI serviceMain(DWORD argc, TCHAR *argv[])
 
 
 
-std::unique_ptr<cMemorySettingsRepository> ParseArguments(int argc, char **argv)
+static std::unique_ptr<cMemorySettingsRepository> ParseArguments(int argc, char ** argv)
 {
 	try
 	{
@@ -434,7 +445,7 @@ std::unique_ptr<cMemorySettingsRepository> ParseArguments(int argc, char **argv)
 ////////////////////////////////////////////////////////////////////////////////
 // main:
 
-int main(int argc, char **argv)
+int main(int argc, char ** argv)
 {
 	#if defined(_MSC_VER) && defined(_DEBUG) && defined(ENABLE_LEAK_FINDER)
 		InitLeakFinder();


### PR DESCRIPTION
Fixed various Clang warnings and removed some file-specific warning flag exceptions.

Removed the `-Wswitch-enum` warning flag in favor of the `-Wswitch` flag which is much more logical.