### PR TITLE
HTTP: Fixed header parsing.

### DIFF
--- a/src/HTTP/HTTPMessage.cpp
+++ b/src/HTTP/HTTPMessage.cpp
@@ -152,6 +152,7 @@ void cHTTPIncomingRequest::AddHeader(const AString & a_Key, const AString & a_Va
 	{
 		m_AllowKeepAlive = true;
 	}
+	Super::AddHeader(a_Key, a_Value);
 }
 
 


### PR DESCRIPTION
Now forms are parsed correctly.

Hopefully fixes https://forum.cuberite.org/thread-2392.html for good.