### PR TITLE
Mobs no longer spawn at the top of the nether.

### DIFF
--- a/src/MobSpawner.cpp
+++ b/src/MobSpawner.cpp
@@ -134,6 +134,11 @@ bool cMobSpawner::CanSpawnHere(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_R
 		return false;
 	}
 
+	if (cChunkDef::IsValidHeight(a_RelY - 1) && (a_Chunk->GetBlock(a_RelX, a_RelY - 1, a_RelZ) == E_BLOCK_BEDROCK))
+	{
+		return false;   // Make sure mobs do not spawn on bedrock.
+	}
+
 	cFastRandom Random;
 	BLOCKTYPE TargetBlock = a_Chunk->GetBlock(a_RelX, a_RelY, a_RelZ);
 


### PR DESCRIPTION
I don't really know if this is the right place for the check, but it
works.
Fixes #3055