### PR TITLE
Implement acacia block height

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ HaoTNN
 Howaner
 jan64
 jasperarmstrong
+kevinr (Kevin Riggle)
 keyboard
 Lapayo
 linnemannr (Reid Linnemann)

--- a/src/Blocks/BlockSapling.h
+++ b/src/Blocks/BlockSapling.h
@@ -92,7 +92,18 @@ public:
 				}
 				break;
 			}
-			// Dark Oaks only grow in a 2x2 area
+			// Acacias don't need horizontal clearance
+			case E_META_SAPLING_ACACIA:
+			{
+				if (!IsLargeTree(a_Chunk, a_RelX, a_RelY, a_RelZ, a_Meta))
+				{
+					return false;
+				}
+				CheckHeight = 7;
+				LargeTree = true;
+				break;
+			}
+			// Dark Oaks don't need horizontal clearance
 			case E_META_SAPLING_DARK_OAK:
 			{
 				if (!IsLargeTree(a_Chunk, a_RelX, a_RelY, a_RelZ, a_Meta))


### PR DESCRIPTION
The server was crashing on one of my personal worlds because the sapling block height assertion check was failing.  It looked like Acacia saplings were missing from this case statement, so I added them, basing them on Dark Oak as that's what the Minecraft wiki seemed to indicate was most appropriate.

I've tested and it works, and it passes the code style check. I've also added myself to CONTRIBUTORS to signify acceptance of releasing my changes under the license.

Comments &c welcome.