### PR TITLE
Improve cPlayer::DoMoveToWorld

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -603,7 +603,6 @@ void cClientHandle::StreamChunk(int a_ChunkX, int a_ChunkZ, cChunkSender::eChunk
 
 
 
-// Removes the client from all chunks. Used when switching worlds or destroying the player
 void cClientHandle::RemoveFromAllChunks()
 {
 	cWorld * World = m_Player->GetWorld();

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -125,7 +125,8 @@ public:  // tolua_export
 	/** Remove all loaded chunks that are no longer in range */
 	void UnloadOutOfRangeChunks(void);
 
-	// Removes the client from all chunks. Used when switching worlds or destroying the player
+	/** Removes the client from all chunks. Used when destroying the player.
+	When switching worlds, RemoveFromWorld does this function's job so it isn't called. */
 	void RemoveFromAllChunks(void);
 
 	inline bool IsLoggedIn(void) const { return (m_State >= csAuthenticating); }


### PR DESCRIPTION
- Sometimes, `DoMoveToWorld` is called outside the tick thread. For thread safety, I moved everything to the world's task queue. This allows thread protection via the `cWorld::m_CSTasks` lock. 

- ~~I also removed a line in the protocol which has a comment about client stability. It eliminated the wild player jitter that sometimes occurs when calling `/portal`.~~ Replaced by #3351.

- ~~I added a call to `cPlayer::GetClientHandle()->RemoveFromAllChunks()`. I believe this, in combination with thread safety, might have eliminated #2547 and/or #2405, but please test this.~~