### PR TITLE
Fixed cChunk::m_Entities corruption upon world travel

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -634,14 +634,6 @@ void cChunk::Tick(std::chrono::milliseconds a_Dt)
 			itr = m_Entities.erase(itr);
 			delete ToDelete;
 		}
-		else if ((*itr)->IsWorldTravellingFrom(m_World))
-		{
-			// Remove all entities that are travelling to another world
-			LOGD("Removing entity from [%d, %d] that's travelling between worlds.", m_PosX, m_PosZ);
-			MarkDirty();
-			(*itr)->SetWorldTravellingFrom(nullptr);
-			itr = m_Entities.erase(itr);
-		}
 		else if (
 			((*itr)->GetChunkX() != m_PosX) ||
 			((*itr)->GetChunkZ() != m_PosZ)

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -40,7 +40,6 @@ cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, d
 	m_AirDrag(0.02f),
 	m_LastPosition(a_X, a_Y, a_Z),
 	m_IsInitialized(false),
-	m_WorldTravellingFrom(nullptr),
 	m_EntityType(a_EntityType),
 	m_World(nullptr),
 	m_IsWorldChangeScheduled(false),
@@ -1499,8 +1498,18 @@ bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 		return false;
 	}
 
+	if (!GetWorld()->DoWithChunk(GetChunkX(), GetChunkZ(), [this](cChunk & a_Chunk) -> bool
+	{
+		a_Chunk.RemoveEntity(this);
+		return true;
+	}))
+	{
+		LOGD("Entity Teleportation failed! Didn't find the source chunk!\n");
+		return false;
+	}
+
 	// Remove all links to the old world
-	SetWorldTravellingFrom(GetWorld());  // cChunk::Tick() handles entity removal
+	// SetWorldTravellingFrom(GetWorld());  // cChunk::Tick() handles entity removal
 	GetWorld()->BroadcastDestroyEntity(*this);
 
 	SetPosition(a_NewPosition);

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -408,12 +408,6 @@ public:
 
 	virtual bool DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
 
-	/** Returns if the entity is travelling away from a specified world */
-	bool IsWorldTravellingFrom(cWorld * a_World) const { return (m_WorldTravellingFrom == a_World); }
-
-	/** Sets the world the entity will be leaving */
-	void SetWorldTravellingFrom(cWorld * a_World) { m_WorldTravellingFrom = a_World; }
-
 	/** Updates clients of changes in the entity. */
 	virtual void BroadcastMovementUpdate(const cClientHandle * a_Exclude = nullptr);
 
@@ -537,11 +531,6 @@ protected:
 
 	/** True when entity is initialised (Initialize()) and false when destroyed pending deletion (Destroy()) */
 	bool m_IsInitialized;
-
-	/** World entity is travelling from (such as when using portals).
-	Set to a valid world pointer by MoveToWorld; reset to nullptr when the entity is removed from the old world.
-	Can't be a simple boolean as context switches between worlds may leave the new chunk processing (and therefore immediately removing) the entity before the old chunk could remove it. */
-	cWorld * m_WorldTravellingFrom;
 
 	eEntityType m_EntityType;
 


### PR DESCRIPTION
Fixes #2724
possibly fixes or completely resolves other [world travel issues](https://github.com/cuberite/cuberite/milestones/Stable%20world%20travel) as well.