### PR TITLE
Added more information about contributing to Cuberite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,11 @@
+How to contribute to Cuberite
+-----------------------------
+Thank you for your interest in Cuberite. Contributing to Cuberite is easy, just fork the project on GitHub, make your changes and submit a pull request to get your code merged. That's all there is to it.
+Check out [GETTING-STARTED.md](https://github.com/cuberite/cuberite/blob/master/GETTING-STARTED.md) for more information about setting up the development environment for Cuberite, finding issues to work on, etc...
+
+If you are new to open source and/or GitHub, or just aren't sure about some details in the contribution process, here's a tutorial to get you started:
+[How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
+
 Code Conventions
 ----------------
 


### PR DESCRIPTION
Added a paragraph about contributing to Cuberite, as well as a link to a github tutorial to CONTRIBUTING.md

The CONTRIBUTING file was severely lacking in actual information about the contribution process, even though it's the first place someone would check to get more information about contributing.

Also added a 'PRs welcome' badge to the readme.