### PR TITLE
Fix running as a service.

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -92,7 +92,8 @@ void cRoot::InputThread(cRoot & a_Params)
 	}
 
 	// We have come here because the std::cin has received an EOF / a terminate signal has been sent, and the server is still running
-	if (!std::cin.good())
+	// Ignore this when running as a service, cin was never opened in that case
+	if (!std::cin.good() && !m_RunAsService)
 	{
 		// Stop the server:
 		a_Params.QueueExecuteConsoleCommand("stop");
@@ -232,15 +233,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 		{
 			m_StopEvent.Wait();
 
-			if (m_TerminateEventRaised && m_RunAsService)
-			{
-				// Dont kill if running as a service
-				m_TerminateEventRaised = false;
-			}
-			else
-			{
-				break;
-			}
+			break;
 		}
 
 		// Stop the server:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,6 +495,9 @@ int main(int argc, char ** argv)
 		}
 	#endif
 
+	// Make sure m_RunAsService is set correctly before checking it's value
+	ParseArguments(argc, argv);
+
 	// Attempt to run as a service
 	if (cRoot::m_RunAsService)
 	{


### PR DESCRIPTION
Two problems identified, both traced to commit 4315a11
Fixes #2900 

(main.cpp) ParseArguments() was no longer being called before checking cRoot::m_RunAsService.
This led to m_RunAsService never being set (we use -d on the command line to instigate a service start).

(Root.cpp) Terminate events were being ignored when running as a service.
We only need to ignore the cin.good() call, not terminate events as a whole.