### PR TITLE
Delay chunk send on multiworld travel

### DIFF
--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -377,6 +377,9 @@ private:
 	/** The requested view distance from the player. It isn't clamped with 1 and the max view distance of the world. */
 	int m_RequestedViewDistance;
 
+	/** If more than zero, represents the number of ticks the client will wait before sending chunks. */
+	int m_ChunkSendDelay;
+
 	AString m_IPString;
 
 	AString m_Username;


### PR DESCRIPTION
The chunks of the old world fail to unload client side if chunks in the new world which have the same coords are sent too fast right after the unload. I don't know if this is a client or server issue.

Because of that, players often see chunks of an old world when traveling to a new world.

This mostly fixes it, but it uses a timer, which means it may not work in high-latency scenarios. In the future, the root cause should be found and a more elegant solution should be made.

Do not merge before #3097 ; since this properly unloads chunks, players are very likely to fall into the void while teleporting and #3097 prevents that.