### PR TITLE
Fixed leaping potion not giving jump boost

### DIFF
--- a/src/Entities/EntityEffect.cpp
+++ b/src/Entities/EntityEffect.cpp
@@ -84,6 +84,7 @@ int cEntityEffect::GetPotionEffectDuration(short a_ItemDamage)
 		case cEntityEffect::effNightVision:
 		case cEntityEffect::effStrength:
 		case cEntityEffect::effWaterBreathing:
+		case cEntityEffect::effJumpBoost:
 		case cEntityEffect::effInvisibility:
 		{
 			base = 3600;


### PR DESCRIPTION
This fixes issue #2599 