### PR TITLE
Out of world

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -2594,16 +2594,6 @@ bool cChunk::GetSignLines(int a_BlockX, int a_BlockY, int a_BlockZ, AString & a_
 
 BLOCKTYPE cChunk::GetBlock(int a_RelX, int a_RelY, int a_RelZ) const
 {
-	if (
-		(a_RelX < 0) || (a_RelX >= Width) ||
-		(a_RelY < 0) || (a_RelY >= Height) ||
-		(a_RelZ < 0) || (a_RelZ >= Width)
-	)
-	{
-		ASSERT(!"GetBlock(x, y, z) out of bounds!");
-		return 0;  // Clip
-	}
-
 	return m_ChunkData.GetBlock(a_RelX, a_RelY, a_RelZ);
 }
 

--- a/src/ChunkData.cpp
+++ b/src/ChunkData.cpp
@@ -150,9 +150,14 @@ cChunkData::~cChunkData()
 
 BLOCKTYPE cChunkData::GetBlock(int a_X, int a_Y, int a_Z) const
 {
-	ASSERT((a_X >= 0) && (a_X < cChunkDef::Width));
-	ASSERT((a_Y >= 0) && (a_Y < cChunkDef::Height));
-	ASSERT((a_Z >= 0) && (a_Z < cChunkDef::Width));
+	if (
+		(a_X < 0) || (a_X >= cChunkDef::Width) ||
+		(a_Y < 0) || (a_Y >= cChunkDef::Height) ||
+		(a_Z < 0) || (a_Z >= cChunkDef::Width)
+	)
+	{
+		return E_BLOCK_AIR;  // Coordinates are outside outside the world, so this must be an air block
+	}
 	int Section = a_Y / SectionHeight;
 	if (m_Sections[Section] != nullptr)
 	{
@@ -222,7 +227,7 @@ NIBBLETYPE cChunkData::GetMeta(int a_RelX, int a_RelY, int a_RelZ) const
 			return 0;
 		}
 	}
-	ASSERT(!"cChunkData::GetMeta(): coords out of chunk range!");
+	// Coordinates are outside outside the world, so it must be an air block with a blank meta
 	return 0;
 }
 

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -250,7 +250,7 @@ bool cPath::StepOnce()
 		{
 			if (ProcessIfWalkable(CurrentCell->m_Location + Vector3i(0, y, 1),  CurrentCell, NORMAL_G_COST))
 			{
-				DoneWest = true;
+				DoneSouth = true;
 				if (y == 0)
 				{
 					WalkableSouth = true;

--- a/tests/ChunkData/Coordinates.cpp
+++ b/tests/ChunkData/Coordinates.cpp
@@ -13,7 +13,7 @@ int main(int argc, char** argv)
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
+
 		virtual void Free(cChunkData::sChunkSection * a_Ptr)
 		{
 			delete a_Ptr;
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
 		testassert(buffer.GetBlock(0, 32, 0) == 0x0);
 		testassert(buffer.GetMeta(0, 48, 0) == 0x0);
 
-		// Out of Range
+		// Out of range SetBlock
 		CheckAsserts(
 			buffer.SetBlock(-1, 0, 0, 0);
 		);
@@ -55,28 +55,7 @@ int main(int argc, char** argv)
 		CheckAsserts(
 			buffer.SetBlock(0, 0, 256, 0);
 		);
-
-		// Out of Range
-		CheckAsserts(
-			buffer.GetBlock(-1, 0, 0);
-		);
-		CheckAsserts(
-			buffer.GetBlock(0, -1, 0);
-		);
-		CheckAsserts(
-			buffer.GetBlock(0, 0, -1);
-		);
-		CheckAsserts(
-			buffer.GetBlock(256, 0, 0);
-		);
-		CheckAsserts(
-			buffer.GetBlock(0, 256, 0);
-		);
-		CheckAsserts(
-			buffer.GetBlock(0, 0, 256);
-		);
-
-		// Out of Range
+		// Out of range SetMeta
 		CheckAsserts(
 			buffer.SetMeta(-1, 0, 0, 0);
 		);
@@ -96,30 +75,26 @@ int main(int argc, char** argv)
 			buffer.SetMeta(0, 0, 256, 0);
 		);
 
-		// Out of Range
-		CheckAsserts(
-			buffer.GetMeta(-1, 0, 0);
-		);
-		CheckAsserts(
-			buffer.GetMeta(0, -1, 0);
-		);
-		CheckAsserts(
-			buffer.GetMeta(0, 0, -1);
-		);
-		CheckAsserts(
-			buffer.GetMeta(256, 0, 0);
-		);
-		CheckAsserts(
-			buffer.GetMeta(0, 256, 0);
-		);
-		CheckAsserts(
-			buffer.GetMeta(0, 0, 256);
-		);
+		// Reading out of range blocks should return air
+		testassert(buffer.GetBlock(-1, 0, 0) == 0);
+		testassert(buffer.GetBlock(0, -1, 0) == 0);
+		testassert(buffer.GetBlock(0, 0, -1) == 0);
+		testassert(buffer.GetBlock(256, 0, 0) == 0);
+		testassert(buffer.GetBlock(0, 256, 0) == 0);
+		testassert(buffer.GetBlock(0, 0, 256) == 0);
+
+		// Reading out of range metas should return 0
+		testassert(buffer.GetMeta(-1, 0, 0) == 0);
+		testassert(buffer.GetMeta(0, -1, 0) == 0);
+		testassert(buffer.GetMeta(0, 0, -1) == 0);
+		testassert(buffer.GetMeta(256, 0, 0) == 0);
+		testassert(buffer.GetMeta(0, 256, 0) == 0);
+		testassert(buffer.GetMeta(0, 0, 256) == 0);
 	}
-	
+
 	{
 		cChunkData buffer(Pool);
-		
+
 		// Zero's
 		buffer.SetBlock(0, 0, 0, 0x0);
 		buffer.SetBlock(0, 0, 1, 0xab);
@@ -131,8 +106,8 @@ int main(int argc, char** argv)
 		testassert(buffer.GetMeta(0, 16, 0) == 0x0);
 		testassert(buffer.GetMeta(0, 16, 1) == 0xc);
 	}
-	
-	
+
+
 	{
 		// Operator =
 		cChunkData buffer(Pool);
@@ -141,6 +116,6 @@ int main(int argc, char** argv)
 		copy = std::move(buffer);
 		testassert(copy.GetBlock(0, 0, 0) == 0x42);
 	}
-	
+
 	return 0;
 }


### PR DESCRIPTION
Please discuss this before merging.

This PR entirely eliminates the good old "block out of bounds" assertion failures by actually removing these assertions. Whenever a blocks with a negative y value or a too high y value is requested, it is considered an air block (because it is actually an air block) rather than asserting.
Also, non player entities immediately self destruct when their y becomes negative.

**Edit:** I've decided to sum up all my comments here:

- Currently, calling Getblock with a negative (or Too big) height causes an assertion failure.
- In my opinion, calling `GetBlock` with a negative height is not an error at all. It should simply return an air block. All heights should valid for reading (But not for writing). A pathfinder **should** treat a hole in the bedrock just like any other hole. In other words, treat it as air. This applies to all other parts of Cuberite that I've dealt with. So, returning air should be safe for negative heights.
- Currently, most of the GetBlock calls have guarding code: `if Y < 0 || Y too big do not call GetBlock`. The pathfinder even has this:  `if Y < 0 || Y too big do returned air; else return whatever getblock() returns;`. The only purpose of all that guard code is evading an assert which, in my opinion, shouldn't have been there.

Closes #3089
Closes #3087
Closes #2539
Closes #3047
...and possibly others.