### PR TITLE
Improved threading model

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1236,10 +1236,10 @@ end
 local IniFile = cIniFile();
 IniFile:ReadFile("somefile.ini")
 local NumKeys = IniFile:GetNumKeys();
-for k = 0, NumKeys do
+for k = 0, (NumKeys - 1) do
 	local NumValues = IniFile:GetNumValues(k);
 	LOG("key \"" .. IniFile:GetKeyName(k) .. "\" has " .. NumValues .. " values:");
-	for v = 0, NumValues do
+	for v = 0, (NumValues - 1) do
 		LOG("  value \"" .. IniFile:GetValueName(k, v) .. "\".");
 	end
 end

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -2654,6 +2654,7 @@ end
 				SetMinNetherPortalWidth = { Params = "number", Return = "", Notes = "Sets the minimum width for a nether portal" },
 				SetShouldUseChatPrefixes = { Params = "", Return = "ShouldUse (bool)", Notes = "Sets whether coloured chat prefixes such as [INFO] is used with the SendMessageXXX() or BroadcastChatXXX(), or simply the entire message is coloured in the respective colour." },
 				SetSignLines = { Params = "X, Y, Z, Line1, Line2, Line3, Line4, [{{cPlayer|Player}}]", Return = "", Notes = "Sets the sign text at the specified coords. The sign-updating hooks are called for the change. The Player parameter is used to indicate the player from whom the change has come, it may be nil." },
+				SetSpawn = { Params = "X, Y, Z", Return = "bool", Notes = "Sets the default spawn at the specified coords." },
 				SetTicksUntilWeatherChange = { Params = "NumTicks", Return = "", Notes = "Sets the number of ticks after which the weather will be changed." },
 				SetTimeOfDay = { Params = "TimeOfDayTicks", Return = "", Notes = "Sets the time of day, expressed as number of ticks past sunrise, in the range 0 .. 24000." },
 				SetTNTShrapnelLevel = { Params = "{{Globals#ShrapnelLevel|ShrapnelLevel}}", Return = "", Notes = "Sets the Shrampel level of the world." },

--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -291,6 +291,126 @@ tolua_lerror:
 
 
 
+/* function: TeleportToCoords */
+static int tolua_cEntity_TeleportToCoords00(lua_State* tolua_S)
+{
+	cLuaState LuaState(tolua_S);
+
+	if (
+		!LuaState.CheckParamUserType(1, "cEntity") ||
+		!LuaState.CheckParamNumber(2, 4) ||
+		!LuaState.CheckParamEnd(5)
+		)
+		return 0;
+	else
+	{
+		cEntity * self = nullptr;
+		double BlockX = 0;
+		double BlockY = 0;
+		double BlockZ = 0;
+
+		LuaState.GetStackValues(1, self, BlockX, BlockY, BlockZ);
+
+		#ifndef TOLUA_RELEASE
+		if (self == nullptr)
+		{
+			tolua_error(LuaState, "invalid 'self' in function 'TeleportToCoords'", nullptr);
+		}
+		#endif
+		{
+			self->TeleportToCoords({ BlockX, BlockY, BlockZ });
+		}
+	}
+	LOGWARNING("Warning in function call 'TeleportToCoords': TeleportToCoords(X, Y, Z) is deprecated. Please use TeleportToCoords(Vector3d)");
+	LuaState.LogStackTrace(0);
+	return 1;
+}
+
+
+
+
+
+/* function: MoveToWorld */
+static int tolua_cEntity_MoveToWorld00(lua_State* tolua_S)
+{
+	cLuaState LuaState(tolua_S);
+
+	if (!LuaState.CheckParamUserType(1, "cEntity"))
+	{
+		return 0;
+	}
+
+	if (LuaState.CheckParamString(2) && (LuaState.CheckParamEnd(3) || LuaState.CheckParamEnd(4)))
+	{
+		cEntity * self = nullptr;
+		std::string WorldName;
+		LuaState.GetStackValues(1, self, WorldName);
+
+		#ifndef TOLUA_RELEASE
+		if (self == nullptr)
+		{
+			tolua_error(LuaState, "invalid 'self' in function 'MoveToWorld'", nullptr);
+		}
+		#endif
+		{
+			self->MoveToWorld(WorldName, self->GetPosition());
+		}
+	}
+	else if (LuaState.CheckParamUserType(2, "cWorld"))
+	{
+		if (LuaState.CheckParamUserType(4, "Vector3d") && LuaState.CheckParamEnd(5))
+		{
+			cEntity * self = nullptr;
+			cWorld * World;
+			Vector3d * Position;
+			LuaState.GetStackValues(1, self, World);
+			LuaState.GetStackValues(4, Position);
+
+			#ifndef TOLUA_RELEASE
+			if (self == nullptr)
+			{
+				tolua_error(LuaState, "invalid 'self' in function 'MoveToWorld'", nullptr);
+			}
+			#endif
+			{
+				self->MoveToWorld(*World, *Position);
+			}
+		}
+		else if (LuaState.CheckParamEnd(4))
+		{
+			cEntity * self = nullptr;
+			std::string WorldName;
+			LuaState.GetStackValues(1, self, WorldName);
+
+			#ifndef TOLUA_RELEASE
+			if (self == nullptr)
+			{
+				tolua_error(LuaState, "invalid 'self' in function 'MoveToWorld'", nullptr);
+			}
+			#endif
+			{
+				self->MoveToWorld(WorldName, self->GetPosition());
+			}
+		}
+		else
+		{
+			return 0;
+		}
+	}
+	else
+	{
+		return 0;
+	}
+
+	LOGWARNING("Warning in function call 'MoveToWorld': the ShouldSendRespawn parameter is deprecated and a destination position is mandatory.");
+	LuaState.LogStackTrace(0);
+	return 1;
+}
+
+
+
+
+
 /** function: cWorld:SetSignLines */
 static int tolua_cWorld_SetSignLines(lua_State * tolua_S)
 {
@@ -415,6 +535,11 @@ void DeprecatedBindings::Bind(lua_State * tolua_S)
 	tolua_beginmodule(tolua_S, "Vector3d");
 		tolua_function(tolua_S,"abs",   tolua_Vector3_Abs<double>);
 		tolua_function(tolua_S,"clamp", tolua_Vector3_Clamp<double>);
+	tolua_endmodule(tolua_S);
+	
+	tolua_beginmodule(tolua_S, "cEntity");
+		tolua_function(tolua_S, "MoveToWorld", tolua_cEntity_MoveToWorld00);
+		tolua_function(tolua_S, "TeleportToCoords", tolua_cEntity_TeleportToCoords00);
 	tolua_endmodule(tolua_S);
 
 	tolua_endmodule(tolua_S);

--- a/src/Bindings/LuaChunkStay.h
+++ b/src/Bindings/LuaChunkStay.h
@@ -30,24 +30,19 @@ class cLuaChunkStay
 	typedef cChunkStay super;
 
 public:
-	cLuaChunkStay(cPluginLua & a_Plugin);
+	cLuaChunkStay();
 
 	~cLuaChunkStay() { }
 
-	/** Adds chunks in the specified on-stack Lua table.
+	/** Adds chunks in the specified Lua table.
+	Can be called only once.
 	Returns true if any chunk added, false (plus log warning) if none. */
-	bool AddChunks(int a_ChunkCoordTableStackPos);
+	bool AddChunks(const cLuaState::cStackTable & a_ChunkCoords);
 
 	/** Enables the ChunkStay for the specified chunkmap, with the specified Lua callbacks. */
 	void Enable(cChunkMap & a_ChunkMap, cLuaState::cCallbackPtr a_OnChunkAvailable, cLuaState::cCallbackPtr a_OnAllChunksAvailable);
 
 protected:
-	/** The plugin which has created the ChunkStay, via cWorld:ChunkStay() binding method.  */
-	cPluginLua & m_Plugin;
-
-	/** The Lua state associated with the callbacks. Only valid when enabled. */
-	cLuaState * m_LuaState;
-
 	/** The Lua function to call in OnChunkAvailable. Only valid when enabled. */
 	cLuaState::cCallbackPtr m_OnChunkAvailable;
 

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -12,7 +12,6 @@
 #include "PluginLua.h"
 #include "PluginManager.h"
 #include "LuaWindow.h"
-#include "LuaChunkStay.h"
 #include "../Root.h"
 #include "../World.h"
 #include "../Entities/Player.h"

--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -450,9 +450,6 @@ static int tolua_cWorld_PrepareChunk(lua_State * tolua_S)
 			{
 				m_LuaState.Call(m_Callback, a_CBChunkX, a_CBChunkZ, a_IsSuccess);
 			}
-
-			// This is the last reference of this object, we must delete it so that it doesn't leak:
-			delete this;
 		}
 
 	protected:

--- a/src/BlockEntities/ChestEntity.h
+++ b/src/BlockEntities/ChestEntity.h
@@ -66,7 +66,7 @@ private:
 				GetWindow()->BroadcastWholeWindow();
 			}
 
-			m_World->MarkChunkDirty(GetChunkX(), GetChunkZ());
+			m_World->QueueTask([this](cWorld & a_World) { a_World.MarkChunkDirty(GetChunkX(), GetChunkZ()); });
 		}
 	}
 

--- a/src/BlockEntities/MobSpawnerEntity.cpp
+++ b/src/BlockEntities/MobSpawnerEntity.cpp
@@ -163,7 +163,7 @@ void cMobSpawnerEntity::SpawnEntity(void)
 					double PosX = Chunk->GetPosX() * cChunkDef::Width + RelX;
 					double PosZ = Chunk->GetPosZ() * cChunkDef::Width + RelZ;
 
-					cMonster * Monster = cMonster::NewMonsterFromType(m_MobType);
+					auto Monster = cMonster::NewMonsterFromType(m_MobType);
 					if (Monster == nullptr)
 					{
 						continue;
@@ -171,7 +171,7 @@ void cMobSpawnerEntity::SpawnEntity(void)
 
 					Monster->SetPosition(PosX, RelY, PosZ);
 					Monster->SetYaw(Random.NextFloat() * 360.0f);
-					if (Chunk->GetWorld()->SpawnMobFinalize(Monster) != cEntity::INVALID_ID)
+					if (Chunk->GetWorld()->SpawnMobFinalize(std::move(Monster)) != cEntity::INVALID_ID)
 					{
 						EntitiesSpawned = true;
 						Chunk->BroadcastSoundParticleEffect(

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -15,13 +15,14 @@ void cBroadcaster::BroadcastParticleEffect(const AString & a_ParticleName, const
 	m_World->DoWithChunkAt(a_Src,
 		[=](cChunk & a_Chunk) -> bool
 		{
-			for (auto && client : a_Chunk.GetAllClients())
+			for (const auto & ClientHandle : a_Chunk.GetAllStrongClientPtrs())
 			{
-				if (client == a_Exclude)
+				if (ClientHandle.get() == a_Exclude)
 				{
 					continue;
 				}
-				client->SendParticleEffect(a_ParticleName, a_Src.x, a_Src.y, a_Src.z, a_Offset.x, a_Offset.y, a_Offset.z, a_ParticleData, a_ParticleAmount);
+
+				ClientHandle->SendParticleEffect(a_ParticleName, a_Src.x, a_Src.y, a_Src.z, a_Offset.x, a_Offset.y, a_Offset.z, a_ParticleData, a_ParticleAmount);
 			};
 			return true;
 		});
@@ -33,13 +34,14 @@ void cBroadcaster::BroadcastParticleEffect(const AString & a_ParticleName, const
 	m_World->DoWithChunkAt(a_Src,
 		[=](cChunk & a_Chunk) -> bool
 		{
-			for (auto && client : a_Chunk.GetAllClients())
+			for (const auto & ClientHandle : a_Chunk.GetAllStrongClientPtrs())
 			{
-				if (client == a_Exclude)
+				if (ClientHandle.get() == a_Exclude)
 				{
 					continue;
 				}
-				client->SendParticleEffect(a_ParticleName, a_Src, a_Offset, a_ParticleData, a_ParticleAmount, a_Data);
+
+				ClientHandle->SendParticleEffect(a_ParticleName, a_Src, a_Offset, a_ParticleData, a_ParticleAmount, a_Data);
 			};
 			return true;
 		});

--- a/src/ByteBuffer.cpp
+++ b/src/ByteBuffer.cpp
@@ -136,7 +136,7 @@ bool cByteBuffer::Write(const void * a_Bytes, size_t a_Count)
 	// Store the current free space for a check after writing:
 	size_t CurFreeSpace = GetFreeSpace();
 	#ifdef _DEBUG
-		size_t CurReadableSpace = GetReadableSpace();
+		auto CurReadableSpace = GetReadableSpace();
 	#endif
 	size_t WrittenBytes = 0;
 

--- a/src/CheckBasicStyle.lua
+++ b/src/CheckBasicStyle.lua
@@ -203,8 +203,6 @@ local g_ViolationPatterns =
 	-- We don't like "Type const *" and "Type const &". Use "const Type *" and "const Type &" instead:
 	{"const %&", "Use 'const Type &' instead of 'Type const &'"},
 	{"const %*", "Use 'const Type *' instead of 'Type const *'"},
-
-	{"virtual [^~]*%(.*%)%s*;%s*$", "Virtual function without override keyword"},
 }
 
 

--- a/src/CheckBasicStyle.lua
+++ b/src/CheckBasicStyle.lua
@@ -203,6 +203,8 @@ local g_ViolationPatterns =
 	-- We don't like "Type const *" and "Type const &". Use "const Type *" and "const Type &" instead:
 	{"const %&", "Use 'const Type &' instead of 'Type const &'"},
 	{"const %*", "Use 'const Type *' instead of 'Type const *'"},
+
+	{"virtual [^~]*%(.*%)%s*;%s*$", "Virtual function without override keyword"},
 }
 
 

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -88,7 +88,7 @@ public:
 		cChunk * a_NeighborXM, cChunk * a_NeighborXP, cChunk * a_NeighborZM, cChunk * a_NeighborZP,  // Neighbor chunks
 		cAllocationPool<cChunkData::sChunkSection> & a_Pool
 	);
-	cChunk(cChunk & other);
+
 	~cChunk();
 
 	/** Returns true iff the chunk block data is valid (loaded / generated) */
@@ -244,22 +244,21 @@ public:
 
 	int  GetHeight( int a_X, int a_Z);
 
-	void SendBlockTo(int a_RelX, int a_RelY, int a_RelZ, cClientHandle * a_Client);
+	void SendBlockTo(int a_RelX, int a_RelY, int a_RelZ, const std::weak_ptr<cClientHandle> & a_Client);
 
 	/** Adds a client to the chunk; returns true if added, false if already there */
-	bool AddClient(cClientHandle * a_Client);
+	bool AddClient(const std::shared_ptr<cClientHandle> & a_Client);
 
 	/** Removes the specified client from the chunk; ignored if client not in chunk. */
-	void RemoveClient(cClientHandle * a_Client);
-
-	/** Returns true if the specified client is present in this chunk. */
-	bool HasClient(cClientHandle * a_Client);
+	void RemoveClient(const std::shared_ptr<cClientHandle> & a_Client);
 
 	/** Returns true if theres any client in the chunk; false otherwise */
 	bool HasAnyClients(void) const;
 
-	void AddEntity(cEntity * a_Entity);
-	void RemoveEntity(cEntity * a_Entity);
+	void AddEntity(std::unique_ptr<cEntity> a_Entity);
+
+	void RemoveEntity(cEntity & a_Entity);
+
 	bool HasEntity(UInt32 a_EntityID);
 
 	/** Calls the callback for each entity; returns true if all entities processed, false if the callback aborted by returning true */
@@ -477,10 +476,13 @@ public:
 	as at least one requests is active the chunk will be ticked). */
 	void SetAlwaysTicked(bool a_AlwaysTicked);
 
-	// Makes a copy of the list
-	cClientHandleList GetAllClients(void) const
+	/** Collects and returns a list of all clients in the world who currently have this chunk. */
+	std::vector<std::shared_ptr<cClientHandle>> GetAllStrongClientPtrs(void);
+
+	/** Returns the internal data structure holding weak pointers to all clients in this chunk. */
+	auto & GetAllWeakClientPtrs(void)
 	{
-		return cClientHandleList(m_LoadedByClient.begin(), m_LoadedByClient.end());
+		return m_LoadedByClient;
 	}
 
 private:

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -519,9 +519,8 @@ private:
 	std::vector<Vector3i> m_ToTickBlocks;
 	sSetBlockVector       m_PendingSendBlocks;  ///< Blocks that have changed and need to be sent to all clients
 
-	// A critical section is not needed, because all chunk access is protected by its parent ChunkMap's csLayers
-	std::vector<cClientHandle *> m_LoadedByClient;
 	cEntityList                  m_Entities;
+	std::vector<std::weak_ptr<cClientHandle>> m_LoadedByClient;
 	cBlockEntityList             m_BlockEntities;
 
 	/** Number of times the chunk has been requested to stay (by various cChunkStay objects); if zero, the chunk can be unloaded */

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -31,7 +31,7 @@ class cEntity;
 class cClientHandle;
 class cBlockEntity;
 
-typedef std::list<cEntity *>        cEntityList;
+typedef std::vector<std::unique_ptr<cEntity>> cEntityList;
 typedef std::list<cBlockEntity *>   cBlockEntityList;
 
 

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -53,6 +53,32 @@ typedef unsigned char HEIGHTTYPE;
 
 
 
+
+class cChunkCoords
+{
+public:
+	int m_ChunkX;
+	int m_ChunkZ;
+
+	cChunkCoords(int a_ChunkX, int a_ChunkZ) : m_ChunkX(a_ChunkX), m_ChunkZ(a_ChunkZ) {}
+
+	bool operator == (const cChunkCoords & a_Other) const
+	{
+		return ((m_ChunkX == a_Other.m_ChunkX) && (m_ChunkZ == a_Other.m_ChunkZ));
+	}
+
+	bool operator != (const cChunkCoords & a_Other) const
+	{
+		return !operator == (a_Other);
+	}
+};
+
+typedef std::vector<cChunkCoords> cChunkCoordsVector;
+
+
+
+
+
 /** Constants used throughout the code, useful typedefs and utility functions */
 class cChunkDef
 {
@@ -140,6 +166,12 @@ public:
 		{
 			a_ChunkZ--;
 		}
+	}
+
+	/** Converts absolute block coords to chunk coords. */
+	inline static cChunkCoords BlockToChunk(const Vector3i & a_Position)
+	{
+		return { FloorC(a_Position.x / cChunkDef::Width),  FloorC(a_Position.x / cChunkDef::Width) };
 	}
 
 
@@ -406,27 +438,6 @@ struct sSetBlock
 
 typedef std::list<sSetBlock> sSetBlockList;
 typedef std::vector<sSetBlock> sSetBlockVector;
-
-
-
-
-
-class cChunkCoords
-{
-public:
-	int m_ChunkX;
-	int m_ChunkZ;
-
-	cChunkCoords(int a_ChunkX, int a_ChunkZ) : m_ChunkX(a_ChunkX), m_ChunkZ(a_ChunkZ) {}
-
-	bool operator == (const cChunkCoords & a_Other) const
-	{
-		return ((m_ChunkX == a_Other.m_ChunkX) && (m_ChunkZ == a_Other.m_ChunkZ));
-	}
-} ;
-
-typedef std::list<cChunkCoords> cChunkCoordsList;
-typedef std::vector<cChunkCoords> cChunkCoordsVector;
 
 
 

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -65,6 +65,8 @@ cChunkMap::~cChunkMap()
 
 cChunkPtr cChunkMap::ConstructChunk(int a_ChunkX, int a_ChunkZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
+	
 	auto Chunk = FindChunk(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -85,6 +87,7 @@ cChunkPtr cChunkMap::ConstructChunk(int a_ChunkX, int a_ChunkZ)
 			).first
 		).second.get();
 	}
+
 	return Chunk;
 }
 
@@ -94,7 +97,7 @@ cChunkPtr cChunkMap::ConstructChunk(int a_ChunkX, int a_ChunkZ)
 
 cChunkPtr cChunkMap::GetChunk(int a_ChunkX, int a_ChunkZ)
 {
-	ASSERT(m_CSChunks.IsLockedByCurrentThread());  // m_CSChunks should already be locked by the operation that called us
+	ASSERT(GetWorld()->IsInTickThread());
 
 	auto Chunk = ConstructChunk(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
@@ -116,7 +119,7 @@ cChunkPtr cChunkMap::GetChunk(int a_ChunkX, int a_ChunkZ)
 
 cChunkPtr cChunkMap::GetChunkNoGen(int a_ChunkX, int a_ChunkZ)
 {
-	ASSERT(m_CSChunks.IsLockedByCurrentThread());  // m_CSChunks should already be locked by the operation that called us
+	ASSERT(GetWorld()->IsInTickThread());
 
 	auto Chunk = ConstructChunk(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
@@ -138,7 +141,7 @@ cChunkPtr cChunkMap::GetChunkNoGen(int a_ChunkX, int a_ChunkZ)
 
 cChunkPtr cChunkMap::GetChunkNoLoad(int a_ChunkX, int a_ChunkZ)
 {
-	ASSERT(m_CSChunks.IsLockedByCurrentThread());  // m_CSChunks should already be locked by the operation that called us
+	ASSERT(GetWorld()->IsInTickThread());
 	return ConstructChunk(a_ChunkX, a_ChunkZ);
 }
 
@@ -148,8 +151,7 @@ cChunkPtr cChunkMap::GetChunkNoLoad(int a_ChunkX, int a_ChunkZ)
 
 bool cChunkMap::LockedGetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta)
 {
-	// We already have m_CSChunks locked since this can be called only from within the tick thread
-	ASSERT(m_CSChunks.IsLockedByCurrentThread());
+	ASSERT(GetWorld()->IsInTickThread());
 
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
@@ -170,8 +172,7 @@ bool cChunkMap::LockedGetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTY
 
 bool cChunkMap::LockedGetBlockType(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE & a_BlockType)
 {
-	// We already have m_CSChunks locked since this can be called only from within the tick thread
-	ASSERT(m_CSChunks.IsLockedByCurrentThread());
+	ASSERT(GetWorld()->IsInTickThread());
 
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
@@ -191,8 +192,7 @@ bool cChunkMap::LockedGetBlockType(int a_BlockX, int a_BlockY, int a_BlockZ, BLO
 
 bool cChunkMap::LockedGetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE & a_BlockMeta)
 {
-	// We already have m_CSChunks locked since this can be called only from within the tick thread
-	ASSERT(m_CSChunks.IsLockedByCurrentThread());
+	ASSERT(GetWorld()->IsInTickThread());
 
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
@@ -212,7 +212,8 @@ bool cChunkMap::LockedGetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIB
 
 bool cChunkMap::LockedSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE   a_BlockType, NIBBLETYPE   a_BlockMeta)
 {
-	// We already have m_CSChunks locked since this can be called only from within the tick thread
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
@@ -232,6 +233,7 @@ bool cChunkMap::LockedSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTY
 bool cChunkMap::LockedFastSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 {
 	// We already have m_CSChunks locked since this can be called only from within the tick thread
+
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
@@ -250,7 +252,7 @@ bool cChunkMap::LockedFastSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLO
 
 cChunk * cChunkMap::FindChunk(int a_ChunkX, int a_ChunkZ)
 {
-	ASSERT(m_CSChunks.IsLockedByCurrentThread());
+	ASSERT(GetWorld()->IsInTickThread());
 
 	auto Chunk = m_Chunks.find({ a_ChunkX, a_ChunkZ });
 	return (Chunk == m_Chunks.end()) ? nullptr : Chunk->second.get();
@@ -262,7 +264,8 @@ cChunk * cChunkMap::FindChunk(int a_ChunkX, int a_ChunkZ)
 
 void cChunkMap::BroadcastAttachEntity(const cEntity & a_Entity, const cEntity & a_Vehicle)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -278,7 +281,8 @@ void cChunkMap::BroadcastAttachEntity(const cEntity & a_Entity, const cEntity & 
 
 void cChunkMap::BroadcastBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int x, z, ChunkX, ChunkZ;
 	x = a_BlockX;
 	z = a_BlockZ;
@@ -298,7 +302,8 @@ void cChunkMap::BroadcastBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 void cChunkMap::BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
@@ -317,7 +322,8 @@ void cChunkMap::BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, in
 
 void cChunkMap::BroadcastBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
@@ -334,7 +340,8 @@ void cChunkMap::BroadcastBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 void cChunkMap::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -350,7 +357,8 @@ void cChunkMap::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer &
 
 void cChunkMap::BroadcastDestroyEntity(const cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -366,7 +374,8 @@ void cChunkMap::BroadcastDestroyEntity(const cEntity & a_Entity, const cClientHa
 
 void cChunkMap::BroadcastDetachEntity(const cEntity & a_Entity, const cEntity & a_PreviousVehicle)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -382,7 +391,8 @@ void cChunkMap::BroadcastDetachEntity(const cEntity & a_Entity, const cEntity & 
 
 void cChunkMap::BroadcastEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -398,7 +408,8 @@ void cChunkMap::BroadcastEntityEffect(const cEntity & a_Entity, int a_EffectID, 
 
 void cChunkMap::BroadcastEntityEquipment(const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -414,7 +425,8 @@ void cChunkMap::BroadcastEntityEquipment(const cEntity & a_Entity, short a_SlotN
 
 void cChunkMap::BroadcastEntityHeadLook(const cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -430,7 +442,8 @@ void cChunkMap::BroadcastEntityHeadLook(const cEntity & a_Entity, const cClientH
 
 void cChunkMap::BroadcastEntityLook(const cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -446,7 +459,8 @@ void cChunkMap::BroadcastEntityLook(const cEntity & a_Entity, const cClientHandl
 
 void cChunkMap::BroadcastEntityMetadata(const cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -462,7 +476,8 @@ void cChunkMap::BroadcastEntityMetadata(const cEntity & a_Entity, const cClientH
 
 void cChunkMap::BroadcastEntityRelMove(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -478,7 +493,8 @@ void cChunkMap::BroadcastEntityRelMove(const cEntity & a_Entity, char a_RelX, ch
 
 void cChunkMap::BroadcastEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -494,7 +510,8 @@ void cChunkMap::BroadcastEntityRelMoveLook(const cEntity & a_Entity, char a_RelX
 
 void cChunkMap::BroadcastEntityStatus(const cEntity & a_Entity, char a_Status, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -510,7 +527,8 @@ void cChunkMap::BroadcastEntityStatus(const cEntity & a_Entity, char a_Status, c
 
 void cChunkMap::BroadcastEntityVelocity(const cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -526,7 +544,8 @@ void cChunkMap::BroadcastEntityVelocity(const cEntity & a_Entity, const cClientH
 
 void cChunkMap::BroadcastEntityAnimation(const cEntity & a_Entity, char a_Animation, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -542,7 +561,8 @@ void cChunkMap::BroadcastEntityAnimation(const cEntity & a_Entity, char a_Animat
 
 void cChunkMap::BroadcastParticleEffect(const AString & a_ParticleName, float a_SrcX, float a_SrcY, float a_SrcZ, float a_OffsetX, float a_OffsetY, float a_OffsetZ, float a_ParticleData, int a_ParticleAmount, cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 
 	cChunkDef::BlockToChunk(FloorC(a_SrcX), FloorC(a_SrcZ), ChunkX, ChunkZ);
@@ -561,7 +581,8 @@ void cChunkMap::BroadcastParticleEffect(const AString & a_ParticleName, float a_
 
 void cChunkMap::BroadcastRemoveEntityEffect(const cEntity & a_Entity, int a_EffectID, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
@@ -578,7 +599,8 @@ void cChunkMap::BroadcastRemoveEntityEffect(const cEntity & a_Entity, int a_Effe
 
 void cChunkMap::BroadcastSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 
 	cChunkDef::BlockToChunk(FloorC(std::floor(a_X)), FloorC(std::floor(a_Z)), ChunkX, ChunkZ);
@@ -597,7 +619,8 @@ void cChunkMap::BroadcastSoundEffect(const AString & a_SoundName, double a_X, do
 
 void cChunkMap::BroadcastSoundParticleEffect(const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 
 	cChunkDef::BlockToChunk(a_SrcX, a_SrcZ, ChunkX, ChunkZ);
@@ -616,7 +639,8 @@ void cChunkMap::BroadcastSoundParticleEffect(const EffectID a_EffectID, int a_Sr
 
 void cChunkMap::BroadcastSpawnEntity(cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
 	if (Chunk == nullptr)
 	{
@@ -632,7 +656,8 @@ void cChunkMap::BroadcastSpawnEntity(cEntity & a_Entity, const cClientHandle * a
 
 void cChunkMap::BroadcastThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
@@ -650,7 +675,8 @@ void cChunkMap::BroadcastThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 void cChunkMap::BroadcastUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
@@ -669,7 +695,8 @@ void cChunkMap::BroadcastUseBed(const cEntity & a_Entity, int a_BlockX, int a_Bl
 
 void cChunkMap::SendBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cClientHandle & a_Client)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
@@ -686,8 +713,9 @@ void cChunkMap::SendBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cClien
 
 bool cChunkMap::UseBlockEntity(cPlayer * a_Player, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	// a_Player rclked block entity at the coords specified, handle it
-	cCSLock Lock(m_CSChunks);
+
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
@@ -704,7 +732,8 @@ bool cChunkMap::UseBlockEntity(cPlayer * a_Player, int a_BlockX, int a_BlockY, i
 
 bool cChunkMap::DoWithChunk(int a_ChunkX, int a_ChunkZ, cChunkCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -716,6 +745,7 @@ bool cChunkMap::DoWithChunk(int a_ChunkX, int a_ChunkZ, cChunkCallback & a_Callb
 
 bool cChunkMap::DoWithChunkAt(Vector3i a_BlockPos, std::function<bool(cChunk &)> a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(a_BlockPos.x, a_BlockPos.z, ChunkX, ChunkZ);
 	struct cCallBackWrapper : cChunkCallback
@@ -741,7 +771,8 @@ bool cChunkMap::DoWithChunkAt(Vector3i a_BlockPos, std::function<bool(cChunk &)>
 
 void cChunkMap::WakeUpSimulators(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
@@ -758,6 +789,7 @@ void cChunkMap::WakeUpSimulators(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 void cChunkMap::WakeUpSimulatorsInArea(int a_MinBlockX, int a_MaxBlockX, int a_MinBlockY, int a_MaxBlockY, int a_MinBlockZ, int a_MaxBlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	// Limit the Y coords:
 	a_MinBlockY = std::max(a_MinBlockY, 0);
 	a_MaxBlockY = std::min(a_MaxBlockY, cChunkDef::Height - 1);
@@ -766,7 +798,7 @@ void cChunkMap::WakeUpSimulatorsInArea(int a_MinBlockX, int a_MaxBlockX, int a_M
 	int MinChunkX, MinChunkZ, MaxChunkX, MaxChunkZ;
 	cChunkDef::BlockToChunk(a_MinBlockX, a_MinBlockZ, MinChunkX, MinChunkZ);
 	cChunkDef::BlockToChunk(a_MaxBlockX, a_MaxBlockZ, MaxChunkX, MaxChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	for (int z = MinChunkZ; z <= MaxChunkZ; z++)
 	{
 		int MinZ = std::max(a_MinBlockZ, z * cChunkDef::Width);
@@ -800,7 +832,8 @@ void cChunkMap::WakeUpSimulatorsInArea(int a_MinBlockX, int a_MaxBlockX, int a_M
 
 void cChunkMap::MarkChunkDirty(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -815,7 +848,8 @@ void cChunkMap::MarkChunkDirty(int a_ChunkX, int a_ChunkZ)
 
 void cChunkMap::MarkChunkSaving(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -830,7 +864,8 @@ void cChunkMap::MarkChunkSaving(int a_ChunkX, int a_ChunkZ)
 
 void cChunkMap::MarkChunkSaved (int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -848,7 +883,8 @@ void cChunkMap::SetChunkData(cSetChunkData & a_SetChunkData)
 	int ChunkX = a_SetChunkData.GetChunkX();
 	int ChunkZ = a_SetChunkData.GetChunkZ();
 	{
-		cCSLock Lock(m_CSChunks);
+		ASSERT(GetWorld()->IsInTickThread());
+
 		cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
 		if (Chunk == nullptr)
 		{
@@ -893,7 +929,8 @@ void cChunkMap::ChunkLighted(
 	const cChunkDef::BlockNibbles & a_SkyLight
 )
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -909,7 +946,8 @@ void cChunkMap::ChunkLighted(
 
 bool cChunkMap::GetChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -925,7 +963,8 @@ bool cChunkMap::GetChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataCallback & a_
 
 bool cChunkMap::GetChunkBlockTypes(int a_ChunkX, int a_ChunkZ, BLOCKTYPE * a_BlockTypes)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -941,7 +980,8 @@ bool cChunkMap::GetChunkBlockTypes(int a_ChunkX, int a_ChunkZ, BLOCKTYPE * a_Blo
 
 bool cChunkMap::IsChunkQueued(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	return (Chunk != nullptr) && Chunk->IsQueued();
 }
@@ -952,7 +992,8 @@ bool cChunkMap::IsChunkQueued(int a_ChunkX, int a_ChunkZ)
 
 bool cChunkMap::IsChunkValid(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	return (Chunk != nullptr) && Chunk->IsValid();
 }
@@ -963,7 +1004,8 @@ bool cChunkMap::IsChunkValid(int a_ChunkX, int a_ChunkZ)
 
 bool cChunkMap::HasChunkAnyClients(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	return (Chunk != nullptr) && Chunk->HasAnyClients();
 }
@@ -974,9 +1016,10 @@ bool cChunkMap::HasChunkAnyClients(int a_ChunkX, int a_ChunkZ)
 
 int  cChunkMap::GetHeight(int a_BlockX, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
+	
 	for (;;)
 	{
-		cCSLock Lock(m_CSChunks);
 		int ChunkX, ChunkZ, BlockY = 0;
 		cChunkDef::AbsoluteToRelative(a_BlockX, BlockY, a_BlockZ, ChunkX, ChunkZ);
 		cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
@@ -991,7 +1034,6 @@ int  cChunkMap::GetHeight(int a_BlockX, int a_BlockZ)
 		}
 
 		// The chunk is not valid, wait for it to become valid:
-		cCSUnlock Unlock(Lock);
 		m_evtChunkValid.Wait();
 	}  // while (true)
 }
@@ -1002,8 +1044,9 @@ int  cChunkMap::GetHeight(int a_BlockX, int a_BlockZ)
 
 bool cChunkMap::TryGetHeight(int a_BlockX, int a_BlockZ, int & a_Height)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	// Returns false if chunk not loaded / generated
-	cCSLock Lock(m_CSChunks);
+
 	int ChunkX, ChunkZ, BlockY = 0;
 	cChunkDef::AbsoluteToRelative(a_BlockX, BlockY, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
@@ -1021,7 +1064,8 @@ bool cChunkMap::TryGetHeight(int a_BlockX, int a_BlockZ, int & a_Height)
 
 void cChunkMap::SetBlocks(const sSetBlockVector & a_Blocks)
 {
-	cCSLock lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr chunk = nullptr;
 	int lastChunkX = 0x7fffffff;  // Bogus coords so that chunk is updated on first pass
 	int lastChunkZ = 0x7fffffff;
@@ -1049,6 +1093,7 @@ void cChunkMap::SetBlocks(const sSetBlockVector & a_Blocks)
 
 void cChunkMap::CollectPickupsByPlayer(cPlayer & a_Player)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int BlockX = static_cast<int>(a_Player.GetPosX());  // Truncating doesn't matter much; we're scanning entire chunks anyway
 	int BlockY = static_cast<int>(a_Player.GetPosY());
 	int BlockZ = static_cast<int>(a_Player.GetPosZ());
@@ -1060,7 +1105,7 @@ void cChunkMap::CollectPickupsByPlayer(cPlayer & a_Player)
 	// We suppose that each player keeps their chunks in memory, therefore it makes little sense to try to re-load or even generate them.
 	// The only time the chunks are not valid is when the player is downloading the initial world and they should not call this at that moment
 
-	cCSLock Lock(m_CSChunks);
+
 	GetChunkNoLoad(ChunkX, ChunkZ)->CollectPickupsByPlayer(a_Player);
 
 	// Check the neighboring chunks as well:
@@ -1076,12 +1121,13 @@ void cChunkMap::CollectPickupsByPlayer(cPlayer & a_Player)
 
 BLOCKTYPE cChunkMap::GetBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int X = a_BlockX, Y = a_BlockY, Z = a_BlockZ;
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(X, Y, Z, ChunkX, ChunkZ);
 
 	// Query the chunk, if loaded:
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1096,12 +1142,13 @@ BLOCKTYPE cChunkMap::GetBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 NIBBLETYPE cChunkMap::GetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int X = a_BlockX, Y = a_BlockY, Z = a_BlockZ;
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(X, Y, Z, ChunkX, ChunkZ);
 
 	// Query the chunk, if loaded:
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1116,10 +1163,11 @@ NIBBLETYPE cChunkMap::GetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 NIBBLETYPE cChunkMap::GetBlockSkyLight(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk( ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1134,10 +1182,11 @@ NIBBLETYPE cChunkMap::GetBlockSkyLight(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 NIBBLETYPE cChunkMap::GetBlockBlockLight(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk( ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1152,11 +1201,12 @@ NIBBLETYPE cChunkMap::GetBlockBlockLight(int a_BlockX, int a_BlockY, int a_Block
 
 void cChunkMap::SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_BlockMeta, bool a_ShouldMarkDirty, bool a_ShouldInformClients)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 	// a_BlockXYZ now contains relative coords!
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1170,13 +1220,14 @@ void cChunkMap::SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYP
 
 void cChunkMap::SetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_SendToClients)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	cChunkInterface ChunkInterface(this);
 	BlockHandler(GetBlock(a_BlockX, a_BlockY, a_BlockZ))->OnDestroyed(ChunkInterface, *m_World, a_BlockX, a_BlockY, a_BlockZ);
 
 	int ChunkX, ChunkZ, X = a_BlockX, Y = a_BlockY, Z = a_BlockZ;
 	cChunkDef::AbsoluteToRelative( X, Y, Z, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk( ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1192,10 +1243,11 @@ void cChunkMap::SetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_B
 
 bool cChunkMap::GetBlockTypeMeta(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ, X = a_BlockX, Y = a_BlockY, Z = a_BlockZ;
 	cChunkDef::AbsoluteToRelative( X, Y, Z, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk( ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1211,10 +1263,11 @@ bool cChunkMap::GetBlockTypeMeta(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCK
 
 bool cChunkMap::GetBlockInfo(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ, X = a_BlockX, Y = a_BlockY, Z = a_BlockZ;
 	cChunkDef::AbsoluteToRelative( X, Y, Z, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk( ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1230,7 +1283,8 @@ bool cChunkMap::GetBlockInfo(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE
 
 void cChunkMap::ReplaceBlocks(const sSetBlockVector & a_Blocks, BLOCKTYPE a_FilterBlockType)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	for (sSetBlockVector::const_iterator itr = a_Blocks.begin(); itr != a_Blocks.end(); ++itr)
 	{
 		cChunkPtr Chunk = GetChunk(itr->m_ChunkX, itr->m_ChunkZ);
@@ -1251,7 +1305,8 @@ void cChunkMap::ReplaceBlocks(const sSetBlockVector & a_Blocks, BLOCKTYPE a_Filt
 
 void cChunkMap::ReplaceTreeBlocks(const sSetBlockVector & a_Blocks)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	for (sSetBlockVector::const_iterator itr = a_Blocks.begin(); itr != a_Blocks.end(); ++itr)
 	{
 		cChunkPtr Chunk = GetChunk(itr->m_ChunkX, itr->m_ChunkZ);
@@ -1285,10 +1340,11 @@ void cChunkMap::ReplaceTreeBlocks(const sSetBlockVector & a_Blocks)
 
 EMCSBiome cChunkMap::GetBiomeAt (int a_BlockX, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ, X = a_BlockX, Y = 0, Z = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(X, Y, Z, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1306,10 +1362,11 @@ EMCSBiome cChunkMap::GetBiomeAt (int a_BlockX, int a_BlockZ)
 
 bool cChunkMap::SetBiomeAt(int a_BlockX, int a_BlockZ, EMCSBiome a_Biome)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ, X = a_BlockX, Y = 0, Z = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(X, Y, Z, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -1325,6 +1382,7 @@ bool cChunkMap::SetBiomeAt(int a_BlockX, int a_BlockZ, EMCSBiome a_Biome)
 
 bool cChunkMap::SetAreaBiome(int a_MinX, int a_MaxX, int a_MinZ, int a_MaxZ, EMCSBiome a_Biome)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	// Translate coords to relative:
 	int Y = 0;
 	int MinChunkX, MinChunkZ, MinX = a_MinX, MinZ = a_MinZ;
@@ -1334,7 +1392,7 @@ bool cChunkMap::SetAreaBiome(int a_MinX, int a_MaxX, int a_MinZ, int a_MaxZ, EMC
 
 	// Go through all chunks, set:
 	bool res = true;
-	cCSLock Lock(m_CSChunks);
+
 	for (int x = MinChunkX; x <= MaxChunkX; x++)
 	{
 		int MinRelX = (x == MinChunkX) ? MinX : 0;
@@ -1363,8 +1421,9 @@ bool cChunkMap::SetAreaBiome(int a_MinX, int a_MaxX, int a_MinZ, int a_MaxZ, EMC
 
 bool cChunkMap::GetBlocks(sSetBlockVector & a_Blocks, bool a_ContinueOnFailure)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	bool res = true;
-	cCSLock Lock(m_CSChunks);
+
 	for (sSetBlockVector::iterator itr = a_Blocks.begin(); itr != a_Blocks.end(); ++itr)
 	{
 		cChunkPtr Chunk = GetChunk(itr->m_ChunkX, itr->m_ChunkZ);
@@ -1389,22 +1448,18 @@ bool cChunkMap::GetBlocks(sSetBlockVector & a_Blocks, bool a_ContinueOnFailure)
 
 bool cChunkMap::DigBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int PosX = a_BlockX, PosY = a_BlockY, PosZ = a_BlockZ, ChunkX, ChunkZ;
 
 	cChunkDef::AbsoluteToRelative(PosX, PosY, PosZ, ChunkX, ChunkZ);
-
+	cChunkPtr DestChunk = GetChunk( ChunkX, ChunkZ);
+	if ((DestChunk == nullptr) || !DestChunk->IsValid())
 	{
-		cCSLock Lock(m_CSChunks);
-		cChunkPtr DestChunk = GetChunk( ChunkX, ChunkZ);
-		if ((DestChunk == nullptr) || !DestChunk->IsValid())
-		{
-			return false;
-		}
-
-		DestChunk->SetBlock(PosX, PosY, PosZ, E_BLOCK_AIR, 0);
-		m_World->GetSimulatorManager()->WakeUp(a_BlockX, a_BlockY, a_BlockZ, DestChunk);
+		return false;
 	}
 
+	DestChunk->SetBlock(PosX, PosY, PosZ, E_BLOCK_AIR, 0);
+	m_World->GetSimulatorManager()->WakeUp(a_BlockX, a_BlockY, a_BlockZ, DestChunk);
 	return true;
 }
 
@@ -1414,14 +1469,14 @@ bool cChunkMap::DigBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 void cChunkMap::SendBlockTo(int a_X, int a_Y, int a_Z, cPlayer * a_Player)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_X, a_Y, a_Z, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
-	if ((Chunk != nullptr) && (Chunk->IsValid()))
+	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
-		Chunk->SendBlockTo(a_X, a_Y, a_Z, a_Player->GetClientHandle());
+		Chunk->SendBlockTo(a_X, a_Y, a_Z, a_Player->GetClientHandlePtr());
 	}
 }
 
@@ -1431,7 +1486,8 @@ void cChunkMap::SendBlockTo(int a_X, int a_Y, int a_Z, cPlayer * a_Player)
 
 void cChunkMap::CompareChunkClients(int a_ChunkX1, int a_ChunkZ1, int a_ChunkX2, int a_ChunkZ2, cClientDiffCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk1 = GetChunkNoGen(a_ChunkX1, a_ChunkZ1);
 	if (Chunk1 == nullptr)
 	{
@@ -1452,16 +1508,15 @@ void cChunkMap::CompareChunkClients(int a_ChunkX1, int a_ChunkZ1, int a_ChunkX2,
 
 void cChunkMap::CompareChunkClients(cChunk * a_Chunk1, cChunk * a_Chunk2, cClientDiffCallback & a_Callback)
 {
-	cClientHandleList Clients1(a_Chunk1->GetAllClients());
-	cClientHandleList Clients2(a_Chunk2->GetAllClients());
+	ASSERT(GetWorld()->IsInTickThread());
 
 	// Find "removed" clients:
-	for (cClientHandleList::iterator itr1 = Clients1.begin(); itr1 != Clients1.end(); ++itr1)
+	for (const auto & LhsClient : a_Chunk1->GetAllStrongClientPtrs())
 	{
 		bool Found = false;
-		for (cClientHandleList::iterator itr2 = Clients2.begin(); itr2 != Clients2.end(); ++itr2)
+		for (const auto & RhsClient : a_Chunk2->GetAllStrongClientPtrs())
 		{
-			if (*itr1 == *itr2)
+			if (LhsClient == RhsClient)
 			{
 				Found = true;
 				break;
@@ -1469,17 +1524,17 @@ void cChunkMap::CompareChunkClients(cChunk * a_Chunk1, cChunk * a_Chunk2, cClien
 		}  // for itr2 - Clients2[]
 		if (!Found)
 		{
-			a_Callback.Removed(*itr1);
+			a_Callback.Removed(LhsClient.get());
 		}
 	}  // for itr1 - Clients1[]
 
 	// Find "added" clients:
-	for (cClientHandleList::iterator itr2 = Clients2.begin(); itr2 != Clients2.end(); ++itr2)
+	for (const auto & RhsClient : a_Chunk2->GetAllStrongClientPtrs())
 	{
 		bool Found = false;
-		for (cClientHandleList::iterator itr1 = Clients1.begin(); itr1 != Clients1.end(); ++itr1)
+		for (const auto & LhsClient : a_Chunk1->GetAllStrongClientPtrs())
 		{
-			if (*itr1 == *itr2)
+			if (LhsClient == RhsClient)
 			{
 				Found = true;
 				break;
@@ -1487,7 +1542,7 @@ void cChunkMap::CompareChunkClients(cChunk * a_Chunk1, cChunk * a_Chunk2, cClien
 		}  // for itr1 - Clients1[]
 		if (!Found)
 		{
-			a_Callback.Added(*itr2);
+			a_Callback.Added(RhsClient.get());
 		}
 	}  // for itr2 - Clients2[]
 }
@@ -1496,9 +1551,10 @@ void cChunkMap::CompareChunkClients(cChunk * a_Chunk1, cChunk * a_Chunk2, cClien
 
 
 
-bool cChunkMap::AddChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client)
+bool cChunkMap::AddChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunk(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -1511,9 +1567,10 @@ bool cChunkMap::AddChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Cli
 
 
 
-void cChunkMap::RemoveChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client)
+void cChunkMap::RemoveChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -1580,7 +1637,7 @@ void cChunkMap::AddEntityIfNotPresent(cEntity * a_Entity)
 
 bool cChunkMap::HasEntity(UInt32 a_UniqueID)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (const auto & Chunk : m_Chunks)
 	{
 		if (Chunk.second->IsValid() && Chunk.second->HasEntity(a_UniqueID))
@@ -1595,26 +1652,9 @@ bool cChunkMap::HasEntity(UInt32 a_UniqueID)
 
 
 
-void cChunkMap::RemoveEntity(cEntity * a_Entity)
-{
-	cCSLock Lock(m_CSChunks);
-	cChunkPtr Chunk = a_Entity->GetParentChunk();
-
-	// Even if a chunk is not valid, it may still contain entities such as players; make sure to remove them (#1190)
-	if (Chunk == nullptr)
-	{
-		return;
-	}
-	Chunk->RemoveEntity(a_Entity);
-}
-
-
-
-
-
 bool cChunkMap::ForEachEntity(cEntityCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (const auto & Chunk : m_Chunks)
 	{
 		if (Chunk.second->IsValid() && !Chunk.second->ForEachEntity(a_Callback))
@@ -1631,7 +1671,8 @@ bool cChunkMap::ForEachEntity(cEntityCallback & a_Callback)
 
 bool cChunkMap::ForEachEntityInChunk(int a_ChunkX, int a_ChunkZ, cEntityCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1646,6 +1687,7 @@ bool cChunkMap::ForEachEntityInChunk(int a_ChunkX, int a_ChunkZ, cEntityCallback
 
 bool cChunkMap::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	// Calculate the chunk range for the box:
 	int MinChunkX = FloorC(a_Box.GetMinX() / cChunkDef::Width);
 	int MinChunkZ = FloorC(a_Box.GetMinZ() / cChunkDef::Width);
@@ -1653,7 +1695,7 @@ bool cChunkMap::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback &
 	int MaxChunkZ = FloorC((a_Box.GetMaxZ() + cChunkDef::Width) / cChunkDef::Width);
 
 	// Iterate over each chunk in the range:
-	cCSLock Lock(m_CSChunks);
+
 	for (int z = MinChunkZ; z <= MaxChunkZ; z++)
 	{
 		for (int x = MinChunkX; x <= MaxChunkX; x++)
@@ -1678,6 +1720,7 @@ bool cChunkMap::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback &
 
 void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, cVector3iArray & a_BlocksAffected)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	// Don't explode if outside of Y range (prevents the following test running into unallocated memory):
 	if (!cChunkDef::IsValidHeight(FloorC(a_BlockY)))
 	{
@@ -1874,7 +1917,8 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 
 bool cChunkMap::DoWithEntityByID(UInt32 a_UniqueID, cEntityCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	bool res = false;
 	for (const auto & Chunk : m_Chunks)
 	{
@@ -1892,7 +1936,8 @@ bool cChunkMap::DoWithEntityByID(UInt32 a_UniqueID, cEntityCallback & a_Callback
 
 bool cChunkMap::ForEachBlockEntityInChunk(int a_ChunkX, int a_ChunkZ, cBlockEntityCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1907,7 +1952,6 @@ bool cChunkMap::ForEachBlockEntityInChunk(int a_ChunkX, int a_ChunkZ, cBlockEnti
 
 bool cChunkMap::ForEachBrewingstandInChunk(int a_ChunkX, int a_ChunkZ, cBrewingstandCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1922,7 +1966,8 @@ bool cChunkMap::ForEachBrewingstandInChunk(int a_ChunkX, int a_ChunkZ, cBrewings
 
 bool cChunkMap::ForEachChestInChunk(int a_ChunkX, int a_ChunkZ, cChestCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1937,7 +1982,8 @@ bool cChunkMap::ForEachChestInChunk(int a_ChunkX, int a_ChunkZ, cChestCallback &
 
 bool cChunkMap::ForEachDispenserInChunk(int a_ChunkX, int a_ChunkZ, cDispenserCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1952,7 +1998,8 @@ bool cChunkMap::ForEachDispenserInChunk(int a_ChunkX, int a_ChunkZ, cDispenserCa
 
 bool cChunkMap::ForEachDropperInChunk(int a_ChunkX, int a_ChunkZ, cDropperCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1967,7 +2014,8 @@ bool cChunkMap::ForEachDropperInChunk(int a_ChunkX, int a_ChunkZ, cDropperCallba
 
 bool cChunkMap::ForEachDropSpenserInChunk(int a_ChunkX, int a_ChunkZ, cDropSpenserCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1982,7 +2030,8 @@ bool cChunkMap::ForEachDropSpenserInChunk(int a_ChunkX, int a_ChunkZ, cDropSpens
 
 bool cChunkMap::ForEachFurnaceInChunk(int a_ChunkX, int a_ChunkZ, cFurnaceCallback & a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoGen(a_ChunkX, a_ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -1997,10 +2046,11 @@ bool cChunkMap::ForEachFurnaceInChunk(int a_ChunkX, int a_ChunkZ, cFurnaceCallba
 
 bool cChunkMap::DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBlockEntityCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2015,10 +2065,11 @@ bool cChunkMap::DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cB
 
 bool cChunkMap::DoWithBeaconAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBeaconCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2036,7 +2087,6 @@ bool cChunkMap::DoWithBrewingstandAt(int a_BlockX, int a_BlockY, int a_BlockZ, c
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2051,10 +2101,11 @@ bool cChunkMap::DoWithBrewingstandAt(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 bool cChunkMap::DoWithChestAt(int a_BlockX, int a_BlockY, int a_BlockZ, cChestCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2069,10 +2120,11 @@ bool cChunkMap::DoWithChestAt(int a_BlockX, int a_BlockY, int a_BlockZ, cChestCa
 
 bool cChunkMap::DoWithDispenserAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDispenserCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2087,10 +2139,11 @@ bool cChunkMap::DoWithDispenserAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDis
 
 bool cChunkMap::DoWithDropperAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDropperCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2105,10 +2158,11 @@ bool cChunkMap::DoWithDropperAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDropp
 
 bool cChunkMap::DoWithDropSpenserAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDropSpenserCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2123,10 +2177,11 @@ bool cChunkMap::DoWithDropSpenserAt(int a_BlockX, int a_BlockY, int a_BlockZ, cD
 
 bool cChunkMap::DoWithFurnaceAt(int a_BlockX, int a_BlockY, int a_BlockZ, cFurnaceCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2140,10 +2195,11 @@ bool cChunkMap::DoWithFurnaceAt(int a_BlockX, int a_BlockY, int a_BlockZ, cFurna
 
 bool cChunkMap::DoWithNoteBlockAt(int a_BlockX, int a_BlockY, int a_BlockZ, cNoteBlockCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2157,10 +2213,11 @@ bool cChunkMap::DoWithNoteBlockAt(int a_BlockX, int a_BlockY, int a_BlockZ, cNot
 
 bool cChunkMap::DoWithCommandBlockAt(int a_BlockX, int a_BlockY, int a_BlockZ, cCommandBlockCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2175,10 +2232,11 @@ bool cChunkMap::DoWithCommandBlockAt(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 bool cChunkMap::DoWithMobHeadAt(int a_BlockX, int a_BlockY, int a_BlockZ, cMobHeadCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2193,10 +2251,11 @@ bool cChunkMap::DoWithMobHeadAt(int a_BlockX, int a_BlockY, int a_BlockZ, cMobHe
 
 bool cChunkMap::DoWithFlowerPotAt(int a_BlockX, int a_BlockY, int a_BlockZ, cFlowerPotCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2211,10 +2270,11 @@ bool cChunkMap::DoWithFlowerPotAt(int a_BlockX, int a_BlockY, int a_BlockZ, cFlo
 
 bool cChunkMap::GetSignLines(int a_BlockX, int a_BlockY, int a_BlockZ, AString & a_Line1, AString & a_Line2, AString & a_Line3, AString & a_Line4)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	int BlockX = a_BlockX, BlockY = a_BlockY, BlockZ = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(BlockX, BlockY, BlockZ, ChunkX, ChunkZ);
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if ((Chunk == nullptr) || !Chunk->IsValid())
 	{
@@ -2229,7 +2289,7 @@ bool cChunkMap::GetSignLines(int a_BlockX, int a_BlockY, int a_BlockZ, AString &
 
 void cChunkMap::TouchChunk(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	GetChunk(a_ChunkX, a_ChunkZ);
 }
 
@@ -2239,7 +2299,8 @@ void cChunkMap::TouchChunk(int a_ChunkX, int a_ChunkZ)
 
 void cChunkMap::PrepareChunk(int a_ChunkX, int a_ChunkZ, std::unique_ptr<cChunkCoordCallback> a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 
 	// If the chunk is not prepared, queue it in the lighting thread, that will do all the needed processing:
@@ -2262,7 +2323,8 @@ void cChunkMap::PrepareChunk(int a_ChunkX, int a_ChunkZ, std::unique_ptr<cChunkC
 
 bool cChunkMap::GenerateChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -2298,7 +2360,6 @@ bool cChunkMap::GenerateChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * 
 				}
 
 				// The chunk failed to load, generate it:
-				cCSLock CBLock(m_ChunkMap.m_CSChunks);
 				cChunkPtr CBChunk = m_ChunkMap.GetChunkNoLoad(a_CBChunkX, a_CBChunkZ);
 
 				if (CBChunk == nullptr)
@@ -2338,7 +2399,8 @@ bool cChunkMap::GenerateChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * 
 
 void cChunkMap::ChunkLoadFailed(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -2353,7 +2415,8 @@ void cChunkMap::ChunkLoadFailed(int a_ChunkX, int a_ChunkZ)
 
 bool cChunkMap::SetSignLines(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
@@ -2370,7 +2433,8 @@ bool cChunkMap::SetSignLines(int a_BlockX, int a_BlockY, int a_BlockZ, const ASt
 
 void cChunkMap::MarkChunkRegenerating(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -2386,7 +2450,8 @@ void cChunkMap::MarkChunkRegenerating(int a_ChunkX, int a_ChunkZ)
 
 bool cChunkMap::IsChunkLighted(int a_ChunkX, int a_ChunkZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	if (Chunk == nullptr)
 	{
@@ -2402,8 +2467,9 @@ bool cChunkMap::IsChunkLighted(int a_ChunkX, int a_ChunkZ)
 
 bool cChunkMap::ForEachChunkInRect(int a_MinChunkX, int a_MaxChunkX, int a_MinChunkZ, int a_MaxChunkZ, cChunkDataCallback & a_Callback)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	bool Result = true;
-	cCSLock Lock(m_CSChunks);
+
 	for (int z = a_MinChunkZ; z <= a_MaxChunkZ; z++)
 	{
 		for (int x = a_MinChunkX; x <= a_MaxChunkX; x++)
@@ -2431,7 +2497,7 @@ bool cChunkMap::ForEachChunkInRect(int a_MinChunkX, int a_MaxChunkX, int a_MinCh
 
 bool cChunkMap::ForEachLoadedChunk(std::function<bool(int, int)> a_Callback)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (const auto & Chunk : m_Chunks)
 	{
 		if (Chunk.second->IsValid())
@@ -2451,6 +2517,7 @@ bool cChunkMap::ForEachLoadedChunk(std::function<bool(int, int)> a_Callback)
 
 bool cChunkMap::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	// Convert block coords to chunks coords:
 	int MinChunkX, MaxChunkX;
 	int MinChunkZ, MaxChunkZ;
@@ -2465,7 +2532,7 @@ bool cChunkMap::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBl
 
 	// Iterate over chunks, write data into each:
 	bool Result = true;
-	cCSLock Lock(m_CSChunks);
+
 	for (int z = MinChunkZ; z <= MaxChunkZ; z++)
 	{
 		for (int x = MinChunkX; x <= MaxChunkX; x++)
@@ -2489,9 +2556,10 @@ bool cChunkMap::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBl
 
 void cChunkMap::GetChunkStats(int & a_NumChunksValid, int & a_NumChunksDirty)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	a_NumChunksValid = 0;
 	a_NumChunksDirty = 0;
-	cCSLock Lock(m_CSChunks);
+
 	for (const auto & Chunk : m_Chunks)
 	{
 		a_NumChunksValid++;
@@ -2511,7 +2579,7 @@ bool cChunkMap::GrowMelonPumpkin(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCK
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
 	if (Chunk != nullptr)
 	{
@@ -2526,10 +2594,11 @@ bool cChunkMap::GrowMelonPumpkin(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCK
 
 int cChunkMap::GrowSugarcane(int a_BlockX, int a_BlockY, int a_BlockZ, int a_NumBlocksToGrow)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
 	if (Chunk != nullptr)
 	{
@@ -2544,10 +2613,11 @@ int cChunkMap::GrowSugarcane(int a_BlockX, int a_BlockY, int a_BlockZ, int a_Num
 
 int cChunkMap::GrowCactus(int a_BlockX, int a_BlockY, int a_BlockZ, int a_NumBlocksToGrow)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
 	if (Chunk != nullptr)
 	{
@@ -2562,10 +2632,11 @@ int cChunkMap::GrowCactus(int a_BlockX, int a_BlockY, int a_BlockZ, int a_NumBlo
 
 bool cChunkMap::GrowTallGrass(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
 	if (Chunk != nullptr)
 	{
@@ -2580,10 +2651,11 @@ bool cChunkMap::GrowTallGrass(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 void cChunkMap::SetNextBlockTick(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
 	if (Chunk != nullptr)
 	{
@@ -2596,7 +2668,7 @@ void cChunkMap::SetNextBlockTick(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 void cChunkMap::CollectMobCensus(cMobCensus & a_ToFill)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (const auto & Chunk : m_Chunks)
 	{
 		// We do count every Mobs in the world. But we are assuming that every chunk not loaded by any client
@@ -2616,7 +2688,7 @@ void cChunkMap::CollectMobCensus(cMobCensus & a_ToFill)
 
 void cChunkMap::SpawnMobs(cMobSpawner & a_MobSpawner)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (const auto & Chunk : m_Chunks)
 	{
 		// We only spawn close to players
@@ -2633,7 +2705,7 @@ void cChunkMap::SpawnMobs(cMobSpawner & a_MobSpawner)
 
 void cChunkMap::Tick(std::chrono::milliseconds a_Dt)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (const auto & Chunk : m_Chunks)
 	{
 		// Only tick chunks that are valid and should be ticked:
@@ -2650,7 +2722,8 @@ void cChunkMap::Tick(std::chrono::milliseconds a_Dt)
 
 void cChunkMap::TickBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
@@ -2667,7 +2740,7 @@ void cChunkMap::TickBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 void cChunkMap::UnloadUnusedChunks(void)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (auto itr = m_Chunks.begin(); itr != m_Chunks.end();)
 	{
 		if (
@@ -2690,7 +2763,7 @@ void cChunkMap::UnloadUnusedChunks(void)
 
 void cChunkMap::SaveAllChunks(void)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	for (const auto & Chunk : m_Chunks)
 	{
 		if (Chunk.second->IsValid() && Chunk.second->IsDirty())
@@ -2706,9 +2779,8 @@ void cChunkMap::SaveAllChunks(void)
 
 int cChunkMap::GetNumChunks(void)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	return static_cast<int>(m_Chunks.size());  // TODO: change return value to unsigned type
-
 }
 
 
@@ -2717,6 +2789,7 @@ int cChunkMap::GetNumChunks(void)
 
 void cChunkMap::ChunkValidated(void)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	m_evtChunkValid.Set();
 }
 
@@ -2726,11 +2799,12 @@ void cChunkMap::ChunkValidated(void)
 
 void cChunkMap::QueueTickBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
+	ASSERT(GetWorld()->IsInTickThread());
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
 	// a_BlockXYZ now contains relative coords!
 
-	cCSLock Lock(m_CSChunks);
+
 	cChunkPtr Chunk = GetChunkNoLoad(ChunkX, ChunkZ);
 	if (Chunk != nullptr)
 	{
@@ -2744,7 +2818,8 @@ void cChunkMap::QueueTickBlock(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 void cChunkMap::SetChunkAlwaysTicked(int a_ChunkX, int a_ChunkZ, bool a_AlwaysTicked)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
+
 	cChunkPtr Chunk = GetChunkNoLoad(a_ChunkX, a_ChunkZ);
 	if (Chunk != nullptr)
 	{
@@ -2762,7 +2837,7 @@ void cChunkMap::FastSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE
 	int ChunkX, ChunkZ, X = a_BlockX, Y = a_BlockY, Z = a_BlockZ;
 	cChunkDef::AbsoluteToRelative(X, Y, Z, ChunkX, ChunkZ);
 
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
@@ -2776,11 +2851,11 @@ void cChunkMap::FastSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE
 
 void cChunkMap::AddChunkStay(cChunkStay & a_ChunkStay)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 
 	// Add it to the list:
 	ASSERT(std::find(m_ChunkStays.begin(), m_ChunkStays.end(), &a_ChunkStay) == m_ChunkStays.end());  // Has not yet been added
-	m_ChunkStays.push_back(&a_ChunkStay);
+	m_ChunkStays.emplace_back(&a_ChunkStay);
 
 	// Schedule all chunks to be loaded / generated, and mark each as locked:
 	const cChunkCoordsVector & WantedChunks = a_ChunkStay.GetChunks();
@@ -2811,7 +2886,7 @@ void cChunkMap::AddChunkStay(cChunkStay & a_ChunkStay)
 /** Removes the specified cChunkStay descendant from the internal list of ChunkStays. */
 void cChunkMap::DelChunkStay(cChunkStay & a_ChunkStay)
 {
-	cCSLock Lock(m_CSChunks);
+	ASSERT(GetWorld()->IsInTickThread());
 
 	// Remove from the list of active chunkstays:
 	bool HasFound = false;

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1582,10 +1582,7 @@ void cChunkMap::RemoveChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_
 
 
 
-
-void cChunkMap::RemoveClientFromChunks(cClientHandle * a_Client)
 {
-	cCSLock Lock(m_CSChunks);
 	for (const auto & Chunk : m_Chunks)
 	{
 		Chunk.second->RemoveClient(a_Client);
@@ -1613,6 +1610,7 @@ void cChunkMap::AddEntity(cEntity * a_Entity)
 
 
 
+	ASSERT(GetWorld()->IsInTickThread());
 
 void cChunkMap::AddEntityIfNotPresent(cEntity * a_Entity)
 {

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -67,6 +67,12 @@ public:
 	cChunkMap(cWorld * a_World);
 	~cChunkMap();
 
+#ifdef _DEBUG
+	/** The ID of the thread currently accessing the object.
+	Used for checking that only one thread accesses the object at a time, via cSingleThreadAccessChecker. */
+	mutable std::thread::id m_ThreadID;
+#endif
+
 	// Broadcast respective packets to all clients of the chunk where the event is taking place
 	// (Please keep these alpha-sorted)
 	void BroadcastAttachEntity(const cEntity & a_Entity, const cEntity & a_Vehicle);
@@ -199,13 +205,10 @@ public:
 	void CompareChunkClients(cChunk * a_Chunk1, cChunk * a_Chunk2, cClientDiffCallback & a_Callback);
 
 	/** Adds client to a chunk, if not already present; returns true if added, false if present */
-	bool AddChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client);
+	bool AddChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client);
 
 	/** Removes the client from the chunk */
-	void RemoveChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client);
-
-	/** Removes the client from all chunks it is present in */
-	void RemoveClientFromChunks(cClientHandle * a_Client);
+	void RemoveChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client);
 
 	/** Adds the entity to its appropriate chunk, takes ownership of the entity pointer */
 	void AddEntity(cEntity * a_Entity);
@@ -395,9 +398,6 @@ public:
 	/** Queues the specified block for ticking (block update) */
 	void QueueTickBlock(int a_BlockX, int a_BlockY, int a_BlockZ);
 
-	/** Returns the CS for locking the chunkmap; only cWorld::cLock may use this function! */
-	cCriticalSection & GetCS(void) { return m_CSChunks; }
-
 	/** Increments (a_AlwaysTicked == true) or decrements (false) the m_AlwaysTicked counter for the specified chunk.
 	If the m_AlwaysTicked counter is greater than zero, the chunk is ticked in the tick-thread regardless of
 	whether it has any clients or not.
@@ -447,7 +447,6 @@ private:
 
 	typedef std::list<cChunkStay *> cChunkStays;
 
-	cCriticalSection m_CSChunks;
 
 	/** A map of chunk coordinates to chunk pointers
 	Uses a map (as opposed to unordered_map) because sorted maps are apparently faster */
@@ -491,7 +490,7 @@ private:
 	/** Fast-sets a block in any chunk while in the cChunk's Tick() method; returns true if successful, false if chunk not loaded (doesn't queue load) */
 	bool LockedFastSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 
-	/** Locates a chunk ptr in the chunkmap; doesn't create it when not found; assumes m_CSChunks is locked. To be called only from cChunkMap. */
+	/** Locates a chunk ptr in the chunkmap; doesn't create it when not found. To be called only from cChunkMap. */
 	cChunk * FindChunk(int a_ChunkX, int a_ChunkZ);
 
 	/** Adds a new cChunkStay descendant to the internal list of ChunkStays; loads its chunks.

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -211,17 +211,10 @@ public:
 	void RemoveChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client);
 
 	/** Adds the entity to its appropriate chunk, takes ownership of the entity pointer */
-	void AddEntity(cEntity * a_Entity);
-
-	/** Adds the entity to its appropriate chunk, if the entity is not already added.
-	Takes ownership of the entity pointer */
-	void AddEntityIfNotPresent(cEntity * a_Entity);
+	void AddEntity(std::unique_ptr<cEntity> a_Entity);
 
 	/** Returns true if the entity with specified ID is present in the chunks */
 	bool HasEntity(UInt32 a_EntityID);
-
-	/** Removes the entity from its appropriate chunk */
-	void RemoveEntity(cEntity * a_Entity);
 
 	/** Calls the callback for each entity in the entire world; returns true if all entities processed, false if the callback aborted by returning true */
 	bool ForEachEntity(cEntityCallback & a_Callback);  // Lua-accessible

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -21,13 +21,15 @@
 #include "json/json.h"
 #include "ChunkSender.h"
 #include "EffectID.h"
-
+#include "Protocol/ProtocolRecognizer.h"
 
 #include <array>
 #include <atomic>
+#include <unordered_map>
 
 
 // fwd:
+class cChunk;
 class cChunkDataSerializer;
 class cInventory;
 class cMonster;
@@ -36,7 +38,6 @@ class cExpOrb;
 class cPainting;
 class cPickup;
 class cPlayer;
-class cProtocol;
 class cWindow;
 class cFallingBlock;
 class cItemHandler;
@@ -44,14 +45,14 @@ class cWorld;
 class cCompositeChat;
 class cStatManager;
 class cClientHandle;
-typedef SharedPtr<cClientHandle> cClientHandlePtr;
 
 
 
 
 
-class cClientHandle  // tolua_export
-	: public cTCPLink::cCallbacks
+class cClientHandle :  // tolua_export
+	public std::enable_shared_from_this<cClientHandle>,
+	public cTCPLink::cCallbacks
 {  // tolua_export
 public:  // tolua_export
 
@@ -62,6 +63,17 @@ public:  // tolua_export
 	#endif
 	static const int MAX_VIEW_DISTANCE = 32;
 	static const int MIN_VIEW_DISTANCE = 1;
+
+	enum class eState
+	{
+		csConnected,         ///< The client has just connected, waiting for their handshake / login
+		csAuthenticating,    ///< The client has logged in, waiting for external authentication
+		csAuthenticated,     ///< The client has been authenticated, will start streaming chunks in the next tick
+		csConfirmingPos,     ///< The client has been sent the position packet, waiting for them to repeat the position back
+		csPlaying,           ///< Normal gameplay
+		csDestroying,        ///< The client is being destroyed, don't queue any more packets / don't add to chunks
+		csDestroyed,         ///< The client has been destroyed, the destructor is to be called from the owner thread
+	};
 
 	/** Creates a new client with the specified IP address in its description and the specified initial view distance. */
 	cClientHandle(const AString & a_IPString, int a_ViewDistance);
@@ -85,6 +97,11 @@ public:  // tolua_export
 	void SetUUID(const AString & a_UUID) { ASSERT(a_UUID.size() == 32); m_UUID = a_UUID; }
 
 	const Json::Value & GetProperties(void) const { return m_Properties; }
+
+	/** Atomically sets the internal client handle state.
+	Allows only a consecutive state to be set.
+	Returns if the state was set or not. */
+	bool SetState(eState a_State);
 
 	/** Sets the player's properties, such as skin image and signature.
 	Used mainly by BungeeCord compatibility code - property querying is done on the BungeeCord server
@@ -119,43 +136,48 @@ public:  // tolua_export
 	/** Authenticates the specified user, called by cAuthenticator */
 	void Authenticate(const AString & a_Name, const AString & a_UUID, const Json::Value & a_Properties);
 
-	/** This function sends a new unloaded chunk to the player. Returns true if all chunks are loaded. */
-	bool StreamNextChunk();
+	/** Send all necessary chunks to the player */
+	void StreamAllChunks();
 
 	/** Remove all loaded chunks that are no longer in range */
 	void UnloadOutOfRangeChunks(void);
 
-	// Removes the client from all chunks. Used when switching worlds or destroying the player
-	void RemoveFromAllChunks(void);
-
-	inline bool IsLoggedIn(void) const { return (m_State >= csAuthenticating); }
+	inline bool IsLoggedIn(void) const { return (m_State >= eState::csAuthenticating); }
 
 	/** Called while the client is being ticked from the world via its cPlayer object */
 	void Tick(float a_Dt);
 
-	/** Called while the client is being ticked from the cServer object */
-	void ServerTick(float a_Dt);
-
+	/** Mark the clienthandle as disconnected.
+	Guarantees that no more data is sent or received. Therefore, MUST be called in context of server tick thread.
+	Will result in cServer releasing the shared_ptr to the handle.
+	Will eventually result in the object's destruction. */
 	void Destroy(void);
 
-	bool IsPlaying   (void) const { return (m_State == csPlaying); }
-	bool IsDestroyed (void) const { return (m_State == csDestroyed); }
-	bool IsDestroying(void) const { return (m_State == csDestroying); }
+	bool IsPlaying   (void) const { return (m_State == eState::csPlaying); }
+	bool IsDestroyed (void) const { return (m_State == eState::csDestroyed); }
+	bool IsDestroying(void) const { return (m_State == eState::csDestroying); }
 
 	// The following functions send the various packets:
 	// (Please keep these alpha-sorted)
 	void SendAttachEntity               (const cEntity & a_Entity, const cEntity & a_Vehicle);
 	void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType);
 	void SendBlockBreakAnim             (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage);
-	void SendBlockChange                (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);  // tolua_export
-	void SendBlockChanges               (int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes);
+
+	/** Sends a singular block change notification to the client.
+	Callers MUST ensure that the client has been sent or is going to be sent the chunk specified by the arguments. */
+	void SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
+
+	/** Sends multiple block changes in a single notification to the client.
+	Callers MUST ensure that the client has been sent or is going to be sent the chunk specified by the arguments. */
+	void SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes);
+
 	void SendChat                       (const AString & a_Message, eMessageType a_ChatPrefix, const AString & a_AdditionalData = "");
 	void SendChat                       (const cCompositeChat & a_Message);
 	void SendChatAboveActionBar         (const AString & a_Message, eMessageType a_ChatPrefix, const AString & a_AdditionalData = "");
 	void SendChatAboveActionBar         (const cCompositeChat & a_Message);
 	void SendChatSystem                 (const AString & a_Message, eMessageType a_ChatPrefix, const AString & a_AdditionalData = "");
 	void SendChatSystem                 (const cCompositeChat & a_Message);
-	void SendChunkData                  (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer);
+	void SendChunkData                  (cWorld & a_ChunkSenderWorld, const cChunkCoords & a_ChunkCoordinates, cChunkDataSerializer & a_Serializer);
 	void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player);
 	void SendDestroyEntity              (const cEntity & a_Entity);
 	void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);
@@ -217,7 +239,6 @@ public:  // tolua_export
 	void SendThunderbolt                (int a_BlockX, int a_BlockY, int a_BlockZ);
 	void SendTitleTimes                 (int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks);
 	void SendTimeUpdate                 (Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_DoDaylightCycle);  // tolua_export
-	void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ);
 	void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity);
 	void SendUpdateSign                 (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4);
 	void SendUseBed                     (const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ);
@@ -258,18 +279,12 @@ public:  // tolua_export
 
 	// tolua_end
 
-	/** Returns true if the client wants the chunk specified to be sent (in m_ChunksToSend) */
-	bool WantsSendChunk(int a_ChunkX, int a_ChunkZ);
-
-	/** Adds the chunk specified to the list of chunks wanted for sending (m_ChunksToSend) */
-	void AddWantedChunk(int a_ChunkX, int a_ChunkZ);
-
 	// Calls that cProtocol descendants use to report state:
 	void PacketBufferFull(void);
 	void PacketUnknown(UInt32 a_PacketType);
 	void PacketError(UInt32 a_PacketType);
 
-	// Calls that cProtocol descendants use for handling packets:
+	/** Calls that cProtocol descendants use for handling packets. */
 	void HandleAnimation(int a_Animation);
 
 	/** Called when the protocol receives a MC|ItemName plugin message, indicating that the player named
@@ -319,10 +334,9 @@ public:  // tolua_export
 	the NPC UI. */
 	void HandleNPCTrade(int a_SlotNum);
 
-	void HandlePing             (void);
 	void HandlePlayerAbilities  (bool a_CanFly, bool a_IsFlying, float FlyingSpeed, float WalkingSpeed);
 	void HandlePlayerLook       (float a_Rotation, float a_Pitch, bool a_IsOnGround);
-	void HandlePlayerMoveLook   (double a_PosX, double a_PosY, double a_PosZ, double a_Stance, float a_Rotation, float a_Pitch, bool a_IsOnGround);  // While m_bPositionConfirmed (normal gameplay)
+	void HandlePlayerMoveLook   (double a_PosX, double a_PosY, double a_PosZ, double a_Stance, float a_Rotation, float a_Pitch, bool a_IsOnGround);
 
 	/** Verifies and sets player position, performing relevant checks
 	Calls relevant methods to process movement related statistics
@@ -361,12 +375,25 @@ public:  // tolua_export
 	/** Called by the protocol recognizer when the protocol version is known. */
 	void SetProtocolVersion(UInt32 a_ProtocolVersion) { m_ProtocolVersion = a_ProtocolVersion; }
 
+	/** Called by cServer::Shutdown to indicate m_Player's destruction is out of our control */
+	void StopPlayerDestructionManagement() { m_ShouldDestroyPlayer = false; }
+
 	/** Returns the protocol version number of the protocol that the client is talking. Returns zero if the protocol version is not (yet) known. */
 	UInt32 GetProtocolVersion(void) const { return m_ProtocolVersion; }  // tolua_export
 
-	void InvalidateCachedSentChunk();
+	/** Add a new functor which will commit processed incoming network data in the world tick thread */
+	template <typename FunctionType, typename... FunctionArguments>
+	void QueueDataCommit(FunctionType && a_Function, FunctionArguments && ... a_FunctionArguments)
+	{
+		m_DataCommitQueue.emplace_back(std::bind(std::forward<FunctionType>(a_Function), std::forward<FunctionArguments>(a_FunctionArguments)...));
+	}
 
-	bool IsPlayerChunkSent();
+	/** Enforces a rate limit on block interactions.
+	Will kick client if limit exceeded.
+	Returns true if the block interactions rate is within MAX_BLOCK_CHANGE_INTERACTIONS per tick. */
+	bool EnforceBlockInteractionsRate(void);
+
+	cProtocol & GetProtocol(void) { return m_Protocol; }
 
 private:
 
@@ -385,15 +412,35 @@ private:
 	AString m_IPString;
 
 	AString m_Username;
-	AString m_Password;
 	Json::Value m_Properties;
 
-	cCriticalSection                                   m_CSChunkLists;
-	std::unordered_set<cChunkCoords, cChunkCoordsHash> m_LoadedChunks;  // Chunks that the player belongs to
-	std::unordered_set<cChunkCoords, cChunkCoordsHash> m_ChunksToSend;  // Chunks that need to be sent to the player (queued because they weren't generated yet or there's not enough time to send them)
-	cChunkCoordsList                                   m_SentChunks;    // Chunks that are currently sent to the client
+	/** Flag indicating whether it is safe to access m_Player in our destructor to destroy it
+	While used inter-thread, atomicity not necessary as is only ever set in the main thread and read in a destructor, which is not called as long as someone has a reference to us */
+	bool m_ShouldDestroyPlayer;
 
-	cProtocol * m_Protocol;
+	struct sChunkCoordsHash
+	{
+		size_t operator()(const cChunkCoords & a_ChunkCoords) const
+		{
+			size_t Seed = static_cast<size_t>(a_ChunkCoords.m_ChunkX) + 0x9e3779b9;
+			return (Seed ^= static_cast<size_t>(a_ChunkCoords.m_ChunkZ) + 0x9e3779b9 + (Seed << 6) + (Seed >> 2));
+		}
+	};
+
+	/** Chunks that are currently loaded by the player */
+	std::unordered_map<cChunkCoords, std::reference_wrapper<cWorld>, cChunkCoordsHash> m_LoadedChunks;
+
+	/** Functors which will commit processed incoming network data to the world.
+	Functors MUST be called in the context of the world's tick thread */
+	std::vector<std::function<void()>> m_DataCommitQueue;
+
+	cProtocolRecognizer m_Protocol;
+
+	/** Empties the incoming send queue in a thread safe manner and processes the data. */
+	void ProcessQueuedIncomingData(void);
+
+	/** Empties the data commit queue and queues the data to be executed in the context of the world tick thread. */
+	void ProcessDataCommitQueue(void);
 
 	/** Protects m_IncomingData against multithreaded access. */
 	cCriticalSection m_CSIncomingData;
@@ -402,29 +449,22 @@ private:
 	Protected by m_CSIncomingData. */
 	AString m_IncomingData;
 
+	/** Empties the outgoing send queue in a thread safe manner and sends the data via the network link. */
+	void ProcessQueuedOutgoingData(void);
+
 	/** Protects m_OutgoingData against multithreaded access. */
 	cCriticalSection m_CSOutgoingData;
 
-	/** Buffer for storing outgoing data from any thread; will get sent in Tick() (to prevent deadlocks).
+	/** Queue for the outgoing data to be sent through the link until it is processed in Tick().
 	Protected by m_CSOutgoingData. */
 	AString m_OutgoingData;
 
-	Vector3d m_ConfirmPosition;
+	/** Protects m_Link against multithreaded access. */
+	cCriticalSection m_CSLink;
 
+	/** Non-owning pointer to the player object we are associated with
+	It is guaranteed to exist whilst the server is running and this clienthandle is alive */
 	cPlayer * m_Player;
-
-	/** This is an optimization which saves you an iteration of m_SentChunks if you just want to know
-	whether or not the player is standing at a sent chunk.
-	If this is equal to the coordinates of the chunk the player is currrently standing at, then this must be a sent chunk
-	and a member of m_SentChunks.
-	Otherwise, this contains an arbitrary value which should not be used. */
-	cChunkCoords m_CachedSentChunk;
-
-	bool m_HasSentDC;  ///< True if a Disconnect packet has been sent in either direction
-
-	// Chunk position when the last StreamChunks() was called; used to avoid re-streaming while in the same chunk
-	int m_LastStreamedChunkX;
-	int m_LastStreamedChunkZ;
 
 	/** Number of ticks since the last network packet was received (increased in Tick(), reset in OnReceivedData()) */
 	std::atomic<int> m_TicksSinceLastPacket;
@@ -451,27 +491,11 @@ private:
 	int m_LastDigBlockY;
 	int m_LastDigBlockZ;
 
-	enum eState
-	{
-		csConnected,         ///< The client has just connected, waiting for their handshake / login
-		csAuthenticating,    ///< The client has logged in, waiting for external authentication
-		csAuthenticated,     ///< The client has been authenticated, will start streaming chunks in the next tick
-		csDownloadingWorld,  ///< The client is waiting for chunks, we're waiting for the loader to provide and send them
-		csConfirmingPos,     ///< The client has been sent the position packet, waiting for them to repeat the position back
-		csPlaying,           ///< Normal gameplay
-		csDestroying,        ///< The client is being destroyed, don't queue any more packets / don't add to chunks
-		csDestroyed,         ///< The client has been destroyed, the destructor is to be called from the owner thread
-
-		// TODO: Add Kicking here as well
-	} ;
-
 	std::atomic<eState> m_State;
 
-	/** m_State needs to be locked in the Destroy() function so that the destruction code doesn't run twice on two different threads */
-	cCriticalSection m_CSDestroyingState;
-
-	/** If set to true during csDownloadingWorld, the tick thread calls CheckIfWorldDownloaded() */
-	bool m_ShouldCheckDownloaded;
+	/** A flag to indicate whether a player has traversed chunks and should therefore have their view resent.
+	The flag is set in position updates, and causes StreamAllChunks to be called in the next server tick. */
+	bool m_ShouldRefreshSentChunks;
 
 	/** Number of explosions sent this tick */
 	int m_NumExplosionsThisTick;
@@ -486,9 +510,6 @@ private:
 
 	/** Contains the UUID used by Mojang to identify the player's account. Short UUID stored here (without dashes) */
 	AString m_UUID;
-
-	/** Set to true when the chunk where the player is is sent to the client. Used for spawning the player */
-	bool m_HasSentPlayerChunk;
 
 	/** Client Settings */
 	AString m_Locale;
@@ -509,16 +530,7 @@ private:
 	m_CSOutgoingData is used to synchronize access for sending data. */
 	cTCPLinkPtr m_Link;
 
-	/** Shared pointer to self, so that this instance can keep itself alive when needed. */
-	cClientHandlePtr m_Self;
-
-
-	/** Returns true if the rate block interactions is within a reasonable limit (bot protection) */
-	bool CheckBlockInteractionsRate(void);
-
-	/** Adds a single chunk to be streamed to the client; used by StreamChunks() */
-	void StreamChunk(int a_ChunkX, int a_ChunkZ, cChunkSender::eChunkPriority a_Priority);
-
+	
 	/** Handles the DIG_STARTED dig packet: */
 	void HandleBlockDigStarted (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, BLOCKTYPE a_OldBlock, NIBBLETYPE a_OldMeta);
 
@@ -539,9 +551,6 @@ private:
 
 	/** Called when the network socket has been closed. */
 	void SocketClosed(void);
-
-	/** Called right after the instance is created to store its SharedPtr inside. */
-	void SetSelf(cClientHandlePtr a_Self);
 
 	// cTCPLink::cCallbacks overrides:
 	virtual void OnLinkCreated(cTCPLinkPtr a_Link) override;

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -23,8 +23,9 @@ cCompositeChat::cCompositeChat(void) :
 
 
 
-cCompositeChat::cCompositeChat(const AString & a_ParseText, eMessageType a_MessageType) :
-	m_MessageType(a_MessageType)
+cCompositeChat::cCompositeChat(const AString & a_ParseText, eMessageType a_MessageType, const AString & a_AdditionalMessageTypeData) :
+	m_MessageType(a_MessageType),
+	m_AdditionalMessageTypeData(a_AdditionalMessageTypeData)
 {
 	ParseText(a_ParseText);
 }

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -130,7 +130,7 @@ public:
 	/** Creates a new chat message and parses the text into parts.
 	Recognizes "http:" and "https:" links and @color-codes.
 	Uses ParseText() for the actual parsing. */
-	cCompositeChat(const AString & a_ParseText, eMessageType a_MessageType = mtCustom);
+	cCompositeChat(const AString & a_ParseText, eMessageType a_MessageType = mtCustom, const AString & a_AdditionalMessageTypeData = "");
 
 	~cCompositeChat();
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -41,7 +41,6 @@ cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, d
 	m_LastPosition(a_X, a_Y, a_Z),
 	m_EntityType(a_EntityType),
 	m_World(nullptr),
-	m_IsWorldChangeScheduled(false),
 	m_IsFireproof(false),
 	m_TicksSinceLastBurnDamage(0),
 	m_TicksSinceLastLavaDamage(0),
@@ -52,6 +51,7 @@ cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, d
 	m_IsSubmerged(false),
 	m_AirLevel(0),
 	m_AirTickTimer(0),
+	m_PortalCooldownData({0, false, true}),
 	m_TicksAlive(0),
 	m_IsTicking(false),
 	m_ParentChunk(nullptr),
@@ -77,9 +77,6 @@ cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, d
 
 cEntity::~cEntity()
 {
-
-	// Before deleting, the entity needs to have been removed from the world, if ever added
-	ASSERT((m_World == nullptr) || !m_World->HasEntity(m_UniqueID));
 	ASSERT(!IsTicking());
 
 	/*
@@ -201,7 +198,7 @@ void cEntity::SetParentChunk(cChunk * a_Chunk)
 
 
 
-cChunk * cEntity::GetParentChunk()
+cChunk * cEntity::GetParentChunk() const
 {
 	return m_ParentChunk;
 }
@@ -1369,36 +1366,13 @@ void cEntity::DetectCacti(void)
 
 
 
-void cEntity::ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_SetPortalCooldown)
-{
-	m_NewWorld = a_World;
-	m_NewWorldPosition = a_NewPosition;
-	m_IsWorldChangeScheduled = true;
-	m_WorldChangeSetPortalCooldown = a_SetPortalCooldown;
-}
-
-
-
-
 bool cEntity::DetectPortal()
 {
-	// If somebody scheduled a world change with ScheduleMoveToWorld, change worlds now.
-	if (m_IsWorldChangeScheduled)
+	if (!m_PortalCooldownData.m_PositionValid)
 	{
-		m_IsWorldChangeScheduled = false;
-
-		if (m_WorldChangeSetPortalCooldown)
-		{
-			// Delay the portal check.
-			m_PortalCooldownData.m_TicksDelayed = 0;
-			m_PortalCooldownData.m_ShouldPreventTeleportation = true;
-		}
-
-		MoveToWorld(m_NewWorld, false, m_NewWorldPosition);
-		return true;
+		return false;
 	}
-
-	if (GetWorld()->GetDimension() == dimOverworld)
+	else if (GetWorld()->GetDimension() == dimOverworld)
 	{
 		if (GetWorld()->GetLinkedNetherWorldName().empty() && GetWorld()->GetLinkedEndWorldName().empty())
 		{
@@ -1412,7 +1386,7 @@ bool cEntity::DetectPortal()
 		return false;
 	}
 
-	int X = POSX_TOINT, Y = POSY_TOINT, Z = POSZ_TOINT;
+	const int X = POSX_TOINT, Y = POSY_TOINT, Z = POSZ_TOINT;
 	if ((Y > 0) && (Y < cChunkDef::Height))
 	{
 		switch (GetWorld()->GetBlock(X, Y, Z))
@@ -1425,62 +1399,56 @@ bool cEntity::DetectPortal()
 					return false;
 				}
 
-				if (IsPlayer() && !(reinterpret_cast<cPlayer *>(this))->IsGameModeCreative() && (m_PortalCooldownData.m_TicksDelayed != 80))
+				if (
+					IsPlayer() &&
+					// !reinterpret_cast<cPlayer *>(this)->IsGameModeCreative() &&  // TODO: fix portal travel prevention - client sends outdated position data throwing off checks
+					(m_PortalCooldownData.m_TicksDelayed != 80)
+				)
 				{
 					// Delay teleportation for four seconds if the entity is a non-creative player
 					m_PortalCooldownData.m_TicksDelayed++;
 					return false;
 				}
-				m_PortalCooldownData.m_TicksDelayed = 0;
+
+				m_PortalCooldownData.m_ShouldPreventTeleportation = true;  // Stop portals from working on respawn
+				m_PortalCooldownData.m_PositionValid = false;
 
 				if (GetWorld()->GetDimension() == dimNether)
 				{
-					if (GetWorld()->GetLinkedOverworldName().empty())
+					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
+					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
+
+					if (GetWorld()->GetLinkedOverworldName().empty() || !OnPreWorldTravel(*TargetWorld))
 					{
 						return false;
-					}
-
-					m_PortalCooldownData.m_ShouldPreventTeleportation = true;  // Stop portals from working on respawn
-
-					if (IsPlayer())
-					{
-						// Send a respawn packet before world is loaded / generated so the client isn't left in limbo
-						(reinterpret_cast<cPlayer *>(this))->GetClientHandle()->SendRespawn(dimOverworld);
 					}
 
 					Vector3d TargetPos = GetPosition();
 					TargetPos.x *= 8.0;
 					TargetPos.z *= 8.0;
 
-					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
-					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
 					LOGD("Jumping nether -> overworld");
-					new cNetherPortalScanner(this, TargetWorld, TargetPos, 256);
+					new cNetherPortalScanner(GetUniqueID(), GetWorld()->GetDimension(), TargetWorld, TargetPos, 256);
+
 					return true;
 				}
 				else
 				{
-					if (GetWorld()->GetLinkedNetherWorldName().empty())
+					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedNetherWorldName());
+					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
+
+					if (GetWorld()->GetLinkedNetherWorldName().empty() || !OnPreWorldTravel(*TargetWorld))
 					{
 						return false;
-					}
-
-					m_PortalCooldownData.m_ShouldPreventTeleportation = true;
-
-					if (IsPlayer())
-					{
-						reinterpret_cast<cPlayer *>(this)->AwardAchievement(achEnterPortal);
-						reinterpret_cast<cPlayer *>(this)->GetClientHandle()->SendRespawn(dimNether);
 					}
 
 					Vector3d TargetPos = GetPosition();
 					TargetPos.x /= 8.0;
 					TargetPos.z /= 8.0;
 
-					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedNetherWorldName());
-					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
 					LOGD("Jumping overworld -> nether");
-					new cNetherPortalScanner(this, TargetWorld, TargetPos, 128);
+					new cNetherPortalScanner(GetUniqueID(), GetWorld()->GetDimension(), TargetWorld, TargetPos, 128);
+
 					return true;
 				}
 			}
@@ -1491,6 +1459,9 @@ bool cEntity::DetectPortal()
 					return false;
 				}
 
+				m_PortalCooldownData.m_ShouldPreventTeleportation = true;
+				m_PortalCooldownData.m_PositionValid = false;
+
 				if (GetWorld()->GetDimension() == dimEnd)
 				{
 
@@ -1499,18 +1470,10 @@ bool cEntity::DetectPortal()
 						return false;
 					}
 
-					m_PortalCooldownData.m_ShouldPreventTeleportation = true;
-
-					if (IsPlayer())
-					{
-						cPlayer * Player = reinterpret_cast<cPlayer *>(this);
-						Player->TeleportToCoords(Player->GetLastBedPos().x, Player->GetLastBedPos().y, Player->GetLastBedPos().z);
-						Player->GetClientHandle()->SendRespawn(dimOverworld);
-					}
-
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
-					return MoveToWorld(TargetWorld, false);
+
+					return MoveToWorld(*TargetWorld, Vector3d(TargetWorld->GetSpawnX(), TargetWorld->GetSpawnY(), TargetWorld->GetSpawnZ()));
 				}
 				else
 				{
@@ -1519,121 +1482,19 @@ bool cEntity::DetectPortal()
 						return false;
 					}
 
-					m_PortalCooldownData.m_ShouldPreventTeleportation = true;
-
-					if (IsPlayer())
-					{
-						reinterpret_cast<cPlayer *>(this)->AwardAchievement(achEnterTheEnd);
-						reinterpret_cast<cPlayer *>(this)->GetClientHandle()->SendRespawn(dimEnd);
-					}
-
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedEndWorldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
-					return MoveToWorld(TargetWorld, false);
-				}
 
+					return MoveToWorld(*TargetWorld, GetPosition());
+				}
 			}
 			default: break;
 		}
 	}
 
 	// Allow portals to work again
-	m_PortalCooldownData.m_ShouldPreventTeleportation = false;
-	m_PortalCooldownData.m_TicksDelayed = 0;
+	m_PortalCooldownData = { 0, false, true };
 	return false;
-}
-
-
-
-
-
-bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
-{
-	UNUSED(a_ShouldSendRespawn);
-	ASSERT(a_World != nullptr);
-	ASSERT(IsTicking());
-
-	if (GetWorld() == a_World)
-	{
-		// Don't move to same world
-		return false;
-	}
-
-	//  Ask the plugins if the entity is allowed to changing the world
-	if (cRoot::Get()->GetPluginManager()->CallHookEntityChangingWorld(*this, *a_World))
-	{
-		// A Plugin doesn't allow the entity to changing the world
-		return false;
-	}
-
-	// Stop ticking, in preperation for detaching from this world.
-	SetIsTicking(false);
-
-	// Tell others we are gone
-	GetWorld()->BroadcastDestroyEntity(*this);
-
-	// Set position to the new position
-	SetPosition(a_NewPosition);
-
-	// Stop all mobs from targeting this entity
-	// Stop this entity from targeting other mobs
-	if (this->IsMob())
-	{
-		cMonster * Monster = static_cast<cMonster*>(this);
-		Monster->SetTarget(nullptr);
-		Monster->StopEveryoneFromTargetingMe();
-	}
-
-	// Queue add to new world and removal from the old one
-	cWorld * OldWorld = GetWorld();
-	cChunk * ParentChunk = GetParentChunk();
-	SetWorld(a_World);  // Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value
-	OldWorld->QueueTask([this, ParentChunk, a_World](cWorld & a_OldWorld)
-	{
-		LOGD("Warping entity #%i (%s) from world \"%s\" to \"%s\". Source chunk: (%d, %d) ",
-			this->GetUniqueID(), this->GetClass(),
-			a_OldWorld.GetName().c_str(), a_World->GetName().c_str(),
-			ParentChunk->GetPosX(), ParentChunk->GetPosZ()
-		);
-		ParentChunk->RemoveEntity(this);
-		a_World->AddEntity(this);
-		cRoot::Get()->GetPluginManager()->CallHookEntityChangedWorld(*this, a_OldWorld);
-	});
-	return true;
-}
-
-
-
-
-
-bool cEntity::MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
-{
-	return DoMoveToWorld(a_World, a_ShouldSendRespawn, a_NewPosition);
-}
-
-
-
-
-
-bool cEntity::MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn)
-{
-	return MoveToWorld(a_World, a_ShouldSendRespawn, Vector3d(a_World->GetSpawnX(), a_World->GetSpawnY(), a_World->GetSpawnZ()));
-}
-
-
-
-
-
-bool cEntity::MoveToWorld(const AString & a_WorldName, bool a_ShouldSendRespawn)
-{
-	cWorld * World = cRoot::Get()->GetWorld(a_WorldName);
-	if (World == nullptr)
-	{
-		LOG("%s: Couldn't find world \"%s\".", __FUNCTION__, a_WorldName.c_str());
-		return false;
-	}
-
-	return DoMoveToWorld(World, a_ShouldSendRespawn, Vector3d(World->GetSpawnX(), World->GetSpawnY(), World->GetSpawnZ()));
 }
 
 
@@ -1836,21 +1697,106 @@ void cEntity::StopBurning(void)
 
 void cEntity::TeleportToEntity(cEntity & a_Entity)
 {
-	TeleportToCoords(a_Entity.GetPosX(), a_Entity.GetPosY(), a_Entity.GetPosZ());
+	TeleportToCoords(a_Entity.GetPosition());
 }
 
 
 
 
 
-void cEntity::TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ)
+void cEntity::TeleportToCoords(const Vector3d & a_Position)
 {
-	//  ask the plugins to allow teleport to the new position.
-	if (!cRoot::Get()->GetPluginManager()->CallHookEntityTeleport(*this, m_LastPosition, Vector3d(a_PosX, a_PosY, a_PosZ)))
+	// Ask the plugins to allow teleport to the new position.
+	if (!cRoot::Get()->GetPluginManager()->CallHookEntityTeleport(*this, m_LastPosition, a_Position))
 	{
-		SetPosition(a_PosX, a_PosY, a_PosZ);
+		SetPosition(a_Position);
 		m_World->BroadcastTeleportEntity(*this);
 	}
+}
+
+
+
+
+
+bool cEntity::MoveToWorld(cWorld & a_NewWorld, const Vector3d & a_NewPosition)
+{
+	auto PreviousDimension = GetWorld()->GetDimension();
+	if (OnPreWorldTravel(a_NewWorld))
+	{
+		OnPostWorldTravel(PreviousDimension, a_NewPosition);
+		SetPosition(a_NewPosition);  // Just in case :)
+		return true;
+	}
+	return false;
+}
+
+
+
+
+
+bool cEntity::MoveToWorld(const AString & a_WorldName, const Vector3d & a_NewPosition)
+{
+	auto World = cRoot::Get()->GetWorld(a_WorldName);
+	if (World == nullptr)
+	{
+		LOG("%s: Couldn't find world \"%s\".", __FUNCTION__, a_WorldName.c_str());
+		return false;
+	}
+
+	return MoveToWorld(*World, a_NewPosition);
+}
+
+
+
+
+
+bool cEntity::OnPreWorldTravel(cWorld & a_NewWorld)
+{
+	ASSERT(IsTicking());
+
+	if (GetWorld() == &a_NewWorld)
+	{
+		// Don't move to same world
+		return false;
+	}
+
+	//  Ask the plugins if the player is allowed to changing the world
+	if (cRoot::Get()->GetPluginManager()->CallHookEntityChangingWorld(*this, a_NewWorld))
+	{
+		// A Plugin doesn't allow the player to changing the world
+		return false;
+	}
+
+	// Prevent further ticking in this world
+	SetIsTicking(false);
+
+	auto Entity = GetParentChunk()->AcquireAssociatedEntityPtr(*this);
+
+	// Broadcast for other people that the player is gone.
+	GetWorld()->BroadcastDestroyEntity(*this);
+
+	cpp14::move_on_copy_wrapper<decltype(Entity)> EntityPtr(std::move(Entity));
+	a_NewWorld.QueueTask(
+		[EntityPtr](cWorld & a_DestinationWorld) mutable
+		{
+			// Entity changed world, call the hook
+			cRoot::Get()->GetPluginManager()->CallHookEntityChangedWorld(*EntityPtr.value, *EntityPtr.value->GetWorld());
+
+			EntityPtr.value->Initialize(std::move(EntityPtr.value), a_DestinationWorld);
+		}
+	);
+
+	return true;
+}
+
+
+
+
+
+void cEntity::OnPostWorldTravel(eDimension a_PreviousDimension, const Vector3d & a_RecommendedPosition)
+{
+	SetPosition(a_RecommendedPosition);
+	m_PortalCooldownData.m_PositionValid = true;
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -130,7 +130,7 @@ const char * cEntity::GetParentClass(void) const
 
 
 
-bool cEntity::Initialize(cWorld & a_World)
+bool cEntity::Initialize(std::unique_ptr<cEntity> a_Entity, cWorld & a_EntityWorld)
 {
 	ASSERT(a_EntityWorld.IsInTickThread());
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -215,7 +215,7 @@ public:
 	void SetPosY    (double a_PosY) { SetPosition({m_Position.x, a_PosY, m_Position.z}); }
 	void SetPosZ    (double a_PosZ) { SetPosition({m_Position.x, m_Position.y, a_PosZ}); }
 	void SetPosition(double a_PosX, double a_PosY, double a_PosZ) { SetPosition({a_PosX, a_PosY, a_PosZ}); }
-	void SetPosition(const Vector3d & a_Position);
+	virtual void SetPosition(const Vector3d & a_Position);
 	void SetYaw     (double a_Yaw);    // In degrees, normalizes to [-180, +180)
 	void SetPitch   (double a_Pitch);  // In degrees, normalizes to [-180, +180)
 	void SetRoll    (double a_Roll);   // In degrees, normalizes to [-180, +180)
@@ -299,6 +299,9 @@ public:
 	The TDI is sent through plugins first, then applied.
 	If it returns false, the entity hasn't receive any damage. */
 	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI);
+
+	/** Returns the position stored before the last call to SetPosition. */
+	Vector3d GetLastPosition(void) const { return m_LastPosition; }
 
 	// tolua_begin
 
@@ -405,22 +408,29 @@ public:
 	virtual void TeleportToEntity(cEntity & a_Entity);
 
 	/** Teleports to the coordinates specified */
-	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
+	virtual void TeleportToCoords(const Vector3d & a_Position);
 
-	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
-	void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false);
+	/** Moves entity to the specified world reference and to the specified position.
+	Returns if the entity changed worlds. */
+	bool MoveToWorld(cWorld & a_NewWorld, const Vector3d & a_NewPosition);
 
-	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
-
-	/** Moves entity to specified world, taking a world pointer */
-	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn = true);
-
-	/** Moves entity to specified world, taking a world name */
-	bool MoveToWorld(const AString & a_WorldName, bool a_ShouldSendRespawn = true);
+	/** Moves entity to the specified world name and to the specified position.
+	Returns if the entity changed worlds. */
+	bool MoveToWorld(const AString & a_WorldName, const Vector3d & a_NewPosition);
 
 	// tolua_end
 
-	virtual bool DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
+	/** Event called on initial world change request.
+	The recommended coordinates have not been calculated, and the destination spawn area may not have been prepared yet.
+	Descendants MAY overload to modify the specifics of their world change behaviour. */
+	virtual bool OnPreWorldTravel(cWorld & a_NewWorld);
+
+	/** Event called after world change request has been fully processed.
+	The suggested spawn coordinates have been calculated.
+	Descendants MAY ignore the recommended position.
+	This function MUST be called within the context of the destination world's tick thread:
+	we may safely ignore the originating world as the entity is guaranteed to no longer be accessed / ticked from that thread. */
+	virtual void OnPostWorldTravel(eDimension a_PreviousDimension, const Vector3d & a_RecommendedPosition);
 
 	/** Updates clients of changes in the entity. */
 	virtual void BroadcastMovementUpdate(const cClientHandle * a_Exclude = nullptr);
@@ -490,14 +500,17 @@ public:
 	}
 
 	/** Sets the internal world pointer to a new cWorld, doesn't update anything else. */
-	void SetWorld(cWorld * a_World) { m_World = a_World; }
+	void SetWorld(cWorld * a_World)
+	{
+		m_World = a_World;
+	}
 
 	/** Sets the parent chunk, which is the chunk responsible for ticking this entity.
 	Only cChunk::AddEntity and cChunk::RemoveEntity cChunk::~cChunk should ever call this. */
 	void SetParentChunk(cChunk * a_Chunk);
 
 	/** Returns the chunk responsible for ticking this entity. */
-	cChunk * GetParentChunk();
+	cChunk * GetParentChunk() const;
 
 	/** Set the entity's status to either ticking or not ticking. */
 	void SetIsTicking(bool a_IsTicking);
@@ -512,6 +525,10 @@ protected:
 		/** Whether the entity has just exited the portal, and should therefore not be teleported again.
 		This prevents teleportation loops, and is reset when the entity has moved out of the portal. */
 		bool m_ShouldPreventTeleportation;
+
+		/** Whether the entity's position has been calculated and set.
+		Processing does not occur until this is true. */
+		bool m_PositionValid;
 	};
 
 	static cCriticalSection m_CSCount;
@@ -562,12 +579,6 @@ protected:
 	eEntityType m_EntityType;
 
 	cWorld * m_World;
-
-	/** State variables for ScheduleMoveToWorld. */
-	bool m_IsWorldChangeScheduled;
-	bool m_WorldChangeSetPortalCooldown;
-	cWorld * m_NewWorld;
-	Vector3d m_NewWorldPosition;
 
 	/** Whether the entity is capable of taking fire or lava damage. */
 	bool m_IsFireproof;
@@ -655,8 +666,6 @@ private:
 	While this ticks, a player can't hit this entity. */
 	int m_InvulnerableTicks;
 } ;  // tolua_export
-
-typedef std::list<cEntity *> cEntityList;
 
 
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -153,7 +153,7 @@ public:
 
 	/** Spawns the entity in the world; returns true if spawned, false if not (plugin disallowed).
 	Adds the entity to the world. */
-	virtual bool Initialize(cWorld & a_World);
+	virtual bool Initialize(std::unique_ptr<cEntity>a_Entity, cWorld & a_EntityWorld);
 
 	// tolua_begin
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -28,8 +28,10 @@ cPawn::cPawn(eEntityType a_EntityType, double a_Width, double a_Height) :
 
 
 cPawn::~cPawn()
+bool cPawn::OnPreWorldTravel(cWorld & a_NewWorld)
 {
 	ASSERT(m_TargetingMe.size() == 0);
+	return super::OnPreWorldTravel(a_NewWorld);
 }
 
 

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -23,6 +23,8 @@ public:
 
 	cPawn(eEntityType a_EntityType, double a_Width, double a_Height);
 	~cPawn();
+
+	virtual bool OnPreWorldTravel(cWorld & a_NewWorld) override;
 	virtual void Destroyed() override;
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -24,7 +24,6 @@ public:
 	cPawn(eEntityType a_EntityType, double a_Width, double a_Height);
 	~cPawn();
 
-	virtual bool OnPreWorldTravel(cWorld & a_NewWorld) override;
 	virtual void Destroyed() override;
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
@@ -33,11 +32,6 @@ public:
 	virtual bool IsFireproof(void) const override;
 	virtual void HandleAir(void) override;
 	virtual void HandleFalling(void);
-
-	/** Tells all pawns which are targeting us to stop targeting us. */
-	void StopEveryoneFromTargetingMe();
-
-
 
 	// tolua_begin
 
@@ -59,23 +53,17 @@ public:
 
 	// tolua_end
 
-	/** Remove the monster from the list of monsters targeting this pawn. */
-	void NoLongerTargetingMe(cMonster * a_Monster);
-
-	/** Add the monster to the list of monsters targeting this pawn. (Does not check if already in list!) */
-	void TargetingMe(cMonster * a_Monster);
-
 protected:
+	/** Resets the targeted entity of all who currently are targeting us in the current world.
+	Fulfils invariant set out in cMonster::m_Target. */
+	void UnsetAllTargeters();
+
 	typedef std::map<cEntityEffect::eType, cEntityEffect *> tEffectMap;
 	tEffectMap m_EntityEffects;
 
 	double m_LastGroundHeight;
 	bool m_bTouchGround;
 
-private:
-
-	/** A list of all monsters that are targeting this pawn. */
-	std::vector<cMonster*> m_TargetingMe;
 } ;  // tolua_export
 
 

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -40,9 +40,7 @@ public:
 	CLASS_PROTODEF(cPlayer)
 
 
-	cPlayer(cClientHandlePtr a_Client, const AString & a_PlayerName);
-
-	virtual bool Initialize(cWorld & a_World) override;
+	cPlayer(std::weak_ptr<cClientHandle> a_Client, const AString & a_PlayerName);
 
 	virtual ~cPlayer();
 
@@ -138,7 +136,7 @@ public:
 	/** Returns whether the player is climbing (ladders, vines etc.) */
 	bool IsClimbing(void) const;
 
-	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ) override;
+	virtual void TeleportToCoords(const Vector3d & a_Position) override;
 
 	// tolua_begin
 
@@ -217,10 +215,6 @@ public:
 
 	void SetIP(const AString & a_IP);
 
-	/** Forces the player to move in the given direction.
-	@deprecated Use SetSpeed instead. */
-	void ForceSetSpeed(const Vector3d & a_Speed);  // tolua_export
-
 	cWindow * GetWindow(void) { return m_CurrentWindow; }  // tolua_export
 	const cWindow * GetWindow(void) const { return m_CurrentWindow; }
 
@@ -236,28 +230,28 @@ public:
 	void CloseWindowIfID(char a_WindowID, bool a_CanRefuse = true);
 
 	/** Returns the raw client handle associated with the player. */
-	cClientHandle * GetClientHandle(void) const { return m_ClientHandle.get(); }
+	cClientHandle * GetClientHandle(void) const { return m_ClientHandle.lock().get(); }
 
 	// tolua_end
 
 	/** Returns the SharedPtr to client handle associated with the player. */
-	cClientHandlePtr GetClientHandlePtr(void) const { return m_ClientHandle; }
+	std::weak_ptr<cClientHandle> GetClientHandlePtr(void) const { return m_ClientHandle; }
 
 	// tolua_begin
 
-	void SendMessage              (const AString & a_Message) { m_ClientHandle->SendChat(a_Message, mtCustom); }
-	void SendMessageInfo          (const AString & a_Message) { m_ClientHandle->SendChat(a_Message, mtInformation); }
-	void SendMessageFailure       (const AString & a_Message) { m_ClientHandle->SendChat(a_Message, mtFailure); }
-	void SendMessageSuccess       (const AString & a_Message) { m_ClientHandle->SendChat(a_Message, mtSuccess); }
-	void SendMessageWarning       (const AString & a_Message) { m_ClientHandle->SendChat(a_Message, mtWarning); }
-	void SendMessageFatal         (const AString & a_Message) { m_ClientHandle->SendChat(a_Message, mtFailure); }
-	void SendMessagePrivateMsg    (const AString & a_Message, const AString & a_Sender) { m_ClientHandle->SendChat(a_Message, mtPrivateMessage, a_Sender); }
-	void SendMessage              (const cCompositeChat & a_Message) { m_ClientHandle->SendChat(a_Message); }
+	void SendMessage(const AString & a_Message);
+	void SendMessageInfo(const AString & a_Message);
+	void SendMessageFailure(const AString & a_Message);
+	void SendMessageSuccess(const AString & a_Message);
+	void SendMessageWarning(const AString & a_Message);
+	void SendMessageFatal(const AString & a_Message);
+	void SendMessagePrivateMsg(const AString & a_Message, const AString & a_Sender);
+	void SendMessage(const cCompositeChat & a_Message);
 
-	void SendSystemMessage        (const AString & a_Message) { m_ClientHandle->SendChatSystem(a_Message, mtCustom); }
-	void SendAboveActionBarMessage(const AString & a_Message) { m_ClientHandle->SendChatAboveActionBar(a_Message, mtCustom); }
-	void SendSystemMessage        (const cCompositeChat & a_Message) { m_ClientHandle->SendChatSystem(a_Message); }
-	void SendAboveActionBarMessage(const cCompositeChat & a_Message) { m_ClientHandle->SendChatAboveActionBar(a_Message); }
+	void SendSystemMessage(const AString & a_Message);
+	void SendAboveActionBarMessage(const AString & a_Message);
+	void SendSystemMessage(const cCompositeChat & a_Message);
+	void SendAboveActionBarMessage(const cCompositeChat & a_Message);
 
 	const AString & GetName(void) const { return m_PlayerName; }
 	void SetName(const AString & a_Name) { m_PlayerName = a_Name; }
@@ -266,7 +260,7 @@ public:
 
 	bool HasPermission(const AString & a_Permission);  // tolua_export
 
-	/** Returns true iff a_Permission matches the a_Template.
+	/** Returns true if a_Permission matches the a_Template.
 	A match is defined by either being exactly the same, or each sub-item matches until there's a wildcard in a_Template.
 	Ie. {"a", "b", "c"} matches {"a", "b", "*"} but doesn't match {"a", "b"} */
 	static bool PermissionMatches(const AStringVector & a_Permission, const AStringVector & a_Template);  // Exported in ManualBindings with AString params
@@ -367,11 +361,21 @@ public:
 	bool IsVisible(void) const { return m_bVisible; }  // tolua_export
 
 	/** Moves the player to the specified world.
-	Returns true if successful, false on failure (world not found). */
-	virtual bool DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition) override;
+	Overloads cEntity to perform additional housekeeping with regards to the clienthandle and world. */
+	virtual bool OnPreWorldTravel(cWorld & a_NewWorld) override;
+
+	/** Sets the player to the correct coordinates having changed world.
+	Overloads cEntity to ensure we return to our own spawn point (not the world spawn) when returning from the End. */
+	virtual void OnPostWorldTravel(eDimension a_PreviousDimension, const Vector3d & a_RecommendedPosition) override;
 
 	/** Saves all player data, such as inventory, to JSON */
 	bool SaveToDisk(void);
+
+	/** Returns whether the player is in the process of changing worlds in a thread-safe manner. */
+	bool IsChangingWorlds(void) const { return m_IsChangingWorlds; }
+
+	/** Sets whether the player is in the process of changing worlds in a thread-safe manner. */
+	void SetIsChangingWorlds(bool a_Flag) { m_IsChangingWorlds = a_Flag; }
 
 	typedef cWorld * cWorldPtr;
 
@@ -517,10 +521,6 @@ public:
 
 	virtual void Detach(void) override;
 
-	/** Called by cClientHandle when the client is being destroyed.
-	The player removes its m_ClientHandle ownership so that the ClientHandle gets deleted. */
-	void RemoveClientHandle(void);
-
 protected:
 
 	typedef std::vector<std::vector<AString> > AStringVectorVector;
@@ -598,15 +598,12 @@ protected:
 
 	std::chrono::steady_clock::time_point m_LastPlayerListTime;
 
-	cClientHandlePtr m_ClientHandle;
+	std::weak_ptr<cClientHandle> m_ClientHandle;
 
 	cSlotNums m_InventoryPaintSlots;
 
 	/** If true, we are locking m_Position to m_FrozenPosition. */
 	bool m_IsFrozen;
-
-	/** Was the player frozen manually by a plugin or automatically by the server? */
-	bool m_IsManuallyFrozen;
 
 	/** Max speed, relative to the game default.
 	1 means regular speed, 2 means twice as fast, 0.5 means half-speed.
@@ -659,10 +656,10 @@ protected:
 	Default save interval is #defined in PLAYER_INVENTORY_SAVE_INTERVAL */
 	unsigned int m_TicksUntilNextSave;
 
-	/** Flag used by food handling system to determine whether a teleport has just happened
-	Will not apply food penalties if found to be true; will set to false after processing
-	*/
-	bool m_bIsTeleporting;
+	/** Flag indicating whether the entity is in the process of changing worlds.
+	MAY be accessed concurrently.
+	Used currently to prevent chunk sending before the player is added to the destination world. */
+	std::atomic_bool m_IsChangingWorlds;
 
 	/** The short UUID (no dashes) of the player, as read from the ClientHandle.
 	If no ClientHandle is given, the UUID is initialized to empty. */
@@ -672,9 +669,6 @@ protected:
 
 	/** Sets the speed and sends it to the client, so that they are forced to move so. */
 	virtual void DoSetSpeed(double a_SpeedX, double a_SpeedY, double a_SpeedZ) override;
-
-	void ResolvePermissions(void);
-	void ResolveGroups(void);
 
 	virtual void Destroyed(void) override;
 
@@ -697,9 +691,4 @@ protected:
 	This can be used both for online and offline UUIDs. */
 	AString GetUUIDFileName(const AString & a_UUID);
 
-private:
-
-	/** Pins the player to a_Location until Unfreeze() is called.
-	If ManuallyFrozen is false, the player will unfreeze when the chunk is loaded. */
-	void FreezeInternal(const Vector3d & a_Location, bool a_ManuallyFrozen);
-} ;  // tolua_export
+};  // tolua_export

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -252,7 +252,7 @@ cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, const Ve
 
 
 
-cProjectileEntity * cProjectileEntity::Create(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem * a_Item, const Vector3d * a_Speed)
+std::unique_ptr<cProjectileEntity> cProjectileEntity::Create(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem * a_Item, const Vector3d * a_Speed)
 {
 	Vector3d Speed;
 	if (a_Speed != nullptr)
@@ -262,15 +262,15 @@ cProjectileEntity * cProjectileEntity::Create(eKind a_Kind, cEntity * a_Creator,
 
 	switch (a_Kind)
 	{
-		case pkArrow:         return new cArrowEntity           (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkEgg:           return new cThrownEggEntity       (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkEnderPearl:    return new cThrownEnderPearlEntity(a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkSnowball:      return new cThrownSnowballEntity  (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkGhastFireball: return new cGhastFireballEntity   (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkFireCharge:    return new cFireChargeEntity      (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkExpBottle:     return new cExpBottleEntity       (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkSplashPotion:  return new cSplashPotionEntity    (a_Creator, a_X, a_Y, a_Z, Speed, *a_Item);
-		case pkWitherSkull:   return new cWitherSkullEntity     (a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkArrow:         return cpp14::make_unique<cArrowEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkEgg:           return cpp14::make_unique<cThrownEggEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkEnderPearl:    return cpp14::make_unique<cThrownEnderPearlEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkSnowball:      return cpp14::make_unique<cThrownSnowballEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkGhastFireball: return cpp14::make_unique<cGhastFireballEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkFireCharge:    return cpp14::make_unique<cFireChargeEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkExpBottle:     return cpp14::make_unique<cExpBottleEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkSplashPotion:  return cpp14::make_unique<cSplashPotionEntity>(a_Creator, a_X, a_Y, a_Z, Speed, *a_Item);
+		case pkWitherSkull:   return cpp14::make_unique<cWitherSkullEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
 		case pkFirework:
 		{
 			ASSERT(a_Item != nullptr);
@@ -279,7 +279,7 @@ cProjectileEntity * cProjectileEntity::Create(eKind a_Kind, cEntity * a_Creator,
 				return nullptr;
 			}
 
-			return new cFireworkEntity(a_Creator, a_X, a_Y, a_Z, *a_Item);
+			return cpp14::make_unique<cFireworkEntity>(a_Creator, a_X, a_Y, a_Z, *a_Item);
 		}
 		case pkFishingFloat: break;
 	}

--- a/src/Entities/ProjectileEntity.h
+++ b/src/Entities/ProjectileEntity.h
@@ -46,7 +46,7 @@ public:
 	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, double a_Width, double a_Height);
 	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, const Vector3d & a_Pos, const Vector3d & a_Speed, double a_Width, double a_Height);
 
-	static cProjectileEntity * Create(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem * a_Item, const Vector3d * a_Speed = nullptr);
+	static std::unique_ptr<cProjectileEntity> Create(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem * a_Item, const Vector3d * a_Speed = nullptr);
 
 	/** Called by the physics blocktracer when the entity hits a solid block, the hit position and the face hit (BLOCK_FACE_) is given */
 	virtual void OnHitSolidBlock(const Vector3d & a_HitPos, eBlockFace a_HitFace);

--- a/src/Entities/ThrownEnderPearlEntity.cpp
+++ b/src/Entities/ThrownEnderPearlEntity.cpp
@@ -86,7 +86,7 @@ void cThrownEnderPearlEntity::TeleportCreator(const Vector3d & a_HitPos)
 		virtual bool Item(cPlayer * a_Entity) override
 		{
 			// Teleport the creator here, make them take 5 damage:
-			a_Entity->TeleportToCoords(m_HitPos.x, m_HitPos.y + 0.2, m_HitPos.z);
+			a_Entity->TeleportToCoords(m_HitPos + Vector3d(0, 0.2, 0));
 			a_Entity->TakeDamage(dtEnderPearl, m_Attacker, 5, 0);
 			return true;
 		}

--- a/src/Generating/ChunkDesc.cpp
+++ b/src/Generating/ChunkDesc.cpp
@@ -8,7 +8,8 @@
 #include "../BlockArea.h"
 #include "../Cuboid.h"
 #include "../Noise/Noise.h"
-#include "../BlockEntities/BlockEntity.h"
+#include "BlockEntities/BlockEntity.h"
+#include "Entities/Entity.h"
 
 
 

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -1483,11 +1483,11 @@ bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX
 	double AnimalY = a_RelY;
 	double AnimalZ = static_cast<double>(a_ChunkDesc.GetChunkZ() * cChunkDef::Width + a_RelZ + 0.5);
 
-	cMonster * NewMob = cMonster::NewMonsterFromType(AnimalToSpawn);
+	auto NewMob = cMonster::NewMonsterFromType(AnimalToSpawn);
 	NewMob->SetHealth(NewMob->GetMaxHealth());
 	NewMob->SetPosition(AnimalX, AnimalY, AnimalZ);
-	a_ChunkDesc.GetEntities().push_back(NewMob);
 	LOGD("Spawning %s #%i at {%.02f, %.02f, %.02f}", NewMob->GetClass(), NewMob->GetUniqueID(), AnimalX, AnimalY, AnimalZ);
+	a_ChunkDesc.GetEntities().emplace_back(std::move(NewMob));
 
 	return true;
 }

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -444,17 +444,49 @@ typename std::enable_if<std::is_arithmetic<T>::value, C>::type CeilC(T a_Value)
 	return static_cast<C>(std::ceil(a_Value));
 }
 
-
-
-//temporary replacement for std::make_unique until we get c++14
-
 namespace cpp14
 {
+	// Temporary replacement for std::make_unique until we get c++14
 	template <class T, class... Args>
 	std::unique_ptr<T> make_unique(Args&&... args)
 	{
 		return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 	}
+
+	// Temporary workaround for ...
+	template <typename StorageType>
+	struct move_on_copy_wrapper
+	{
+		move_on_copy_wrapper(StorageType && a_Value) :
+			value(std::move(a_Value))
+		{
+		}
+
+		move_on_copy_wrapper(const move_on_copy_wrapper & a_Other) :
+			value(std::move(a_Other.value))
+		{
+		}
+
+		move_on_copy_wrapper& operator=(const move_on_copy_wrapper & a_Other)
+		{
+			value = std::move(a_Other.value);
+			return *this;
+		}
+
+		mutable StorageType value;
+	};
+}
+
+namespace std
+{
+	template <typename WeakPtrType>
+	struct equal_to<std::weak_ptr<WeakPtrType>>
+	{
+		/* constexpr */ bool operator()(const std::weak_ptr<WeakPtrType> & a_Lhs, const std::weak_ptr<WeakPtrType> & a_Rhs) const
+		{
+			return (!a_Lhs.owner_before(a_Rhs) && !a_Rhs.owner_before(a_Lhs));
+		}
+	};
 }
 
 // a tick is 50 ms

--- a/src/Items/ItemBoat.h
+++ b/src/Items/ItemBoat.h
@@ -92,8 +92,7 @@ public:
 		}
 
 		// Spawn block at water level
-		cBoat * Boat = new cBoat(x + 0.5, y + 0.5, z + 0.5);
-		Boat->Initialize(*a_World);
+		a_World->SpawnBoat(x + 0.5, y + 0.5, z + 0.5);
 
 		return true;
 	}

--- a/src/Items/ItemBow.h
+++ b/src/Items/ItemBow.h
@@ -69,15 +69,10 @@ public:
 		}
 
 		// Create the arrow entity:
-		cArrowEntity * Arrow = new cArrowEntity(*a_Player, Force * 2);
-		if (Arrow == nullptr)
+		auto ArrowPtr = cpp14::make_unique<cArrowEntity>(*a_Player, Force * 2);
+		auto Arrow = ArrowPtr.get();
+		if (!Arrow->Initialize(std::move(ArrowPtr), *a_Player->GetWorld()))
 		{
-			return;
-		}
-		if (!Arrow->Initialize(*a_Player->GetWorld()))
-		{
-			delete Arrow;
-			Arrow = nullptr;
 			return;
 		}
 		a_Player->GetWorld()->BroadcastSoundEffect(

--- a/src/Items/ItemFishingRod.h
+++ b/src/Items/ItemFishingRod.h
@@ -244,9 +244,9 @@ public:
 		}
 		else
 		{
-			cFloater * Floater = new cFloater(a_Player->GetPosX(), a_Player->GetStance(), a_Player->GetPosZ(), a_Player->GetLookVector() * 15, a_Player->GetUniqueID(), static_cast<int>(100 + static_cast<unsigned int>(a_World->GetTickRandomNumber(800)) - (a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100)));
-			Floater->Initialize(*a_World);
+			auto Floater = cpp14::make_unique<cFloater>(a_Player->GetPosX(), a_Player->GetStance(), a_Player->GetPosZ(), a_Player->GetLookVector() * 15, a_Player->GetUniqueID(), static_cast<int>(100 + static_cast<unsigned int>(a_World->GetTickRandomNumber(800)) - (a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100)));
 			a_Player->SetIsFishing(true, Floater->GetUniqueID());
+			Floater->Initialize(std::move(Floater), *a_World);
 		}
 		return true;
 	}

--- a/src/Items/ItemItemFrame.h
+++ b/src/Items/ItemItemFrame.h
@@ -38,11 +38,9 @@ public:
 
 		if (Block == E_BLOCK_AIR)
 		{
-			cItemFrame * ItemFrame = new cItemFrame(a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
-			if (!ItemFrame->Initialize(*a_World))
+			auto ItemFrame = cpp14::make_unique<cItemFrame>(a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
+			if (!ItemFrame->Initialize(std::move(ItemFrame), *a_World))
 			{
-				delete ItemFrame;
-				ItemFrame = nullptr;
 				return false;
 			}
 

--- a/src/Items/ItemMinecart.h
+++ b/src/Items/ItemMinecart.h
@@ -59,21 +59,8 @@ public:
 		double x = static_cast<double>(a_BlockX) + 0.5;
 		double y = static_cast<double>(a_BlockY) + 0.5;
 		double z = static_cast<double>(a_BlockZ) + 0.5;
-		cMinecart * Minecart = nullptr;
-		switch (m_ItemType)
-		{
-			case E_ITEM_MINECART:             Minecart = new cRideableMinecart     (x, y, z, cItem(), 1); break;
-			case E_ITEM_CHEST_MINECART:       Minecart = new cMinecartWithChest    (x, y, z); break;
-			case E_ITEM_FURNACE_MINECART:     Minecart = new cMinecartWithFurnace  (x, y, z); break;
-			case E_ITEM_MINECART_WITH_TNT:    Minecart = new cMinecartWithTNT      (x, y, z); break;
-			case E_ITEM_MINECART_WITH_HOPPER: Minecart = new cMinecartWithHopper   (x, y, z); break;
-			default:
-			{
-				ASSERT(!"Unhandled minecart item");
-				return false;
-			}
-		}  // switch (m_ItemType)
-		Minecart->Initialize(*a_World);
+		
+		a_World->SpawnMinecart(x, y, z, m_ItemType);
 
 		if (!a_Player->IsGameModeCreative())
 		{

--- a/src/Items/ItemPainting.h
+++ b/src/Items/ItemPainting.h
@@ -70,8 +70,8 @@ public:
 				{ "BurningSkull" }
 			};
 
-			cPainting * Painting = new cPainting(gPaintingTitlesList[a_World->GetTickRandomNumber(ARRAYCOUNT(gPaintingTitlesList) - 1)].Title, a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
-			Painting->Initialize(*a_World);
+			auto Painting = cpp14::make_unique<cPainting>(gPaintingTitlesList[a_World->GetTickRandomNumber(ARRAYCOUNT(gPaintingTitlesList) - 1)].Title, a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
+			Painting->Initialize(std::move(Painting), *a_World);
 
 			if (!a_Player->IsGameModeCreative())
 			{

--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -20,62 +20,20 @@ class cReader :
 {
 	virtual void ChunkData(const cChunkData & a_ChunkBuffer) override
 	{
-		BLOCKTYPE * OutputRows = m_BlockTypes;
-		int InputIdx = 0;
-		int OutputIdx = m_ReadingChunkX + m_ReadingChunkZ * cChunkDef::Width * 3;
-		int MaxHeight = std::min(+cChunkDef::Height, m_MaxHeight + 16);  // Need 16 blocks above the highest
-		for (int y = 0; y < MaxHeight; y++)
-		{
-			for (int z = 0; z < cChunkDef::Width; z++)
-			{
-				a_ChunkBuffer.CopyBlockTypes(OutputRows + OutputIdx * 16, static_cast<size_t>(InputIdx * 16), 16);
-				InputIdx++;
-				OutputIdx += 3;
-			}  // for z
-			// Skip into the next y-level in the 3x3 chunk blob; each level has cChunkDef::Width * 9 rows
-			// We've already walked cChunkDef::Width * 3 in the "for z" cycle, that makes cChunkDef::Width * 6 rows left to skip
-			OutputIdx += cChunkDef::Width * 6;
-		}  // for y
-	}  // BlockTypes()
-
+		a_ChunkBuffer.CopyBlockTypes(m_BlockTypes.data());
+	}
 
 	virtual void HeightMap(const cChunkDef::HeightMap * a_Heightmap) override
 	{
-		// Copy the entire heightmap, distribute it into the 3x3 chunk blob:
-		typedef struct {HEIGHTTYPE m_Row[16]; } ROW;
-		const ROW * InputRows  = reinterpret_cast<const ROW *>(a_Heightmap);
-		ROW * OutputRows = reinterpret_cast<ROW *>(m_HeightMap);
-		int InputIdx = 0;
-		int OutputIdx = m_ReadingChunkX + m_ReadingChunkZ * cChunkDef::Width * 3;
-		for (int z = 0; z < cChunkDef::Width; z++)
-		{
-			OutputRows[OutputIdx] = InputRows[InputIdx++];
-			OutputIdx += 3;
-		}  // for z
-
-		// Find the highest block in the entire chunk, use it as a base for m_MaxHeight:
-		HEIGHTTYPE MaxHeight = m_MaxHeight;
-		for (size_t i = 0; i < ARRAYCOUNT(*a_Heightmap); i++)
-		{
-			if ((*a_Heightmap)[i] > MaxHeight)
-			{
-				MaxHeight = (*a_Heightmap)[i];
-			}
-		}
-		m_MaxHeight = MaxHeight;
+		std::copy(std::begin(*a_Heightmap), std::end(*a_Heightmap), std::begin(m_HeightMap));
 	}
 
 public:
-	int m_ReadingChunkX;  // 0, 1 or 2; x-offset of the chunk we're reading from the BlockTypes start
-	int m_ReadingChunkZ;  // 0, 1 or 2; z-offset of the chunk we're reading from the BlockTypes start
-	HEIGHTTYPE m_MaxHeight;  // Maximum value in this chunk's heightmap
-	BLOCKTYPE * m_BlockTypes;  // 3x3 chunks of block types, organized as a single XZY blob of data (instead of 3x3 XZY blobs)
-	HEIGHTTYPE * m_HeightMap;  // 3x3 chunks of height map,  organized as a single XZY blob of data (instead of 3x3 XZY blobs)
 
-	cReader(BLOCKTYPE * a_BlockTypes, HEIGHTTYPE * a_HeightMap) :
-		m_ReadingChunkX(0),
-		m_ReadingChunkZ(0),
-		m_MaxHeight(0),
+	cLightingThread::BlockDataArray & m_BlockTypes;  // 3x3 chunks of block types, organized as a single XZY blob of data (instead of 3x3 XZY blobs)
+	cLightingThread::HeightDataArray & m_HeightMap;  // 3x3 chunks of height map,  organized as a single XZY blob of data (instead of 3x3 XZY blobs)
+
+	cReader(cLightingThread::BlockDataArray & a_BlockTypes, cLightingThread::HeightDataArray & a_HeightMap) :
 		m_BlockTypes(a_BlockTypes),
 		m_HeightMap(a_HeightMap)
 	{
@@ -91,9 +49,7 @@ public:
 
 cLightingThread::cLightingThread(void) :
 	super("cLightingThread"),
-	m_World(nullptr),
-	m_MaxHeight(0),
-	m_NumSeeds(0)
+	m_World(nullptr)
 {
 }
 
@@ -124,24 +80,8 @@ bool cLightingThread::Start(cWorld * a_World)
 
 void cLightingThread::Stop(void)
 {
-	{
-		cCSLock Lock(m_CS);
-		for (cChunkStays::iterator itr = m_PendingQueue.begin(), end = m_PendingQueue.end(); itr != end; ++itr)
-		{
-			(*itr)->Disable();
-			delete *itr;
-		}
-		m_PendingQueue.clear();
-		for (cChunkStays::iterator itr = m_Queue.begin(), end = m_Queue.end(); itr != end; ++itr)
-		{
-			(*itr)->Disable();
-			delete *itr;
-		}
-		m_Queue.clear();
-	}
 	m_ShouldTerminate = true;
-	m_evtItemAdded.Set();
-
+	m_evtItemDataLoaded.Set();
 	Wait();
 }
 
@@ -153,28 +93,25 @@ void cLightingThread::QueueChunk(int a_ChunkX, int a_ChunkZ, std::unique_ptr<cCh
 {
 	ASSERT(m_World != nullptr);  // Did you call Start() properly?
 
-	cChunkStay * ChunkStay = new cLightingChunkStay(*this, a_ChunkX, a_ChunkZ, std::move(a_CallbackAfter));
+	// If the chunk is already lit, skip it:
+	if (m_World->IsChunkValid(a_ChunkX, a_ChunkZ) && m_World->IsChunkLighted(a_ChunkX, a_ChunkZ))
+	{
+		if (a_CallbackAfter != nullptr)
+		{
+			a_CallbackAfter->Call(a_ChunkX, a_ChunkZ, true);
+		}
+		return;
+	}
+
+
+	auto ChunkStay = new cLightingChunkStay(*this, a_ChunkX, a_ChunkZ, std::move(a_CallbackAfter));
 	{
 		// The ChunkStay will enqueue itself using the QueueChunkStay() once it is fully loaded
 		// In the meantime, put it into the PendingQueue so that it can be removed when stopping the thread
 		cCSLock Lock(m_CS);
-		m_PendingQueue.push_back(ChunkStay);
+		m_PendingQueue.emplace_back(ChunkStay);
 	}
 	ChunkStay->Enable(*m_World->GetChunkMap());
-}
-
-
-
-
-
-void cLightingThread::WaitForQueueEmpty(void)
-{
-	cCSLock Lock(m_CS);
-	while (!m_ShouldTerminate && (!m_Queue.empty() || !m_PendingQueue.empty()))
-	{
-		cCSUnlock Unlock(Lock);
-		m_evtQueueEmpty.Wait();
-	}
 }
 
 
@@ -184,7 +121,7 @@ void cLightingThread::WaitForQueueEmpty(void)
 size_t cLightingThread::GetQueueLength(void)
 {
 	cCSLock Lock(m_CS);
-	return m_Queue.size() + m_PendingQueue.size();
+	return m_PendingQueue.size();
 }
 
 
@@ -193,44 +130,39 @@ size_t cLightingThread::GetQueueLength(void)
 
 void cLightingThread::Execute(void)
 {
-	for (;;)
+	while (!m_ShouldTerminate)
 	{
+		m_evtItemDataLoaded.Wait();
+
+		decltype(m_Queue) QueuedChunks;
 		{
 			cCSLock Lock(m_CS);
-			if (m_Queue.empty())
-			{
-				cCSUnlock Unlock(Lock);
-				m_evtItemAdded.Wait();
-			}
+			std::swap(m_Queue, QueuedChunks);
 		}
 
-		if (m_ShouldTerminate)
+		for (const auto & Entry : QueuedChunks)
 		{
-			return;
+			Entry->m_BlockTypes = cpp14::make_unique<BlockDataArray>();
+			Entry->m_HeightMap = cpp14::make_unique<HeightDataArray>();
 		}
 
-		// Process one items from the queue:
-		cLightingChunkStay * Item;
-		{
-			cCSLock Lock(m_CS);
-			if (m_Queue.empty())
+		m_World->QueueTask(
+			[&QueuedChunks](cWorld & a_World)
 			{
-				continue;
+				for (const auto & Entry : QueuedChunks)
+				{
+					cReader Reader(*Entry->m_BlockTypes, *Entry->m_HeightMap);
+					VERIFY(a_World.GetChunkData(Entry->m_ChunkX, Entry->m_ChunkZ, Reader));
+				}
 			}
-			Item = static_cast<cLightingChunkStay *>(m_Queue.front());
-			m_Queue.pop_front();
-			if (m_Queue.empty())
-			{
-				m_evtQueueEmpty.Set();
-			}
-		}  // CSLock(m_CS)
+		).wait();
 
-		LightChunk(*Item);
-		Item->Disable();
-		delete Item;
-	}
+		for (const auto & Entry : QueuedChunks)
+		{
+			LightChunk(*Entry);
+		}
+	}  // while (!m_ShouldTerminate)
 }
-
 
 
 
@@ -238,24 +170,12 @@ void cLightingThread::Execute(void)
 
 void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 {
-	// If the chunk is already lit, skip it (report as success):
-	if (m_World->IsChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ))
-	{
-		if (a_Item.m_CallbackAfter != nullptr)
-		{
-			a_Item.m_CallbackAfter->Call(a_Item.m_ChunkX, a_Item.m_ChunkZ, true);
-		}
-		return;
-	}
+	std::unique_ptr<BlockDataArray>
+		BlockLight{ cpp14::make_unique<decltype(BlockLight)::element_type>() },
+		SkyLight{ cpp14::make_unique<decltype(BlockLight)::element_type>() }
+	;
 
-	cChunkDef::BlockNibbles BlockLight, SkyLight;
-
-	ReadChunks(a_Item.m_ChunkX, a_Item.m_ChunkZ);
-
-	PrepareBlockLight();
-	CalcLight(m_BlockLight);
-
-	PrepareSkyLight();
+	CalcLight(a_Item, PrepareBlockLight(a_Item, *BlockLight), *BlockLight);
 
 	/*
 	// DEBUG: Save chunk data with highlighted seeds for visual inspection:
@@ -269,10 +189,10 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 			for (int y = cChunkDef::Height / 2; y >= 0; y--)
 			{
 				unsigned char Seeds     [cChunkDef::Width * 3];
-				memcpy(Seeds, m_BlockTypes + y * BlocksPerYLayer + z * cChunkDef::Width * 3, cChunkDef::Width * 3);
+				memcpy(Seeds, m_BlockTypes + y * cLightingChunkStay::BlocksPerYLayer + z * cChunkDef::Width * 3, cChunkDef::Width * 3);
 				for (int x = 0; x < cChunkDef::Width * 3; x++)
 				{
-					if (m_IsSeed1[y * BlocksPerYLayer + z * cChunkDef::Width * 3 + x])
+					if (m_IsSeed1[y * cLightingChunkStay::BlocksPerYLayer + z * cChunkDef::Width * 3 + x])
 					{
 						Seeds[x] = E_BLOCK_DIAMOND_BLOCK;
 					}
@@ -284,7 +204,7 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 	}
 	//*/
 
-	CalcLight(m_SkyLight);
+	CalcLight(a_Item, PrepareSkyLight(a_Item, *SkyLight), *SkyLight);
 
 	/*
 	// DEBUG: Save XY slices of the chunk data and lighting for visual inspection:
@@ -299,13 +219,13 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 		{
 			for (int y = cChunkDef::Height / 2; y >= 0; y--)
 			{
-				f1.Write(m_BlockTypes + y * BlocksPerYLayer + z * cChunkDef::Width * 3, cChunkDef::Width * 3);
+				f1.Write(m_BlockTypes + y * cLightingChunkStay::BlocksPerYLayer + z * cChunkDef::Width * 3, cChunkDef::Width * 3);
 				unsigned char SkyLight  [cChunkDef::Width * 3];
 				unsigned char BlockLight[cChunkDef::Width * 3];
 				for (int x = 0; x < cChunkDef::Width * 3; x++)
 				{
-					SkyLight[x]   = m_SkyLight  [y * BlocksPerYLayer + z * cChunkDef::Width * 3 + x] << 4;
-					BlockLight[x] = m_BlockLight[y * BlocksPerYLayer + z * cChunkDef::Width * 3 + x] << 4;
+					SkyLight[x]   = m_SkyLight  [y * cLightingChunkStay::BlocksPerYLayer + z * cChunkDef::Width * 3 + x] << 4;
+					BlockLight[x] = m_BlockLight[y * cLightingChunkStay::BlocksPerYLayer + z * cChunkDef::Width * 3 + x] << 4;
 				}
 				f2.Write(SkyLight,   cChunkDef::Width * 3);
 				f3.Write(BlockLight, cChunkDef::Width * 3);
@@ -317,85 +237,91 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 	}
 	//*/
 
-	CompressLight(m_BlockLight, BlockLight);
-	CompressLight(m_SkyLight, SkyLight);
+	std::shared_ptr<BlockNibbles>
+		CompressedBlockLight{ std::make_shared<decltype(CompressedBlockLight)::element_type>() },
+		CompressedSkyLight{ std::make_shared<decltype(CompressedSkyLight)::element_type>() }
+	;
+	CompressLight(*BlockLight, *CompressedBlockLight);
+	CompressLight(*SkyLight, *CompressedSkyLight);
 
-	m_World->ChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ, BlockLight, SkyLight);
-
-	if (a_Item.m_CallbackAfter != nullptr)
-	{
-		a_Item.m_CallbackAfter->Call(a_Item.m_ChunkX, a_Item.m_ChunkZ, true);
-	}
-}
-
-
-
-
-
-void cLightingThread::ReadChunks(int a_ChunkX, int a_ChunkZ)
-{
-	cReader Reader(m_BlockTypes, m_HeightMap);
-
-	for (int z = 0; z < 3; z++)
-	{
-		Reader.m_ReadingChunkZ = z;
-		for (int x = 0; x < 3; x++)
+	m_World->QueueTask(
+		[&a_Item, CompressedBlockLight, CompressedSkyLight](cWorld & a_World)
 		{
-			Reader.m_ReadingChunkX = x;
-			VERIFY(m_World->GetChunkData(a_ChunkX + x - 1, a_ChunkZ + z - 1, Reader));
-		}  // for z
-	}  // for x
+			a_World.ChunkLighted(
+				a_Item.m_ChunkX,
+				a_Item.m_ChunkZ,
+				reinterpret_cast<const cChunkDef::BlockNibbles &>(*CompressedBlockLight->data()),
+				reinterpret_cast<const cChunkDef::BlockNibbles &>(*CompressedSkyLight->data())
+			);
 
-	memset(m_BlockLight, 0, sizeof(m_BlockLight));
-	memset(m_SkyLight,   0, sizeof(m_SkyLight));
-	m_MaxHeight = Reader.m_MaxHeight;
-}
-
-
-
-
-
-void cLightingThread::PrepareSkyLight(void)
-{
-	// Clear seeds:
-	memset(m_IsSeed1, 0, sizeof(m_IsSeed1));
-	m_NumSeeds = 0;
-
-	// Walk every column that has all XZ neighbors
-	for (int z = 1; z < cChunkDef::Width * 3 - 1; z++)
-	{
-		int BaseZ = z * cChunkDef::Width * 3;
-		for (int x = 1; x < cChunkDef::Width * 3 - 1; x++)
-		{
-			int idx = BaseZ + x;
-			int Current   = m_HeightMap[idx] + 1;
-			int Neighbor1 = m_HeightMap[idx + 1] + 1;  // X + 1
-			int Neighbor2 = m_HeightMap[idx - 1] + 1;  // X - 1
-			int Neighbor3 = m_HeightMap[idx + cChunkDef::Width * 3] + 1;  // Z + 1
-			int Neighbor4 = m_HeightMap[idx - cChunkDef::Width * 3] + 1;  // Z - 1
-			int MaxNeighbor = std::max(std::max(Neighbor1, Neighbor2), std::max(Neighbor3, Neighbor4));  // Maximum of the four neighbors
-
-			// Fill the column from the top down to Current with all-light:
-			for (int y = cChunkDef::Height - 1, Index = idx + y * BlocksPerYLayer; y >= Current; y--, Index -= BlocksPerYLayer)
+			if (a_Item.m_CallbackAfter != nullptr)
 			{
-				m_SkyLight[Index] = 15;
+				a_Item.m_CallbackAfter->Call(a_Item.m_ChunkX, a_Item.m_ChunkZ, true);
 			}
 
-			// Add Current as a seed:
-			if (Current < cChunkDef::Height)
-			{
-				int CurrentIdx = idx + Current * BlocksPerYLayer;
-				m_IsSeed1[CurrentIdx] = true;
-				m_SeedIdx1[m_NumSeeds++] = static_cast<UInt32>(CurrentIdx);
-			}
-
-			// Add seed from Current up to the highest neighbor:
-			for (int y = Current + 1, Index = idx + y * BlocksPerYLayer; y < MaxNeighbor; y++, Index += BlocksPerYLayer)
-			{
-				m_IsSeed1[Index] = true;
-				m_SeedIdx1[m_NumSeeds++] = static_cast<UInt32>(Index);
-			}
+			a_Item.Disable();
 		}
+	);
+}
+
+
+
+
+
+std::vector<size_t> cLightingThread::PrepareSkyLight(const cLightingChunkStay & a_Item, BlockDataArray & a_SkyLight)
+{
+	std::vector<size_t> IndicesToProcess;
+	IndicesToProcess.reserve(a_Item.m_HeightMap->size() * 40);
+
+	for (size_t Index = 0; Index != a_Item.m_HeightMap->size(); ++Index)
+	{
+		for (int Y = cChunkDef::Height - 1; Y >= (*a_Item.m_HeightMap)[Index]; --Y)
+		{
+			auto HeightAdjustedIndex = Index + Y * cChunkDef::Width * cChunkDef::Width;
+			a_SkyLight[HeightAdjustedIndex] = 15;
+
+			IndicesToProcess.emplace_back(HeightAdjustedIndex);
+		}
+	}
+
+	return IndicesToProcess;
+}
+
+
+
+
+
+std::vector<size_t> cLightingThread::PrepareBlockLight(const cLightingChunkStay & a_Item, BlockDataArray & a_BlockLight)
+{
+	std::vector<size_t> IndicesToProcess;
+	IndicesToProcess.reserve(cChunkDef::Width * cChunkDef::Width);
+
+	for (size_t Index = 0; Index != a_Item.m_BlockTypes->size(); ++Index)
+	{
+		auto Light = cBlockInfo::GetLightValue((*a_Item.m_BlockTypes)[Index]);
+		a_BlockLight[Index] = Light;
+
+		if (Light > 1)
+		{
+			IndicesToProcess.emplace_back(Index);
+		}
+	}
+
+	return IndicesToProcess;
+}
+
+
+
+
+
+void cLightingThread::CalcLight(const cLightingChunkStay & a_Item, std::vector<size_t> a_IndicesToProcess, BlockDataArray & a_Light)
+{
+	while (!a_IndicesToProcess.empty())
+	{
+		auto Back = a_IndicesToProcess.back();
+		a_IndicesToProcess.pop_back();
+
+		DiscoverLightAdjacents(a_IndicesToProcess, a_Item, a_Light, Back);
 	}
 }
 
@@ -403,35 +329,42 @@ void cLightingThread::PrepareSkyLight(void)
 
 
 
-void cLightingThread::PrepareBlockLight(void)
+void cLightingThread::DiscoverLightAdjacents(std::vector<size_t> & a_IndicesToProcess, const cLightingChunkStay & a_Item, BlockDataArray & a_Light, size_t a_OriginatorIndex)
 {
-	// Clear seeds:
-	memset(m_IsSeed1, 0, sizeof(m_IsSeed1));
-	memset(m_IsSeed2, 0, sizeof(m_IsSeed2));
-	m_NumSeeds = 0;
+	auto Position = cChunkDef::IndexToCoordinate(a_OriginatorIndex);
 
-	// Walk every column that has all XZ neighbors, make a seed for each light-emitting block:
-	for (int z = 1; z < cChunkDef::Width * 3 - 1; z++)
+	if (Position.x % cChunkDef::Width != 15)
 	{
-		int BaseZ = z * cChunkDef::Width * 3;
-		for (int x = 1; x < cChunkDef::Width * 3 - 1; x++)
-		{
-			int idx = BaseZ + x;
-			for (int y = m_HeightMap[idx], Index = idx + y * BlocksPerYLayer; y >= 0; y--, Index -= BlocksPerYLayer)
-			{
-				if (cBlockInfo::GetLightValue(m_BlockTypes[Index]) == 0)
-				{
-					continue;
-				}
+		// TODO: update neighbouring chunk
+		UpdateLightAdjacent(a_IndicesToProcess, a_Item, a_Light, a_OriginatorIndex, a_OriginatorIndex + 1);
+	}
 
-				// Add current block as a seed:
-				m_IsSeed1[Index] = true;
-				m_SeedIdx1[m_NumSeeds++] = static_cast<UInt32>(Index);
+	if (Position.x % cChunkDef::Width != 0)
+	{
+		// TODO: update neighbouring chunk
+		UpdateLightAdjacent(a_IndicesToProcess, a_Item, a_Light, a_OriginatorIndex, a_OriginatorIndex - 1);
+	}
 
-				// Light it up:
-				m_BlockLight[Index] = cBlockInfo::GetLightValue(m_BlockTypes[Index]);
-			}
-		}
+	if (Position.z % cChunkDef::Width != 15)
+	{
+		// TODO: update neighbouring chunk
+		UpdateLightAdjacent(a_IndicesToProcess, a_Item, a_Light, a_OriginatorIndex, a_OriginatorIndex + cChunkDef::Width);
+	}
+
+	if (Position.z % cChunkDef::Width != 0)
+	{
+		// TODO: update neighbouring chunk
+		UpdateLightAdjacent(a_IndicesToProcess, a_Item, a_Light, a_OriginatorIndex, a_OriginatorIndex - cChunkDef::Width);
+	}
+
+	if (Position.y != cChunkDef::Height - 1)
+	{
+		UpdateLightAdjacent(a_IndicesToProcess, a_Item, a_Light, a_OriginatorIndex, a_OriginatorIndex + cChunkDef::Width * cChunkDef::Width);
+	}
+
+	if (Position.y != 0)
+	{
+		UpdateLightAdjacent(a_IndicesToProcess, a_Item, a_Light, a_OriginatorIndex, a_OriginatorIndex - cChunkDef::Width * cChunkDef::Width);
 	}
 }
 
@@ -439,43 +372,12 @@ void cLightingThread::PrepareBlockLight(void)
 
 
 
-void cLightingThread::PrepareBlockLight2(void)
+void cLightingThread::UpdateLightAdjacent(std::vector<size_t> & a_IndicesToProcess, const cLightingChunkStay & a_Item, BlockDataArray & a_Light, size_t a_OriginatorIndex, size_t a_DestinationIndex)
 {
-	// Clear seeds:
-	memset(m_IsSeed1, 0, sizeof(m_IsSeed1));
-	memset(m_IsSeed2, 0, sizeof(m_IsSeed2));
-	m_NumSeeds = 0;
-
-	// Add each emissive block into the seeds:
-	for (int y = 0; y < m_MaxHeight; y++)
+	// Assertions for index validity occur within PropagateLightToAdjacent
+	if (PropagateLightToAdjacent(a_Item, a_Light, a_OriginatorIndex, a_DestinationIndex))
 	{
-		int BaseY = y * BlocksPerYLayer;  // Partial offset into m_BlockTypes for the Y coord
-		for (int z = 1; z < cChunkDef::Width * 3 - 1; z++)
-		{
-			int HBaseZ = z * cChunkDef::Width * 3;  // Partial offset into m_Heightmap for the Z coord
-			int BaseZ = BaseY + HBaseZ;  // Partial offset into m_BlockTypes for the Y and Z coords
-			for (int x = 1; x < cChunkDef::Width * 3 - 1; x++)
-			{
-				int idx = BaseZ + x;
-				if (y > m_HeightMap[HBaseZ + x])
-				{
-					// We're above the heightmap, ignore the block
-					continue;
-				}
-				if (cBlockInfo::GetLightValue(m_BlockTypes[idx]) == 0)
-				{
-					// Not a light-emissive block
-					continue;
-				}
-
-				// Add current block as a seed:
-				m_IsSeed1[idx] = true;
-				m_SeedIdx1[m_NumSeeds++] = static_cast<UInt32>(idx);
-
-				// Light it up:
-				m_BlockLight[idx] = cBlockInfo::GetLightValue(m_BlockTypes[idx]);
-			}
-		}
+		a_IndicesToProcess.emplace_back(a_DestinationIndex);
 	}
 }
 
@@ -483,113 +385,13 @@ void cLightingThread::PrepareBlockLight2(void)
 
 
 
-void cLightingThread::CalcLight(NIBBLETYPE * a_Light)
+void cLightingThread::CompressLight(const BlockDataArray & a_LightArray, BlockNibbles & a_ChunkLight)
 {
-	size_t NumSeeds2 = 0;
-	while (m_NumSeeds > 0)
+	for (size_t Index = 0; Index != a_ChunkLight.size(); ++Index)
 	{
-		// Buffer 1 -> buffer 2
-		memset(m_IsSeed2, 0, sizeof(m_IsSeed2));
-		NumSeeds2 = 0;
-		CalcLightStep(a_Light, m_NumSeeds, m_IsSeed1, m_SeedIdx1, NumSeeds2, m_IsSeed2, m_SeedIdx2);
-		if (NumSeeds2 == 0)
-		{
-			return;
-		}
-
-		// Buffer 2 -> buffer 1
-		memset(m_IsSeed1, 0, sizeof(m_IsSeed1));
-		m_NumSeeds = 0;
-		CalcLightStep(a_Light, NumSeeds2, m_IsSeed2, m_SeedIdx2, m_NumSeeds, m_IsSeed1, m_SeedIdx1);
+		auto AdjustedIndex = Index * 2;
+		a_ChunkLight[Index] = a_LightArray[AdjustedIndex] | static_cast<NIBBLETYPE>(a_LightArray[AdjustedIndex + 1] << 4);
 	}
-}
-
-
-
-
-
-void cLightingThread::CalcLightStep(
-	NIBBLETYPE * a_Light,
-	size_t a_NumSeedsIn,    unsigned char * a_IsSeedIn,  unsigned int * a_SeedIdxIn,
-	size_t & a_NumSeedsOut, unsigned char * a_IsSeedOut, unsigned int * a_SeedIdxOut
-)
-{
-	UNUSED(a_IsSeedIn);
-	size_t NumSeedsOut = 0;
-	for (size_t i = 0; i < a_NumSeedsIn; i++)
-	{
-		UInt32 SeedIdx = static_cast<UInt32>(a_SeedIdxIn[i]);
-		int SeedX = SeedIdx % (cChunkDef::Width * 3);
-		int SeedZ = (SeedIdx / (cChunkDef::Width * 3)) % (cChunkDef::Width * 3);
-		int SeedY = SeedIdx / BlocksPerYLayer;
-
-		// Propagate seed:
-		if (SeedX < cChunkDef::Width * 3 - 1)
-		{
-			PropagateLight(a_Light, SeedIdx, SeedIdx + 1, NumSeedsOut, a_IsSeedOut, a_SeedIdxOut);
-		}
-		if (SeedX > 0)
-		{
-			PropagateLight(a_Light, SeedIdx, SeedIdx - 1, NumSeedsOut, a_IsSeedOut, a_SeedIdxOut);
-		}
-		if (SeedZ < cChunkDef::Width * 3 - 1)
-		{
-			PropagateLight(a_Light, SeedIdx, SeedIdx + cChunkDef::Width * 3, NumSeedsOut, a_IsSeedOut, a_SeedIdxOut);
-		}
-		if (SeedZ > 0)
-		{
-			PropagateLight(a_Light, SeedIdx, SeedIdx - cChunkDef::Width * 3, NumSeedsOut, a_IsSeedOut, a_SeedIdxOut);
-		}
-		if (SeedY < cChunkDef::Height - 1)
-		{
-			PropagateLight(a_Light, SeedIdx, SeedIdx + cChunkDef::Width * cChunkDef::Width * 3 * 3, NumSeedsOut, a_IsSeedOut, a_SeedIdxOut);
-		}
-		if (SeedY > 0)
-		{
-			PropagateLight(a_Light, SeedIdx, SeedIdx - cChunkDef::Width * cChunkDef::Width * 3 * 3, NumSeedsOut, a_IsSeedOut, a_SeedIdxOut);
-		}
-	}  // for i - a_SeedIdxIn[]
-	a_NumSeedsOut = NumSeedsOut;
-}
-
-
-
-
-
-void cLightingThread::CompressLight(NIBBLETYPE * a_LightArray, NIBBLETYPE * a_ChunkLight)
-{
-	int InIdx = cChunkDef::Width * 49;  // Index to the first nibble of the middle chunk in the a_LightArray
-	int OutIdx = 0;
-	for (int y = 0; y < cChunkDef::Height; y++)
-	{
-		for (int z = 0; z < cChunkDef::Width; z++)
-		{
-			for (int x = 0; x < cChunkDef::Width; x += 2)
-			{
-				a_ChunkLight[OutIdx++] = static_cast<NIBBLETYPE>(a_LightArray[InIdx + 1] << 4) | a_LightArray[InIdx];
-				InIdx += 2;
-			}
-			InIdx += cChunkDef::Width * 2;
-		}
-		// Skip into the next y-level in the 3x3 chunk blob; each level has cChunkDef::Width * 9 rows
-		// We've already walked cChunkDef::Width * 3 in the "for z" cycle, that makes cChunkDef::Width * 6 rows left to skip
-		InIdx += cChunkDef::Width * cChunkDef::Width * 6;
-	}
-}
-
-
-
-
-
-void cLightingThread::QueueChunkStay(cLightingChunkStay & a_ChunkStay)
-{
-	// Move the ChunkStay from the Pending queue to the lighting queue.
-	{
-		cCSLock Lock(m_CS);
-		m_PendingQueue.remove(&a_ChunkStay);
-		m_Queue.push_back(&a_ChunkStay);
-	}
-	m_evtItemAdded.Set();
 }
 
 
@@ -600,20 +402,13 @@ void cLightingThread::QueueChunkStay(cLightingChunkStay & a_ChunkStay)
 // cLightingThread::cLightingChunkStay:
 
 cLightingThread::cLightingChunkStay::cLightingChunkStay(cLightingThread & a_LightingThread, int a_ChunkX, int a_ChunkZ, std::unique_ptr<cChunkCoordCallback> a_CallbackAfter) :
-	m_LightingThread(a_LightingThread),
+	m_CallbackAfter(std::move(a_CallbackAfter)),
 	m_ChunkX(a_ChunkX),
 	m_ChunkZ(a_ChunkZ),
-	m_CallbackAfter(std::move(a_CallbackAfter))
+	m_MaxHeight(0),  // Required by cReader to be initialised to zero
+	m_LightingThread(a_LightingThread)
 {
-	Add(a_ChunkX + 1, a_ChunkZ + 1);
-	Add(a_ChunkX + 1, a_ChunkZ);
-	Add(a_ChunkX + 1, a_ChunkZ - 1);
-	Add(a_ChunkX,     a_ChunkZ + 1);
-	Add(a_ChunkX,     a_ChunkZ);
-	Add(a_ChunkX,     a_ChunkZ - 1);
-	Add(a_ChunkX - 1, a_ChunkZ + 1);
-	Add(a_ChunkX - 1, a_ChunkZ);
-	Add(a_ChunkX - 1, a_ChunkZ - 1);
+	Add(a_ChunkX, a_ChunkZ);
 }
 
 
@@ -622,7 +417,43 @@ cLightingThread::cLightingChunkStay::cLightingChunkStay(cLightingThread & a_Ligh
 
 bool cLightingThread::cLightingChunkStay::OnAllChunksAvailable(void)
 {
-	m_LightingThread.QueueChunkStay(*this);
+	if (m_LightingThread.m_ShouldTerminate)
+	{
+		return false;
+	}
+
+	ASSERT(m_LightingThread.m_World->IsChunkValid(m_ChunkX, m_ChunkZ));
+
+	// If the chunk is already lit, skip it:
+	if (m_LightingThread.m_World->IsChunkLighted(m_ChunkX, m_ChunkZ))
+	{
+		if (m_CallbackAfter != nullptr)
+		{
+			m_CallbackAfter->Call(m_ChunkX, m_ChunkZ, true);
+		}
+
+
+		{
+			cCSLock Lock(m_LightingThread.m_CS);
+			m_LightingThread.m_PendingQueue.erase(
+				std::remove(m_LightingThread.m_PendingQueue.begin(), m_LightingThread.m_PendingQueue.end(), this),
+				m_LightingThread.m_PendingQueue.end()
+			);
+		}
+
+		return true;
+	}
+
+	{
+		cCSLock Lock(m_LightingThread.m_CS);
+		m_LightingThread.m_PendingQueue.erase(
+			std::remove(m_LightingThread.m_PendingQueue.begin(), m_LightingThread.m_PendingQueue.end(), this),
+			m_LightingThread.m_PendingQueue.end()
+		);
+		m_LightingThread.m_Queue.emplace_back(this);
+	}
+
+	m_LightingThread.m_evtItemDataLoaded.Set();
 
 	// Keep the ChunkStay alive:
 	return false;
@@ -634,7 +465,7 @@ bool cLightingThread::cLightingChunkStay::OnAllChunksAvailable(void)
 
 void cLightingThread::cLightingChunkStay::OnDisabled(void)
 {
-	// Nothing needed in this callback
+	delete this;
 }
 
 

--- a/src/MemorySettingsRepository.h
+++ b/src/MemorySettingsRepository.h
@@ -53,29 +53,26 @@ private:
 
 	struct sValue
 	{
-		sValue(AString value):
+		sValue(AString value) :
 			#ifdef _DEBUG
 				m_Type(eType::String),
 			#endif
 			m_stringValue (value)
-		{
-		}
+		{}
 
-		sValue(Int64 value):
+		sValue(Int64 value) :
 			#ifdef _DEBUG
 				m_Type(eType::Int64),
 			#endif
 			m_intValue(value)
-		{
-		}
+		{}
 
-		sValue(bool value):
+		sValue(bool value) :
 			#ifdef _DEBUG
 				m_Type(eType::Bool),
 			#endif
 			m_boolValue(value)
-		{
-		}
+		{}
 
 		AString getStringValue() const { ASSERT(m_Type == eType::String); return m_stringValue; }
 		Int64   getIntValue()    const { ASSERT(m_Type == eType::Int64);  return m_intValue;    }

--- a/src/MobSpawner.cpp
+++ b/src/MobSpawner.cpp
@@ -347,15 +347,14 @@ bool cMobSpawner::CanSpawnHere(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_R
 
 
 
-cMonster * cMobSpawner::TryToSpawnHere(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_RelZ, EMCSBiome a_Biome, int & a_MaxPackSize)
+std::unique_ptr<cMonster> cMobSpawner::TryToSpawnHere(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_RelZ, EMCSBiome a_Biome, int & a_MaxPackSize)
 {
-	cMonster * toReturn = nullptr;
 	if (m_NewPack)
 	{
 		m_MobType = ChooseMobType(a_Biome);
 		if (m_MobType == mtInvalidType)
 		{
-			return toReturn;
+			return nullptr;
 		}
 		if (m_MobType == mtWolf)
 		{
@@ -373,14 +372,15 @@ cMonster * cMobSpawner::TryToSpawnHere(cChunk * a_Chunk, int a_RelX, int a_RelY,
 
 	if ((m_AllowedTypes.find(m_MobType) != m_AllowedTypes.end()) && CanSpawnHere(a_Chunk, a_RelX, a_RelY, a_RelZ, m_MobType, a_Biome))
 	{
-		cMonster * newMob = cMonster::NewMonsterFromType(m_MobType);
+		auto newMob = cMonster::NewMonsterFromType(m_MobType);
 		if (newMob)
 		{
-			m_Spawned.insert(newMob);
+			m_Spawned.insert(std::move(newMob));
 		}
-		toReturn = newMob;
+		return newMob;
 	}
-	return toReturn;
+
+	return nullptr;
 }
 
 

--- a/src/MobSpawner.h
+++ b/src/MobSpawner.h
@@ -38,7 +38,7 @@ public :
 	If this is the first of a Pack, determine the type of monster
 	a_Biome, BlockType & BlockMeta are used to decide what kind of Mob can Spawn here
 	a_MaxPackSize is set to the maximal size for a pack this type of mob */
-	cMonster * TryToSpawnHere(cChunk * a_Chunk, int A_RelX, int a_RelY, int a_RelZ, EMCSBiome a_Biome, int & a_MaxPackSize);
+	std::unique_ptr<cMonster> TryToSpawnHere(cChunk * a_Chunk, int A_RelX, int a_RelY, int a_RelZ, EMCSBiome a_Biome, int & a_MaxPackSize);
 
 	/** Mark the beginning of a new Pack.
 	All mobs of the same Pack are the same type */
@@ -47,7 +47,7 @@ public :
 	// return true if there is at least one allowed type
 	bool CanSpawnAnything(void);
 
-	typedef const std::set<cMonster *> tSpawnedContainer;
+	typedef const std::set<std::unique_ptr<cMonster>> tSpawnedContainer;
 	tSpawnedContainer & getSpawned(void);
 
 	/** Returns true if specified type of mob can spawn on specified block */
@@ -65,7 +65,7 @@ protected :
 	std::set<eMonsterType> m_AllowedTypes;
 	bool m_NewPack;
 	eMonsterType m_MobType;
-	std::set<cMonster*> m_Spawned;
+	std::set<std::unique_ptr<cMonster>> m_Spawned;
 	cFastRandom m_Random;
 } ;
 

--- a/src/Mobs/Blaze.cpp
+++ b/src/Mobs/Blaze.cpp
@@ -39,15 +39,9 @@ bool cBlaze::Attack(std::chrono::milliseconds a_Dt)
 		// Setting this higher gives us more wiggle room for attackrate
 		Vector3d Speed = GetLookVector() * 20;
 		Speed.y = Speed.y + 1;
-		cFireChargeEntity * FireCharge = new cFireChargeEntity(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
-		if (FireCharge == nullptr)
+		auto FireCharge = cpp14::make_unique<cFireChargeEntity>(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
+		if (!FireCharge->Initialize(std::move(FireCharge), *m_World))
 		{
-			return false;
-		}
-		if (!FireCharge->Initialize(*m_World))
-		{
-			delete FireCharge;
-			FireCharge = nullptr;
 			return false;
 		}
 		ResetAttackCooldown();

--- a/src/Mobs/Ghast.cpp
+++ b/src/Mobs/Ghast.cpp
@@ -39,15 +39,9 @@ bool cGhast::Attack(std::chrono::milliseconds a_Dt)
 		// Setting this higher gives us more wiggle room for attackrate
 		Vector3d Speed = GetLookVector() * 20;
 		Speed.y = Speed.y + 1;
-		cGhastFireballEntity * GhastBall = new cGhastFireballEntity(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
-		if (GhastBall == nullptr)
+		auto GhastBall = cpp14::make_unique<cGhastFireballEntity>(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
+		if (!GhastBall->Initialize(std::move(GhastBall), *m_World))
 		{
-			return false;
-		}
-		if (!GhastBall->Initialize(*m_World))
-		{
-			delete GhastBall;
-			GhastBall = nullptr;
 			return false;
 		}
 		ResetAttackCooldown();

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -123,7 +123,7 @@ cMonster::~cMonster()
 
 void cMonster::Destroyed()
 {
-	SetTarget(nullptr);  // Tell them we're no longer targeting them.
+	SetTarget(nullptr);
 	super::Destroyed();
 }
 
@@ -912,47 +912,26 @@ int cMonster::GetSpawnDelay(cMonster::eFamily a_MobFamily)
 
 
 
-
-/** Sets the target. */
-void cMonster::SetTarget (cPawn * a_NewTarget)
+void cMonster::SetTarget(cPawn * a_NewTarget)
 {
-	ASSERT((a_NewTarget == nullptr) || (IsTicking()));
-	if (m_Target == a_NewTarget)
+	ASSERT((a_NewTarget == nullptr) || IsTicking());
+
+	if (a_NewTarget == nullptr)
 	{
+		m_Target = nullptr;
 		return;
 	}
-	cPawn * OldTarget = m_Target;
+
+	ASSERT(a_NewTarget->IsTicking());
 	m_Target = a_NewTarget;
-
-	if (OldTarget != nullptr)
-	{
-		// Notify the old target that we are no longer targeting it.
-		OldTarget->NoLongerTargetingMe(this);
-	}
-
-	if (a_NewTarget != nullptr)
-	{
-		ASSERT(a_NewTarget->IsTicking());
-		// Notify the new target that we are now targeting it.
-		m_Target->TargetingMe(this);
-	}
-
+	ASSERT(GetTarget() != nullptr);
 }
 
 
 
 
 
-void cMonster::UnsafeUnsetTarget()
-{
-	m_Target = nullptr;
-}
-
-
-
-
-
-cPawn * cMonster::GetTarget ()
+cPawn * cMonster::GetTarget()
 {
 	return m_Target;
 }
@@ -961,29 +940,25 @@ cPawn * cMonster::GetTarget ()
 
 
 
-cMonster * cMonster::NewMonsterFromType(eMonsterType a_MobType)
+std::unique_ptr<cMonster> cMonster::NewMonsterFromType(eMonsterType a_MobType)
 {
 	cFastRandom Random;
-	cMonster * toReturn = nullptr;
 
 	// Create the mob entity
 	switch (a_MobType)
 	{
 		case mtMagmaCube:
 		{
-			toReturn = new cMagmaCube(1 << Random.NextInt(3));  // Size 1, 2 or 4
-			break;
+			return cpp14::make_unique<cMagmaCube>(1 << Random.NextInt(3));  // Size 1, 2 or 4
 		}
 		case mtSlime:
 		{
-			toReturn = new cSlime(1 << Random.NextInt(3));  // Size 1, 2 or 4
-			break;
+			return cpp14::make_unique<cSlime>(1 << Random.NextInt(3));  // Size 1, 2 or 4
 		}
 		case mtSkeleton:
 		{
 			// TODO: Actual detection of spawning in Nether
-			toReturn = new cSkeleton((Random.NextInt(1) == 0) ? false : true);
-			break;
+			return cpp14::make_unique<cSkeleton>((Random.NextInt(1) == 0) ? false : true);
 		}
 		case mtVillager:
 		{
@@ -994,8 +969,7 @@ cMonster * cMonster::NewMonsterFromType(eMonsterType a_MobType)
 				VillagerType = 0;
 			}
 
-			toReturn = new cVillager(static_cast<cVillager::eVillagerType>(VillagerType));
-			break;
+			return cpp14::make_unique<cVillager>(static_cast<cVillager::eVillagerType>(VillagerType));
 		}
 		case mtHorse:
 		{
@@ -1011,42 +985,41 @@ cMonster * cMonster::NewMonsterFromType(eMonsterType a_MobType)
 				HorseType = 0;
 			}
 
-			toReturn = new cHorse(HorseType, HorseColor, HorseStyle, HorseTameTimes);
-			break;
+			return cpp14::make_unique<cHorse>(HorseType, HorseColor, HorseStyle, HorseTameTimes);
 		}
 
-		case mtBat:           toReturn = new cBat();                      break;
-		case mtBlaze:         toReturn = new cBlaze();                    break;
-		case mtCaveSpider:    toReturn = new cCaveSpider();               break;
-		case mtChicken:       toReturn = new cChicken();                  break;
-		case mtCow:           toReturn = new cCow();                      break;
-		case mtCreeper:       toReturn = new cCreeper();                  break;
-		case mtEnderDragon:   toReturn = new cEnderDragon();              break;
-		case mtEnderman:      toReturn = new cEnderman();                 break;
-		case mtGhast:         toReturn = new cGhast();                    break;
-		case mtGiant:         toReturn = new cGiant();                    break;
-		case mtGuardian:      toReturn = new cGuardian();                 break;
-		case mtIronGolem:     toReturn = new cIronGolem();                break;
-		case mtMooshroom:     toReturn = new cMooshroom();                break;
-		case mtOcelot:        toReturn = new cOcelot();                   break;
-		case mtPig:           toReturn = new cPig();                      break;
-		case mtRabbit:        toReturn = new cRabbit();                   break;
-		case mtSheep:         toReturn = new cSheep();                    break;
-		case mtSilverfish:    toReturn = new cSilverfish();               break;
-		case mtSnowGolem:     toReturn = new cSnowGolem();                break;
-		case mtSpider:        toReturn = new cSpider();                   break;
-		case mtSquid:         toReturn = new cSquid();                    break;
-		case mtWitch:         toReturn = new cWitch();                    break;
-		case mtWither:	      toReturn = new cWither();                   break;
-		case mtWolf:          toReturn = new cWolf();                     break;
-		case mtZombie:        toReturn = new cZombie(false);              break;  // TODO: Infected zombie parameter
-		case mtZombiePigman:  toReturn = new cZombiePigman();             break;
+		case mtBat:           return cpp14::make_unique<cBat>();
+		case mtBlaze:         return cpp14::make_unique<cBlaze>();
+		case mtCaveSpider:    return cpp14::make_unique<cCaveSpider>();
+		case mtChicken:       return cpp14::make_unique<cChicken>();
+		case mtCow:           return cpp14::make_unique<cCow>();
+		case mtCreeper:       return cpp14::make_unique < cCreeper>();
+		case mtEnderDragon:   return cpp14::make_unique<cEnderDragon>();
+		case mtEnderman:      return cpp14::make_unique<cEnderman>();
+		case mtGhast:         return cpp14::make_unique<cGhast>();
+		case mtGiant:         return cpp14::make_unique<cGiant>();
+		case mtGuardian:      return cpp14::make_unique<cGuardian>();
+		case mtIronGolem:     return cpp14::make_unique<cIronGolem>();
+		case mtMooshroom:     return cpp14::make_unique<cMooshroom>();
+		case mtOcelot:        return cpp14::make_unique<cOcelot>();
+		case mtPig:           return cpp14::make_unique<cPig>();
+		case mtRabbit:        return cpp14::make_unique<cRabbit>();
+		case mtSheep:         return cpp14::make_unique<cSheep>();
+		case mtSilverfish:    return cpp14::make_unique<cSilverfish>();
+		case mtSnowGolem:     return cpp14::make_unique<cSnowGolem>();
+		case mtSpider:        return cpp14::make_unique<cSpider>();
+		case mtSquid:         return cpp14::make_unique<cSquid>();
+		case mtWitch:         return cpp14::make_unique<cWitch>();
+		case mtWither:	      return cpp14::make_unique<cWither>();
+		case mtWolf:          return cpp14::make_unique<cWolf>();
+		case mtZombie:        return cpp14::make_unique<cZombie>(false);  // TODO: Infected zombie parameter
+		case mtZombiePigman:  return cpp14::make_unique<cZombiePigman>();
 		default:
 		{
 			ASSERT(!"Unhandled mob type whilst trying to spawn mob!");
+			return nullptr;
 		}
 	}
-	return toReturn;
 }
 
 

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -161,20 +161,16 @@ public:
 	// tolua_end
 
 	/** Sets the target that this mob will chase. Pass a nullptr to unset. */
-	void SetTarget (cPawn * a_NewTarget);
-
-	/** Unset the target without notifying the target entity. Do not use this, use SetTarget(nullptr) instead.
-	This is only used by cPawn internally. */
-	void UnsafeUnsetTarget();
+	void SetTarget(cPawn * a_NewTarget);
 
 	/** Returns the current target. */
-	cPawn * GetTarget ();
+	cPawn * GetTarget();
 
 	/** Creates a new object of the specified mob.
 	a_MobType is the type of the mob to be created
 	Asserts and returns null if mob type is not specified
 	*/
-	static cMonster * NewMonsterFromType(eMonsterType a_MobType);
+	static std::unique_ptr<cMonster> NewMonsterFromType(eMonsterType a_MobType);
 
 protected:
 
@@ -200,7 +196,11 @@ protected:
 	bool ReachedFinalDestination(void) { return ((m_FinalDestination - GetPosition()).SqrLength() < WAYPOINT_RADIUS * WAYPOINT_RADIUS); }
 
 	/** Returns whether or not the target is close enough for attack. */
-	bool TargetIsInRange(void) { ASSERT(m_Target != nullptr); return ((m_Target->GetPosition() - GetPosition()).SqrLength() < (m_AttackRange * m_AttackRange)); }
+	bool TargetIsInRange(void)
+	{
+		ASSERT(GetTarget() != nullptr);
+		return ((GetTarget()->GetPosition() - GetPosition()).SqrLength() < (m_AttackRange * m_AttackRange));
+	}
 
 	/** Returns if a monster can reach a given height by jumping. */
 	inline bool DoesPosYRequireJump(int a_PosY)
@@ -267,7 +267,9 @@ protected:
 	void AddRandomWeaponDropItem(cItems & a_Drops, unsigned int a_LootingLevel);
 
 private:
-	/** A pointer to the entity this mobile is aiming to reach */
+	/** A pointer to the entity this mobile is aiming to reach.
+	The validity of this pointer SHALL be guaranteed by the pointee;
+	it MUST be reset when the pointee changes worlds or is destroyed. */
 	cPawn * m_Target;
 
 } ;  // tolua_export

--- a/src/Mobs/Skeleton.cpp
+++ b/src/Mobs/Skeleton.cpp
@@ -57,15 +57,9 @@ bool cSkeleton::Attack(std::chrono::milliseconds a_Dt)
 		Vector3d Inaccuracy = Vector3d(Random.NextFloat(0.5) - 0.25, Random.NextFloat(0.5) - 0.25, Random.NextFloat(0.5) - 0.25);
 		Vector3d Speed = (GetTarget()->GetPosition() + Inaccuracy - GetPosition()) * 5;
 		Speed.y = Speed.y - 1 + Random.NextInt(3);
-		cArrowEntity * Arrow = new cArrowEntity(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
-		if (Arrow == nullptr)
+		auto Arrow = cpp14::make_unique<cArrowEntity>(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
+		if (!Arrow->Initialize(std::move(Arrow), *m_World))
 		{
-			return false;
-		}
-		if (!Arrow->Initialize(*m_World))
-		{
-			delete Arrow;
-			Arrow = nullptr;
 			return false;
 		}
 		ResetAttackCooldown();

--- a/src/Mobs/Slime.cpp
+++ b/src/Mobs/Slime.cpp
@@ -78,10 +78,10 @@ void cSlime::KilledBy(TakeDamageInfo & a_TDI)
 			double AddX = (i % 2 - 0.5) * m_Size / 4.0;
 			double AddZ = (i / 2 - 0.5) * m_Size / 4.0;
 
-			cSlime * NewSlime = new cSlime(m_Size / 2);
+			auto NewSlime = cpp14::make_unique<cSlime>(m_Size / 2);
 			NewSlime->SetPosition(GetPosX() + AddX, GetPosY() + 0.5, GetPosZ() + AddZ);
 			NewSlime->SetYaw(Random.NextFloat(1.0f) * 360.0f);
-			m_World->SpawnMobFinalize(NewSlime);
+			m_World->SpawnMobFinalize(std::move(NewSlime));
 		}
 	}
 	super::KilledBy(a_TDI);

--- a/src/Mobs/Wither.cpp
+++ b/src/Mobs/Wither.cpp
@@ -15,6 +15,7 @@ cWither::cWither(void) :
 	m_WitherInvulnerableTicks(220)
 {
 	SetMaxHealth(300);
+	SetHealth(GetMaxHealth() / 3);
 }
 
 
@@ -24,18 +25,6 @@ cWither::cWither(void) :
 bool cWither::IsArmored(void) const
 {
 	return GetHealth() <= (GetMaxHealth() / 2);
-}
-
-
-
-
-
-bool cWither::Initialize(cWorld & a_World)
-{
-	// Set health before BroadcastSpawnEntity()
-	SetHealth(GetMaxHealth() / 3);
-
-	return super::Initialize(a_World);
 }
 
 

--- a/src/Mobs/Wither.h
+++ b/src/Mobs/Wither.h
@@ -25,7 +25,6 @@ public:
 	bool IsArmored(void) const;
 
 	// cEntity overrides
-	virtual bool Initialize(cWorld & a_World) override;
 	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
 	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;

--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -361,7 +361,7 @@ void cWolf::TickFollowPlayer()
 			if (!Callback.OwnerFlying)
 			{
 				Callback.OwnerPos.y = FindFirstNonAirBlockPosition(Callback.OwnerPos.x, Callback.OwnerPos.z);
-				TeleportToCoords(Callback.OwnerPos.x, Callback.OwnerPos.y, Callback.OwnerPos.z);
+				TeleportToCoords(Callback.OwnerPos);
 				SetTarget(nullptr);
 			}
 		}

--- a/src/NetherPortalScanner.h
+++ b/src/NetherPortalScanner.h
@@ -16,7 +16,7 @@ class cWorld;
 class cNetherPortalScanner : public cChunkStay
 {
 public:
-	cNetherPortalScanner(cEntity * a_MovingEntity, cWorld * a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY);
+	cNetherPortalScanner(UInt32 a_MovingEntityID, eDimension a_PreviousDimension, cWorld * a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY);
 	virtual void OnChunkAvailable(int a_ChunkX, int a_ChunkY) override;
 	virtual bool OnAllChunksAvailable(void) override;
 	virtual void OnDisabled(void) override;
@@ -49,8 +49,11 @@ private:
 	/** Whether the given location is a valid location to build a portal. */
 	bool IsValidBuildLocation(Vector3i a_BlockPosition);
 
-	/** The entity that's being moved. */
-	cEntity * m_Entity;
+	/** The ID of the entity that's being moved. */
+	UInt32 m_EntityID;
+
+	/** The dimension the entity was originally in. */
+	eDimension m_PreviousDimension;
 
 	/** The world we're moving the entity to. */
 	cWorld * m_World;

--- a/src/OSSupport/Event.cpp
+++ b/src/OSSupport/Event.cpp
@@ -62,16 +62,3 @@ void cEvent::Set(void)
 
 
 
-void cEvent::SetAll(void)
-{
-	{
-		std::unique_lock<std::mutex> Lock(m_Mutex);
-		m_ShouldContinue = true;
-	}
-	m_CondVar.notify_all();
-}
-
-
-
-
-

--- a/src/OSSupport/Event.h
+++ b/src/OSSupport/Event.h
@@ -30,10 +30,6 @@ public:
 	If there was no thread waiting, the next call to Wait() will not block. */
 	void Set(void);
 
-	/** Sets the event - releases all threads that have been waiting in Wait().
-	If there was no thread waiting, the next call to Wait() will not block. */
-	void SetAll(void);
-
 	/** Waits for the event until either it is signalled, or the (relative) timeout is passed.
 	Returns true if the event was signalled, false if the timeout was hit or there was an error. */
 	bool Wait(unsigned a_TimeoutMSec);

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -616,7 +616,7 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 {
 	// Send the Join Game packet:
 	{
-		cServer * Server = cRoot::Get()->GetServer();
+		auto Server = cRoot::Get()->GetServer();
 		cPacketizer Pkt(*this, 0x01);  // Join Game packet
 		Pkt.WriteBEUInt32(a_Player.GetUniqueID());
 		Pkt.WriteBEUInt8(static_cast<UInt8>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
@@ -926,15 +926,11 @@ void cProtocol180::SendPlayerListUpdatePing(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	auto ClientHandle = a_Player.GetClientHandlePtr();
-	if (ClientHandle != nullptr)
-	{
-		cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
-		Pkt.WriteVarInt32(2);
-		Pkt.WriteVarInt32(1);
-		Pkt.WriteUUID(a_Player.GetUUID());
-		Pkt.WriteVarInt32(static_cast<UInt32>(ClientHandle->GetPing()));
-	}
+	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
+	Pkt.WriteVarInt32(2);
+	Pkt.WriteVarInt32(1);
+	Pkt.WriteUUID(a_Player.GetUUID());
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_Player.GetClientHandle()->GetPing()));
 }
 
 
@@ -2236,7 +2232,7 @@ void cProtocol180::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 
 void cProtocol180::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 {
-	m_Client->HandleAnimation(0);  // Packet exists solely for arm-swing notification
+	m_Client->QueueDataCommit(&cClientHandle::HandleAnimation, m_Client, 0);  // Packet exists solely for arm-swing notification
 }
 
 
@@ -2245,6 +2241,11 @@ void cProtocol180::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 
 void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 {
+	if (!m_Client->EnforceBlockInteractionsRate())
+	{
+		return;
+	}
+
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Status);
 
 	int BlockX, BlockY, BlockZ;
@@ -2254,7 +2255,7 @@ void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 	}
 
 	HANDLE_READ(a_ByteBuffer, ReadBEInt8, Int8, Face);
-	m_Client->HandleLeftClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), Status);
+	m_Client->QueueDataCommit(&cClientHandle::HandleLeftClick, m_Client, BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), Status);
 }
 
 
@@ -2263,6 +2264,11 @@ void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 
 void cProtocol180::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 {
+	if (!m_Client->EnforceBlockInteractionsRate())
+	{
+		return;
+	}
+
 	int BlockX, BlockY, BlockZ;
 	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
 	{
@@ -2277,7 +2283,7 @@ void cProtocol180::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorX);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorY);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorZ);
-	m_Client->HandleRightClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), CursorX, CursorY, CursorZ, m_Client->GetPlayer()->GetEquippedItem());
+	m_Client->QueueDataCommit(&cClientHandle::HandleRightClick, m_Client, BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), CursorX, CursorY, CursorZ, Item);
 }
 
 
@@ -2287,7 +2293,7 @@ void cProtocol180::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 void cProtocol180::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Message);
-	m_Client->HandleChat(Message);
+	m_Client->QueueDataCommit(&cClientHandle::HandleChat, m_Client, Message);
 }
 
 
@@ -2314,26 +2320,22 @@ void cProtocol180::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
 void cProtocol180::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, ActionID);
+
 	switch (ActionID)
 	{
 		case 0:
-		{
-			// Respawn
-			m_Client->HandleRespawn();
+		{  // Respawn
+			m_Client->QueueDataCommit(&cClientHandle::HandleRespawn, m_Client);
 			break;
 		}
 		case 1:
-		{
-			// Request stats
-			const cStatManager & Manager = m_Client->GetPlayer()->GetStatManager();
-			SendStatistics(Manager);
-
+		{  // Request stats
+			m_Client->QueueDataCommit(&cClientHandle::SendStatistics, m_Client, m_Client->GetPlayer()->GetStatManager());
 			break;
 		}
 		case 2:
-		{
-			// Open Inventory achievement
-			m_Client->GetPlayer()->AwardAchievement(achOpenInv);
+		{  // Open Inventory achievement
+			m_Client->QueueDataCommit(&cPlayer::AwardAchievement, m_Client->GetPlayer(), achOpenInv);
 			break;
 		}
 	}
@@ -2351,7 +2353,7 @@ void cProtocol180::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffe
 	{
 		return;
 	}
-	m_Client->HandleCreativeInventory(SlotNum, Item, (SlotNum == -1) ? caLeftClickOutside : caLeftClick);
+	m_Client->QueueDataCommit(&cClientHandle::HandleCreativeInventory, m_Client, SlotNum, Item, (SlotNum == -1) ? caLeftClickOutside : caLeftClick);
 }
 
 
@@ -2366,11 +2368,11 @@ void cProtocol180::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 
 	switch (Action)
 	{
-		case 0: m_Client->HandleEntityCrouch(PlayerID, true);     break;  // Crouch
-		case 1: m_Client->HandleEntityCrouch(PlayerID, false);    break;  // Uncrouch
-		case 2: m_Client->HandleEntityLeaveBed(PlayerID);         break;  // Leave Bed
-		case 3: m_Client->HandleEntitySprinting(PlayerID, true);  break;  // Start sprinting
-		case 4: m_Client->HandleEntitySprinting(PlayerID, false); break;  // Stop sprinting
+		case 0: m_Client->QueueDataCommit(&cClientHandle::HandleEntityCrouch, m_Client, PlayerID, true);     break;  // Crouch
+		case 1: m_Client->QueueDataCommit(&cClientHandle::HandleEntityCrouch, m_Client, PlayerID, false);    break;  // Uncrouch
+		case 2: m_Client->QueueDataCommit(&cClientHandle::HandleEntityLeaveBed, m_Client, PlayerID);         break;  // Leave Bed
+		case 3: m_Client->QueueDataCommit(&cClientHandle::HandleEntitySprinting, m_Client, PlayerID, true);  break;  // Start sprinting
+		case 4: m_Client->QueueDataCommit(&cClientHandle::HandleEntitySprinting, m_Client, PlayerID, false); break;  // Stop sprinting
 	}
 }
 
@@ -2415,7 +2417,7 @@ void cProtocol180::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
 		CanFly = true;
 	}
 
-	m_Client->HandlePlayerAbilities(CanFly, IsFlying, FlyingSpeed, WalkingSpeed);
+	m_Client->QueueDataCommit(&cClientHandle::HandlePlayerAbilities, m_Client, CanFly, IsFlying, FlyingSpeed, WalkingSpeed);
 }
 
 
@@ -2427,7 +2429,7 @@ void cProtocol180::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Yaw);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Pitch);
 	HANDLE_READ(a_ByteBuffer, ReadBool,    bool,  IsOnGround);
-	m_Client->HandlePlayerLook(Yaw, Pitch, IsOnGround);
+	m_Client->QueueDataCommit(&cClientHandle::HandlePlayerLook, m_Client, Yaw, Pitch, IsOnGround);
 }
 
 
@@ -2440,7 +2442,7 @@ void cProtocol180::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosZ);
 	HANDLE_READ(a_ByteBuffer, ReadBool,     bool,   IsOnGround);
-	m_Client->HandlePlayerPos(PosX, PosY, PosZ, PosY + (m_Client->GetPlayer()->IsCrouched() ? 1.54 : 1.62), IsOnGround);
+	m_Client->QueueDataCommit(&cClientHandle::HandlePlayerPos, m_Client, PosX, PosY, PosZ, PosY + (m_Client->GetPlayer()->IsCrouched() ? 1.54 : 1.62), IsOnGround);
 }
 
 
@@ -2455,7 +2457,7 @@ void cProtocol180::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  Yaw);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  Pitch);
 	HANDLE_READ(a_ByteBuffer, ReadBool,     bool,   IsOnGround);
-	m_Client->HandlePlayerMoveLook(PosX, PosY, PosZ, PosY + 1.62, Yaw, Pitch, IsOnGround);
+	m_Client->QueueDataCommit(&cClientHandle::HandlePlayerMoveLook, m_Client, PosX, PosY, PosZ, PosY + 1.62, Yaw, Pitch, IsOnGround);
 }
 
 
@@ -2496,7 +2498,7 @@ void cProtocol180::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
 void cProtocol180::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
-	m_Client->HandleSlotSelected(SlotNum);
+	m_Client->QueueDataCommit(&cClientHandle::HandleSlotSelected, m_Client, SlotNum);
 }
 
 
@@ -2511,7 +2513,7 @@ void cProtocol180::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 
 	if ((Flags & 0x2) != 0)
 	{
-		m_Client->HandleUnmount();
+		m_Client->QueueDataCommit(&cClientHandle::HandleUnmount, m_Client);
 	}
 	else if ((Flags & 0x1) != 0)
 	{
@@ -2519,7 +2521,7 @@ void cProtocol180::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 	}
 	else
 	{
-		m_Client->HandleSteerVehicle(Forward, Sideways);
+		m_Client->QueueDataCommit(&cClientHandle::HandleSteerVehicle, m_Client, Forward, Sideways);
 	}
 }
 
@@ -2537,7 +2539,7 @@ void cProtocol180::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
 		HANDLE_READ(a_ByteBuffer, ReadBEInt64, Int64, Position);
 	}
 
-	m_Client->HandleTabCompletion(Text);
+	m_Client->QueueDataCommit(&cClientHandle::HandleTabCompletion, m_Client, Text);
 }
 
 
@@ -2580,12 +2582,12 @@ void cProtocol180::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 	{
 		case 0:
 		{
-			m_Client->HandleUseEntity(EntityID, false);
+			m_Client->QueueDataCommit(&cClientHandle::HandleUseEntity, m_Client, EntityID, false);
 			break;
 		}
 		case 1:
 		{
-			m_Client->HandleUseEntity(EntityID, true);
+			m_Client->QueueDataCommit(&cClientHandle::HandleUseEntity, m_Client, EntityID, true);
 			break;
 		}
 		case 2:
@@ -2614,7 +2616,7 @@ void cProtocol180::HandlePacketEnchantItem(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, WindowID);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Enchantment);
 
-	m_Client->HandleEnchantItem(WindowID, Enchantment);
+	m_Client->QueueDataCommit(&cClientHandle::HandleEnchantItem, m_Client, WindowID, Enchantment);
 }
 
 
@@ -2666,7 +2668,7 @@ void cProtocol180::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 		}
 	}
 
-	m_Client->HandleWindowClick(WindowID, SlotNum, Action, Item);
+	m_Client->QueueDataCommit(&cClientHandle::HandleWindowClick, m_Client, WindowID, SlotNum, Action, Item);
 }
 
 
@@ -2676,7 +2678,7 @@ void cProtocol180::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 void cProtocol180::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, WindowID);
-	m_Client->HandleWindowClose(WindowID);
+	m_Client->QueueDataCommit(&cClientHandle::HandleWindowClose, m_Client, WindowID);
 }
 
 
@@ -2696,13 +2698,20 @@ void cProtocol180::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 				HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, BlockY);
 				HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, BlockZ);
 				HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Command);
-				m_Client->HandleCommandBlockBlockChange(BlockX, BlockY, BlockZ, Command);
+				m_Client->QueueDataCommit(&cClientHandle::HandleCommandBlockBlockChange, m_Client, BlockX, BlockY, BlockZ, Command);
 				break;
 			}
 
 			default:
 			{
-				m_Client->SendChat(Printf("Failure setting command block command; unhandled mode %u (0x%02x)", Mode, Mode), mtFailure);
+				m_Client->QueueDataCommit(
+					static_cast<void(cClientHandle::*)(const AString &, eMessageType, const AString &)>(&cClientHandle::SendChat),
+					m_Client,
+					Printf("Failure setting command block command; unhandled mode %u (0x%02x)", Mode, Mode),
+					mtFailure,
+					""
+				);
+
 				LOG("Unhandled MC|AdvCdm packet mode.");
 				return;
 			}
@@ -2721,19 +2730,19 @@ void cProtocol180::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 	{
 		HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, Effect1);
 		HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, Effect2);
-		m_Client->HandleBeaconSelection(Effect1, Effect2);
+		m_Client->QueueDataCommit(&cClientHandle::HandleBeaconSelection, m_Client, Effect1, Effect2);
 		return;
 	}
 	else if (a_Channel == "MC|ItemName")
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, ItemName);
-		m_Client->HandleAnvilItemName(ItemName);
+		m_Client->QueueDataCommit(&cClientHandle::HandleAnvilItemName, m_Client, ItemName);
 		return;
 	}
 	else if (a_Channel == "MC|TrSel")
 	{
 		HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, SlotNum);
-		m_Client->HandleNPCTrade(SlotNum);
+		m_Client->QueueDataCommit(&cClientHandle::HandleNPCTrade, m_Client, SlotNum);
 		return;
 	}
 	LOG("Unhandled vanilla plugin channel: \"%s\".", a_Channel.c_str());
@@ -2890,7 +2899,7 @@ void cProtocol180::StartEncryption(const Byte * a_Key)
 
 	// Prepare the m_AuthServerID:
 	cSha1Checksum Checksum;
-	cServer * Server = cRoot::Get()->GetServer();
+	auto Server = cRoot::Get()->GetServer();
 	const AString & ServerID = Server->GetServerID();
 	Checksum.Update(reinterpret_cast<const Byte *>(ServerID.c_str()), ServerID.length());
 	Checksum.Update(a_Key, 16);

--- a/src/Protocol/Protocol18x.h
+++ b/src/Protocol/Protocol18x.h
@@ -234,8 +234,6 @@ protected:
 	/** Sends the packet to the client. Called by the cPacketizer's destructor. */
 	virtual void SendPacket(cPacketizer & a_Packet) override;
 
-	void SendCompass(const cWorld & a_World);
-
 	/** Reads an item out of the received data, sets a_Item to the values read.
 	Returns false if not enough received data.
 	a_KeepRemainingBytes tells the function to keep that many bytes at the end of the buffer. */

--- a/src/Protocol/Protocol19x.h
+++ b/src/Protocol/Protocol19x.h
@@ -258,7 +258,7 @@ protected:
 
 	/** Converts the BlockFace received by the protocol into eBlockFace constants.
 	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
-	eBlockFace FaceIntToBlockFace(UInt32 a_FaceInt);
+	static eBlockFace FaceIntToBlockFace(UInt32 a_FaceInt);
 
 	/** Writes the item data into a packet. */
 	void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item);

--- a/src/Root.h
+++ b/src/Root.h
@@ -225,10 +225,10 @@ private:
 	/** Loads the worlds from settings.ini, creates the worldmap */
 	void LoadWorlds(cSettingsRepositoryInterface & a_Settings, bool a_IsNewIniFile);
 
-	/** Starts each world's life */
+	/** Starts the tick thread of each loaded world. */
 	void StartWorlds(void);
 
-	/** Stops each world's threads, so that it's safe to unload them */
+	/** Stops each world's threads, so that it's safe to unload them. */
 	void StopWorlds(void);
 
 	/** Unloads all worlds from memory */

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -153,16 +153,6 @@ cServer::cServer(void) :
 
 
 
-void cServer::ClientMovedToWorld(const cClientHandle * a_Client)
-{
-	cCSLock Lock(m_CSClients);
-	m_ClientsToRemove.push_back(const_cast<cClientHandle *>(a_Client));
-}
-
-
-
-
-
 void cServer::PlayerCreated(const cPlayer * a_Player)
 {
 	UNUSED(a_Player);
@@ -300,10 +290,12 @@ void cServer::PrepareKeys(void)
 cTCPLink::cCallbacksPtr cServer::OnConnectionAccepted(const AString & a_RemoteIPAddress)
 {
 	LOGD("Client \"%s\" connected!", a_RemoteIPAddress.c_str());
-	cClientHandlePtr NewHandle = std::make_shared<cClientHandle>(a_RemoteIPAddress, m_ClientViewDistance);
-	NewHandle->SetSelf(NewHandle);
-	cCSLock Lock(m_CSClients);
-	m_Clients.push_back(NewHandle);
+
+	auto NewHandle = std::make_shared<cClientHandle>(a_RemoteIPAddress, m_ClientViewDistance);
+	{
+		cCSLock Lock(m_CSClients);
+		m_Clients.push_back(NewHandle);
+	}
 	return NewHandle;
 }
 
@@ -330,8 +322,15 @@ bool cServer::Tick(float a_Dt)
 	// Let the Root process all the queued commands:
 	cRoot::Get()->TickCommands();
 
-	// Tick all clients not yet assigned to a world:
+	// Tick all clients:
 	TickClients(a_Dt);
+
+	// Process queued tasks:
+	TickQueuedTasks();
+
+	// cClientHandle::Destroy guarantees that no more data will be sent after it is called, and this may be from TickQueuedTasks, therefore,
+	// remove destroyed clients, after processing queued tasks:
+	ReleaseDestroyedClients();
 
 	if (!m_bRestarting)
 	{
@@ -351,41 +350,49 @@ bool cServer::Tick(float a_Dt)
 
 void cServer::TickClients(float a_Dt)
 {
-	cClientHandlePtrs RemoveClients;
+	cCSLock Lock(m_CSClients);
+	for (const auto & Client : m_Clients)
 	{
-		cCSLock Lock(m_CSClients);
+		Client->Tick(a_Dt);
+	}
+}
 
-		// Remove clients that have moved to a world (the world will be ticking them from now on)
-		for (auto itr = m_ClientsToRemove.begin(), end = m_ClientsToRemove.end(); itr != end; ++itr)
-		{
-			for (auto itrC = m_Clients.begin(), endC = m_Clients.end(); itrC != endC; ++itrC)
-			{
-				if (itrC->get() == *itr)
-				{
-					m_Clients.erase(itrC);
-					break;
-				}
-			}
-		}  // for itr - m_ClientsToRemove[]
-		m_ClientsToRemove.clear();
 
-		// Tick the remaining clients, take out those that have been destroyed into RemoveClients
-		for (auto itr = m_Clients.begin(); itr != m_Clients.end();)
-		{
-			if ((*itr)->IsDestroyed())
+
+
+
+void cServer::ReleaseDestroyedClients(void)
+{
+	cCSLock Lock(m_CSClients);
+	m_Clients.erase(
+		std::remove_if(
+			m_Clients.begin(),
+			m_Clients.end(),
+			[](const decltype(m_Clients)::value_type & a_Client)
 			{
-				// Delete the client later, when CS is not held, to avoid deadlock: https://forum.cuberite.org/thread-374.html
-				RemoveClients.push_back(*itr);
-				itr = m_Clients.erase(itr);
-				continue;
+				return a_Client->IsDestroyed();
 			}
-			(*itr)->ServerTick(a_Dt);
-			++itr;
-		}  // for itr - m_Clients[]
+		),
+		m_Clients.end()
+	);
+}
+
+
+
+
+
+void cServer::TickQueuedTasks(void)
+{
+	decltype(m_Tasks) Tasks;
+	{
+		cCSLock Lock(m_CSTasks);
+		std::swap(Tasks, m_Tasks);
 	}
 
-	// Delete the clients that have been destroyed
-	RemoveClients.clear();
+	for (const auto & Task : Tasks)
+	{
+		Task();
+	}
 }
 
 
@@ -495,7 +502,7 @@ void cServer::ExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallbac
 	{
 		class WorldCallback : public cWorldListCallback
 		{
-			virtual bool Item(cWorld * a_World) override
+			virtual bool Item(cWorld * a_EntityWorld) override
 			{
 				class EntityCallback : public cEntityCallback
 				{
@@ -507,8 +514,15 @@ void cServer::ExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallbac
 						}
 						return false;
 					}
-				} EC;
-				a_World->ForEachEntity(EC);
+				};
+
+				a_EntityWorld->QueueTask(
+					[](cWorld & a_World)
+					{
+						EntityCallback EC;
+						a_World.ForEachEntity(EC);
+					}
+				);
 				return false;
 			}
 		} WC;
@@ -646,6 +660,16 @@ void cServer::BindBuiltInConsoleCommands(void)
 
 void cServer::Shutdown(void)
 {
+	{
+		// Notify all clients of the shutdown:
+		cCSLock Lock(m_CSClients);
+		for (const auto & Client : m_Clients)
+		{
+			Client->StopPlayerDestructionManagement();
+			// TODO: send "Server shut down: kthnxbai!"
+		}
+	}
+
 	// Stop listening on all sockets:
 	for (auto srv: m_ServerHandles)
 	{
@@ -653,19 +677,14 @@ void cServer::Shutdown(void)
 	}
 	m_ServerHandles.clear();
 
+	// At this point, OnRemoteClosed will eventually be called for the clienthandle before it is deleted
+	// No need to manually call Destroy
+
 	// Notify the tick thread and wait for it to terminate:
 	m_bRestarting = true;
 	m_RestartEvent.Wait();
 
 	cRoot::Get()->SaveAllChunks();
-
-	// Remove all clients:
-	cCSLock Lock(m_CSClients);
-	for (auto itr = m_Clients.begin(); itr != m_Clients.end(); ++itr)
-	{
-		(*itr)->Destroy();
-	}
-	m_Clients.clear();
 }
 
 
@@ -695,7 +714,7 @@ void cServer::AuthenticateUser(int a_ClientID, const AString & a_Name, const ASt
 	{
 		if ((*itr)->GetUniqueID() == a_ClientID)
 		{
-			(*itr)->Authenticate(a_Name, a_UUID, a_Properties);
+			QueueTask(std::bind(&cClientHandle::Authenticate, *itr, a_Name, a_UUID, a_Properties));
 			return;
 		}
 	}  // for itr - m_Clients[]

--- a/src/Server.h
+++ b/src/Server.h
@@ -35,9 +35,6 @@
 // fwd:
 class cPlayer;
 class cClientHandle;
-typedef SharedPtr<cClientHandle> cClientHandlePtr;
-typedef std::list<cClientHandlePtr> cClientHandlePtrs;
-typedef std::list<cClientHandle *> cClientHandles;
 class cCommandOutputCallback;
 class cSettingsRepositoryInterface;
 
@@ -97,18 +94,15 @@ public:
 
 	void Shutdown(void);
 
+	/** Returns whether cServer::Shutdown has been called */
+	bool IsShuttingDown(void) { return m_bRestarting; }
+
 	void KickUser(int a_ClientID, const AString & a_Reason);
 
 	/** Authenticates the specified user, called by cAuthenticator */
 	void AuthenticateUser(int a_ClientID, const AString & a_Name, const AString & a_UUID, const Json::Value & a_Properties);
 
 	const AString & GetServerID(void) const { return m_ServerID; }  // tolua_export
-
-	/** Called by cClientHandle's destructor; stop m_SocketThreads from calling back into a_Client */
-	void ClientDestroying(const cClientHandle * a_Client);
-
-	/** Don't tick a_Client anymore, it will be ticked from its cPlayer instead */
-	void ClientMovedToWorld(const cClientHandle * a_Client);
 
 	/** Notifies the server that a player was created; the server uses this to adjust the number of players */
 	void PlayerCreated(const cPlayer * a_Player);
@@ -143,6 +137,21 @@ public:
 	from the settings. */
 	bool ShouldAllowMultiWorldTabCompletion(void) const { return m_ShouldAllowMultiWorldTabCompletion; }
 
+	/** Queues a new task to be executed in the context of the server tick thread */
+	template <typename FunctionType>
+	void QueueTask(FunctionType && a_Task)
+	{
+		cCSLock Lock(m_CSTasks);
+		m_Tasks.emplace_back(a_Task);
+	}
+
+#ifdef _DEBUG
+
+	/** Debug-only function to ensure the current execution is within the context of the server tick thread */
+	bool IsInTickThread(void) { return m_TickThread.IsCurrentThread(); }
+
+#endif
+
 private:
 
 	friend class cRoot;  // so cRoot can create and destroy cServer
@@ -172,10 +181,7 @@ private:
 	cCriticalSection m_CSClients;
 
 	/** Clients that are connected to the server and not yet assigned to a cWorld. */
-	cClientHandlePtrs m_Clients;
-
-	/** Clients that have just been moved into a world and are to be removed from m_Clients in the next Tick(). */
-	cClientHandles m_ClientsToRemove;
+	std::vector<std::shared_ptr<cClientHandle>> m_Clients;
 
 	/** Protects m_PlayerCount against multithreaded access. */
 	mutable cCriticalSection m_CSPlayerCount;
@@ -241,6 +247,12 @@ private:
 	Initialized in InitServer(), used in Start(). */
 	AStringVector m_Ports;
 
+	/** Enforces thread safety for member variable m_Tasks */
+	cCriticalSection m_CSTasks;
+
+	/** Stores tasks queued onto the server tick thread to be executed as soon as possible with tick resolution */
+	std::vector<std::function<void(void)>> m_Tasks;
+
 
 	cServer(void);
 
@@ -255,6 +267,12 @@ private:
 
 	/** Ticks the clients in m_Clients, manages the list in respect to removing clients */
 	void TickClients(float a_Dt);
+
+	/** Removes all clienthandles who return true as a response to a call to IsDestroyed() */
+	void ReleaseDestroyedClients(void);
+
+	/** Processes tasks queued in m_Tasks within the server tick thread */
+	void TickQueuedTasks(void);
 };  // tolua_export
 
 

--- a/src/SetChunkData.cpp
+++ b/src/SetChunkData.cpp
@@ -6,6 +6,7 @@
 #include "Globals.h"
 #include "SetChunkData.h"
 #include "BlockEntities/BlockEntity.h"
+#include "Entities/Entity.h"
 
 
 

--- a/src/SetChunkData.h
+++ b/src/SetChunkData.h
@@ -116,10 +116,6 @@ protected:
 	bool m_ShouldMarkDirty;
 };
 
-typedef SharedPtr<cSetChunkData> cSetChunkDataPtr;  // TODO: Change to unique_ptr once we go C++11
-typedef std::vector<cSetChunkDataPtr> cSetChunkDataPtrs;
-
-
 
 
 

--- a/src/Simulator/SandSimulator.cpp
+++ b/src/Simulator/SandSimulator.cpp
@@ -61,8 +61,8 @@ void cSandSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX,
 				Pos.x, Pos.y, Pos.z, ItemTypeToString(BlockType).c_str(), ItemTypeToString(BlockBelow).c_str()
 			);
 			*/
-			cFallingBlock * FallingBlock = new cFallingBlock(Pos, BlockType, a_Chunk->GetMeta(itr->x, itr->y, itr->z));
-			FallingBlock->Initialize(m_World);
+			auto FallingBlock = cpp14::make_unique<cFallingBlock>(Pos, BlockType, a_Chunk->GetMeta(itr->x, itr->y, itr->z));
+			FallingBlock->Initialize(std::move(FallingBlock), m_World);
 			a_Chunk->SetBlock(itr->x, itr->y, itr->z, E_BLOCK_AIR, 0);
 		}
 	}

--- a/src/SpawnPrepare.cpp
+++ b/src/SpawnPrepare.cpp
@@ -12,17 +12,17 @@ class cSpawnPrepareCallback :
 	public cChunkCoordCallback
 {
 public:
-	cSpawnPrepareCallback(cSpawnPrepare & a_SpawnPrepare) :
-		m_SpawnPrepare(a_SpawnPrepare)
+	cSpawnPrepareCallback(std::shared_ptr<cSpawnPrepare> a_SpawnPrepare) :
+		m_SpawnPrepare(std::move(a_SpawnPrepare))
 	{
 	}
 protected:
 
-	cSpawnPrepare & m_SpawnPrepare;
+	std::shared_ptr<cSpawnPrepare> m_SpawnPrepare;
 
 	virtual void Call(int a_ChunkX, int a_ChunkZ, bool a_IsSuccess) override
 	{
-		m_SpawnPrepare.PreparedChunkCallback(a_ChunkX, a_ChunkZ);
+		m_SpawnPrepare->PreparedChunkCallback(a_ChunkX, a_ChunkZ);
 	}
 };
 
@@ -30,16 +30,13 @@ protected:
 
 
 
-cSpawnPrepare::cSpawnPrepare(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChunkZ, int a_PrepareDistance, int a_FirstIdx):
+cSpawnPrepare::cSpawnPrepare(cWorld & a_World, int a_PrepareDistance, std::function<void()> a_PreparationCompletedCallback):
 	m_World(a_World),
-	m_SpawnChunkX(a_SpawnChunkX),
-	m_SpawnChunkZ(a_SpawnChunkZ),
-	m_PrepareDistance(a_PrepareDistance),
-	m_NextIdx(a_FirstIdx),
-	m_MaxIdx(a_PrepareDistance * a_PrepareDistance),
+	m_TotalChunks(a_PrepareDistance * a_PrepareDistance),
 	m_NumPrepared(0),
 	m_LastReportTime(std::chrono::steady_clock::now()),
-	m_LastReportChunkCount(0)
+	m_LastReportChunkCount(0),
+	m_PreparationCompletedCallback(std::move(a_PreparationCompletedCallback))
 {
 }
 
@@ -49,43 +46,19 @@ cSpawnPrepare::cSpawnPrepare(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChu
 
 
 
-void cSpawnPrepare::PrepareChunks(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChunkZ, int a_PrepareDistance)
+void cSpawnPrepare::PrepareChunks(cWorld & a_World, int a_PrepareDistance, std::function<void()> a_PreparationCompletedCallback)
 {
+	auto PerformanceAnalysisObject = std::make_shared<cSpawnPrepare>(a_World, a_PrepareDistance, a_PreparationCompletedCallback);
+	auto HalfPrepareDistance = (a_PrepareDistance - 1) / 2.f;
+	auto NegativePrepareDistance = FloorC(-HalfPrepareDistance), PositivePrepareDistance = FloorC(HalfPrepareDistance);
 
-	// Queue the initial chunks:
-	int MaxIdx = a_PrepareDistance * a_PrepareDistance;
-	int maxQueue = std::min(MaxIdx - 1, 100);  // Number of chunks to queue at once
-	cSpawnPrepare prep(a_World, a_SpawnChunkX, a_SpawnChunkZ, a_PrepareDistance, maxQueue);
-	for (int i = 0; i < maxQueue; i++)
+	for (int ChunkX = NegativePrepareDistance; ChunkX <= PositivePrepareDistance; ++ChunkX)
 	{
-		int chunkX, chunkZ;
-		prep.DecodeChunkCoords(i, chunkX, chunkZ);
-		a_World.PrepareChunk(chunkX, chunkZ, cpp14::make_unique<cSpawnPrepareCallback>(prep));
-	}  // for i
-
-	// Wait for the lighting thread to prepare everything. Event is set in the Call() callback:
-	if (MaxIdx > 0)
-	{
-		prep.m_EvtFinished.Wait();
+		for (int ChunkZ = NegativePrepareDistance; ChunkZ <= PositivePrepareDistance; ++ChunkZ)
+		{
+			a_World.PrepareChunk(ChunkX, ChunkZ, cpp14::make_unique<cSpawnPrepareCallback>(PerformanceAnalysisObject));
+		}
 	}
-}
-
-
-
-
-
-void cSpawnPrepare::DecodeChunkCoords(int a_Idx, int & a_ChunkX, int & a_ChunkZ)
-{
-	// A zigzag pattern from the top to bottom, each row alternating between forward-x and backward-x:
-	int z = a_Idx / m_PrepareDistance;
-	int x = a_Idx % m_PrepareDistance;
-	if ((z & 1) == 0)
-	{
-		// Reverse every second row:
-		x = m_PrepareDistance - 1 - x;
-	}
-	a_ChunkZ = m_SpawnChunkZ + z - m_PrepareDistance / 2;
-	a_ChunkX = m_SpawnChunkX + x - m_PrepareDistance / 2;
 }
 
 
@@ -94,35 +67,237 @@ void cSpawnPrepare::DecodeChunkCoords(int a_Idx, int & a_ChunkX, int & a_ChunkZ)
 
 void cSpawnPrepare::PreparedChunkCallback(int a_ChunkX, int a_ChunkZ)
 {
-	// Check if this was the last chunk:
 	m_NumPrepared += 1;
-	if (m_NumPrepared >= m_MaxIdx)
+	if (m_NumPrepared == m_TotalChunks)
 	{
-		m_EvtFinished.Set();
-		// Must return here, because "this" may have gotten deleted by the previous line
-		return;
-	}
+		if (m_PreparationCompletedCallback)
+		{
+			m_PreparationCompletedCallback();
+		}
 
-	// Queue another chunk, if appropriate:
-	if (m_NextIdx < m_MaxIdx)
-	{
-		int chunkX, chunkZ;
-		DecodeChunkCoords(m_NextIdx, chunkX, chunkZ);
-		m_World.GetLightingThread().QueueChunk(chunkX, chunkZ, cpp14::make_unique<cSpawnPrepareCallback>(*this));
-		m_NextIdx += 1;
+		LOG("Preparing spawn (%s): completed!", m_World.GetName().c_str());
+		return;
 	}
 
 	// Report progress every 1 second:
 	auto Now = std::chrono::steady_clock::now();
 	if (Now - m_LastReportTime > std::chrono::seconds(1))
 	{
-		float PercentDone = static_cast<float>(m_NumPrepared * 100) / m_MaxIdx;
+		float PercentDone = static_cast<float>(m_NumPrepared * 100) / m_TotalChunks;
 		float ChunkSpeed = static_cast<float>((m_NumPrepared - m_LastReportChunkCount) * 1000) / std::chrono::duration_cast<std::chrono::milliseconds>(Now - m_LastReportTime).count();
 		LOG("Preparing spawn (%s): %.02f%% (%d/%d; %.02f chunks / sec)",
-			m_World.GetName().c_str(), PercentDone, m_NumPrepared.load(std::memory_order_seq_cst), m_MaxIdx, ChunkSpeed
+			m_World.GetName().c_str(), PercentDone, m_NumPrepared, m_TotalChunks, ChunkSpeed
 		);
 		m_LastReportTime = Now;
 		m_LastReportChunkCount = m_NumPrepared;
 	}
 }
 
+
+
+
+
+bool cSpawnPrepare::IsValidSpawnBiome(cWorld & a_World, int a_ChunkX, int a_ChunkZ)
+{
+	auto Biome = a_World.GetBiomeAt(a_ChunkX, a_ChunkZ);
+	if ((Biome != EMCSBiome::biOcean) && (Biome != EMCSBiome::biFrozenOcean) && (Biome != EMCSBiome::biDeepOcean))
+	{
+		return true;
+	}
+
+	return false;
+}
+
+
+
+
+
+Vector3d cSpawnPrepare::GenerateRandomSpawn(cWorld & a_World, int a_PrepareDistance)
+{
+	LOGD("Generating random spawnpoint...");
+	int ChunkX = 0, ChunkZ = 0;
+
+	for (int CurrentRadius = 0; CurrentRadius <= a_PrepareDistance; ++CurrentRadius)
+	{
+		// Iterate through right and left sides
+		for (int PerpendicularRadius = -CurrentRadius; PerpendicularRadius <= CurrentRadius; ++PerpendicularRadius)
+		{
+			if (cSpawnPrepare::IsValidSpawnBiome(a_World, CurrentRadius, PerpendicularRadius))
+			{
+				ChunkX = CurrentRadius;
+				ChunkZ = PerpendicularRadius;
+				goto IUsedAGotoEatThat;
+			}
+
+			if (cSpawnPrepare::IsValidSpawnBiome(a_World, -CurrentRadius, PerpendicularRadius))
+			{
+				ChunkX = -CurrentRadius;
+				ChunkZ = PerpendicularRadius;
+				goto IUsedAGotoEatThat;
+			}
+		}
+
+		// Iterate through top and bottom sides, omitting the corners
+		for (int PerpendicularRadius = -CurrentRadius + 1; PerpendicularRadius < CurrentRadius; ++PerpendicularRadius)
+		{
+			if (cSpawnPrepare::IsValidSpawnBiome(a_World, PerpendicularRadius, CurrentRadius))
+			{
+				ChunkX = PerpendicularRadius;
+				ChunkZ = CurrentRadius;
+				goto IUsedAGotoEatThat;
+			}
+
+			if (cSpawnPrepare::IsValidSpawnBiome(a_World, PerpendicularRadius, -CurrentRadius))
+			{
+				ChunkX = PerpendicularRadius;
+				ChunkZ = -CurrentRadius;
+				goto IUsedAGotoEatThat;
+			}
+		}
+	}
+
+IUsedAGotoEatThat:
+
+	for (auto BlockX = ChunkX * cChunkDef::Width; BlockX != (ChunkX + 1) * cChunkDef::Width; ++BlockX)
+	{
+		for (auto BlockZ = ChunkZ * cChunkDef::Width; BlockZ != (ChunkZ + 1)  * cChunkDef::Width; ++BlockZ)
+		{
+			Vector3d Position;
+			Position.x = static_cast<double>(BlockX);
+			Position.z = static_cast<double>(BlockZ);
+
+			if (CanSpawnAt(a_World, Position.x, Position.y, Position.z))
+			{
+				Position += {0.5, 0.0, 0.5};
+
+				LOGINFO("Generated spawn position at {%.2f, %.2f, %.2f}", Position.x, Position.y, Position.z);
+				return Position;
+			}
+		}
+	}
+
+	int Height;
+	VERIFY(a_World.TryGetHeight(0, 0, Height));
+
+	LOGWARNING("Did not find an acceptable spawnpoint. Defaulted to spawn at the origin, elevation %i blocks", Height);
+	return { 0.0, static_cast<double>(Height), 0.0 };
+}
+
+
+
+
+
+bool cSpawnPrepare::CanSpawnAt(cWorld & a_World, double a_X, double & a_Y, double a_Z)
+{
+	// All this blocks can only be found above ground.
+	// Apart from netherrack (as the Nether is technically a massive cave)
+	static const BLOCKTYPE ValidSpawnBlocks[] =
+	{
+		E_BLOCK_GRASS,
+		E_BLOCK_SAND,
+		E_BLOCK_SNOW,
+		E_BLOCK_SNOW_BLOCK,
+		E_BLOCK_NETHERRACK,
+		E_BLOCK_END_STONE
+	};
+
+	static const int ValidSpawnBlocksCount = ARRAYCOUNT(ValidSpawnBlocks);
+
+	// Increase this by two, because we need two more blocks for body and head
+	int HighestSpawnPoint;
+	VERIFY(a_World.TryGetHeight(static_cast<int>(a_X), static_cast<int>(a_Z), HighestSpawnPoint));
+	HighestSpawnPoint += 2;
+
+	const int LowestSpawnPoint = static_cast<int>(HighestSpawnPoint / 2.0f);
+
+	for (int PotentialY = HighestSpawnPoint; PotentialY > LowestSpawnPoint; --PotentialY)
+	{
+		BLOCKTYPE HeadBlock = a_World.GetBlock(static_cast<int>(a_X), PotentialY, static_cast<int>(a_Z));
+
+		// Is this block safe for spawning
+		if (HeadBlock != E_BLOCK_AIR)
+		{
+			continue;
+		}
+
+		BLOCKTYPE BodyBlock = a_World.GetBlock(static_cast<int>(a_X), PotentialY - 1, static_cast<int>(a_Z));
+
+		// Is this block safe for spawning
+		if (BodyBlock != E_BLOCK_AIR)
+		{
+			continue;
+		}
+
+		BLOCKTYPE FloorBlock = a_World.GetBlock(static_cast<int>(a_X), PotentialY - 2, static_cast<int>(a_Z));
+
+		// Early out - Is the floor block air
+		if (FloorBlock == E_BLOCK_AIR)
+		{
+			continue;
+		}
+
+		// Is the floor block ok
+		bool ValidSpawnBlock = false;
+		for (int BlockIndex = 0; BlockIndex < ValidSpawnBlocksCount; ++BlockIndex)
+		{
+			ValidSpawnBlock |= (ValidSpawnBlocks[BlockIndex] == FloorBlock);
+		}
+
+		if (!ValidSpawnBlock)
+		{
+			continue;
+		}
+
+		if (!CheckPlayerSpawnPoint(a_World, static_cast<int>(a_X), PotentialY - 1, static_cast<int>(a_Z)))
+		{
+			continue;
+		}
+
+		a_Y = PotentialY - 1.0;
+		return true;
+	}
+
+	return false;
+}
+
+
+
+
+
+bool cSpawnPrepare::CheckPlayerSpawnPoint(cWorld & a_World, int a_PosX, int a_PosY, int a_PosZ)
+{
+	// Check height bounds
+	if (!cChunkDef::IsValidHeight(a_PosY))
+	{
+		return false;
+	}
+
+	// Check that surrounding blocks are neither solid or liquid
+	static const Vector3i SurroundingCoords[] =
+	{
+		Vector3i(0,  0,  1),
+		Vector3i(1,  0,  1),
+		Vector3i(1,  0,  0),
+		Vector3i(1,  0, -1),
+		Vector3i(0,  0, -1),
+		Vector3i(-1, 0, -1),
+		Vector3i(-1, 0,  0),
+		Vector3i(-1, 0,  1),
+	};
+
+	static const int SurroundingCoordsCount = ARRAYCOUNT(SurroundingCoords);
+
+	for (int CoordIndex = 0; CoordIndex < SurroundingCoordsCount; ++CoordIndex)
+	{
+		const int XPos = a_PosX + SurroundingCoords[CoordIndex].x;
+		const int ZPos = a_PosZ + SurroundingCoords[CoordIndex].z;
+
+		const BLOCKTYPE BlockType = a_World.GetBlock(XPos, a_PosY, ZPos);
+		if (cBlockInfo::IsSolid(BlockType) || IsBlockLiquid(BlockType))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/SpawnPrepare.h
+++ b/src/SpawnPrepare.h
@@ -12,25 +12,19 @@ class cSpawnPrepare
 {
 
 public:
-	static void PrepareChunks(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChunkZ, int a_PrepareDistance);
+	cSpawnPrepare(cWorld & a_World, int a_PrepareDistance, std::function<void()> a_PreparationCompletedCallback);
+
+	static void PrepareChunks(cWorld & a_World, int a_PrepareDistance, std::function<void()> a_PreparationCompletedCallback = {});
+
+	/** Generates a random spawnpoint on solid land by walking chunks and finding their biomes */
+	static Vector3d GenerateRandomSpawn(cWorld & a_World, int a_PrepareDistance);
 
 protected:
 	cWorld & m_World;
-	int m_SpawnChunkX;
-	int m_SpawnChunkZ;
-	int m_PrepareDistance;
-
-	/** The index of the next chunk to be queued in the lighting thread. */
-	int m_NextIdx;
-
-	/** The maximum index of the prepared chunks. Queueing stops when m_NextIdx reaches this number. */
-	int m_MaxIdx;
+	const int m_TotalChunks;
 
 	/** Total number of chunks already finished preparing. Preparation finishes when this number reaches m_MaxIdx. */
-	std::atomic<int> m_NumPrepared;
-
-	/** Event used to signal that the preparation is finished. */
-	cEvent m_EvtFinished;
+	int m_NumPrepared;
 
 	/** The timestamp of the last progress report emitted. */
 	std::chrono::steady_clock::time_point m_LastReportTime;
@@ -38,12 +32,19 @@ protected:
 	/** Number of chunks prepared when the last progress report was emitted. */
 	int m_LastReportChunkCount;
 
-	cSpawnPrepare(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChunkZ, int a_PrepareDistance, int a_FirstIdx);
+	std::function<void()> m_PreparationCompletedCallback;
 
 	void PreparedChunkCallback(int a_ChunkX, int a_ChunkZ);
 
-	/** Decodes the index into chunk coords. Provides the specific chunk ordering. */
-	void DecodeChunkCoords(int a_Idx, int & a_ChunkX, int & a_ChunkZ);
+	/** Returns if the biome of the given chunk coordinates is a valid spawn candidate. */
+	static bool IsValidSpawnBiome(cWorld & a_World, int a_ChunkX, int a_ChunkZ);
+
+	/** Can the specified coordinates be used as a spawn point?
+	Returns true if spawn position is valid and sets a_Y to the valid spawn height */
+	static bool CanSpawnAt(cWorld & a_World, double a_X, double & a_Y, double a_Z);
+
+	/** Check if player starting point is acceptable */
+	static bool CheckPlayerSpawnPoint(cWorld & a_World, int a_PosX, int a_PosY, int a_PosZ);
 
 	friend class cSpawnPrepareCallback;
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -324,6 +324,33 @@ void cWorld::SetNextBlockTick(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 
 
+bool cWorld::SetSpawn(double a_X, double a_Y, double a_Z)
+{
+		cIniFile IniFile;
+
+		IniFile.ReadFile(m_IniFileName);
+		IniFile.SetValueF("SpawnPosition", "X", a_X);
+		IniFile.SetValueF("SpawnPosition", "Y", a_Y);
+		IniFile.SetValueF("SpawnPosition", "Z", a_Z);
+		if (IniFile.WriteFile(m_IniFileName))
+		{
+			m_SpawnX = a_X;
+			m_SpawnY = a_Y;
+			m_SpawnZ = a_Z;
+			LOGD("Spawn set at {%f, %f, %f}", m_SpawnX, m_SpawnY, m_SpawnZ);
+			return true;
+		}
+		else
+		{
+			LOGWARNING("Couldn't write new spawn settings to \"%s\".", m_IniFileName.c_str());
+		}
+		return false;
+}
+
+
+
+
+
 void cWorld::InitializeSpawn(void)
 {
 	// For the debugging builds, don't make the server build too much world upon start:
@@ -337,12 +364,6 @@ void cWorld::InitializeSpawn(void)
 	{
 		// Spawn position wasn't already explicitly set, enumerate random solid-land coordinate and then write it to the world configuration:
 		GenerateRandomSpawn(DefaultViewDist);
-		cIniFile IniFile;
-		IniFile.ReadFile(m_IniFileName);
-		IniFile.SetValueF("SpawnPosition", "X", m_SpawnX);
-		IniFile.SetValueF("SpawnPosition", "Y", m_SpawnY);
-		IniFile.SetValueF("SpawnPosition", "Z", m_SpawnZ);
-		IniFile.WriteFile(m_IniFileName);
 	}
 
 	cIniFile IniFile;
@@ -649,9 +670,7 @@ void cWorld::GenerateRandomSpawn(int a_MaxSpawnRadius)
 	double SpawnY = 0.0;
 	if (CanSpawnAt(BiomeOffset.x, SpawnY, BiomeOffset.z))
 	{
-		m_SpawnX = BiomeOffset.x + 0.5;
-		m_SpawnY = SpawnY;
-		m_SpawnZ = BiomeOffset.z + 0.5;
+		SetSpawn(BiomeOffset.x + 0.5, SpawnY, BiomeOffset.z + 0.5);
 
 		LOGINFO("Generated spawnpoint position at {%.2f, %.2f, %.2f}", m_SpawnX, m_SpawnY, m_SpawnZ);
 		return;
@@ -681,9 +700,7 @@ void cWorld::GenerateRandomSpawn(int a_MaxSpawnRadius)
 
 			if (CanSpawnAt(PotentialSpawn.x, SpawnY, PotentialSpawn.z))
 			{
-				m_SpawnX = PotentialSpawn.x + 0.5;
-				m_SpawnY = SpawnY;
-				m_SpawnZ = PotentialSpawn.z + 0.5;
+				SetSpawn(PotentialSpawn.x + 0.5, SpawnY, PotentialSpawn.z + 0.5);
 
 				int ChunkX, ChunkZ;
 				cChunkDef::BlockToChunk(static_cast<int>(m_SpawnX), static_cast<int>(m_SpawnZ), ChunkX, ChunkZ);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -62,6 +62,8 @@
 #include "SpawnPrepare.h"
 #include "FastRandom.h"
 
+#include <memory>
+
 
 
 const int TIME_SUNSET        = 12000;
@@ -69,18 +71,6 @@ const int TIME_NIGHT_START   = 13187;
 const int TIME_NIGHT_END     = 22812;
 const int TIME_SUNRISE       = 23999;
 const int TIME_SPAWN_DIVISOR =   148;
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// cWorld::cLock:
-
-cWorld::cLock::cLock(cWorld & a_World) :
-	super(&(a_World.m_ChunkMap->GetCS()))
-{
-}
 
 
 
@@ -101,6 +91,10 @@ cWorld::cTickThread::cTickThread(cWorld & a_World) :
 
 void cWorld::cTickThread::Execute(void)
 {
+	m_World.Initialise();
+	m_World.InitialiseSpawn();
+	cRoot::Get()->GetPluginManager()->CallHookWorldStarted(m_World);
+
 	auto LastTime = std::chrono::steady_clock::now();
 	auto TickTime = std::chrono::duration_cast<std::chrono::milliseconds>(cTickTime(1));
 
@@ -108,9 +102,14 @@ void cWorld::cTickThread::Execute(void)
 	{
 		auto NowTime = std::chrono::steady_clock::now();
 		auto WaitTime = std::chrono::duration_cast<std::chrono::milliseconds>(NowTime - LastTime);
-		m_World.Tick(WaitTime, TickTime);
-		TickTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - NowTime);
 
+		if (m_World.m_ShouldTick)
+		{
+			m_World.Tick(WaitTime, TickTime);
+		}
+		m_World.TickQueuedTasks();
+
+		TickTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - NowTime);
 		if (TickTime < cTickTime(1))
 		{
 			// Stretch tick time until it's at least 1 tick
@@ -119,6 +118,36 @@ void cWorld::cTickThread::Execute(void)
 
 		LastTime = NowTime;
 	}
+
+	class DestructionCallback : public cEntityCallback
+	{
+		virtual bool Item(cEntity * a_Entity) override
+		{
+			a_Entity->Destroy(false);
+			return false;
+		}
+	} DestructionCallback;
+	m_World.ForEachEntity(DestructionCallback);
+
+	// Write settings to file; these are all plugin changeable values - keep updated!
+	cIniFile IniFile;
+	IniFile.ReadFile(m_World.m_IniFileName);
+		if (m_World.GetDimension() == dimOverworld)
+		{
+			IniFile.SetValue("LinkedWorlds", "NetherWorldName", m_World.m_LinkedNetherWorldName);
+			IniFile.SetValue("LinkedWorlds", "EndWorldName", m_World.m_LinkedEndWorldName);
+		}
+		else
+		{
+			IniFile.SetValue("LinkedWorlds", "OverworldName", m_World.m_LinkedOverworldName);
+		}
+		IniFile.SetValueI("Physics", "TNTShrapnelLevel", static_cast<int>(m_World.m_TNTShrapnelLevel));
+		IniFile.SetValueB("Mechanics", "CommandBlocksEnabled", m_World.m_bCommandBlocksEnabled);
+		IniFile.SetValueB("Mechanics", "UseChatPrefixes", m_World.m_bUseChatPrefixes);
+		IniFile.SetValueB("General", "IsDaylightCycleEnabled", m_World.m_IsDaylightCycleEnabled);
+		IniFile.SetValueI("General", "Weather", static_cast<int>(m_World.m_Weather));
+		IniFile.SetValueI("General", "TimeInTicks", m_World.GetTimeOfDay());
+	IniFile.WriteFile(m_World.m_IniFileName);
 }
 
 
@@ -129,6 +158,7 @@ void cWorld::cTickThread::Execute(void)
 // cWorld:
 
 cWorld::cWorld(const AString & a_WorldName, eDimension a_Dimension, const AString & a_LinkedOverworldName) :
+	m_ShouldTick(true),
 	m_WorldName(a_WorldName),
 	m_LinkedOverworldName(a_LinkedOverworldName),
 	m_IniFileName(m_WorldName + "/world.ini"),
@@ -217,8 +247,6 @@ cWorld::~cWorld()
 	delete m_WaterSimulator;     m_WaterSimulator    = nullptr;
 	delete m_LavaSimulator;      m_LavaSimulator     = nullptr;
 	delete m_RedstoneSimulator;  m_RedstoneSimulator = nullptr;
-
-	m_Storage.WaitForFinish();
 
 	// Unload the scoreboard
 	cScoreboardSerializer Serializer(m_WorldName, &m_Scoreboard);
@@ -351,29 +379,41 @@ bool cWorld::SetSpawn(double a_X, double a_Y, double a_Z)
 
 
 
-void cWorld::InitializeSpawn(void)
+void cWorld::InitialiseSpawn(void)
 {
 	// For the debugging builds, don't make the server build too much world upon start:
 	#if defined(_DEBUG) || defined(ANDROID_NDK)
-	const int DefaultViewDist = 9;
+	static const int DefaultViewDist = 9;
 	#else
-	const int DefaultViewDist = 20;  // Always prepare an area 20 chunks across, no matter what the actual cClientHandle::VIEWDISTANCE is
+	static const int DefaultViewDist = 20;  // Always prepare an area 20 chunks across, no matter what the actual cClientHandle::VIEWDISTANCE is
 	#endif  // _DEBUG
 
-	if (!m_IsSpawnExplicitlySet)
+	int ViewDist;
 	{
-		// Spawn position wasn't already explicitly set, enumerate random solid-land coordinate and then write it to the world configuration:
-		GenerateRandomSpawn(DefaultViewDist);
+		cIniFile IniFile;
+		IniFile.ReadFile(m_IniFileName);
+		ViewDist = IniFile.GetValueSetI("SpawnPosition", "PregenerateDistance", DefaultViewDist);
+		IniFile.WriteFile(m_IniFileName);
+
 	}
 
-	cIniFile IniFile;
-	IniFile.ReadFile(m_IniFileName);
-	int ViewDist = IniFile.GetValueSetI("SpawnPosition", "PregenerateDistance", DefaultViewDist);
-	IniFile.WriteFile(m_IniFileName);
-
-	int ChunkX = 0, ChunkZ = 0;
-	cChunkDef::BlockToChunk(FloorC(m_SpawnX), FloorC(m_SpawnZ), ChunkX, ChunkZ);
-	cSpawnPrepare::PrepareChunks(*this, ChunkX, ChunkZ, ViewDist);
+	if (m_IsSpawnExplicitlySet)
+	{
+		cSpawnPrepare::PrepareChunks(*this, ViewDist);
+	}
+	else
+	{
+		// Spawn position wasn't already explicitly set, enumerate random solid-land coordinate and then write it to the world configuration:
+		cSpawnPrepare::PrepareChunks(
+			*this,
+			ViewDist,
+			[this]
+			{
+				auto Spawn = cSpawnPrepare::GenerateRandomSpawn(*this, DefaultViewDist);
+				SetSpawn(Spawn.x, Spawn.y, Spawn.z);
+			}
+		);
+	}
 
 	#ifdef TEST_LINEBLOCKTRACER
 	// DEBUG: Test out the cLineBlockTracer class by tracing a few lines:
@@ -433,7 +473,7 @@ void cWorld::InitializeSpawn(void)
 
 
 
-void cWorld::Start(void)
+void cWorld::Initialise()
 {
 	m_SpawnX = 0;
 	m_SpawnY = cChunkDef::Height;
@@ -617,7 +657,6 @@ void cWorld::Start(void)
 	m_Storage.Start(this, m_StorageSchema, m_StorageCompressionFactor);
 	m_Generator.Start(m_GeneratorCallbacks, m_GeneratorCallbacks, IniFile);
 	m_ChunkSender.Start();
-	m_TickThread.Start();
 
 	// Init of the spawn monster time (as they are supposed to have different spawn rate)
 	m_LastSpawnMonster.insert(std::map<cMonster::eFamily, cTickTimeLong>::value_type(cMonster::mfHostile, cTickTimeLong(0)));
@@ -632,203 +671,6 @@ void cWorld::Start(void)
 	{
 		LOGWARNING("Could not write world config to %s", m_IniFileName.c_str());
 	}
-}
-
-
-
-
-
-void cWorld::GenerateRandomSpawn(int a_MaxSpawnRadius)
-{
-	LOGD("Generating random spawnpoint...");
-
-	// Number of checks to make sure we have a valid biome
-	// 100 checks will check across 400 chunks, we should have
-	// a valid biome by then.
-	static const int BiomeCheckCount = 100;
-
-	// Make sure we are in a valid biome
-	Vector3i BiomeOffset = Vector3i(0, 0, 0);
-	for (int BiomeCheckIndex = 0; BiomeCheckIndex < BiomeCheckCount; ++BiomeCheckIndex)
-	{
-		EMCSBiome Biome = GetBiomeAt(BiomeOffset.x, BiomeOffset.z);
-		if ((Biome == EMCSBiome::biOcean) || (Biome == EMCSBiome::biFrozenOcean))
-		{
-			BiomeOffset += Vector3d(cChunkDef::Width * 4, 0, 0);
-			continue;
-		}
-
-		// Found a usable biome
-		// Spawn chunks so we can find a nice spawn.
-		int ChunkX = 0, ChunkZ = 0;
-		cChunkDef::BlockToChunk(BiomeOffset.x, BiomeOffset.z, ChunkX, ChunkZ);
-		cSpawnPrepare::PrepareChunks(*this, ChunkX, ChunkZ, a_MaxSpawnRadius);
-		break;
-	}
-
-	// Check 0, 0 first.
-	double SpawnY = 0.0;
-	if (CanSpawnAt(BiomeOffset.x, SpawnY, BiomeOffset.z))
-	{
-		SetSpawn(BiomeOffset.x + 0.5, SpawnY, BiomeOffset.z + 0.5);
-
-		LOGINFO("Generated spawnpoint position at {%.2f, %.2f, %.2f}", m_SpawnX, m_SpawnY, m_SpawnZ);
-		return;
-	}
-
-	// A search grid (searches clockwise around the origin)
-	static const int HalfChunk = static_cast<int>(cChunkDef::Width / 2.0f);
-	static const Vector3i ChunkOffset[] =
-	{
-		Vector3i(0, 0, HalfChunk),
-		Vector3i(HalfChunk, 0, HalfChunk),
-		Vector3i(HalfChunk, 0, 0),
-		Vector3i(HalfChunk, 0, -HalfChunk),
-		Vector3i(0, 0, -HalfChunk),
-		Vector3i(-HalfChunk, 0, -HalfChunk),
-		Vector3i(-HalfChunk, 0, 0),
-		Vector3i(-HalfChunk, 0, HalfChunk),
-	};
-
-	static const int PerRadiSearchCount = ARRAYCOUNT(ChunkOffset);
-
-	for (int RadiusOffset = 1; RadiusOffset < (a_MaxSpawnRadius * 2); ++RadiusOffset)
-	{
-		for (int SearchGridIndex = 0; SearchGridIndex < PerRadiSearchCount; ++SearchGridIndex)
-		{
-			const Vector3i PotentialSpawn = BiomeOffset + (ChunkOffset[SearchGridIndex] * RadiusOffset);
-
-			if (CanSpawnAt(PotentialSpawn.x, SpawnY, PotentialSpawn.z))
-			{
-				SetSpawn(PotentialSpawn.x + 0.5, SpawnY, PotentialSpawn.z + 0.5);
-
-				int ChunkX, ChunkZ;
-				cChunkDef::BlockToChunk(static_cast<int>(m_SpawnX), static_cast<int>(m_SpawnZ), ChunkX, ChunkZ);
-				cSpawnPrepare::PrepareChunks(*this, ChunkX, ChunkZ, a_MaxSpawnRadius);
-
-				LOGINFO("Generated spawnpoint position at {%.2f, %.2f, %.2f}", m_SpawnX, m_SpawnY, m_SpawnZ);
-				return;
-			}
-		}
-	}
-
-	m_SpawnY = GetHeight(static_cast<int>(m_SpawnX), static_cast<int>(m_SpawnZ));
-	LOGWARNING("Did not find an acceptable spawnpoint. Generated a random spawnpoint position at {%.2f, %.2f, %.2f}", m_SpawnX, m_SpawnY, m_SpawnZ);
-}
-
-
-
-
-
-bool cWorld::CanSpawnAt(double a_X, double & a_Y, double a_Z)
-{
-	// All this blocks can only be found above ground.
-	// Apart from netherrack (as the Nether is technically a massive cave)
-	static const BLOCKTYPE ValidSpawnBlocks[] =
-	{
-		E_BLOCK_GRASS,
-		E_BLOCK_SAND,
-		E_BLOCK_SNOW,
-		E_BLOCK_SNOW_BLOCK,
-		E_BLOCK_NETHERRACK
-	};
-
-	static const int ValidSpawnBlocksCount = ARRAYCOUNT(ValidSpawnBlocks);
-
-	// Increase this by two, because we need two more blocks for body and head
-	static const int HighestSpawnPoint = GetHeight(static_cast<int>(a_X), static_cast<int>(a_Z)) + 2;
-	static const int LowestSpawnPoint = static_cast<int>(HighestSpawnPoint / 2.0f);
-
-	for (int PotentialY = HighestSpawnPoint; PotentialY > LowestSpawnPoint; --PotentialY)
-	{
-		BLOCKTYPE HeadBlock = GetBlock(static_cast<int>(a_X), PotentialY, static_cast<int>(a_Z));
-
-		// Is this block safe for spawning
-		if (HeadBlock != E_BLOCK_AIR)
-		{
-			continue;
-		}
-
-		BLOCKTYPE BodyBlock = GetBlock(static_cast<int>(a_X), PotentialY - 1, static_cast<int>(a_Z));
-
-		// Is this block safe for spawning
-		if (BodyBlock != E_BLOCK_AIR)
-		{
-			continue;
-		}
-
-		BLOCKTYPE FloorBlock = GetBlock(static_cast<int>(a_X), PotentialY - 2, static_cast<int>(a_Z));
-
-		// Early out - Is the floor block air
-		if (FloorBlock == E_BLOCK_AIR)
-		{
-			continue;
-		}
-
-		// Is the floor block ok
-		bool ValidSpawnBlock = false;
-		for (int BlockIndex = 0; BlockIndex < ValidSpawnBlocksCount; ++BlockIndex)
-		{
-			ValidSpawnBlock |= (ValidSpawnBlocks[BlockIndex] == FloorBlock);
-		}
-
-		if (!ValidSpawnBlock)
-		{
-			continue;
-		}
-
-		if (!CheckPlayerSpawnPoint(static_cast<int>(a_X), PotentialY - 1, static_cast<int>(a_Z)))
-		{
-			continue;
-		}
-
-		a_Y = PotentialY - 1.0;
-		return true;
-	}
-
-	return false;
-}
-
-
-
-
-
-bool cWorld::CheckPlayerSpawnPoint(int a_PosX, int a_PosY, int a_PosZ)
-{
-	// Check height bounds
-	if (!cChunkDef::IsValidHeight(a_PosY))
-	{
-		return false;
-	}
-
-	// Check that surrounding blocks are neither solid or liquid
-	static const Vector3i SurroundingCoords[] =
-	{
-		Vector3i(0,  0,  1),
-		Vector3i(1,  0,  1),
-		Vector3i(1,  0,  0),
-		Vector3i(1,  0, -1),
-		Vector3i(0,  0, -1),
-		Vector3i(-1, 0, -1),
-		Vector3i(-1, 0,  0),
-		Vector3i(-1, 0,  1),
-	};
-
-	static const int SurroundingCoordsCount = ARRAYCOUNT(SurroundingCoords);
-
-	for (int CoordIndex = 0; CoordIndex < SurroundingCoordsCount; ++CoordIndex)
-	{
-		const int XPos = a_PosX + SurroundingCoords[CoordIndex].x;
-		const int ZPos = a_PosZ + SurroundingCoords[CoordIndex].z;
-
-		const BLOCKTYPE BlockType = GetBlock(XPos, a_PosY, ZPos);
-		if (cBlockInfo::IsSolid(BlockType) || IsBlockLiquid(BlockType))
-		{
-			return false;
-		}
-	}
-
-	return true;
 }
 
 
@@ -948,41 +790,18 @@ void cWorld::InitialiseAndLoadMobSpawningValues(cIniFile & a_IniFile)
 
 void cWorld::Stop(void)
 {
-	// Delete the clients that have been in this world:
-	{
-		cCSLock Lock(m_CSClients);
-		for (auto itr = m_Clients.begin(); itr != m_Clients.end(); ++itr)
-		{
-			(*itr)->Destroy();
-		}  // for itr - m_Clients[]
-		m_Clients.clear();
-	}
+	// Stop calling cWorld::Tick; prevents occurences where a worker thread is stopped but
+	// SUDDENLY, A WILD CHUNK SAVE TASK APPEARS!!!
+	// NB: queued tasks which may be generated by worker threads are still processed
+	m_ShouldTick = false;
 
-	// Write settings to file; these are all plugin changeable values - keep updated!
-	cIniFile IniFile;
-	IniFile.ReadFile(m_IniFileName);
-		if (GetDimension() == dimOverworld)
-		{
-			IniFile.SetValue("LinkedWorlds", "NetherWorldName", m_LinkedNetherWorldName);
-			IniFile.SetValue("LinkedWorlds", "EndWorldName",    m_LinkedEndWorldName);
-		}
-		else
-		{
-			IniFile.SetValue("LinkedWorlds", "OverworldName", m_LinkedOverworldName);
-		}
-		IniFile.SetValueI("Physics", "TNTShrapnelLevel", static_cast<int>(m_TNTShrapnelLevel));
-		IniFile.SetValueB("Mechanics", "CommandBlocksEnabled", m_bCommandBlocksEnabled);
-		IniFile.SetValueB("Mechanics", "UseChatPrefixes", m_bUseChatPrefixes);
-		IniFile.SetValueB("General", "IsDaylightCycleEnabled", m_IsDaylightCycleEnabled);
-		IniFile.SetValueI("General", "Weather", static_cast<int>(m_Weather));
-		IniFile.SetValueI("General", "TimeInTicks", GetTimeOfDay());
-	IniFile.WriteFile(m_IniFileName);
-
-	m_TickThread.Stop();
 	m_Lighting.Stop();
 	m_Generator.Stop();
 	m_ChunkSender.Stop();
 	m_Storage.Stop();
+
+	// Finally, stop the tick thread
+	m_TickThread.Stop();
 }
 
 
@@ -993,17 +812,6 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 {
 	// Call the plugins
 	cPluginManager::Get()->CallHookWorldTick(*this, a_Dt, a_LastTickDurationMSec);
-
-	// Set any chunk data that has been queued for setting:
-	cSetChunkDataPtrs SetChunkDataQueue;
-	{
-		cCSLock Lock(m_CSSetChunkDataQueue);
-		std::swap(SetChunkDataQueue, m_SetChunkDataQueue);
-	}
-	for (cSetChunkDataPtrs::iterator itr = SetChunkDataQueue.begin(), end = SetChunkDataQueue.end(); itr != end; ++itr)
-	{
-		SetChunkData(**itr);
-	}  // for itr - SetChunkDataQueue[]
 
 	m_WorldAge += a_Dt;
 
@@ -1029,29 +837,11 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 		}
 	}
 
-	// Add entities waiting in the queue to be added:
-	{
-		cCSLock Lock(m_CSEntitiesToAdd);
-		for (auto & Entity : m_EntitiesToAdd)
-		{
-			Entity->SetWorld(this);
-			m_ChunkMap->AddEntity(Entity);
-			ASSERT(!Entity->IsTicking());
-			Entity->SetIsTicking(true);
-		}
-		m_EntitiesToAdd.clear();
-	}
-
-	// Add players waiting in the queue to be added:
-	AddQueuedPlayers();
-
 	m_ChunkMap->Tick(a_Dt);
 	TickMobs(a_Dt);
 	m_MapManager.TickMaps();
 
-	TickClients(static_cast<float>(a_Dt.count()));
 	TickQueuedBlocks();
-	TickQueuedTasks();
 
 	GetSimulatorManager()->Simulate(static_cast<float>(a_Dt.count()));
 
@@ -1066,7 +856,6 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 	{
 		UnloadUnusedChunks();
 	}
-
 }
 
 
@@ -1109,9 +898,6 @@ void cWorld::TickWeather(float a_Dt)
 
 void cWorld::TickMobs(std::chrono::milliseconds a_Dt)
 {
-	// _X 2013_10_22: This is a quick fix for #283 - the world needs to be locked while ticking mobs
-	cWorld::cLock Lock(*this);
-
 	// before every Mob action, we have to count them depending on the distance to players, on their family ...
 	cMobCensus MobCensus;
 	m_ChunkMap->CollectMobCensus(MobCensus);
@@ -1213,7 +999,10 @@ void cWorld::TickQueuedTasks(void)
 		}
 
 		// Partition everything to be executed by returning false to move to end of list if time reached
-		auto MoveBeginIterator = std::partition(m_Tasks.begin(), m_Tasks.end(), [this](const decltype(m_Tasks)::value_type & a_Task)
+		auto MoveBeginIterator = std::partition(
+			m_Tasks.begin(),
+			m_Tasks.end(),
+			[this](const auto & a_Task)
 			{
 				if (a_Task.first < std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count())
 				{
@@ -1233,60 +1022,10 @@ void cWorld::TickQueuedTasks(void)
 	}
 
 	// Execute each task:
-	for (const auto & Task : Tasks)
+	for (auto & Task : Tasks)
 	{
 		Task.second(*this);
-	}  // for itr - m_Tasks[]
-}
-
-
-
-
-void cWorld::TickClients(float a_Dt)
-{
-	cClientHandlePtrs RemoveClients;
-	{
-		cCSLock Lock(m_CSClients);
-
-		// Remove clients scheduled for removal:
-		for (auto itr = m_ClientsToRemove.begin(), end = m_ClientsToRemove.end(); itr != end; ++itr)
-		{
-			for (auto itrC = m_Clients.begin(), endC = m_Clients.end(); itrC != endC; ++itrC)
-			{
-				if (itrC->get() == *itr)
-				{
-					m_Clients.erase(itrC);
-					break;
-				}
-			}
-		}  // for itr - m_ClientsToRemove[]
-		m_ClientsToRemove.clear();
-
-		// Add clients scheduled for adding:
-		for (auto itr = m_ClientsToAdd.begin(), end = m_ClientsToAdd.end(); itr != end; ++itr)
-		{
-			ASSERT(std::find(m_Clients.begin(), m_Clients.end(), *itr) == m_Clients.end());
-			m_Clients.push_back(*itr);
-		}  // for itr - m_ClientsToRemove[]
-		m_ClientsToAdd.clear();
-
-		// Tick the clients, take out those that have been destroyed into RemoveClients
-		for (auto itr = m_Clients.begin(); itr != m_Clients.end();)
-		{
-			if ((*itr)->IsDestroyed())
-			{
-				// Remove the client later, when CS is not held, to avoid deadlock
-				RemoveClients.push_back(*itr);
-				itr = m_Clients.erase(itr);
-				continue;
-			}
-			(*itr)->Tick(a_Dt);
-			++itr;
-		}  // for itr - m_Clients[]
 	}
-
-	// Delete the clients queued for removal:
-	RemoveClients.clear();
 }
 
 
@@ -1412,29 +1151,26 @@ void cWorld::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_Blo
 	m_ChunkMap->DoExplosionAt(a_ExplosionSize, a_BlockX, a_BlockY, a_BlockZ, BlocksAffected);
 	BroadcastSoundEffect("random.explode", static_cast<double>(a_BlockX), static_cast<double>(a_BlockY), static_cast<double>(a_BlockZ), 1.0f, 0.6f);
 
+	for (const auto & Player : m_Players)
 	{
-		cCSLock Lock(m_CSPlayers);
-		for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+		cClientHandle * ch = Player->GetClientHandle();
+		if (ch == nullptr)
 		{
-			cClientHandle * ch = (*itr)->GetClientHandle();
-			if (ch == nullptr)
-			{
-				continue;
-			}
+			continue;
+		}
 
-			Vector3d distance_explosion = (*itr)->GetPosition() - explosion_pos;
-			if (distance_explosion.SqrLength() < 4096.0)
+		Vector3d distance_explosion = Player->GetPosition() - explosion_pos;
+		if (distance_explosion.SqrLength() < 4096.0)
+		{
+			double real_distance = std::max(0.004, distance_explosion.Length());
+			double power = a_ExplosionSize / real_distance;
+			if (power <= 1)
 			{
-				double real_distance = std::max(0.004, distance_explosion.Length());
-				double power = a_ExplosionSize / real_distance;
-				if (power <= 1)
-				{
-					power = 0;
-				}
-				distance_explosion.Normalize();
-				distance_explosion *= power;
-				ch->SendExplosion(a_BlockX, a_BlockY, a_BlockZ, static_cast<float>(a_ExplosionSize), BlocksAffected, distance_explosion);
+				power = 0;
 			}
+			distance_explosion.Normalize();
+			distance_explosion *= power;
+			ch->SendExplosion(a_BlockX, a_BlockY, a_BlockZ, static_cast<float>(a_ExplosionSize), BlocksAffected, distance_explosion);
 		}
 	}
 
@@ -2390,10 +2126,9 @@ void cWorld::BroadcastBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 
 void cWorld::BroadcastChat(const AString & a_Message, const cClientHandle * a_Exclude, eMessageType a_ChatPrefix)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2408,10 +2143,9 @@ void cWorld::BroadcastChat(const AString & a_Message, const cClientHandle * a_Ex
 
 void cWorld::BroadcastChat(const cCompositeChat & a_Message, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2543,10 +2277,9 @@ void cWorld::BroadcastEntityAnimation(const cEntity & a_Entity, char a_Animation
 
 void cWorld::BroadcastPlayerListAddPlayer(const cPlayer & a_Player, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2561,10 +2294,9 @@ void cWorld::BroadcastPlayerListAddPlayer(const cPlayer & a_Player, const cClien
 
 void cWorld::BroadcastPlayerListRemovePlayer(const cPlayer & a_Player, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn())
 		{
 			continue;
@@ -2579,10 +2311,9 @@ void cWorld::BroadcastPlayerListRemovePlayer(const cPlayer & a_Player, const cCl
 
 void cWorld::BroadcastPlayerListUpdateGameMode(const cPlayer & a_Player, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2597,10 +2328,9 @@ void cWorld::BroadcastPlayerListUpdateGameMode(const cPlayer & a_Player, const c
 
 void cWorld::BroadcastPlayerListUpdatePing(const cPlayer & a_Player, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2615,10 +2345,9 @@ void cWorld::BroadcastPlayerListUpdatePing(const cPlayer & a_Player, const cClie
 
 void cWorld::BroadcastPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2642,10 +2371,9 @@ void cWorld::BroadcastRemoveEntityEffect(const cEntity & a_Entity, int a_EffectI
 
 void cWorld::BroadcastScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2660,10 +2388,9 @@ void cWorld::BroadcastScoreboardObjective(const AString & a_Name, const AString 
 
 void cWorld::BroadcastScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2678,10 +2405,9 @@ void cWorld::BroadcastScoreUpdate(const AString & a_Objective, const AString & a
 
 void cWorld::BroadcastDisplayObjective(const AString & a_Objective, cScoreboard::eDisplaySlot a_Display)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2723,10 +2449,9 @@ void cWorld::BroadcastSpawnEntity(cEntity & a_Entity, const cClientHandle * a_Ex
 
 void cWorld::BroadcastTeleportEntity(const cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2750,10 +2475,9 @@ void cWorld::BroadcastThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 
 void cWorld::BroadcastTimeUpdate(const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2777,10 +2501,9 @@ void cWorld::BroadcastUseBed(const cEntity & a_Entity, int a_BlockX, int a_Block
 
 void cWorld::BroadcastWeather(eWeather a_Weather, const cClientHandle * a_Exclude)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
 		{
 			continue;
@@ -2829,28 +2552,30 @@ void cWorld::MarkChunkSaved (int a_ChunkX, int a_ChunkZ)
 
 
 
-void cWorld::QueueSetChunkData(const cSetChunkDataPtr & a_SetChunkData)
+void cWorld::QueueSetChunkData(cSetChunkData & a_SetChunkData)
 {
-	ASSERT(IsChunkQueued(a_SetChunkData->GetChunkX(), a_SetChunkData->GetChunkZ()));
-
 	// Validate biomes, if needed:
-	if (!a_SetChunkData->AreBiomesValid())
+	if (!a_SetChunkData.AreBiomesValid())
 	{
 		// The biomes are not assigned, get them from the generator:
-		m_Generator.GenerateBiomes(a_SetChunkData->GetChunkX(), a_SetChunkData->GetChunkZ(), a_SetChunkData->GetBiomes());
-		a_SetChunkData->MarkBiomesValid();
+		m_Generator.GenerateBiomes(a_SetChunkData.GetChunkX(), a_SetChunkData.GetChunkZ(), a_SetChunkData.GetBiomes());
+		a_SetChunkData.MarkBiomesValid();
 	}
 
 	// Validate heightmap, if needed:
-	if (!a_SetChunkData->IsHeightMapValid())
+	if (!a_SetChunkData.IsHeightMapValid())
 	{
-		a_SetChunkData->CalculateHeightMap();
+		a_SetChunkData.CalculateHeightMap();
 	}
 
-	// Store a copy of the data in the queue:
-	// TODO: If the queue is too large, wait for it to get processed. Not likely, though.
-	cCSLock Lock(m_CSSetChunkDataQueue);
-	m_SetChunkDataQueue.push_back(a_SetChunkData);
+	cpp14::move_on_copy_wrapper<std::remove_reference<decltype(a_SetChunkData)>::type> SetChunkData(std::move(a_SetChunkData));
+	QueueTask(
+		[SetChunkData](cWorld & a_World)
+		{
+			// TODO: make SetChunkData and all called functions const
+			a_World.SetChunkData(const_cast<cSetChunkData &>(SetChunkData.value));
+		}
+	);
 }
 
 
@@ -2864,7 +2589,7 @@ void cWorld::SetChunkData(cSetChunkData & a_SetChunkData)
 
 	m_ChunkMap->SetChunkData(a_SetChunkData);
 
-	// Initialize the entities (outside the m_ChunkMap's CS, to fix FS #347):
+	// Initialise the entities:
 	cEntityList Entities;
 	std::swap(a_SetChunkData.GetEntities(), Entities);
 	for (cEntityList::iterator itr = Entities.begin(), end = Entities.end(); itr != end; ++itr)
@@ -2872,31 +2597,10 @@ void cWorld::SetChunkData(cSetChunkData & a_SetChunkData)
 		(*itr)->Initialize(*this);
 	}
 
-	// If a client is requesting this chunk, send it to them:
-	int ChunkX = a_SetChunkData.GetChunkX();
-	int ChunkZ = a_SetChunkData.GetChunkZ();
-	cChunkSender & ChunkSender = m_ChunkSender;
-	DoWithChunk(
-		ChunkX, ChunkZ,
-		[&ChunkSender] (cChunk & a_Chunk) -> bool
-		{
-			if (a_Chunk.HasAnyClients())
-			{
-				ChunkSender.QueueSendChunkTo(
-					a_Chunk.GetPosX(),
-					a_Chunk.GetPosZ(),
-					cChunkSender::E_CHUNK_PRIORITY_MEDIUM,
-					a_Chunk.GetAllClients()
-				);
-			}
-			return true;
-		}
-	);
-
 	// Save the chunk right after generating, so that we don't have to generate it again on next run
 	if (a_SetChunkData.ShouldMarkDirty())
 	{
-		m_Storage.QueueSaveChunk(ChunkX, ChunkZ);
+		m_Storage.QueueSaveChunk(a_SetChunkData.GetChunkX(), a_SetChunkData.GetChunkZ());
 	}
 }
 
@@ -2992,41 +2696,33 @@ void cWorld::CollectPickupsByPlayer(cPlayer & a_Player)
 
 void cWorld::AddPlayer(cPlayer * a_Player)
 {
-	cCSLock Lock(m_CSPlayersToAdd);
-	m_PlayersToAdd.push_back(a_Player);
+	ASSERT(m_TickThread.IsCurrentThread());
+
+	m_Players.emplace_back(a_Player);
+
+	// Stream chunks to all eligible clients:
+	auto Client = a_Player->GetClientHandle();
+	if (Client != nullptr)
+	{
+		Client->SendHealth();
+		Client->SendWholeInventory(*a_Player->GetWindow());
+
+		if (GetDimension() == dimOverworld)
+		{
+			Client->SendWeather(GetWeather());
+		}
+	}
+	// Don't worry, the client handle may have been deleted right after a world move operation was queued
 }
 
 
 
 
 
-void cWorld::RemovePlayer(cPlayer * a_Player, bool a_RemoveFromChunk)
+void cWorld::RemovePlayer(cPlayer * a_Player)
 {
-	if (a_RemoveFromChunk)
-	{
-		// To prevent iterator invalidations when an entity goes through a portal and calls this function whilst being ticked by cChunk
-		// we should not change cChunk's entity list if asked not to
-		m_ChunkMap->RemoveEntity(a_Player);
-	}
-	{
-		cCSLock Lock(m_CSPlayersToAdd);
-		m_PlayersToAdd.remove(a_Player);
-	}
-	{
-		cCSLock Lock(m_CSPlayers);
-		LOGD("Removing player %s from world \"%s\"", a_Player->GetName().c_str(), m_WorldName.c_str());
-		m_Players.remove(a_Player);
-	}
-
-	// Remove the player's client from the list of clients to be ticked:
-	cClientHandle * Client = a_Player->GetClientHandle();
-	if (Client != nullptr)
-	{
-		Client->RemoveFromWorld();
-		m_ChunkMap->RemoveClientFromChunks(Client);
-		cCSLock Lock(m_CSClients);
-		m_ClientsToRemove.push_back(Client);
-	}
+	LOGD("Removing player %s from world \"%s\"", a_Player->GetName().c_str(), m_WorldName.c_str());
+	m_Players.erase(std::remove(m_Players.begin(), m_Players.end(), a_Player), m_Players.end());
 }
 
 
@@ -3036,8 +2732,7 @@ void cWorld::RemovePlayer(cPlayer * a_Player, bool a_RemoveFromChunk)
 bool cWorld::ForEachPlayer(cPlayerListCallback & a_Callback)
 {
 	// Calls the callback for each player in the list
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(), itr2 = itr; itr != m_Players.end(); itr = itr2)
+	for (auto itr = m_Players.begin(), itr2 = itr; itr != m_Players.end(); itr = itr2)
 	{
 		++itr2;
 		if (!(*itr)->IsTicking())
@@ -3059,19 +2754,19 @@ bool cWorld::ForEachPlayer(cPlayerListCallback & a_Callback)
 bool cWorld::DoWithPlayer(const AString & a_PlayerName, cPlayerListCallback & a_Callback)
 {
 	// Calls the callback for the specified player in the list
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		if (!(*itr)->IsTicking())
+		if (!Player->IsTicking())
 		{
 			continue;
 		}
-		if (NoCaseCompare((*itr)->GetName(), a_PlayerName) == 0)
+
+		if (NoCaseCompare(Player->GetName(), a_PlayerName) == 0)
 		{
-			a_Callback.Item(*itr);
+			a_Callback.Item(Player);
 			return true;
 		}
-	}  // for itr - m_Players[]
+	}
 	return false;
 }
 
@@ -3085,24 +2780,24 @@ bool cWorld::FindAndDoWithPlayer(const AString & a_PlayerNameHint, cPlayerListCa
 	size_t BestRating = 0;
 	size_t NameLength = a_PlayerNameHint.length();
 
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		if (!(*itr)->IsTicking())
+		if (!Player->IsTicking())
 		{
 			continue;
 		}
-		size_t Rating = RateCompareString (a_PlayerNameHint, (*itr)->GetName());
+
+		size_t Rating = RateCompareString (a_PlayerNameHint, Player->GetName());
 		if (Rating >= BestRating)
 		{
-			BestMatch = *itr;
+			BestMatch = Player;
 			BestRating = Rating;
 		}
 		if (Rating == NameLength)  // Perfect match
 		{
 			break;
 		}
-	}  // for itr - m_Players[]
+	}
 
 	if (BestMatch != nullptr)
 	{
@@ -3117,16 +2812,16 @@ bool cWorld::FindAndDoWithPlayer(const AString & a_PlayerNameHint, cPlayerListCa
 
 bool cWorld::DoWithPlayerByUUID(const AString & a_PlayerUUID, cPlayerListCallback & a_Callback)
 {
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		if (!(*itr)->IsTicking())
+		if (!Player->IsTicking())
 		{
 			continue;
 		}
-		if ((*itr)->GetUUID() == a_PlayerUUID)
+
+		if (Player->GetUUID() == a_PlayerUUID)
 		{
-			return a_Callback.Item(*itr);
+			return a_Callback.Item(Player);
 		}
 	}
 	return false;
@@ -3144,14 +2839,14 @@ cPlayer * cWorld::FindClosestPlayer(const Vector3d & a_Pos, float a_SightLimit, 
 	double ClosestDistance = a_SightLimit;
 	cPlayer * ClosestPlayer = nullptr;
 
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::const_iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		if (!(*itr)->IsTicking())
+		if (!Player->IsTicking())
 		{
 			continue;
 		}
-		Vector3f Pos = (*itr)->GetPosition();
+
+		Vector3f Pos = Player->GetPosition();
 		double Distance = (Pos - a_Pos).Length();
 
 		if (Distance < ClosestDistance)
@@ -3161,13 +2856,13 @@ cPlayer * cWorld::FindClosestPlayer(const Vector3d & a_Pos, float a_SightLimit, 
 				if (!LineOfSight.Trace(a_Pos, (Pos - a_Pos), static_cast<int>((Pos - a_Pos).Length())))
 				{
 					ClosestDistance = Distance;
-					ClosestPlayer = *itr;
+					ClosestPlayer = Player;
 				}
 			}
 			else
 			{
 				ClosestDistance = Distance;
-				ClosestPlayer = *itr;
+				ClosestPlayer = Player;
 			}
 		}
 	}
@@ -3181,13 +2876,12 @@ cPlayer * cWorld::FindClosestPlayer(const Vector3d & a_Pos, float a_SightLimit, 
 void cWorld::SendPlayerList(cPlayer * a_DestPlayer)
 {
 	// Sends the playerlist to a_DestPlayer
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+	for (const auto & Player : m_Players)
 	{
-		cClientHandle * ch = (*itr)->GetClientHandle();
+		cClientHandle * ch = Player->GetClientHandle();
 		if ((ch != nullptr) && !ch->IsDestroyed())
 		{
-			a_DestPlayer->GetClientHandle()->SendPlayerListAddPlayer(*(*itr));
+			a_DestPlayer->GetClientHandle()->SendPlayerListAddPlayer(*Player);
 		}
 	}
 }
@@ -3225,19 +2919,6 @@ bool cWorld::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback & a_
 
 bool cWorld::DoWithEntityByID(UInt32 a_UniqueID, cEntityCallback & a_Callback)
 {
-	// First check the entities-to-add:
-	{
-		cCSLock Lock(m_CSEntitiesToAdd);
-		for (auto & ent: m_EntitiesToAdd)
-		{
-			if (ent->GetUniqueID() == a_UniqueID)
-			{
-				a_Callback.Item(ent);
-				return true;
-			}
-		}  // for ent - m_EntitiesToAdd[]
-	}
-
 	// Then check the chunkmap:
 	return m_ChunkMap->DoWithEntityByID(a_UniqueID, a_Callback);
 }
@@ -3255,7 +2936,7 @@ void cWorld::CompareChunkClients(int a_ChunkX1, int a_ChunkZ1, int a_ChunkX2, in
 
 
 
-bool cWorld::AddChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client)
+bool cWorld::AddChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client)
 {
 	return m_ChunkMap->AddChunkClient(a_ChunkX, a_ChunkZ, a_Client);
 }
@@ -3264,46 +2945,9 @@ bool cWorld::AddChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client
 
 
 
-void cWorld::RemoveChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client)
+void cWorld::RemoveChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client)
 {
 	m_ChunkMap->RemoveChunkClient(a_ChunkX, a_ChunkZ, a_Client);
-}
-
-
-
-
-
-void cWorld::RemoveClientFromChunks(cClientHandle * a_Client)
-{
-	m_ChunkMap->RemoveClientFromChunks(a_Client);
-}
-
-
-
-
-
-void cWorld::SendChunkTo(int a_ChunkX, int a_ChunkZ, cChunkSender::eChunkPriority a_Priority, cClientHandle * a_Client)
-{
-	m_ChunkSender.QueueSendChunkTo(a_ChunkX, a_ChunkZ, a_Priority, a_Client);
-}
-
-
-
-
-
-void cWorld::ForceSendChunkTo(int a_ChunkX, int a_ChunkZ, cChunkSender::eChunkPriority a_Priority, cClientHandle * a_Client)
-{
-	a_Client->AddWantedChunk(a_ChunkX, a_ChunkZ);
-	m_ChunkSender.QueueSendChunkTo(a_ChunkX, a_ChunkZ, a_Priority, a_Client);
-}
-
-
-
-
-
-void cWorld::RemoveClientFromChunkSender(cClientHandle * a_Client)
-{
-	m_ChunkSender.RemoveClient(a_Client);
 }
 
 
@@ -3500,16 +3144,6 @@ void cWorld::QueueSaveAllChunks(void)
 
 
 
-void cWorld::QueueTask(std::function<void(cWorld &)> a_Task)
-{
-	cCSLock Lock(m_CSTasks);
-	m_Tasks.emplace_back(0, a_Task);
-}
-
-
-
-
-
 void cWorld::ScheduleTask(int a_DelayTicks, std::function<void (cWorld &)> a_Task)
 {
 	Int64 TargetTick = a_DelayTicks + std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count();
@@ -3517,7 +3151,7 @@ void cWorld::ScheduleTask(int a_DelayTicks, std::function<void (cWorld &)> a_Tas
 	// Insert the task into the list of scheduled tasks
 	{
 		cCSLock Lock(m_CSTasks);
-		m_Tasks.emplace_back(TargetTick, a_Task);
+		m_Tasks.emplace_back(TargetTick, decltype(m_Tasks)::value_type::second_type(a_Task));
 	}
 }
 
@@ -3527,9 +3161,6 @@ void cWorld::ScheduleTask(int a_DelayTicks, std::function<void (cWorld &)> a_Tas
 
 void cWorld::AddEntity(cEntity * a_Entity)
 {
-	a_Entity->SetWorld(this);
-	cCSLock Lock(m_CSEntitiesToAdd);
-	m_EntitiesToAdd.push_back(a_Entity);
 }
 
 
@@ -3538,20 +3169,8 @@ void cWorld::AddEntity(cEntity * a_Entity)
 
 bool cWorld::HasEntity(UInt32 a_UniqueID)
 {
-	// Check if the entity is in the queue to be added to the world:
-	{
-		cCSLock Lock(m_CSEntitiesToAdd);
-		for (cEntityList::const_iterator itr = m_EntitiesToAdd.begin(), end = m_EntitiesToAdd.end(); itr != end; ++itr)
-		{
-			if ((*itr)->GetUniqueID() == a_UniqueID)
-			{
-				return true;
-			}
-		}  // for itr - m_EntitiesToAdd[]
-	}
-
 	// Check if the entity is in the chunkmap:
-	if (m_ChunkMap.get() == nullptr)
+	if (m_ChunkMap == nullptr)
 	{
 		// Chunkmap has already been destroyed, there are no entities anymore.
 		return false;
@@ -3740,13 +3359,12 @@ void cWorld::TabCompleteUserName(const AString & a_Text, AStringVector & a_Resul
 
 	std::vector<pair_t> UsernamesByWeight;
 
-	cCSLock Lock(m_CSPlayers);
-	for (cPlayerList::iterator itr = m_Players.begin(), end = m_Players.end(); itr != end; ++itr)
+	for (const auto & Player : m_Players)
 	{
-		AString PlayerName ((*itr)->GetName());
-		if ((*itr)->HasCustomName())
+		AString PlayerName = Player->GetName();
+		if (Player->HasCustomName())
 		{
-			PlayerName = (*itr)->GetCustomName();
+			PlayerName = Player->GetCustomName();
 		}
 
 		AString::size_type Found = StrToLower(PlayerName).find(StrToLower(LastWord));  // Try to find last word in playername
@@ -3757,7 +3375,6 @@ void cWorld::TabCompleteUserName(const AString & a_Text, AStringVector & a_Resul
 
 		UsernamesByWeight.push_back(std::make_pair(Found, PlayerName));  // Match! Store it with the position of the match as a weight
 	}
-	Lock.Unlock();
 
 	std::sort(UsernamesByWeight.begin(), UsernamesByWeight.end());  // Sort lexicographically (by the first value, then second), so higher weights (usernames with match closer to start) come first (#1274)
 
@@ -3889,66 +3506,6 @@ cFluidSimulator * cWorld::InitializeFluidSimulator(cIniFile & a_IniFile, const c
 
 
 
-
-void cWorld::AddQueuedPlayers(void)
-{
-	ASSERT(m_TickThread.IsCurrentThread());
-
-	// Grab the list of players to add, it has to be locked to access it:
-	cPlayerList PlayersToAdd;
-	{
-		cCSLock Lock(m_CSPlayersToAdd);
-		std::swap(PlayersToAdd, m_PlayersToAdd);
-	}
-
-	// Add all the players in the grabbed list:
-	{
-		cCSLock Lock(m_CSPlayers);
-		for (auto Player : PlayersToAdd)
-		{
-			ASSERT(std::find(m_Players.begin(), m_Players.end(), Player) == m_Players.end());  // Is it already in the list? HOW?
-			LOGD("Adding player %s to world \"%s\".", Player->GetName().c_str(), m_WorldName.c_str());
-
-			m_Players.push_back(Player);
-			Player->SetWorld(this);
-
-			// Add to chunkmap, if not already there (Spawn vs MoveToWorld):
-			m_ChunkMap->AddEntityIfNotPresent(Player);
-			ASSERT(!Player->IsTicking());
-			Player->SetIsTicking(true);
-		}  // for itr - PlayersToAdd[]
-	}  // Lock(m_CSPlayers)
-
-	// Add all the players' clienthandles:
-	{
-		cCSLock Lock(m_CSClients);
-		for (cPlayerList::iterator itr = PlayersToAdd.begin(), end = PlayersToAdd.end(); itr != end; ++itr)
-		{
-			cClientHandlePtr Client = (*itr)->GetClientHandlePtr();
-			if (Client != nullptr)
-			{
-				m_Clients.push_back(Client);
-			}
-		}  // for itr - PlayersToAdd[]
-	}  // Lock(m_CSClients)
-
-	// Stream chunks to all eligible clients:
-	for (cPlayerList::iterator itr = PlayersToAdd.begin(), end = PlayersToAdd.end(); itr != end; ++itr)
-	{
-		cClientHandle * Client = (*itr)->GetClientHandle();
-		if (Client != nullptr)
-		{
-			Client->SendPlayerMoveLook();
-			Client->SendHealth();
-			Client->SendWholeInventory(*(*itr)->GetWindow());
-		}
-	}  // for itr - PlayersToAdd[]
-}
-
-
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // cWorld::cChunkGeneratorCallbacks:
 
@@ -3966,7 +3523,7 @@ void cWorld::cChunkGeneratorCallbacks::OnChunkGenerated(cChunkDesc & a_ChunkDesc
 	cChunkDef::BlockNibbles BlockMetas;
 	a_ChunkDesc.CompressBlockMetas(BlockMetas);
 
-	cSetChunkDataPtr SetChunkData(new cSetChunkData(
+	auto SetChunkData(cSetChunkData(
 		a_ChunkDesc.GetChunkX(), a_ChunkDesc.GetChunkZ(),
 		a_ChunkDesc.GetBlockTypes(), BlockMetas,
 		nullptr, nullptr,  // We don't have lighting, chunk will be lighted when needed
@@ -3974,7 +3531,7 @@ void cWorld::cChunkGeneratorCallbacks::OnChunkGenerated(cChunkDesc & a_ChunkDesc
 		std::move(a_ChunkDesc.GetEntities()), std::move(a_ChunkDesc.GetBlockEntities()),
 		true
 	));
-	SetChunkData->RemoveInvalidBlockEntities();
+	SetChunkData.RemoveInvalidBlockEntities();
 	m_World->QueueSetChunkData(SetChunkData);
 }
 

--- a/src/World.h
+++ b/src/World.h
@@ -276,7 +276,7 @@ public:
 
 	/** Adds the entity into its appropriate chunk; takes ownership of the entity ptr.
 	The entity is added lazily - this function only puts it in a queue that is then processed by the Tick thread. */
-	void AddEntity(cEntity * a_Entity);
+	void AddEntity(std::unique_ptr<cEntity> a_Entity);
 
 	/** Returns true if an entity with the specified UniqueID exists in the world.
 	Note: Only loaded chunks are considered. */
@@ -770,7 +770,7 @@ public:
 	/** Spawns a mob of the specified type. Returns the mob's UniqueID if recognized and spawned, cEntity::INVALID_ID otherwise */
 	virtual UInt32 SpawnMob(double a_PosX, double a_PosY, double a_PosZ, eMonsterType a_MonsterType, bool a_Baby = false) override;  // tolua_export
 
-	UInt32 SpawnMobFinalize(cMonster * a_Monster);
+	UInt32 SpawnMobFinalize(std::unique_ptr<cMonster> a_Monster);
 
 	/** Creates a projectile of the specified type. Returns the projectile's UniqueID if successful, cEntity::INVALID_ID otherwise
 	Item parameter is currently used for Fireworks to correctly set entity metadata based on item metadata. */

--- a/src/World.h
+++ b/src/World.h
@@ -28,7 +28,7 @@
 #include "FastRandom.h"
 #include "ClientHandle.h"
 #include "EffectID.h"
-#include <functional>
+#include <future>
 
 
 
@@ -39,9 +39,6 @@ class cRedstoneSimulator;
 class cItem;
 class cPlayer;
 class cClientHandle;
-typedef SharedPtr<cClientHandle> cClientHandlePtr;
-typedef std::list<cClientHandlePtr> cClientHandlePtrs;
-typedef std::list<cClientHandle *> cClientHandles;
 class cEntity;
 class cBlockEntity;
 class cWorldGenerator;  // The generator that actually generates the chunks for a single world
@@ -58,12 +55,6 @@ class cCompositeChat;
 class cCuboid;
 class cSetChunkData;
 class cBroadcaster;
-
-
-typedef std::list< cPlayer * > cPlayerList;
-
-typedef SharedPtr<cSetChunkData> cSetChunkDataPtr;  // TODO: Change to unique_ptr once we go C++11
-typedef std::vector<cSetChunkDataPtr> cSetChunkDataPtrs;
 
 typedef cItemCallback<cPlayer>             cPlayerListCallback;
 typedef cItemCallback<cEntity>             cEntityCallback;
@@ -92,14 +83,9 @@ public:
 
 	// tolua_end
 
-	/** A simple RAII locker for the chunkmap - locks the chunkmap in its constructor, unlocks it in the destructor */
-	class cLock :
-		public cCSLock
-	{
-		typedef cCSLock super;
-	public:
-		cLock(cWorld & a_World);
-	};
+	cWorld(const AString & a_WorldName, eDimension a_Dimension = dimOverworld, const AString & a_LinkedOverworldName = "");
+	virtual ~cWorld();
+	cWorld(const cWorld & a_World) = delete;
 
 	static const char * GetClassStatic(void)  // Needed for ManualBindings's ForEach templates
 	{
@@ -234,7 +220,7 @@ public:
 
 	/** Puts the chunk data into a queue to be set into the chunkmap in the tick thread.
 	If the chunk data doesn't contain valid biomes, the biomes are calculated before adding the data into the queue. */
-	void QueueSetChunkData(const cSetChunkDataPtr & a_SetChunkData);
+	void QueueSetChunkData(cSetChunkData & a_SetChunkData);
 
 	void ChunkLighted(
 		int a_ChunkX, int a_ChunkZ,
@@ -267,9 +253,8 @@ public:
 
 	/** Removes the player from the world.
 	Removes the player from the addition queue, too, if appropriate.
-	If the player has a ClientHandle, the ClientHandle is removed from all chunks in the world and will not be ticked by this world anymore.
-	@param a_RemoveFromChunk determines if the entity should be removed from its chunk as well. Should be false when ticking from cChunk. */
-	void RemovePlayer(cPlayer * a_Player, bool a_RemoveFromChunk);
+	If the player has a ClientHandle, the ClientHandle is removed from all chunks in the world and will not be ticked by this world anymore. */
+	void RemovePlayer(cPlayer * a_Player);
 
 	/** Calls the callback for each player in the list; returns true if all players processed, false if the callback aborted by returning true */
 	virtual bool ForEachPlayer(cPlayerListCallback & a_Callback) override;  // >> EXPORTED IN MANUALBINDINGS <<
@@ -316,24 +301,12 @@ public:
 	void CompareChunkClients(int a_ChunkX1, int a_ChunkZ1, int a_ChunkX2, int a_ChunkZ2, cClientDiffCallback & a_Callback);
 
 	/** Adds client to a chunk, if not already present; returns true if added, false if present */
-	bool AddChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client);
+	bool AddChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client);
 
 	/** Removes client from the chunk specified */
-	void RemoveChunkClient(int a_ChunkX, int a_ChunkZ, cClientHandle * a_Client);
+	void RemoveChunkClient(int a_ChunkX, int a_ChunkZ, const std::shared_ptr<cClientHandle> & a_Client);
 
-	/** Removes the client from all chunks it is present in */
-	void RemoveClientFromChunks(cClientHandle * a_Client);
-
-	/** Sends the chunk to the client specified, if the client doesn't have the chunk yet.
-	If chunk not valid, the request is postponed (ChunkSender will send that chunk when it becomes valid + lighted). */
-	void SendChunkTo(int a_ChunkX, int a_ChunkZ, cChunkSender::eChunkPriority a_Priority, cClientHandle * a_Client);
-
-	/** Sends the chunk to the client specified, even if the client already has the chunk.
-	If the chunk's not valid, the request is postponed (ChunkSender will send that chunk when it becomes valid + lighted). */
-	void ForceSendChunkTo(int a_ChunkX, int a_ChunkZ, cChunkSender::eChunkPriority a_Priority, cClientHandle * a_Client);
-
-	/** Removes client from ChunkSender's queue of chunks to be sent */
-	void RemoveClientFromChunkSender(cClientHandle * a_Client);
+	cChunkSender & GetChunkSender(void) { return m_ChunkSender; }
 
 	/** Touches the chunk, causing it to be loaded or generated */
 	void TouchChunk(int a_ChunkX, int a_ChunkZ);
@@ -675,7 +648,13 @@ public:
 	void QueueSaveAllChunks(void);  // tolua_export
 
 	/** Queues a task onto the tick thread. The task object will be deleted once the task is finished */
-	void QueueTask(std::function<void(cWorld &)> a_Task);  // Exported in ManualBindings.cpp
+	template <typename FunctionType>
+	std::future<void> QueueTask(FunctionType && a_Task)  // Exported in ManualBindings.cpp
+	{
+		cCSLock Lock(m_CSTasks);
+		m_Tasks.emplace_back(-1, std::forward<FunctionType>(a_Task));
+		return m_Tasks.back().second.get_future();
+	}
 
 	/** Queues a lambda task onto the tick thread, with the specified delay. */
 	void ScheduleTask(int a_DelayTicks, std::function<void(cWorld &)> a_Task);
@@ -694,10 +673,16 @@ public:
 
 	cLightingThread & GetLightingThread(void) { return m_Lighting; }
 
-	void InitializeSpawn(void);
+	/** Starts the tick thread that belongs to this world. */
+	void Start(void) { m_TickThread.Start(); }
 
-	/** Starts threads that belong to this world */
-	void Start(void);
+	/** Performs one-off initial configuration of the world.
+	MUST be called within the context of the world tick thread. */
+	void Initialise(void);
+
+	/** Performs one-off initial configuration of the world spawn.
+	MUST be called within the context of the world tick thread. */
+	void InitialiseSpawn(void);
 
 	/** Stops threads that belong to this world (part of deinit) */
 	void Stop(void);
@@ -809,6 +794,14 @@ public:
 
 	cBroadcaster GetBroadcaster();
 
+#ifdef _DEBUG
+
+	/** Debug-only function to ensure the current execution is within the context of this world's tick thread
+	Enforces single-thread access requirements of cWorld, cChunkMap, cChunk, cEntity and descendants, etc. */
+	bool IsInTickThread(void) { return m_TickThread.IsCurrentThread(); }
+
+#endif
+
 private:
 
 	friend class cRoot;
@@ -846,8 +839,11 @@ private:
 
 	public:
 		cChunkGeneratorCallbacks(cWorld & a_World);
-	} ;
+	};
 
+	/** Flag to indicate whether cWorld::Tick should be called in cTickThread::Execute.
+	MUST NOT be mutated by a caller other than cWorld::Stop. */
+	bool m_ShouldTick;
 
 	AString m_WorldName;
 
@@ -909,8 +905,9 @@ private:
 	std::unique_ptr<cFireSimulator>      m_FireSimulator;
 	cRedstoneSimulator * m_RedstoneSimulator;
 
-	cCriticalSection m_CSPlayers;
-	cPlayerList      m_Players;
+	/** Stores pointers to all players in the world for easy access.
+	Players MUST be removed from this list through a call to RemovePlayer before they are destroyed. */
+	std::vector<cPlayer *> m_Players;
 
 	cWorldStorage     m_Storage;
 
@@ -982,41 +979,7 @@ private:
 	cCriticalSection m_CSTasks;
 
 	/** Tasks that have been queued onto the tick thread, possibly to be executed at target tick in the future; guarded by m_CSTasks */
-	std::vector<std::pair<Int64, std::function<void(cWorld &)>>> m_Tasks;
-
-	/** Guards m_Clients */
-	cCriticalSection  m_CSClients;
-
-	/** List of clients in this world, these will be ticked by this world */
-	cClientHandlePtrs m_Clients;
-
-	/** Clients that are scheduled for removal (ticked in another world), waiting for TickClients() to remove them */
-	cClientHandles m_ClientsToRemove;
-
-	/** Clients that are scheduled for adding, waiting for TickClients to add them */
-	cClientHandlePtrs m_ClientsToAdd;
-
-	/** Guards m_EntitiesToAdd */
-	cCriticalSection m_CSEntitiesToAdd;
-
-	/** List of entities that are scheduled for adding, waiting for the Tick thread to add them. */
-	cEntityList m_EntitiesToAdd;
-
-	/** Guards m_PlayersToAdd */
-	cCriticalSection m_CSPlayersToAdd;
-
-	/** List of players that are scheduled for adding, waiting for the Tick thread to add them. */
-	cPlayerList m_PlayersToAdd;
-
-	/** CS protecting m_SetChunkDataQueue. */
-	cCriticalSection m_CSSetChunkDataQueue;
-
-	/** Queue for the chunk data to be set into m_ChunkMap by the tick thread. Protected by m_CSSetChunkDataQueue */
-	cSetChunkDataPtrs m_SetChunkDataQueue;
-
-
-	cWorld(const AString & a_WorldName, eDimension a_Dimension = dimOverworld, const AString & a_LinkedOverworldName = "");
-	virtual ~cWorld();
+	std::vector<std::pair<Int64, std::packaged_task<void(cWorld &)>>> m_Tasks;
 
 	void Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_LastTickDurationMSec);
 
@@ -1029,23 +992,10 @@ private:
 	/** Executes all tasks queued onto the tick thread */
 	void TickQueuedTasks(void);
 
-	/** Ticks all clients that are in this world */
-	void TickClients(float a_Dt);
-
 	/** Unloads all chunks immediately. */
 	void UnloadUnusedChunks(void);
 
 	void UpdateSkyDarkness(void);
-
-	/** Generates a random spawnpoint on solid land by walking chunks and finding their biomes */
-	void GenerateRandomSpawn(int a_MaxSpawnRadius);
-
-	/** Can the specified coordinates be used as a spawn point?
-	Returns true if spawn position is valid and sets a_Y to the valid spawn height */
-	bool CanSpawnAt(double a_X, double & a_Y, double a_Z);
-
-	/** Check if player starting point is acceptable */
-	bool CheckPlayerSpawnPoint(int a_PosX, int a_PosY, int a_PosZ);
 
 	/** Chooses a reasonable transition from the current weather to a new weather */
 	eWeather ChooseNewWeather(void);
@@ -1055,10 +1005,6 @@ private:
 
 	/** Creates a new redstone simulator. */
 	cRedstoneSimulator * InitializeRedstoneSimulator(cIniFile & a_IniFile);
-
-	/** Adds the players queued in the m_PlayersToAdd queue into the m_Players list.
-	Assumes it is called from the Tick thread. */
-	void AddQueuedPlayers(void);
 
 	/** Sets generator values to dimension specific defaults, if those values do not exist */
 	void InitialiseGeneratorDefaults(cIniFile & a_IniFile);

--- a/src/World.h
+++ b/src/World.h
@@ -475,6 +475,9 @@ public:
 	bool DigBlock   (int a_X, int a_Y, int a_Z);
 	virtual void SendBlockTo(int a_X, int a_Y, int a_Z, cPlayer * a_Player) override;
 
+	/** Set default spawn at the given coordinates. */
+	bool SetSpawn(double a_X, double a_Y, double a_Z);
+
 	double GetSpawnX(void) const { return m_SpawnX; }
 	double GetSpawnY(void) const { return m_SpawnY; }
 	double GetSpawnZ(void) const { return m_SpawnZ; }

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -1651,7 +1651,7 @@ void cWSSAnvil::LoadBoatFromNBT(cEntityList & a_Entities, const cParsedNBT & a_N
 	{
 		return;
 	}
-	a_Entities.push_back(Boat.release());
+	a_Entities.emplace_back(std::move(Boat));
 }
 
 
@@ -1665,7 +1665,7 @@ void cWSSAnvil::LoadEnderCrystalFromNBT(cEntityList & a_Entities, const cParsedN
 	{
 		return;
 	}
-	a_Entities.push_back(EnderCrystal.release());
+	a_Entities.emplace_back(std::move(EnderCrystal));
 }
 
 
@@ -1690,7 +1690,7 @@ void cWSSAnvil::LoadFallingBlockFromNBT(cEntityList & a_Entities, const cParsedN
 	{
 		return;
 	}
-	a_Entities.push_back(FallingBlock.release());
+	a_Entities.emplace_back(std::move(FallingBlock));
 }
 
 
@@ -1704,7 +1704,7 @@ void cWSSAnvil::LoadMinecartRFromNBT(cEntityList & a_Entities, const cParsedNBT 
 	{
 		return;
 	}
-	a_Entities.push_back(Minecart.release());
+	a_Entities.emplace_back(std::move(Minecart));
 }
 
 
@@ -1736,7 +1736,7 @@ void cWSSAnvil::LoadMinecartCFromNBT(cEntityList & a_Entities, const cParsedNBT 
 			Minecart->SetSlot(a_NBT.GetByte(Slot), Item);
 		}
 	}  // for itr - ItemDefs[]
-	a_Entities.push_back(Minecart.release());
+	a_Entities.emplace_back(std::move(Minecart));
 }
 
 
@@ -1753,7 +1753,7 @@ void cWSSAnvil::LoadMinecartFFromNBT(cEntityList & a_Entities, const cParsedNBT 
 
 	// TODO: Load the Push and Fuel tags
 
-	a_Entities.push_back(Minecart.release());
+	a_Entities.emplace_back(std::move(Minecart));
 }
 
 
@@ -1770,7 +1770,7 @@ void cWSSAnvil::LoadMinecartTFromNBT(cEntityList & a_Entities, const cParsedNBT 
 
 	// TODO: Everything to do with TNT carts
 
-	a_Entities.push_back(Minecart.release());
+	a_Entities.emplace_back(std::move(Minecart));
 }
 
 
@@ -1787,7 +1787,7 @@ void cWSSAnvil::LoadMinecartHFromNBT(cEntityList & a_Entities, const cParsedNBT 
 
 	// TODO: Everything to do with hopper carts
 
-	a_Entities.push_back(Minecart.release());
+	a_Entities.emplace_back(std::move(Minecart));
 }
 
 
@@ -1821,7 +1821,7 @@ void cWSSAnvil::LoadPickupFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		Pickup->SetAge(a_NBT.GetShort(Age));
 	}
 
-	a_Entities.push_back(Pickup.release());
+	a_Entities.emplace_back(std::move(Pickup));
 }
 
 
@@ -1843,7 +1843,7 @@ void cWSSAnvil::LoadTNTFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NB
 		TNT->SetFuseTicks(static_cast<int>(a_NBT.GetByte(FuseTicks)));
 	}
 
-	a_Entities.push_back(TNT.release());
+	a_Entities.emplace_back(std::move(TNT));
 }
 
 
@@ -1872,7 +1872,7 @@ void cWSSAnvil::LoadExpOrbFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		ExpOrb->SetReward(a_NBT.GetShort(Reward));
 	}
 
-	a_Entities.push_back(ExpOrb.release());
+	a_Entities.emplace_back(std::move(ExpOrb));
 }
 
 
@@ -1937,7 +1937,7 @@ void cWSSAnvil::LoadItemFrameFromNBT(cEntityList & a_Entities, const cParsedNBT 
 		ItemFrame->SetItemRotation(static_cast<Byte>(a_NBT.GetByte(Rotation)));
 	}
 
-	a_Entities.push_back(ItemFrame.release());
+	a_Entities.emplace_back(std::move(ItemFrame));
 }
 
 
@@ -1960,7 +1960,7 @@ void cWSSAnvil::LoadPaintingFromNBT(cEntityList & a_Entities, const cParsedNBT &
 	}
 
 	LoadHangingFromNBT(*Painting.get(), a_NBT, a_TagIdx);
-	a_Entities.push_back(Painting.release());
+	a_Entities.emplace_back(std::move(Painting));
 }
 
 
@@ -2031,7 +2031,7 @@ void cWSSAnvil::LoadArrowFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 	}
 
 	// Store the new arrow in the entities list:
-	a_Entities.push_back(Arrow.release());
+	a_Entities.emplace_back(std::move(Arrow));
 }
 
 
@@ -2054,7 +2054,7 @@ void cWSSAnvil::LoadSplashPotionFromNBT(cEntityList & a_Entities, const cParsedN
 	SplashPotion->SetPotionColor(a_NBT.FindChildByName(a_TagIdx, "PotionName"));
 
 	// Store the new splash potion in the entities list:
-	a_Entities.push_back(SplashPotion.release());
+	a_Entities.emplace_back(std::move(SplashPotion));
 }
 
 
@@ -2070,7 +2070,7 @@ void cWSSAnvil::LoadSnowballFromNBT(cEntityList & a_Entities, const cParsedNBT &
 	}
 
 	// Store the new snowball in the entities list:
-	a_Entities.push_back(Snowball.release());
+	a_Entities.emplace_back(std::move(Snowball));
 }
 
 
@@ -2086,7 +2086,7 @@ void cWSSAnvil::LoadEggFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NB
 	}
 
 	// Store the new egg in the entities list:
-	a_Entities.push_back(Egg.release());
+	a_Entities.emplace_back(std::move(Egg));
 }
 
 
@@ -2102,7 +2102,7 @@ void cWSSAnvil::LoadFireballFromNBT(cEntityList & a_Entities, const cParsedNBT &
 	}
 
 	// Store the new fireball in the entities list:
-	a_Entities.push_back(Fireball.release());
+	a_Entities.emplace_back(std::move(Fireball));
 }
 
 
@@ -2118,7 +2118,7 @@ void cWSSAnvil::LoadFireChargeFromNBT(cEntityList & a_Entities, const cParsedNBT
 	}
 
 	// Store the new FireCharge in the entities list:
-	a_Entities.push_back(FireCharge.release());
+	a_Entities.emplace_back(std::move(FireCharge));
 }
 
 
@@ -2134,7 +2134,7 @@ void cWSSAnvil::LoadThrownEnderpearlFromNBT(cEntityList & a_Entities, const cPar
 	}
 
 	// Store the new enderpearl in the entities list:
-	a_Entities.push_back(Enderpearl.release());
+	a_Entities.emplace_back(std::move(Enderpearl));
 }
 
 
@@ -2154,7 +2154,7 @@ void cWSSAnvil::LoadBatFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NB
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2174,7 +2174,7 @@ void cWSSAnvil::LoadBlazeFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2194,7 +2194,7 @@ void cWSSAnvil::LoadCaveSpiderFromNBT(cEntityList & a_Entities, const cParsedNBT
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2214,7 +2214,7 @@ void cWSSAnvil::LoadChickenFromNBT(cEntityList & a_Entities, const cParsedNBT & 
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2234,7 +2234,7 @@ void cWSSAnvil::LoadCowFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NB
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2254,7 +2254,7 @@ void cWSSAnvil::LoadCreeperFromNBT(cEntityList & a_Entities, const cParsedNBT & 
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2274,7 +2274,7 @@ void cWSSAnvil::LoadEnderDragonFromNBT(cEntityList & a_Entities, const cParsedNB
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2294,7 +2294,7 @@ void cWSSAnvil::LoadEndermanFromNBT(cEntityList & a_Entities, const cParsedNBT &
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2314,7 +2314,7 @@ void cWSSAnvil::LoadGhastFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2334,7 +2334,7 @@ void cWSSAnvil::LoadGiantFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2354,7 +2354,7 @@ void cWSSAnvil::LoadGuardianFromNBT(cEntityList & a_Entities, const cParsedNBT &
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2400,7 +2400,7 @@ void cWSSAnvil::LoadHorseFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2420,7 +2420,7 @@ void cWSSAnvil::LoadIronGolemFromNBT(cEntityList & a_Entities, const cParsedNBT 
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2449,7 +2449,7 @@ void cWSSAnvil::LoadMagmaCubeFromNBT(cEntityList & a_Entities, const cParsedNBT 
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2469,7 +2469,7 @@ void cWSSAnvil::LoadMooshroomFromNBT(cEntityList & a_Entities, const cParsedNBT 
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2502,7 +2502,7 @@ void cWSSAnvil::LoadOcelotFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2535,7 +2535,7 @@ void cWSSAnvil::LoadPigFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NB
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2579,7 +2579,7 @@ void cWSSAnvil::LoadRabbitFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2625,7 +2625,7 @@ void cWSSAnvil::LoadSheepFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2645,7 +2645,7 @@ void cWSSAnvil::LoadSilverfishFromNBT(cEntityList & a_Entities, const cParsedNBT
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2673,7 +2673,7 @@ void cWSSAnvil::LoadSkeletonFromNBT(cEntityList & a_Entities, const cParsedNBT &
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2702,7 +2702,7 @@ void cWSSAnvil::LoadSlimeFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2722,7 +2722,7 @@ void cWSSAnvil::LoadSnowGolemFromNBT(cEntityList & a_Entities, const cParsedNBT 
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2742,7 +2742,7 @@ void cWSSAnvil::LoadSpiderFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2762,7 +2762,7 @@ void cWSSAnvil::LoadSquidFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2804,7 +2804,7 @@ void cWSSAnvil::LoadVillagerFromNBT(cEntityList & a_Entities, const cParsedNBT &
 	}
 
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2824,7 +2824,7 @@ void cWSSAnvil::LoadWitchFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 		return;
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2850,7 +2850,7 @@ void cWSSAnvil::LoadWitherFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		Monster->SetWitherInvulnerableTicks(static_cast<unsigned int>(a_NBT.GetInt(CurrLine)));
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2917,7 +2917,7 @@ void cWSSAnvil::LoadWolfFromNBT(cEntityList & a_Entities, const cParsedNBT & a_N
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2958,7 +2958,7 @@ void cWSSAnvil::LoadZombieFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 
@@ -2991,7 +2991,7 @@ void cWSSAnvil::LoadPigZombieFromNBT(cEntityList & a_Entities, const cParsedNBT 
 		Monster->SetAge(Age);
 	}
 
-	a_Entities.push_back(Monster.release());
+	a_Entities.emplace_back(std::move(Monster));
 }
 
 


### PR DESCRIPTION
This is a branch by @tigerw.
Opening a PR for the sake of convenient commenting. See #3113
- Hopefully alleviated many deadlocks/crashes/unclear ownership relations/etc.
- Miscellaneous fixes

---

LogicParrot comments (Continously updated):

Code comments:
- DoMoveToWorld API call - You have deprecated this and now it shows a warning. In the new version, the "destination position is mandatory". Why so? In current master, not specifying destination position leads to the spawnpoint, a perfectly useful use case.
- Potentially too many world change related variables - See my first comment in this thread. This is a burden from the current master, but you've added an additional variable, and there's a chance we can actually eliminate some redundancy.

Ingame testing comments:
- The branch fails the "wolf test"; tamed Wolves have intricate interactions with mobs and players, and trying them is a somewhat strict test. Playing around with tamed wolves currently crashes the server.
- The server crashes when breaking a block in survival mode.
- The server crashes when a skeleton kills a zombie.
- Nether portals do not work.
- Logging out in survival mode while targeted by a zombie crashes the server.

*Note that crashes include debugmode assertion failures.
