### PR TITLE
Changed the format of the MobHead data

### DIFF
--- a/Server/Plugins/APIDump/Classes/BlockEntities.lua
+++ b/Server/Plugins/APIDump/Classes/BlockEntities.lua
@@ -282,10 +282,13 @@ World:ForEachChestInChunk(Player:GetChunkX(), Player:GetChunkZ(),
 		{
 			SetType = { Params = "eMobHeadType", Return = "", Notes = "Set the type of the mob head" },
 			SetRotation = { Params = "eMobHeadRotation", Return = "", Notes = "Sets the rotation of the mob head" },
-			SetOwner = { Params = "string", Return = "", Notes = "Set the player name for mob heads with player type" },
+			SetOwner = { Params = "cPlayer", Return = "", Notes = "Set the {{cPlayer|player}} for mob heads with player type" },
 			GetType = { Params = "", Return = "eMobHeadType", Notes = "Returns the type of the mob head" },
 			GetRotation = { Params = "", Return = "eMobHeadRotation", Notes = "Returns the rotation of the mob head" },
-			GetOwner = { Params = "", Return = "string", Notes = "Returns the player name of the mob head" },
+			GetOwnerName = { Params = "", Return = "string", Notes = "Returns the player name of the mob head" },
+			GetOwnerUUID = { Params = "", Return = "string", Notes = "Returns the player UUID of the mob head" },
+			GetOwnerTexture = { Params = "", Return = "string", Notes = "Returns the player texture of the mob head" },
+			GetOwnerTextureSignature = { Params = "", Return = "string", Notes = "Returns the signature of the player texture of the mob head" },
 		},
 	},  -- cMobHeadEntity
 

--- a/src/BlockEntities/MobHeadEntity.cpp
+++ b/src/BlockEntities/MobHeadEntity.cpp
@@ -14,8 +14,7 @@
 cMobHeadEntity::cMobHeadEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World) :
 	super(E_BLOCK_HEAD, a_BlockX, a_BlockY, a_BlockZ, a_World),
 	m_Type(SKULL_TYPE_SKELETON),
-	m_Rotation(SKULL_ROTATION_NORTH),
-	m_Owner("")
+	m_Rotation(SKULL_ROTATION_NORTH)
 {
 }
 
@@ -35,9 +34,9 @@ bool cMobHeadEntity::UsedBy(cPlayer * a_Player)
 
 void cMobHeadEntity::SetType(const eMobHeadType & a_Type)
 {
-	if ((!m_Owner.empty()) && (a_Type != SKULL_TYPE_PLAYER))
+	if ((!m_OwnerName.empty()) && (a_Type != SKULL_TYPE_PLAYER))
 	{
-		m_Owner = "";
+		m_OwnerName = m_OwnerUUID = m_OwnerTexture = m_OwnerTextureSignature = "";
 	}
 	m_Type = a_Type;
 }
@@ -55,13 +54,43 @@ void cMobHeadEntity::SetRotation(eMobHeadRotation a_Rotation)
 
 
 
-void cMobHeadEntity::SetOwner(const AString & a_Owner)
+void cMobHeadEntity::SetOwner(const cPlayer & a_Owner)
 {
-	if ((a_Owner.length() > 16) || (m_Type != SKULL_TYPE_PLAYER))
+	if (m_Type != SKULL_TYPE_PLAYER)
 	{
 		return;
 	}
-	m_Owner = a_Owner;
+
+	m_OwnerName = a_Owner.GetName();
+	m_OwnerUUID = a_Owner.GetUUID();
+
+	const Json::Value & Properties = a_Owner.GetClientHandle()->GetProperties();
+	for (auto & Node : Properties)
+	{
+		if (Node.get("name", "").asString() == "textures")
+		{
+			m_OwnerTexture = Node.get("value", "").asString();
+			m_OwnerTextureSignature = Node.get("signature", "").asString();
+			break;
+		}
+	}
+}
+
+
+
+
+
+void cMobHeadEntity::SetOwner(const AString & a_OwnerUUID, const AString & a_OwnerName, const AString & a_OwnerTexture, const AString & a_OwnerTextureSignature)
+{
+	if (m_Type != SKULL_TYPE_PLAYER)
+	{
+		return;
+	}
+
+	m_OwnerUUID = a_OwnerUUID;
+	m_OwnerName = a_OwnerName;
+	m_OwnerTexture = a_OwnerTexture;
+	m_OwnerTextureSignature = a_OwnerTextureSignature;
 }
 
 

--- a/src/BlockEntities/MobHeadEntity.h
+++ b/src/BlockEntities/MobHeadEntity.h
@@ -39,8 +39,11 @@ public:
 	/** Set the rotation of the mob head */
 	void SetRotation(eMobHeadRotation a_Rotation);
 	
-	/** Set the player name for mob heads with player type */
-	void SetOwner(const AString & a_Owner);
+	/** Set the player for mob heads with player type */
+	void SetOwner(const cPlayer & a_Owner);
+
+	/** Sets the player components for the mob heads with player type */
+	void SetOwner(const AString & a_OwnerUUID, const AString & a_OwnerName, const AString & a_OwnerTexture, const AString & a_OwnerTextureSignature);
 	
 	/** Returns the type of the mob head */
 	eMobHeadType GetType(void) const { return m_Type; }
@@ -49,7 +52,16 @@ public:
 	eMobHeadRotation GetRotation(void) const { return m_Rotation; }
 	
 	/** Returns the player name of the mob head */
-	AString GetOwner(void) const { return m_Owner; }
+	AString GetOwnerName(void) const { return m_OwnerName; }
+
+	/** Returns the player UUID of the mob head */
+	AString GetOwnerUUID(void) const { return m_OwnerUUID; }
+
+	/** Returns the texture of the mob head */
+	AString GetOwnerTexture(void) const { return m_OwnerTexture; }
+
+	/** Returns the texture signature of the mob head */
+	AString GetOwnerTextureSignature(void) const { return m_OwnerTextureSignature; }
 	
 	// tolua_end
 	
@@ -60,7 +72,11 @@ private:
 
 	eMobHeadType m_Type;
 	eMobHeadRotation m_Rotation;
-	AString m_Owner;
+
+	AString m_OwnerName;
+	AString m_OwnerUUID;
+	AString m_OwnerTexture;
+	AString m_OwnerTextureSignature;
 } ;  // tolua_export
 
 

--- a/src/Protocol/Protocol17x.cpp
+++ b/src/Protocol/Protocol17x.cpp
@@ -2784,7 +2784,7 @@ void cProtocol172::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_
 			Writer.AddInt("z", MobHeadEntity.GetPosZ());
 			Writer.AddByte("SkullType", MobHeadEntity.GetType() & 0xFF);
 			Writer.AddByte("Rot", MobHeadEntity.GetRotation() & 0xFF);
-			Writer.AddString("ExtraType", MobHeadEntity.GetOwner().c_str());
+			Writer.AddString("ExtraType", MobHeadEntity.GetOwnerName());
 			Writer.AddString("id", "Skull");  // "Tile Entity ID" - MC wiki; vanilla server always seems to send this though
 			break;
 		}

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -3109,8 +3109,21 @@ void cProtocol180::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_
 			Writer.AddInt("z", MobHeadEntity.GetPosZ());
 			Writer.AddByte("SkullType", MobHeadEntity.GetType() & 0xFF);
 			Writer.AddByte("Rot", MobHeadEntity.GetRotation() & 0xFF);
-			Writer.AddString("ExtraType", MobHeadEntity.GetOwner().c_str());
 			Writer.AddString("id", "Skull");  // "Tile Entity ID" - MC wiki; vanilla server always seems to send this though
+
+			// The new Block Entity format for a Mob Head. See: http://minecraft.gamepedia.com/Head#Block_entity
+			Writer.BeginCompound("Owner");
+				Writer.AddString("Id", MobHeadEntity.GetOwnerUUID());
+				Writer.AddString("Name", MobHeadEntity.GetOwnerName());
+				Writer.BeginCompound("Properties");
+					Writer.BeginList("textures", TAG_Compound);
+						Writer.BeginCompound("");
+							Writer.AddString("Signature", MobHeadEntity.GetOwnerTextureSignature());
+							Writer.AddString("Value", MobHeadEntity.GetOwnerTexture());
+						Writer.EndCompound();
+					Writer.EndList();
+				Writer.EndCompound();
+			Writer.EndCompound();
 			break;
 		}
 

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -358,7 +358,20 @@ void cNBTChunkSerializer::AddMobHeadEntity(cMobHeadEntity * a_MobHead)
 		AddBasicTileEntity(a_MobHead, "Skull");
 		m_Writer.AddByte  ("SkullType", a_MobHead->GetType() & 0xFF);
 		m_Writer.AddByte  ("Rot",       a_MobHead->GetRotation() & 0xFF);
-		m_Writer.AddString("ExtraType", a_MobHead->GetOwner());
+
+		// The new Block Entity format for a Mob Head. See: http://minecraft.gamepedia.com/Head#Block_entity
+		m_Writer.BeginCompound("Owner");
+			m_Writer.AddString("Id", a_MobHead->GetOwnerUUID());
+			m_Writer.AddString("Name", a_MobHead->GetOwnerName());
+			m_Writer.BeginCompound("Properties");
+				m_Writer.BeginList("textures", TAG_Compound);
+					m_Writer.BeginCompound("");
+						m_Writer.AddString("Signature", a_MobHead->GetOwnerTextureSignature());
+						m_Writer.AddString("Value", a_MobHead->GetOwnerTexture());
+					m_Writer.EndCompound();
+				m_Writer.EndList();
+			m_Writer.EndCompound();
+		m_Writer.EndCompound();
 	m_Writer.EndCompound();
 }
 

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -1293,10 +1293,47 @@ cBlockEntity * cWSSAnvil::LoadMobHeadFromNBT(const cParsedNBT & a_NBT, int a_Tag
 		MobHead->SetRotation(static_cast<eMobHeadRotation>(a_NBT.GetByte(currentLine)));
 	}
 
-	currentLine = a_NBT.FindChildByName(a_TagIdx, "ExtraType");
-	if (currentLine >= 0)
+	int ownerLine = a_NBT.FindChildByName(a_TagIdx, "Owner");
+	if (ownerLine >= 0)
 	{
-		MobHead->SetOwner(a_NBT.GetString(currentLine));
+		AString OwnerName, OwnerUUID, OwnerTexture, OwnerTextureSignature;
+
+		currentLine = a_NBT.FindChildByName(ownerLine, "Id");
+		if (currentLine >= 0)
+		{
+			OwnerUUID = a_NBT.GetString(currentLine);
+		}
+
+		currentLine = a_NBT.FindChildByName(ownerLine, "Name");
+		if (currentLine >= 0)
+		{
+			OwnerName = a_NBT.GetString(currentLine);
+		}
+
+		int textureLine = a_NBT.GetFirstChild(  // The first texture of
+			a_NBT.FindChildByName(              // The texture list of
+				a_NBT.FindChildByName(          // The Properties compound of
+					ownerLine,                  // The Owner compound
+					"Properties"
+				),
+				"textures"
+			)
+		);
+		if (textureLine >= 0)
+		{
+			currentLine = a_NBT.FindChildByName(textureLine, "Signature");
+			if (currentLine >= 0)
+			{
+				OwnerTextureSignature = a_NBT.GetString(currentLine);
+			}
+
+			currentLine = a_NBT.FindChildByName(textureLine, "Value");
+			if (currentLine >= 0)
+			{
+				OwnerTexture = a_NBT.GetString(currentLine);
+			}
+		}
+		MobHead->SetOwner(OwnerUUID, OwnerName, OwnerTexture, OwnerTextureSignature);
 	}
 
 	return MobHead.release();


### PR DESCRIPTION
The NBT format now carries the texture data and transmit it to the client.
This now fixes the displaying of MobHeads in MInecraft 1.8.
See: http://minecraft.gamepedia.com/Head#Block_entity
Related to #2674