### PR TITLE
[PhantomWorlds - 3] Regenerate worlds with proper dimension types and linkages

### DIFF
--- a/src/World.cpp
+++ b/src/World.cpp
@@ -512,8 +512,18 @@ void cWorld::Start(void)
 
 	if (GetDimension() == dimOverworld)
 	{
-		m_LinkedNetherWorldName = IniFile.GetValueSet("LinkedWorlds", "NetherWorldName", GetName() + "_nether");
-		m_LinkedEndWorldName    = IniFile.GetValueSet("LinkedWorlds", "EndWorldName",    GetName() + "_end");
+		AString MyNetherName = GetName() + "_nether";
+		AString MyEndName = GetName() + "_end";
+		if (cRoot::Get()->GetWorld(MyNetherName) == nullptr)
+		{
+			MyNetherName = "";
+		}
+		if (cRoot::Get()->GetWorld(MyEndName) == nullptr)
+		{
+			MyEndName = "";
+		}
+		m_LinkedNetherWorldName = IniFile.GetValueSet("LinkedWorlds", "NetherWorldName", MyNetherName);
+		m_LinkedEndWorldName    = IniFile.GetValueSet("LinkedWorlds", "EndWorldName",    MyEndName);
 	}
 	else
 	{


### PR DESCRIPTION
Fixes part 3 of #2810
When a nether world folder is removed, an overworld is created instead. This is unexpected. I fixed it. Also, previously newly created overworlds always linked to two worlds, even if these worlds do not exist. I fixed that too. Here is exactly what happens now:

- If a world exists in settings.ini but has no world.ini, then:
  - If the world name is x_nether, create a world.ini with the a dimension type "nether"
    - If a world called x exists, set it as x_nether's overworld
    - Otherwise set the default world as x_nether's overworld

  - If the world name is x_end, create a world.ini with the a dimension type "end"
    - If a world called x exists, set it as x_end's overworld
    - Otherwise set the default world as x_end's overworld

 - If the world name is x (and doesn't end with _end or _nether)
    - Create a world.ini with a dimension type of "overworld"
    - If a world called x_nether exists, set it as x's nether world, otherwise set x's nether world to blank.
    - If a world called x_end  exists, set it as x's end world, otherwise set x's nether world to blank.

**Note:** This is all about best-guessing how a newly created INI file should look like. 
 - It will never touch an already existing world.ini file at all. 
 - It will never put linkages to a nonexisting world in the newly created `world.ini`.
(Both points are deducable from the rules above, but I thought I should mention them explicitly)