### PR TITLE
Fixed race conditions

### DIFF
--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -415,7 +415,7 @@ private:
 	int m_LastStreamedChunkZ;
 
 	/** Number of ticks since the last network packet was received (increased in Tick(), reset in OnReceivedData()) */
-	int m_TicksSinceLastPacket;
+	std::atomic<int> m_TicksSinceLastPacket;
 	
 	/** Duration of the last completed client ping. */
 	std::chrono::steady_clock::duration m_Ping;

--- a/src/Server.h
+++ b/src/Server.h
@@ -189,7 +189,7 @@ private:
 
 	bool m_bIsConnected;  // true - connected false - not connected
 
-	bool m_bRestarting;
+	std::atomic<bool> m_bRestarting;
 	
 	/** The private key used for the assymetric encryption start in the protocols */
 	cRsaPrivateKey m_PrivateKey;


### PR DESCRIPTION
Fixed a few race conditions.

`m_TicksSinceLastPacket`is accessed on line [ClientHandle.cpp:2018](https://github.com/cuberite/cuberite/blob/master/src/ClientHandle.cpp#L2018) and line [ClientHandle.cpp:3063](https://github.com/cuberite/cuberite/blob/master/src/ClientHandle.cpp#L3063).

Reverted: ~~[`LogSimple`](https://github.com/cuberite/cuberite/blob/master/src/Logger.cpp#L33) is called from different threads on startup, moving the lock to the top of the method fixes the race.~~

`m_bRestarting` is accessed fom `Server::Tick`, [Server.cpp:639](https://github.com/cuberite/cuberite/blob/master/src/Server.cpp#L639) and [Server.cpp:335](https://github.com/cuberite/cuberite/blob/master/src/Server.cpp#L639)
