### PR TITLE
cMonster::m_target safety across worlds

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1959,6 +1959,10 @@ bool cChunk::ForEachEntity(cEntityCallback & a_Callback)
 	for (cEntityList::iterator itr = m_Entities.begin(), itr2 = itr; itr != m_Entities.end(); itr = itr2)
 	{
 		++itr2;
+		if ((*itr)->IsDestroyed())
+		{
+			continue;
+		}
 		if (a_Callback.Item(*itr))
 		{
 			return false;
@@ -1977,6 +1981,10 @@ bool cChunk::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback & a_
 	for (cEntityList::iterator itr = m_Entities.begin(), itr2 = itr; itr != m_Entities.end(); itr = itr2)
 	{
 		++itr2;
+		if ((*itr)->IsDestroyed())
+		{
+			continue;
+		}
 		cBoundingBox EntBox((*itr)->GetPosition(), (*itr)->GetWidth() / 2, (*itr)->GetHeight());
 		if (!EntBox.DoesIntersect(a_Box))
 		{
@@ -2000,7 +2008,7 @@ bool cChunk::DoWithEntityByID(UInt32 a_EntityID, cEntityCallback & a_Callback, b
 	// The entity list is locked by the parent chunkmap's CS
 	for (cEntityList::iterator itr = m_Entities.begin(), end = m_Entities.end(); itr != end; ++itr)
 	{
-		if ((*itr)->GetUniqueID() == a_EntityID)
+		if (((*itr)->GetUniqueID() == a_EntityID) && (!(*itr)->IsDestroyed()))
 		{
 			a_CallbackResult = a_Callback.Item(*itr);
 			return true;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1514,6 +1514,13 @@ bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 
 	SetPosition(a_NewPosition);
 
+	if (this->IsMob())
+	{
+		cMonster * Monster = static_cast<cMonster*>(this);
+		Monster->SetTarget(nullptr);
+		Monster->StopEveryoneFromTargetingMe();
+	}
+
 	// Queue add to new world
 	a_World->AddEntity(this);
 	cWorld * OldWorld = cRoot::Get()->GetWorld(GetWorld()->GetName());  // Required for the hook HOOK_ENTITY_CHANGED_WORLD

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -4,6 +4,9 @@
 #include "Entity.h"
 #include "EntityEffect.h"
 
+// fwd cMonster
+class cMonster;
+
 
 
 
@@ -14,21 +17,28 @@ class cPawn :
 {
 	// tolua_end
 	typedef cEntity super;
-	
+
 public:
 	CLASS_PROTODEF(cPawn)
 
 	cPawn(eEntityType a_EntityType, double a_Width, double a_Height);
-	
+	~cPawn();
+	virtual void Destroyed() override;
+
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
-	
+
 	virtual bool IsFireproof(void) const override;
 	virtual void HandleAir(void) override;
 	virtual void HandleFalling(void);
 
+	/** Tells all pawns which are targeting us to stop targeting us. */
+	void StopEveryoneFromTargetingMe();
+
+
+
 	// tolua_begin
-	
+
 	/** Applies an entity effect
 	Checks with plugins if they allow the addition.
 	@param a_EffectType          The entity effect to apply
@@ -37,21 +47,27 @@ public:
 	@param a_DistanceModifier    The scalar multiplied to the potion duration, only applies to splash potions)
 	*/
 	void AddEntityEffect(cEntityEffect::eType a_EffectType, int a_EffectDurationTicks, short a_EffectIntensity, double a_DistanceModifier = 1);
-	
+
 	/** Removes a currently applied entity effect
 	@param a_EffectType The entity effect to remove
 	*/
 	void RemoveEntityEffect(cEntityEffect::eType a_EffectType);
-	
+
 	/** Returns true, if the entity effect is currently applied
 	@param a_EffectType The entity effect to check
 	*/
 	bool HasEntityEffect(cEntityEffect::eType a_EffectType) const;
-	
+
 	/** Removes all currently applied entity effects (used when drinking milk) */
 	void ClearEntityEffects(void);
 
 	// tolua_end
+
+	/** remove the monster from the list of monsters targeting this pawn. */
+	void NoLongerTargetingMe(cMonster * a_Monster);
+
+	/** Add the monster to the list of monsters targeting this pawn. (Does not check if already in list!) */
+	void TargetingMe(cMonster * a_Monster);
 
 protected:
 	typedef std::map<cEntityEffect::eType, cEntityEffect *> tEffectMap;
@@ -59,6 +75,11 @@ protected:
 
 	double m_LastGroundHeight;
 	bool m_bTouchGround;
+
+private:
+
+	/** A list of all monsters that are targeting this pawn. */
+	std::vector<cMonster*> m_TargetingMe;
 } ;  // tolua_export
 
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -176,6 +176,7 @@ cPlayer::~cPlayer(void)
 void cPlayer::Destroyed()
 {
 	CloseWindow(false);
+	super::Destroyed();
 }
 
 
@@ -1681,7 +1682,6 @@ void cPlayer::FreezeInternal(const Vector3d & a_Location, bool a_ManuallyFrozen)
 bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
 {
 	ASSERT(a_World != nullptr);
-
 	if (GetWorld() == a_World)
 	{
 		// Don't move to same world
@@ -1708,6 +1708,9 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 
 	// Remove player from world
 	GetWorld()->RemovePlayer(this, false);
+	// Stop all mobs from targeting this player
+
+	StopEveryoneFromTargetingMe();
 
 	// Send the respawn packet:
 	if (a_ShouldSendRespawn && (m_ClientHandle != nullptr))
@@ -1719,6 +1722,9 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 	GetWorld()->BroadcastDestroyEntity(*this);
 
 	SetPosition(a_NewPosition);
+
+	// Stop all mobs from targeting this player
+	StopEveryoneFromTargetingMe();
 
 	// Queue adding player to the new world, including all the necessary adjustments to the object
 	a_World->AddPlayer(this);

--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -26,9 +26,9 @@ void cAggressiveMonster::InStateChasing(std::chrono::milliseconds a_Dt, cChunk &
 {
 	super::InStateChasing(a_Dt, a_Chunk);
 
-	if (m_Target != nullptr)
+	if (GetTarget() != nullptr)
 	{
-		MoveToPosition(m_Target->GetPosition());
+		MoveToPosition(GetTarget()->GetPosition());
 	}
 }
 
@@ -62,14 +62,14 @@ void cAggressiveMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		CheckEventSeePlayer(a_Chunk);
 	}
 
-	if (m_Target == nullptr)
+	if (GetTarget() == nullptr)
 	{
 		return;
 	}
 
 	cTracer LineOfSight(GetWorld());
 	Vector3d MyHeadPosition = GetPosition() + Vector3d(0, GetHeight(), 0);
-	Vector3d AttackDirection(m_Target->GetPosition() + Vector3d(0, m_Target->GetHeight(), 0) - MyHeadPosition);
+	Vector3d AttackDirection(GetTarget()->GetPosition() + Vector3d(0, GetTarget()->GetHeight(), 0) - MyHeadPosition);
 
 
 	if (TargetIsInRange() && !LineOfSight.Trace(MyHeadPosition, AttackDirection, static_cast<int>(AttackDirection.Length())) && (GetHealth() > 0.0))
@@ -85,14 +85,14 @@ void cAggressiveMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 bool cAggressiveMonster::Attack(std::chrono::milliseconds a_Dt)
 {
-	if ((m_Target == nullptr) || (m_AttackCoolDownTicksLeft != 0))
+	if ((GetTarget() == nullptr) || (m_AttackCoolDownTicksLeft != 0))
 	{
 		return false;
 	}
 
 	// Setting this higher gives us more wiggle room for attackrate
 	ResetAttackCooldown();
-	m_Target->TakeDamage(dtMobAttack, this, m_AttackDamage, 0);
+	GetTarget()->TakeDamage(dtMobAttack, this, m_AttackDamage, 0);
 
 	return true;
 }

--- a/src/Mobs/Blaze.cpp
+++ b/src/Mobs/Blaze.cpp
@@ -34,7 +34,7 @@ void cBlaze::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 
 bool cBlaze::Attack(std::chrono::milliseconds a_Dt)
 {
-	if ((m_Target != nullptr) && (m_AttackCoolDownTicksLeft == 0))
+	if ((GetTarget() != nullptr) && (m_AttackCoolDownTicksLeft == 0))
 	{
 		// Setting this higher gives us more wiggle room for attackrate
 		Vector3d Speed = GetLookVector() * 20;

--- a/src/Mobs/CaveSpider.cpp
+++ b/src/Mobs/CaveSpider.cpp
@@ -33,11 +33,11 @@ bool cCaveSpider::Attack(std::chrono::milliseconds a_Dt)
 	{
 		return false;
 	}
-	
-	if (m_Target->IsPawn())
+
+	if (GetTarget()->IsPawn())
 	{
 		// TODO: Easy = no poison, Medium = 7 seconds, Hard = 15 seconds
-		static_cast<cPawn *>(m_Target)->AddEntityEffect(cEntityEffect::effPoison, 7 * 20, 0);
+		static_cast<cPawn *>(GetTarget())->AddEntityEffect(cEntityEffect::effPoison, 7 * 20, 0);
 	}
 	return true;
 }

--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -27,7 +27,7 @@ void cCreeper::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
 
-	if ((m_Target == nullptr) || (!TargetIsInRange() && !m_BurnedWithFlintAndSteel))
+	if ((GetTarget() == nullptr) || (!TargetIsInRange() && !m_BurnedWithFlintAndSteel))
 	{
 		if (m_bIsBlowing)
 		{

--- a/src/Mobs/Enderman.cpp
+++ b/src/Mobs/Enderman.cpp
@@ -104,7 +104,7 @@ void cEnderman::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 
 void cEnderman::CheckEventSeePlayer(cChunk & a_Chunk)
 {
-	if (m_Target != nullptr)
+	if (GetTarget() != nullptr)
 	{
 		return;
 	}

--- a/src/Mobs/Ghast.cpp
+++ b/src/Mobs/Ghast.cpp
@@ -34,7 +34,7 @@ void cGhast::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 
 bool cGhast::Attack(std::chrono::milliseconds a_Dt)
 {
-	if ((m_Target != nullptr) && (m_AttackCoolDownTicksLeft == 0))
+	if ((GetTarget() != nullptr) && (m_AttackCoolDownTicksLeft == 0))
 	{
 		// Setting this higher gives us more wiggle room for attackrate
 		Vector3d Speed = GetLookVector() * 20;

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -44,6 +44,10 @@ public:
 	*/
 	cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, double a_Width, double a_Height);
 
+	~cMonster();
+
+	virtual void Destroyed() override;
+
 	CLASS_PROTODEF(cMonster)
 
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
@@ -156,6 +160,16 @@ public:
 
 	// tolua_end
 
+	/** Sets the target that this mob will chase. Pass a nullptr to unset. */
+	void SetTarget (cPawn * a_NewTarget);
+
+	/** Unset the target without notifying the target entity. Do not use this, use SetTarget(nullptr) instead.
+	This is only used by cPawn internally. */
+	void UnsafeUnsetTarget();
+
+	/** Returns the current target. */
+	cPawn * GetTarget ();
+
 	/** Creates a new object of the specified mob.
 	a_MobType is the type of the mob to be created
 	Asserts and returns null if mob type is not specified
@@ -163,9 +177,6 @@ public:
 	static cMonster * NewMonsterFromType(eMonsterType a_MobType);
 
 protected:
-
-	/** A pointer to the entity this mobile is aiming to reach */
-	cEntity * m_Target;
 
 	/** The pathfinder instance handles pathfinding for this monster. */
 	cPathFinder m_PathFinder;
@@ -254,5 +265,9 @@ protected:
 
 	/** Adds weapon that is equipped with the chance saved in m_DropChance[...] (this will be greter than 1 if picked up or 0.085 + (0.01 per LootingLevel) if born with) to the drop */
 	void AddRandomWeaponDropItem(cItems & a_Drops, unsigned int a_LootingLevel);
+
+private:
+	/** A pointer to the entity this mobile is aiming to reach */
+	cPawn * m_Target;
 
 } ;  // tolua_export

--- a/src/Mobs/PassiveAggressiveMonster.cpp
+++ b/src/Mobs/PassiveAggressiveMonster.cpp
@@ -26,9 +26,9 @@ bool cPassiveAggressiveMonster::DoTakeDamage(TakeDamageInfo & a_TDI)
 		return false;
 	}
 
-	if ((m_Target != nullptr) && (m_Target->IsPlayer()))
+	if ((GetTarget() != nullptr) && (GetTarget()->IsPlayer()))
 	{
-		if (!static_cast<cPlayer *>(m_Target)->IsGameModeCreative())
+		if (!static_cast<cPlayer *>(GetTarget())->IsGameModeCreative())
 		{
 			m_EMState = CHASING;
 		}

--- a/src/Mobs/Skeleton.cpp
+++ b/src/Mobs/Skeleton.cpp
@@ -52,10 +52,10 @@ bool cSkeleton::Attack(std::chrono::milliseconds a_Dt)
 {
 	StopMovingToPosition();  // Todo handle this in a better way, the skeleton does some uneeded recalcs due to inStateChasing
 	cFastRandom Random;
-	if ((m_Target != nullptr) && (m_AttackCoolDownTicksLeft == 0))
+	if ((GetTarget() != nullptr) && (m_AttackCoolDownTicksLeft == 0))
 	{
 		Vector3d Inaccuracy = Vector3d(Random.NextFloat(0.5) - 0.25, Random.NextFloat(0.5) - 0.25, Random.NextFloat(0.5) - 0.25);
-		Vector3d Speed = (m_Target->GetPosition() + Inaccuracy - GetPosition()) * 5;
+		Vector3d Speed = (GetTarget()->GetPosition() + Inaccuracy - GetPosition()) * 5;
 		Speed.y = Speed.y - 1 + Random.NextInt(3);
 		cArrowEntity * Arrow = new cArrowEntity(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
 		if (Arrow == nullptr)

--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -30,7 +30,7 @@ cWolf::cWolf(void) :
 
 bool cWolf::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
-	cEntity * PreviousTarget = m_Target;
+	cPawn * PreviousTarget = GetTarget();
 	if (!super::DoTakeDamage(a_TDI))
 	{
 		return false;
@@ -38,14 +38,13 @@ bool cWolf::DoTakeDamage(TakeDamageInfo & a_TDI)
 
 	if ((a_TDI.Attacker != nullptr) && a_TDI.Attacker->IsPawn())
 	{
-		cPawn * Pawn = static_cast<cPawn*>(m_Target);
-		if (Pawn->IsPlayer())
+		if (GetTarget()->IsPlayer())
 		{
 			if (m_IsTame)
 			{
-				if ((static_cast<cPlayer*>(Pawn)->GetUUID() == m_OwnerUUID))
+				if ((static_cast<cPlayer*>(GetTarget())->GetUUID() == m_OwnerUUID))
 				{
-					m_Target = PreviousTarget;  // Do not attack owner
+					SetTarget(PreviousTarget);  // Do not attack owner
 				}
 				else
 				{
@@ -100,16 +99,16 @@ bool cWolf::Attack(std::chrono::milliseconds a_Dt)
 {
 	UNUSED(a_Dt);
 
-	if ((m_Target != nullptr) && (m_Target->IsPlayer()))
+	if ((GetTarget() != nullptr) && (GetTarget()->IsPlayer()))
 	{
-		if (static_cast<cPlayer *>(m_Target)->GetUUID() == m_OwnerUUID)
+		if (static_cast<cPlayer *>(GetTarget())->GetUUID() == m_OwnerUUID)
 		{
-			m_Target = nullptr;
+			SetTarget(nullptr);
 			return false;
 		}
 	}
 
-	NotifyAlliesOfFight(static_cast<cPawn*>(m_Target));
+	NotifyAlliesOfFight(static_cast<cPawn*>(GetTarget()));
 	return super::Attack(a_Dt);
 
 }
@@ -129,7 +128,7 @@ void cWolf::ReceiveNearbyFightInfo(AString a_PlayerID, cPawn * a_Opponent, bool 
 	}
 
 	// If we already have a target
-	if (m_Target != nullptr)
+	if (GetTarget() != nullptr)
 	{
 		// If a wolf is asking for help and we already have a target, do nothing
 		if (!a_IsPlayerInvolved)
@@ -159,7 +158,7 @@ void cWolf::ReceiveNearbyFightInfo(AString a_PlayerID, cPawn * a_Opponent, bool 
 		}
 	}
 
-	m_Target = a_Opponent;
+	SetTarget(a_Opponent);
 
 
 }
@@ -264,7 +263,7 @@ void cWolf::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		super::Tick(a_Dt, a_Chunk);
 	}
 
-	if (m_Target == nullptr)
+	if (GetTarget() == nullptr)
 	{
 		cPlayer * a_Closest_Player = m_World->FindClosestPlayer(GetPosition(), static_cast<float>(m_SightDistance));
 		if (a_Closest_Player != nullptr)
@@ -311,11 +310,11 @@ void cWolf::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	{
 		if (IsSitting())
 		{
-			m_Target = nullptr;
+			SetTarget(nullptr);
 		}
 		else
 		{
-			MoveToPosition(m_Target->GetPosition());
+			MoveToPosition(GetTarget()->GetPosition());
 			if (TargetIsInRange())
 			{
 				Attack(a_Dt);
@@ -359,18 +358,18 @@ void cWolf::TickFollowPlayer()
 		{
 			Callback.OwnerPos.y = FindFirstNonAirBlockPosition(Callback.OwnerPos.x, Callback.OwnerPos.z);
 			TeleportToCoords(Callback.OwnerPos.x, Callback.OwnerPos.y, Callback.OwnerPos.z);
-			m_Target = nullptr;
+			SetTarget(nullptr);
 		}
 		if (Distance < 2)
 		{
-			if (m_Target == nullptr)
+			if (GetTarget() == nullptr)
 			{
 				StopMovingToPosition();
 			}
 		}
 		else
 		{
-			if (m_Target == nullptr)
+			if (GetTarget() == nullptr)
 			{
 				MoveToPosition(Callback.OwnerPos);
 			}

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2875,6 +2875,10 @@ bool cWorld::ForEachPlayer(cPlayerListCallback & a_Callback)
 	for (cPlayerList::iterator itr = m_Players.begin(), itr2 = itr; itr != m_Players.end(); itr = itr2)
 	{
 		++itr2;
+		if ((*itr)->IsDestroyed())
+		{
+			continue;
+		}
 		if (a_Callback.Item(*itr))
 		{
 			return false;
@@ -2893,6 +2897,10 @@ bool cWorld::DoWithPlayer(const AString & a_PlayerName, cPlayerListCallback & a_
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
 	{
+		if ((*itr)->IsDestroyed())
+		{
+			continue;
+		}
 		if (NoCaseCompare((*itr)->GetName(), a_PlayerName) == 0)
 		{
 			a_Callback.Item(*itr);
@@ -2915,6 +2923,10 @@ bool cWorld::FindAndDoWithPlayer(const AString & a_PlayerNameHint, cPlayerListCa
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
 	{
+		if ((*itr)->IsDestroyed())
+		{
+			continue;
+		}
 		size_t Rating = RateCompareString (a_PlayerNameHint, (*itr)->GetName());
 		if (Rating >= BestRating)
 		{
@@ -2943,6 +2955,10 @@ bool cWorld::DoWithPlayerByUUID(const AString & a_PlayerUUID, cPlayerListCallbac
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
 	{
+		if ((*itr)->IsDestroyed())
+		{
+			continue;
+		}
 		if ((*itr)->GetUUID() == a_PlayerUUID)
 		{
 			return a_Callback.Item(*itr);
@@ -2966,6 +2982,10 @@ cPlayer * cWorld::FindClosestPlayer(const Vector3d & a_Pos, float a_SightLimit, 
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::const_iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
 	{
+		if ((*itr)->IsDestroyed())
+		{
+			continue;
+		}
 		Vector3f Pos = (*itr)->GetPosition();
 		double Distance = (Pos - a_Pos).Length();
 


### PR DESCRIPTION
Fixes #2896.
I used @madmaxoft 's "solution 3".

Summary of what this is all about:
 - Every cPawn(player or mob) keeps a list of monsters targeting it.
 - cMonster is responsible for notifying cPawn of target changes to keep the list up to date. See `cMonster::setTarget`
 - When a cPawn is destroyed, it tells all monsters to stop targeting it.
 - When a cPawn travels to a new world, it tells all monsters to stop targeting it.
 - When a monster is destroyed or moves to a new world, the previous two points are  done (because all monsters are cPawn), but additionally, the monster sets the target to null, thus notifying its target that it is no longer targeting it and keeping the list up to date.
 - The cWorld / Chunk `doWith...` functions must never do stuff with Pawns that are destroyed.
 - Added lots of asserts.