### PR TITLE
[WIP/RFC] Configurable block destruction for explosions

### DIFF
--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -114,16 +114,16 @@ static int tolua_cWorld_ChunkStay(lua_State * tolua_S)
 static int tolua_cWorld_DoExplosionAt(lua_State * tolua_S)
 {
 	/* Function signature:
-	World:DoExplosionAt(ExplosionSize, BlockX, BlockY, BlockZ, CanCauseFire, SourceType, [SourceData])
+	World:DoExplosionAt(ExplosionSize, BlockX, BlockY, BlockZ, CanCauseFire, CanDestroyBlocks, CanDamageEntities, SourceType, [SourceData])
 	*/
 
 	cLuaState L(tolua_S);
 	if (
 		!L.CheckParamUserType     (1, "cWorld") ||
 		!L.CheckParamNumber       (2, 5) ||
-		!L.CheckParamBool         (6) ||
-		!L.CheckParamNumber       (7) ||
-		!L.CheckParamEnd          (9)
+		!L.CheckParamBool         (6, 8) ||
+		!L.CheckParamNumber       (9) ||
+		!L.CheckParamEnd          (10)
 	)
 	{
 		return 0;
@@ -134,8 +134,10 @@ static int tolua_cWorld_DoExplosionAt(lua_State * tolua_S)
 	double ExplosionSize;
 	int BlockX, BlockY, BlockZ;
 	bool CanCauseFire;
+	bool CanDestroyBlocks;
+	bool CanDamageEntities;
 	int SourceTypeInt;
-	if (!L.GetStackValues(1, World, ExplosionSize, BlockX, BlockY, BlockZ, CanCauseFire, SourceTypeInt))
+	if (!L.GetStackValues(1, World, ExplosionSize, BlockX, BlockY, BlockZ, CanCauseFire, CanDestroyBlocks, CanDamageEntities, SourceTypeInt))
 	{
 		LOGWARNING("World:DoExplosionAt(): invalid parameters");
 		L.LogStackTrace();
@@ -194,7 +196,7 @@ static int tolua_cWorld_DoExplosionAt(lua_State * tolua_S)
 	}
 
 	// Create the actual explosion:
-	World->DoExplosionAt(ExplosionSize, BlockX, BlockY, BlockZ, CanCauseFire, SourceType, SourceData);
+	World->DoExplosionAt(ExplosionSize, BlockX, BlockY, BlockZ, CanCauseFire, CanDestroyBlocks, CanDamageEntities, SourceType, SourceData);
 
 	return 0;
 }

--- a/src/Bindings/Plugin.h
+++ b/src/Bindings/Plugin.h
@@ -62,7 +62,7 @@ public:
 	virtual bool OnEntityChangedWorld       (cEntity & a_Entity, cWorld & a_World) = 0;
 	virtual bool OnExecuteCommand           (cPlayer * a_Player, const AStringVector & a_Split, const AString & a_EntireCommand, cPluginManager::CommandResult & a_Result) = 0;
 	virtual bool OnExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) = 0;
-	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) = 0;
+	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, bool & a_CanDestroyBlocks, bool & a_CanDamageEntities, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) = 0;
 	virtual bool OnHandshake                (cClientHandle & a_Client, const AString & a_Username) = 0;
 	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum) = 0;
 	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum) = 0;

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -694,7 +694,7 @@ bool cPluginLua::OnExploded(cWorld & a_World, double a_ExplosionSize, bool a_Can
 
 
 
-bool cPluginLua::OnExploding(cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData)
+bool cPluginLua::OnExploding(cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, bool & a_CanDestroyBlocks, bool & a_CanDamageEntities, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData)
 {
 	cCSLock Lock(m_CriticalSection);
 	if (!m_LuaState.IsValid())
@@ -707,15 +707,15 @@ bool cPluginLua::OnExploding(cWorld & a_World, double & a_ExplosionSize, bool & 
 	{
 		switch (a_Source)
 		{
-			case esBed:           m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>            (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esEnderCrystal:  m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cEntity *>             (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esGhastFireball: m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cGhastFireballEntity *>(a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esMonster:       m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esOther:         m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source,                                                         cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esPlugin:        m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source,                                                         cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esPrimedTNT:     m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cTNTEntity *>          (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esWitherBirth:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
-			case esWitherSkull:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cWitherSkullEntity *>  (a_SourceData), cLuaState::Return, res, a_CanCauseFire, a_ExplosionSize); break;
+			case esBed:           m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, reinterpret_cast<Vector3i *>            (a_SourceData), cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esEnderCrystal:  m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cEntity *>             (a_SourceData), cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esGhastFireball: m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cGhastFireballEntity *>(a_SourceData), cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esMonster:       m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esOther:         m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source,                                                         cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esPlugin:        m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source,                                                         cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esPrimedTNT:     m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cTNTEntity *>          (a_SourceData), cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esWitherBirth:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cMonster *>            (a_SourceData), cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
+			case esWitherSkull:   m_LuaState.Call(static_cast<int>(**itr), &a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, reinterpret_cast<cWitherSkullEntity *>  (a_SourceData), cLuaState::Return, res, a_CanDamageEntities, a_CanDestroyBlocks, a_CanCauseFire, a_ExplosionSize); break;
 			case esMax:
 			{
 				ASSERT(!"Invalid explosion source");

--- a/src/Bindings/PluginLua.h
+++ b/src/Bindings/PluginLua.h
@@ -121,7 +121,7 @@ public:
 	virtual bool OnEntityChangedWorld       (cEntity & a_Entity, cWorld & a_World) override;
 	virtual bool OnExecuteCommand           (cPlayer * a_Player, const AStringVector & a_Split, const AString & a_EntireCommand, cPluginManager::CommandResult & a_Result) override;
 	virtual bool OnExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) override;
-	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) override;
+	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, bool & a_CanDestroyBlocks, bool & a_CanDamageEntities, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) override;
 	virtual bool OnHandshake                (cClientHandle & a_Client, const AString & a_Username) override;
 	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum) override;
 	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum) override;

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -637,14 +637,14 @@ bool cPluginManager::CallHookExploded(cWorld & a_World, double a_ExplosionSize, 
 
 
 
-bool cPluginManager::CallHookExploding(cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData)
+bool cPluginManager::CallHookExploding(cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, bool & a_CanDestroyBlocks, bool & a_CanDamageEntities, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData)
 {
 	FIND_HOOK(HOOK_EXPLODING);
 	VERIFY_HOOK;
 
 	for (PluginList::iterator itr = Plugins->second.begin(); itr != Plugins->second.end(); ++itr)
 	{
-		if ((*itr)->OnExploding(a_World, a_ExplosionSize, a_CanCauseFire, a_X, a_Y, a_Z, a_Source, a_SourceData))
+		if ((*itr)->OnExploding(a_World, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_X, a_Y, a_Z, a_Source, a_SourceData))
 		{
 			return true;
 		}

--- a/src/Bindings/PluginManager.h
+++ b/src/Bindings/PluginManager.h
@@ -213,7 +213,7 @@ public:
 	bool CallHookEntityChangedWorld       (cEntity & a_Entity, cWorld & a_World);
 	bool CallHookExecuteCommand           (cPlayer * a_Player, const AStringVector & a_Split, const AString & a_EntireCommand, CommandResult & a_Result);  // If a_Player == nullptr, it is a console cmd
 	bool CallHookExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData);
-	bool CallHookExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData);
+	bool CallHookExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, bool & a_CanDestroyBlocks, bool & a_CanDamageEntities, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData);
 	bool CallHookHandshake                (cClientHandle & a_ClientHandle, const AString & a_Username);
 	bool CallHookHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum);
 	bool CallHookHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum);

--- a/src/Blocks/BlockBed.cpp
+++ b/src/Blocks/BlockBed.cpp
@@ -86,7 +86,7 @@ bool cBlockBedHandler::OnUse(cChunkInterface & a_ChunkInterface, cWorldInterface
 	if (a_WorldInterface.GetDimension() != dimOverworld)
 	{
 		Vector3i Coords(a_BlockX, a_BlockY, a_BlockZ);
-		a_WorldInterface.DoExplosionAt(5, a_BlockX, a_BlockY, a_BlockZ, true, esBed, &Coords);
+		a_WorldInterface.DoExplosionAt(5, a_BlockX, a_BlockY, a_BlockZ, true, true, true, esBed, &Coords);
 	}
 	else
 	{

--- a/src/Blocks/WorldInterface.h
+++ b/src/Blocks/WorldInterface.h
@@ -25,7 +25,8 @@ public:
 
 	virtual cBroadcastInterface & GetBroadcastManager() = 0;
 
-	virtual void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, eExplosionSource a_Source, void * a_SourceData) = 0;
+	virtual void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, bool a_CanDestroyBlocks, bool a_CanDamageEntities, eExplosionSource a_Source, void * a_SourceData) = 0;
+
 
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities: */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool IsPlayerCreated = false) = 0;

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -236,7 +236,7 @@ public:
 	bool ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback & a_Callback);  // Lua-accessible
 
 	/** Destroys and returns a list of blocks destroyed in the explosion at the specified coordinates */
-	void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, cVector3iArray & a_BlockAffected);
+	void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanDestroyBlocks, bool a_CanDamageEntities, cVector3iArray & a_BlocksAffected);
 
 	/** Calls the callback if the entity with the specified ID is found, with the entity object as the callback param.
 	Returns true if entity found and callback returned false. */

--- a/src/Entities/EnderCrystal.cpp
+++ b/src/Entities/EnderCrystal.cpp
@@ -43,7 +43,7 @@ void cEnderCrystal::KilledBy(TakeDamageInfo & a_TDI)
 {
 	super::KilledBy(a_TDI);
 
-	m_World->DoExplosionAt(6.0, GetPosX(), GetPosY(), GetPosZ(), true, esEnderCrystal, this);
+	m_World->DoExplosionAt(6.0, GetPosX(), GetPosY(), GetPosZ(), true, true, true, esEnderCrystal, this);
 
 	Destroy();
 

--- a/src/Entities/GhastFireballEntity.cpp
+++ b/src/Entities/GhastFireballEntity.cpp
@@ -21,7 +21,7 @@ cGhastFireballEntity::cGhastFireballEntity(cEntity * a_Creator, double a_X, doub
 
 void cGhastFireballEntity::Explode(Vector3i a_Block)
 {
-	m_World->DoExplosionAt(1, a_Block.x, a_Block.y, a_Block.z, true, esGhastFireball, this);
+	m_World->DoExplosionAt(1, a_Block.x, a_Block.y, a_Block.z, true, true, true, esGhastFireball, this);
 }
 
 

--- a/src/Entities/TNTEntity.cpp
+++ b/src/Entities/TNTEntity.cpp
@@ -47,7 +47,7 @@ void cTNTEntity::Explode(void)
 	m_FuseTicks = 0;
 	Destroy(true);
 	LOGD("BOOM at {%f, %f, %f}", GetPosX(), GetPosY(), GetPosZ());
-	m_World->DoExplosionAt(4.0, GetPosX() + 0.49, GetPosY() + 0.49, GetPosZ() + 0.49, true, esPrimedTNT, this);
+	m_World->DoExplosionAt(4.0, GetPosX() + 0.49, GetPosY() + 0.49, GetPosZ() + 0.49, true, true, true, esPrimedTNT, this);
 }
 
 

--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -45,7 +45,7 @@ void cCreeper::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 		if ((m_ExplodingTimer == 30) && (GetHealth() > 0.0))  // only explode when not already dead
 		{
-			m_World->DoExplosionAt((m_bIsCharged ? 5 : 3), GetPosX(), GetPosY(), GetPosZ(), false, esMonster, this);
+			m_World->DoExplosionAt((m_bIsCharged ? 5 : 3), GetPosX(), GetPosY(), GetPosZ(), false, true, true, esMonster, this);
 			Destroy();  // Just in case we aren't killed by the explosion
 		}
 	}

--- a/src/Mobs/Wither.cpp
+++ b/src/Mobs/Wither.cpp
@@ -76,7 +76,7 @@ void cWither::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 		if (NewTicks == 0)
 		{
-			m_World->DoExplosionAt(7.0, GetPosX(), GetPosY(), GetPosZ(), false, esWitherBirth, this);
+			m_World->DoExplosionAt(7.0, GetPosX(), GetPosY(), GetPosZ(), false, true, true, esWitherBirth, this);
 		}
 
 		m_WitherInvulnerableTicks = NewTicks;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1361,9 +1361,9 @@ bool cWorld::ForEachFurnaceInChunk(int a_ChunkX, int a_ChunkZ, cFurnaceCallback 
 
 
 
-void cWorld::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, eExplosionSource a_Source, void * a_SourceData)
+void cWorld::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, bool a_CanDestroyBlocks, bool a_CanDamageEntities, eExplosionSource a_Source, void * a_SourceData)
 {
-	if (cPluginManager::Get()->CallHookExploding(*this, a_ExplosionSize, a_CanCauseFire, a_BlockX, a_BlockY, a_BlockZ, a_Source, a_SourceData) || (a_ExplosionSize <= 0))
+	if (cPluginManager::Get()->CallHookExploding(*this, a_ExplosionSize, a_CanCauseFire, a_CanDestroyBlocks, a_CanDamageEntities, a_BlockX, a_BlockY, a_BlockZ, a_Source, a_SourceData) || (a_ExplosionSize <= 0))
 	{
 		return;
 	}
@@ -1371,7 +1371,7 @@ void cWorld::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_Blo
 	// TODO: Implement block hardiness
 	Vector3d explosion_pos = Vector3d(a_BlockX, a_BlockY, a_BlockZ);
 	cVector3iArray BlocksAffected;
-	m_ChunkMap->DoExplosionAt(a_ExplosionSize, a_BlockX, a_BlockY, a_BlockZ, BlocksAffected);
+	m_ChunkMap->DoExplosionAt(a_ExplosionSize, a_BlockX, a_BlockY, a_BlockZ, a_CanDestroyBlocks, a_CanDamageEntities, BlocksAffected);
 	BroadcastSoundEffect("random.explode", static_cast<double>(a_BlockX), static_cast<double>(a_BlockY), static_cast<double>(a_BlockZ), 1.0f, 0.6f);
 
 	{

--- a/src/World.h
+++ b/src/World.h
@@ -513,7 +513,7 @@ public:
 	Executes the HOOK_EXPLODING and HOOK_EXPLODED hooks as part of the processing.
 	a_SourceData exact type depends on the a_Source, see the declaration of the esXXX constants in BlockID.h for details.
 	Exported to Lua manually in ManualBindings_World.cpp in order to support the variable a_SourceData param. */
-	virtual void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, eExplosionSource a_Source, void * a_SourceData) override;
+	virtual void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, bool a_CanDestroyBlocks, bool a_CanDamageEntities, eExplosionSource a_Source, void * a_SourceData) override;
 
 	/** Calls the callback for the block entity at the specified coords; returns false if there's no block entity at those coords, true if found */
 	virtual bool DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBlockEntityCallback & a_Callback) override;  // Exported in ManualBindings.cpp


### PR DESCRIPTION
Added CanDestroyBlocks and CanDamageEntities parameters to the DoExplosionAt function, Lua bindings and plugin hooks to allow blocking creeper explosion damage, etc.... Breaks the plugin API because of the added parameters.

This is just a request for comments and is not really the final pull request. Are the changes I made okay or did I miss something important? As it is now it runs fine on my machine, although I'm not entirely sure if the Lua bindings and hooks are correct.

Fixes #3011