### PR TITLE
Fix for issue #2218

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -35,7 +35,8 @@ public:
 	const cVector3iArray GetTerracingConnectionOffsets(const Vector3i & a_Position)
 	{
 		cVector3iArray RelativePositions;
-		bool IsYPTerracingBlocked = cBlockInfo::IsSolid(m_World.GetBlock(a_Position + OffsetYP()));
+		auto YPTerraceBlock = m_World.GetBlock(a_Position + OffsetYP());
+		bool IsYPTerracingBlocked = cBlockInfo::IsSolid(YPTerraceBlock) && !cBlockInfo::IsTransparent(YPTerraceBlock);
 
 		for (const auto & Adjacent : GetRelativeLaterals())
 		{
@@ -46,9 +47,10 @@ public:
 			{
 				RelativePositions.emplace_back(Adjacent + OffsetYP());
 			}
-
+			auto YMTerraceBlock = m_World.GetBlock(a_Position + Adjacent);
 			if (
-				!cBlockInfo::IsSolid(m_World.GetBlock(a_Position + Adjacent)) &&  // IsYMTerracingBlocked (i.e. check block above lower terracing position, a.k.a. just the plain adjacent)
+				// IsYMTerracingBlocked (i.e. check block above lower terracing position, a.k.a. just the plain adjacent)
+				(!cBlockInfo::IsSolid(YMTerraceBlock) || cBlockInfo::IsTransparent(YMTerraceBlock)) &&
 				(m_World.GetBlock(a_Position + Adjacent + OffsetYM()) == E_BLOCK_REDSTONE_WIRE)
 			)
 			{


### PR DESCRIPTION
Fixed issue #2218 where redstone wire is blocked by transparent blocks when they shouldn't.