### PR TITLE
Limited the username length to 16 characters.

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1719,6 +1719,12 @@ bool cClientHandle::CheckMultiLogin(const AString & a_Username)
 
 bool cClientHandle::HandleHandshake(const AString & a_Username)
 {
+	if (a_Username.length() > 16)
+	{
+		Kick("Your username is too long(>16 characters)");
+		return false;
+	}
+
 	if (!cRoot::Get()->GetPluginManager()->CallHookHandshake(*this, a_Username))
 	{
 		if (cRoot::Get()->GetServer()->GetNumPlayers() >= cRoot::Get()->GetServer()->GetMaxPlayers())

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -89,6 +89,8 @@ cPlayer::cPlayer(cClientHandlePtr a_Client, const AString & a_PlayerName) :
 	m_UUID((a_Client != nullptr) ? a_Client->GetUUID() : ""),
 	m_CustomName("")
 {
+	ASSERT(a_PlayerName.length() <= 16);  // Otherwise this player could crash many clients...
+
 	m_InventoryWindow = new cInventoryWindow(*this);
 	m_CurrentWindow = m_InventoryWindow;
 	m_InventoryWindow->OpenedByPlayer(*this);


### PR DESCRIPTION
This fixes a client crash, because Minecraft requires that a username is not longer than 16 characters.
See also: http://minecraft.gamepedia.com/The_Player#Name
Fixes #2545