### PR TITLE
Fix cPawn push logic

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1864,6 +1864,19 @@ bool cEntity::IsA(const char * a_ClassName) const
 
 
 
+bool cEntity::IsAttachedTo(const cEntity * a_Entity) const
+{
+	if ((m_AttachedTo != nullptr) && (a_Entity->GetUniqueID() == m_AttachedTo->GetUniqueID()))
+	{
+		return true;
+	}
+	return false;
+}
+
+
+
+
+
 void cEntity::SetHeadYaw(double a_HeadYaw)
 {
 	m_HeadYaw = a_HeadYaw;

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -423,6 +423,9 @@ public:
 	/** Detaches from the currently attached entity, if any */
 	virtual void Detach(void);
 
+	/** Returns true if this entity is attached to the specified entity */
+	bool IsAttachedTo(const cEntity * a_Entity) const;
+
 	/** Makes sure head yaw is not over the specified range. */
 	void WrapHeadYaw();
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -73,6 +73,12 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 				return false;
 			}
 
+			// do not push a boat / minecart you're sitting in
+			if (m_Pusher->IsAttachedTo(a_Entity))
+			{
+				return false;
+			}
+
 			Vector3d v3Delta = a_Entity->GetPosition() - m_Pusher->GetPosition();
 			v3Delta.y = 0.0;  // we only push sideways
 			v3Delta *= 1.0 / (v3Delta.Length() + 0.01);  // we push harder if we're close


### PR DESCRIPTION
This adds a boolean IsAttachedTo method to cEntity and cPawn uses it to perform a check before a cPawn instance pushes another entity. fixes #2886 