### PR TITLE
Update RedstoneSimulator to delete unused cached PowerData

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
@@ -125,8 +125,11 @@ void cIncrementalRedstoneSimulator::Simulate(float a_dt)
 		}
 
 		auto CurrentHandler = cIncrementalRedstoneSimulator::CreateComponent(m_World, CurrentBlock, &m_Data);
-		if (CurrentHandler == nullptr)
+		if (CurrentHandler == nullptr)  // Block at CurrentPosition doesn't have a corresponding redstone handler
 		{
+			// Clean up cached PowerData for CurrentPosition
+			static_cast<cIncrementalRedstoneSimulator *>(m_World.GetRedstoneSimulator())->GetChunkData()->ErasePowerData(CurrentLocation);
+
 			continue;
 		}
 

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneSimulatorChunkData.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneSimulatorChunkData.h
@@ -41,6 +41,12 @@ public:
 		return (Result == m_MechanismDelays.end()) ? nullptr : &Result->second;
 	}
 
+	/** Erase cached PowerData for position */
+	void ErasePowerData(const Vector3i & a_Position)
+	{
+		m_CachedPowerLevels.erase(a_Position);
+	}
+
 	cRedstoneHandler::PoweringData ExchangeUpdateOncePowerData(const Vector3i & a_Position, cRedstoneHandler::PoweringData a_PoweringData)
 	{
 		auto Result = m_CachedPowerLevels.find(a_Position);


### PR DESCRIPTION
The RedstoneSimulator now erases cached PowerData for a position whenever an update is requested for a postion where the block doesn't have a corresponding RedstoneHandler. 

The PowerData for a position gets cached when there's a block (i.e. powered rail) with a corresponding redstone handler. When an updated is initiated for the position, the redstone handler will check if the new power is different from the cached one and will skip the update if the answer is no.

The problem is, when the block gets destroyed the cache remains unchanged, an update for the position gets initiated which the RedstoneSimulator skips* because the new block (Air) doesn't have a redstone handler. So, when an activated block is destroyed the cached power for that position still says it is activated. A new block at that position that's supposed to get activated will skip its update because the cached data wrongfully shows it is already activated.

*This is where the pull request will erase the cache for the position, before the update skips.

Reproduce the bug: Place red stone torch, place powered rail next to it (its activated), destroy the rail, place a new powered rail at the position (it is not activated). 

closes #2946 (I guess) 