### PR TITLE
Make Wolf wait to follow flying player

### DIFF
--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -224,6 +224,7 @@ void cWolf::TickFollowPlayer()
 		}
 	public:
 		Vector3d OwnerPos;
+		bool OwnerFlying;
 	} Callback;
 
 	if (m_World->DoWithPlayer(m_OwnerName, Callback))

--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -219,6 +219,7 @@ void cWolf::TickFollowPlayer()
 		virtual bool Item(cPlayer * a_Player) override
 		{
 			OwnerPos = a_Player->GetPosition();
+			OwnerFlying = a_Player->isFlying();
 			return false;
 		}
 	public:
@@ -236,7 +237,10 @@ void cWolf::TickFollowPlayer()
 		}
 		else
 		{
-			MoveToPosition(Callback.OwnerPos);
+			if (!Callback.OwnerFlying)
+			{
+				MoveToPosition(Callback.OwnerPos);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Checks if a player is not flying before telling the Wolf to move to position. Fixes issue https://github.com/cuberite/cuberite/issues/3013