### PR TITLE
LuaTCPLink: Report data received via SSL just before connection closed.

### DIFF
--- a/src/Bindings/LuaTCPLink.cpp
+++ b/src/Bindings/LuaTCPLink.cpp
@@ -416,9 +416,10 @@ void cLuaTCPLink::OnReceivedData(const char * a_Data, size_t a_Length)
 	}
 
 	// If we're running in SSL mode, put the data into the SSL decryptor:
-	if (m_SslContext != nullptr)
+	auto sslContext = m_SslContext;
+	if (sslContext != nullptr)
 	{
-		m_SslContext->StoreReceivedData(a_Data, a_Length);
+		sslContext->StoreReceivedData(a_Data, a_Length);
 		return;
 	}
 
@@ -440,6 +441,13 @@ void cLuaTCPLink::OnRemoteClosed(void)
 	if (!m_Callbacks.IsValid())
 	{
 		return;
+	}
+
+	// If running in SSL mode and there's data left in the SSL contect, report it:
+	auto sslContext = m_SslContext;
+	if (sslContext != nullptr)
+	{
+		sslContext->FlushBuffers();
 	}
 
 	// Call the callback:


### PR DESCRIPTION
DO NOT MERGE YET, this is for shared testing.

@LogicParrot edit:
Binaries for testing
 - [Windows x64](https://builds.cuberite.org/job/Cuberite%20Windows%20x64%20pr-testing/1/artifact/Install/Cuberite.zip)
 - [Gnu/Linux x64](https://builds.cuberite.org/job/Cuberite%20Linux%20x64%20pr-testing/1/artifact/Cuberite.tar.gz)