### PR TITLE
[WIP] Fix minecart entity collision

### DIFF
--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -845,24 +845,16 @@ bool cMinecart::TestEntityCollision(NIBBLETYPE a_RailMeta)
 		{
 			if (MinecartCollisionCallback.GetCollidedEntityPosition().z >= GetPosZ())
 			{
-				if ((-GetSpeedZ() * 0.4) < 0.01)
+				if (GetSpeedZ() > 0)  // True if minecart is moving into the direction of the entity
 				{
-					AddSpeedZ(-4);
-				}
-				else
-				{
-					SetSpeedZ(-GetSpeedZ() * 0.4);
+					SetSpeedZ(0);  // Entity handles the pushing
 				}
 			}
-			else
+			else  // if (MinecartCollisionCallback.GetCollidedEntityPosition().z < GetPosZ())
 			{
-				if ((GetSpeedZ() * 0.4) < 0.01)
+				if (GetSpeedZ() < 0)  // True if minecart is moving into the direction of the entity
 				{
-					AddSpeedZ(4);
-				}
-				else
-				{
-					SetSpeedZ(GetSpeedZ() * 0.4);
+					SetSpeedZ(0);  // Entity handles the pushing
 				}
 			}
 			return true;
@@ -871,24 +863,16 @@ bool cMinecart::TestEntityCollision(NIBBLETYPE a_RailMeta)
 		{
 			if (MinecartCollisionCallback.GetCollidedEntityPosition().x >= GetPosX())
 			{
-				if ((-GetSpeedX() * 0.4) < 0.01)
+				if (GetSpeedX() > 0)  // True if minecart is moving into the direction of the entity
 				{
-					AddSpeedX(-4);
-				}
-				else
-				{
-					SetSpeedX(-GetSpeedX() * 0.4);
+					SetSpeedX(0);  // Entity handles the pushing
 				}
 			}
-			else
+			else  // if (MinecartCollisionCallback.GetCollidedEntityPosition().x < GetPosX())
 			{
-				if ((GetSpeedX() * 0.4) < 0.01)
+				if (GetSpeedX() < 0)  // True if minecart is moving into the direction of the entity
 				{
-					AddSpeedX(4);
-				}
-				else
-				{
-					SetSpeedX(GetSpeedX() * 0.4);
+					SetSpeedX(0);  // Entity handles the pushing
 				}
 			}
 			return true;

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -75,7 +75,7 @@ protected:
 	void SnapToRail(NIBBLETYPE a_RailMeta);
 	/** Tests if a solid block is in front of a cart, and stops the cart (and returns true) if so; returns false if no obstruction */
 	bool TestBlockCollision(NIBBLETYPE a_RailMeta);
-	/** Tests if this mincecart's bounding box is intersecting another entity's bounding box (collision) and pushes mincecart away */
+	/** Tests if this mincecart's bounding box is intersecting another entity's bounding box (collision) and pushes mincecart away if necessary */
 	bool TestEntityCollision(NIBBLETYPE a_RailMeta);
 
 } ;


### PR DESCRIPTION
* Minecarts no longer handle a collision if the entity is behind them.
* Minecarts will leave the pushing after a collision on a straight rail to the entity.

Minecarts would handle it if there was a "collision" with an entity which was in the opposite direction they are moving by slowing down, aka player running into the minecart from behind. I saw no reason why they would do that, the case is no longer handled. 

On straight rails minecarts will just stop now on collision with an entity, if the entity can push it will push the minecart.

fixes #2944 