### PR TITLE
Hotfix Add check if entity is in chunk before changing tick status

### DIFF
--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1019,7 +1019,10 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 			(*itr)->SetWorld(this);
 			m_ChunkMap->AddEntity(*itr);
 			ASSERT(!(*itr)->IsTicking());
-			(*itr)->SetIsTicking(true);
+			if (m_ChunkMap->HasEntity((*itr)->GetUniqueID()))
+			{
+				(*itr)->SetIsTicking(true);
+			}
 		}
 		m_EntitiesToAdd.clear();
 	}
@@ -3805,7 +3808,10 @@ void cWorld::AddQueuedPlayers(void)
 			// Add to chunkmap, if not already there (Spawn vs MoveToWorld):
 			m_ChunkMap->AddEntityIfNotPresent(*itr);
 			ASSERT(!(*itr)->IsTicking());
-			(*itr)->SetIsTicking(true);
+			if (m_ChunkMap->HasEntity((*itr)->GetUniqueID()))
+			{
+				(*itr)->SetIsTicking(true);
+			}
 		}  // for itr - PlayersToAdd[]
 	}  // Lock(m_CSPlayers)
 


### PR DESCRIPTION
World tick would set the tick status of an entity to true after TRYING to add it to a chunk, this would lead to a failed assertion because a entity without a parentchunk was ticking.

Only set the tick status to true if the entity was added successful. 
<s>Remove IsTicking Assert before setting the tick status, this assertion should be (and is) done inside SetIsTicking.</s>

See my last comment in #3030