### PR TITLE
Fix int gens

### DIFF
--- a/src/Generating/IntGen.h
+++ b/src/Generating/IntGen.h
@@ -29,9 +29,9 @@ by using templates.
 
 #pragma once
 
-#include "../BiomeDef.h"
-
 #include <tuple>
+#include "../BiomeDef.h"
+#include "../Noise/Noise.h"
 
 
 

--- a/src/Generating/ProtIntGen.h
+++ b/src/Generating/ProtIntGen.h
@@ -28,13 +28,25 @@ overhead; this however means that there's (an arbitrary) limit to the size of th
 
 
 
+/** Maximum size of the generated area.
+This value is used only if there isn't an override in place.
+To adjust the actual buffer size, just do a "#define PROT_INT_BUFFER_SIZE 9000" before including this header.
+Note, however, that you should use a consistent value throughout a single project. */
+#ifndef PROT_INT_BUFFER_SIZE
+	#define PROT_INT_BUFFER_SIZE 900
+#endif
+
+
+
+
+
 /** Interface that all the generator classes provide. */
 class cProtIntGen
 {
 protected:
 	/** Maximum size of the generated area.
 	Adjust the constant if you need larger areas, these are just so that we can use fixed-size buffers. */
-	static const int m_BufferSize = 900;
+	static const int m_BufferSize = PROT_INT_BUFFER_SIZE;
 
 public:
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -99,24 +99,9 @@
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
 
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark virtual methods as overriding (forcing them to have a virtual function of the same signature in the base class)
-	#define override
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
-
 #endif
+
+
 
 
 #ifdef  _DEBUG

--- a/src/LinearUpscale.h
+++ b/src/LinearUpscale.h
@@ -92,8 +92,8 @@ template <typename TYPE> void LinearUpscale2DArray(
 {
 	// For optimization reasons, we're storing the upscaling ratios in a fixed-size arrays of these sizes
 	// Feel free to enlarge them if needed, but keep in mind that they're on the stack
-	const int MAX_UPSCALE_X = 128;
-	const int MAX_UPSCALE_Y = 128;
+	const int MAX_UPSCALE_X = 129;
+	const int MAX_UPSCALE_Y = 129;
 
 	ASSERT(a_Src != nullptr);
 	ASSERT(a_Dst != nullptr);
@@ -101,8 +101,8 @@ template <typename TYPE> void LinearUpscale2DArray(
 	ASSERT(a_SrcSizeY > 0);
 	ASSERT(a_UpscaleX > 0);
 	ASSERT(a_UpscaleY > 0);
-	ASSERT(a_UpscaleX <= MAX_UPSCALE_X);
-	ASSERT(a_UpscaleY <= MAX_UPSCALE_Y);
+	ASSERT(a_UpscaleX < MAX_UPSCALE_X);
+	ASSERT(a_UpscaleY < MAX_UPSCALE_Y);
 
 	// Pre-calculate the upscaling ratios:
 	TYPE RatioX[MAX_UPSCALE_X];


### PR DESCRIPTION
Various small fixes for the IntGen classes.

These were found when reusing the code for a visualisation tool.