### PR TITLE
Never fall through unloaded or unsent chunks

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -638,13 +638,13 @@ void cChunk::Tick(std::chrono::milliseconds a_Dt)
 		}
 
 		// Do not move mobs that are detached from the world to neighbors. They're either scheduled for teleportation or for removal.
+		// Because the schedulded destruction is going to look for them in this chunk. See cEntity::destroy.
 		if (!(*itr)->IsTicking())
 		{
 			++itr;
 			continue;
 		}
 
-		// Because the schedulded destruction is going to look for them in this chunk. See cEntity::destroy.
 		if ((((*itr)->GetChunkX() != m_PosX) ||
 			((*itr)->GetChunkZ() != m_PosZ))
 		)

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -363,6 +363,8 @@ public:  // tolua_export
 	/** Returns the protocol version number of the protocol that the client is talking. Returns zero if the protocol version is not (yet) known. */
 	UInt32 GetProtocolVersion(void) const { return m_ProtocolVersion; }  // tolua_export
 
+	void InvalidateCachedSentChunk();
+
 private:
 
 	friend class cServer;  // Needs access to SetSelf()
@@ -407,6 +409,13 @@ private:
 	Vector3d m_ConfirmPosition;
 
 	cPlayer * m_Player;
+
+	/** This is an optimization which saves you an iteration of m_SentChunks if you just want to know
+	whether or not the player is standing at a sent chunk.
+	If this is equal to the coordinates of the chunk the player is currrently standing at, then this must be a sent chunk
+	and a member of m_SentChunks.
+	Otherwise, this contains an arbitrary value which should not be used. */
+	cChunkCoords m_CachedSentChunk;
 
 	bool m_HasSentDC;  ///< True if a Disconnect packet has been sent in either direction
 

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -50,6 +50,8 @@ public:
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
+	void TickFreezeCode(bool a_MyChunkIsSent);
+
 	virtual void HandlePhysics(std::chrono::milliseconds a_Dt, cChunk &) override { UNUSED(a_Dt); }
 
 	/** Returns the currently equipped weapon; empty item if none */


### PR DESCRIPTION
Players now freeze when going to chunks that are not yet sent to the client. This typically happens when flying fast, running, teleporting to other worlds, or teleporting to far coordinates on the same world.

Also, players never get stuck inside solids on teleport.

Closes #2964 
Closes #3088

Todo:
 - ~~For the world travel case, also send the proper packets for the teleport loading screen. As suggested by @tigerw in #2814~~
 - Done: Optimize the clientHandle changes. Currently the code is slow, written quickly just for testing.

Binaries:
- [Gnu/Linux](https://builds.cuberite.org/job/Cuberite%20Linux%20x64%20ingame-testing-needed/7/artifact/Cuberite.tar.gz)
- [Raspberry Pi](https://builds.cuberite.org/job/Cuberite%20Linux%20raspi-armhf%20ingame-testing-needed/6/artifact/Cuberite.tar.gz)
- [Windows](https://builds.cuberite.org/job/Cuberite%20Windows%20x64%20ingame-testing-needed/5/artifact/Install/Cuberite.zip)

Note: Chunk generator's logging was supressed because it adds noise when testing this PR by flying fast. This will be undone in the final version.