### PR TITLE
Improve Player freeze code

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1946,7 +1946,6 @@ a_Player:OpenWindow(Window);
 				GetFoodPoisonedTicksRemaining = { Params = "", Return = "", Notes = "Returns the number of ticks left for the food posoning effect" },
 				GetFoodSaturationLevel = { Params = "", Return = "number", Notes = "Returns the food saturation (overcharge of the food level, is depleted before food level)" },
 				GetFoodTickTimer = { Params = "", Return = "", Notes = "Returns the number of ticks past the last food-based heal or damage action; when this timer reaches 80, a new heal / damage is applied." },
-				GetFrozenDuration = { Params = "", Return = "number", Notes = "Returns the number of ticks since the player was frozen" },
 				GetGameMode = { Return = "{{Globals#GameMode|GameMode}}", Notes = "Returns the player's gamemode. The player may have their gamemode unassigned, in which case they inherit the gamemode from the current {{cWorld|world}}.<br /> <b>NOTE:</b> Instead of comparing the value returned by this function to the gmXXX constants, use the IsGameModeXXX() functions. These functions handle the gamemode inheritance automatically."},
 				GetIP = { Return = "string", Notes = "Returns the IP address of the player, if available. Returns an empty string if there's no IP to report."},
 				GetInventory = { Return = "{{cInventory|Inventory}}", Notes = "Returns the player's inventory"},

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -604,7 +604,19 @@ void cChunk::SpawnMobs(cMobSpawner & a_MobSpawner)
 
 void cChunk::Tick(std::chrono::milliseconds a_Dt)
 {
-	m_IsInTick = true;
+	// If we are not valid, tick players and bailout
+	if (!IsValid())
+	{
+		for (auto Entity : m_Entities)
+		{
+			if (Entity->IsPlayer())
+			{
+				Entity->Tick(a_Dt, *this);
+			}
+		}
+		return;
+	}
+
 	BroadcastPendingBlockChanges();
 
 	CheckBlocks();
@@ -668,7 +680,6 @@ void cChunk::Tick(std::chrono::milliseconds a_Dt)
 	}  // for itr - m_Entitites[]
 
 	ApplyWeatherToTop();
-	m_IsInTick = false;
 }
 
 

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -502,7 +502,6 @@ private:
 
 	/** If the chunk fails to load, should it be queued in the generator or reset back to invalid? */
 	bool m_ShouldGenerateIfLoadFailed;
-	bool m_IsInTick;       // True if the chunk is executing the tick() method.
 	bool m_IsLightValid;   // True if the blocklight and skylight are calculated
 	bool m_IsDirty;        // True if the chunk has changed since it was last saved
 	bool m_IsSaving;       // True if the chunk is being saved

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -2920,8 +2920,9 @@ void cChunkMap::cChunkLayer::Tick(std::chrono::milliseconds a_Dt)
 {
 	for (size_t i = 0; i < ARRAYCOUNT(m_Chunks); i++)
 	{
-		// Only tick chunks that are valid and should be ticked:
-		if ((m_Chunks[i] != nullptr) && m_Chunks[i]->IsValid() && m_Chunks[i]->ShouldBeTicked())
+		// Only tick chunks that should be ticked:
+		// Note that chunks that are not IsValid() will only tick players and then bailout
+		if ((m_Chunks[i] != nullptr) && m_Chunks[i]->ShouldBeTicked())
 		{
 			m_Chunks[i]->Tick(a_Dt);
 		}

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -365,6 +365,8 @@ public:  // tolua_export
 
 	void InvalidateCachedSentChunk();
 
+	bool IsPlayerChunkSent();
+
 private:
 
 	friend class cServer;  // Needs access to SetSelf()

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -50,7 +50,7 @@ public:
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
-	void TickFreezeCode(bool a_MyChunkIsSent);
+	void TickFreezeCode();
 
 	virtual void HandlePhysics(std::chrono::milliseconds a_Dt, cChunk &) override { UNUSED(a_Dt); }
 
@@ -147,9 +147,6 @@ public:
 
 	/** Is the player frozen? */
 	bool IsFrozen();
-
-	/** How long has the player been frozen? */
-	int GetFrozenDuration();
 
 	/** Cancels Freeze(...) and allows the player to move naturally. */
 	void Unfreeze();
@@ -605,14 +602,8 @@ protected:
 
 	cSlotNums m_InventoryPaintSlots;
 
-	/** if m_IsFrozen is true, we lock m_Location to this position. */
-	Vector3d m_FrozenPosition;
-
 	/** If true, we are locking m_Position to m_FrozenPosition. */
 	bool m_IsFrozen;
-
-	/** */
-	int m_FreezeCounter;
 
 	/** Was the player frozen manually by a plugin or automatically by the server? */
 	bool m_IsManuallyFrozen;


### PR DESCRIPTION
- Closes #3123
- Closes #3122
- Almost eliminates freeze-related clientside jitter by implementing client-side freeze
- Players now tick even in unloaded chunks
- Removes unneeded member variables (@tigerw)