### PR TITLE
Bed's world is now saved

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1998,7 +1998,7 @@ a_Player:OpenWindow(Window);
 				SendAboveActionBarMessage = { Params = "Message", Return = "", Notes = "Sends the specified message to the player (shows above action bar, doesn't show for < 1.8 clients)." },
 				SendSystemMessage = { Params = "Message", Return = "", Notes = "Sends the specified message to the player (doesn't show for < 1.8 clients)." },
 				SendRotation = { Params = "YawDegrees, PitchDegrees", Return = "", Notes = "Sends the specified rotation to the player, forcing them to look that way" },
-				SetBedPos = { Params = "{{Vector3i|Position}}", Return = "", Notes = "Sets the internal representation of the last bed position the player has slept in. The player will respawn at this position if they die." },
+				SetBedPos = { Params = "{{Vector3i|Position}}, [{{cWorld*|World}}]", Return = "", Notes = "Sets the position and world of the player's respawn point, which is also known as the bed position. The player will respawn at this position and world upon death. If the world is not specified, it is set to the player's current world." },
 				SetCanFly = { Params = "CanFly", Notes = "Sets if the player can fly or not." },
 				SetCrouch = { Params = "IsCrouched", Return = "", Notes = "Sets the crouch state, broadcasts the change to other players." },
 				SetCurrentExperience = { Params = "XPAmount", Return = "", Notes = "Sets the current amount of experience (and indirectly, the XP level)." },

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -828,6 +828,27 @@ void cPlayer::SetCustomName(const AString & a_CustomName)
 
 
 
+void cPlayer::SetBedPos(const Vector3i & a_Pos)
+{
+	m_LastBedPos = a_Pos;
+	m_SpawnWorld = m_World;
+}
+
+
+
+
+
+void cPlayer::SetBedPos(const Vector3i & a_Pos, cWorld * a_World)
+{
+	m_LastBedPos = a_Pos;
+	ASSERT(a_World != nullptr);
+	m_SpawnWorld = a_World;
+}
+
+
+
+
+
 void cPlayer::SetFlying(bool a_IsFlying)
 {
 	if (a_IsFlying == m_IsFlying)
@@ -1078,12 +1099,19 @@ void cPlayer::Respawn(void)
 	m_LifetimeTotalXp = 0;
 	// ToDo: send score to client? How?
 
-	m_ClientHandle->SendRespawn(GetWorld()->GetDimension(), true);
+	m_ClientHandle->SendRespawn(m_SpawnWorld->GetDimension(), true);
 
 	// Extinguish the fire:
 	StopBurning();
 
-	TeleportToCoords(GetLastBedPos().x, GetLastBedPos().y, GetLastBedPos().z);
+	if (GetWorld() != m_SpawnWorld)
+	{
+		MoveToWorld(m_SpawnWorld, false, GetLastBedPos());
+	}
+	else
+	{
+		TeleportToCoords(GetLastBedPos().x, GetLastBedPos().y, GetLastBedPos().z);
+	}
 
 	SetVisible(true);
 }
@@ -1895,9 +1923,16 @@ bool cPlayer::LoadFromFile(const AString & a_FileName, cWorldPtr & a_World)
 		a_World = cRoot::Get()->GetDefaultWorld();
 	}
 
+
 	m_LastBedPos.x = root.get("SpawnX", a_World->GetSpawnX()).asInt();
 	m_LastBedPos.y = root.get("SpawnY", a_World->GetSpawnY()).asInt();
 	m_LastBedPos.z = root.get("SpawnZ", a_World->GetSpawnZ()).asInt();
+	AString SpawnWorldName =  root.get("SpawnWorld", cRoot::Get()->GetDefaultWorld()->GetName()).asString();
+	m_SpawnWorld = cRoot::Get()->GetWorld(SpawnWorldName);
+	if (m_SpawnWorld == nullptr)
+	{
+		m_SpawnWorld = cRoot::Get()->GetDefaultWorld();
+	}
 
 	// Load the player stats.
 	// We use the default world name (like bukkit) because stats are shared between dimensions / worlds.
@@ -1955,6 +1990,7 @@ bool cPlayer::SaveToDisk()
 	root["SpawnX"]              = GetLastBedPos().x;
 	root["SpawnY"]              = GetLastBedPos().y;
 	root["SpawnZ"]              = GetLastBedPos().z;
+	root["SpawnWorld"]        = m_SpawnWorld->GetName();
 
 	if (m_World != nullptr)
 	{

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -459,8 +459,12 @@ public:
 	*/
 	Vector3i GetLastBedPos(void) const { return m_LastBedPos; }
 
-	/** Sets the player's bed (home) position */
-	void SetBedPos(const Vector3i & a_Pos) { m_LastBedPos = a_Pos; }
+	/** Sets the player's bed (home / respawn) position to the specified position.
+	Sets the respawn world to the player's world. */
+	void SetBedPos(const Vector3i & a_Pos);
+
+	/** Sets the player's bed (home / respawn) position and respawn world to the specified parameters. */
+	void SetBedPos(const Vector3i & a_Pos, cWorld * a_World);
 
 	// tolua_end
 
@@ -583,6 +587,9 @@ protected:
 
 	/** The player's last saved bed position */
 	Vector3i m_LastBedPos;
+
+	/** The world which the player respawns in upon death */
+	cWorld * m_SpawnWorld;
 
 	eGameMode m_GameMode;
 	AString m_IP;


### PR DESCRIPTION
The bed's world is now saved per player. Previously, only the bed's coordinates were saved, if the player was in the wrong world, then  upon death they'd teleport to some weird spot which is not the player's bed.

Closes #2454