### PR TITLE
Updated cChunk::SetMeta, fixed grass growth

### DIFF
--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -250,7 +250,6 @@ void cBlockInfo::Initialize(cBlockInfoArray & a_Info)
 	a_Info[E_BLOCK_REDSTONE_WIRE       ].m_Transparent = true;
 	a_Info[E_BLOCK_SAPLING             ].m_Transparent = true;
 	a_Info[E_BLOCK_SIGN_POST           ].m_Transparent = true;
-	a_Info[E_BLOCK_SNOW                ].m_Transparent = true;
 	a_Info[E_BLOCK_SPRUCE_DOOR         ].m_Transparent = true;
 	a_Info[E_BLOCK_SPRUCE_FENCE        ].m_Transparent = true;
 	a_Info[E_BLOCK_SPRUCE_FENCE_GATE   ].m_Transparent = true;

--- a/src/Blocks/BlockDirt.h
+++ b/src/Blocks/BlockDirt.h
@@ -51,8 +51,8 @@ public:
 		{
 			BLOCKTYPE above = a_Chunk.GetBlock(a_RelX, a_RelY + 1, a_RelZ);
 
-			// Grass turns back to dirt when the block above is not transparent
-			if (!cBlockInfo::IsTransparent(above))
+			// Grass turns back to dirt when the block above it is not transparent or water
+			if (!cBlockInfo::IsTransparent(above) || IsBlockWater(above))
 			{
 				a_Chunk.FastSetBlock(a_RelX, a_RelY, a_RelZ, E_BLOCK_DIRT, E_META_DIRT_NORMAL);
 				return;
@@ -97,10 +97,13 @@ public:
 				// Not a regular dirt block
 				continue;
 			}
-			BLOCKTYPE above = a_Chunk.GetBlock(BlockX, BlockY + 1, BlockZ);
-			NIBBLETYPE light = std::max(a_Chunk.GetBlockLight(BlockX, BlockY + 1, BlockZ), a_Chunk.GetTimeAlteredLight(a_Chunk.GetSkyLight(BlockX, BlockY + 1, BlockZ)));
-			// Grass does not spread to blocks with a light level less than 5
-			if ((light > 4)  && cBlockInfo::IsTransparent(above))
+			BLOCKTYPE above = Chunk->GetBlock(BlockX, BlockY + 1, BlockZ);
+			NIBBLETYPE light = std::max(Chunk->GetBlockLight(BlockX, BlockY + 1, BlockZ), Chunk->GetTimeAlteredLight(Chunk->GetSkyLight(BlockX, BlockY + 1, BlockZ)));
+			if ((light > 4)  &&
+				cBlockInfo::IsTransparent(above) &&
+				(!IsBlockLava(above)) &&
+				(!IsBlockWaterOrIce(above))
+			)
 			{
 				if (!cRoot::Get()->GetPluginManager()->CallHookBlockSpread(*Chunk->GetWorld(), Chunk->GetPosX() * cChunkDef::Width + BlockX, BlockY, Chunk->GetPosZ() * cChunkDef::Width + BlockZ, ssGrassSpread))
 				{

--- a/src/Blocks/BlockLeaves.h
+++ b/src/Blocks/BlockLeaves.h
@@ -79,7 +79,7 @@ public:
 		NIBBLETYPE Meta = a_ChunkInterface.GetBlockMeta(a_BlockX, a_BlockY, a_BlockZ);
 		if ((Meta & 0x08) != 0)
 		{
-			a_ChunkInterface.SetBlockMeta(a_BlockX, a_BlockY, a_BlockZ, Meta & 0x7);
+			a_ChunkInterface.SetBlockMeta(a_BlockX, a_BlockY, a_BlockZ, Meta & 0x7, false, false);
 		}
 	}
 
@@ -116,8 +116,10 @@ public:
 
 		if (HasNearLog(Area, BlockX, a_RelY, BlockZ))
 		{
-			// Wood found, the leaves stay; mark them as checked:
-			a_Chunk.SetMeta(a_RelX, a_RelY, a_RelZ, Meta | 0x8);
+			// Wood found, the leaves stay; mark them as checked.
+			// There is no point in saving this to disk or informing the client
+			// So we use SetMetaQuiet
+			a_Chunk.SetMeta(a_RelX, a_RelY, a_RelZ, Meta | 0x8, false, false);
 			return;
 		}
 

--- a/src/Blocks/ChunkInterface.cpp
+++ b/src/Blocks/ChunkInterface.cpp
@@ -61,13 +61,10 @@ void cChunkInterface::SetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTY
 
 
 
-
-void cChunkInterface::SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_MetaData)
+void cChunkInterface::SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_MetaData, bool a_ShouldMarkDirty, bool a_ShouldInformClient)
 {
-	m_ChunkMap->SetBlockMeta(a_BlockX, a_BlockY, a_BlockZ, a_MetaData);
+	m_ChunkMap->SetBlockMeta(a_BlockX, a_BlockY, a_BlockZ, a_MetaData, a_ShouldMarkDirty, a_ShouldInformClient);
 }
-
-
 
 
 

--- a/src/Blocks/ChunkInterface.h
+++ b/src/Blocks/ChunkInterface.h
@@ -27,7 +27,7 @@ public:
 	*/
 	void SetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 
-	void SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_MetaData);
+	void SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_MetaData, bool a_ShouldMarkDirty = true, bool a_ShouldInformClient = true);
 
 	/** Sets the block at the specified coords to the specified value.
 	The replacement doesn't trigger block updates.

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -392,15 +392,24 @@ public:
 	{
 		return m_ChunkData.GetMeta(a_RelX, a_RelY, a_RelZ);
 	}
-	inline void       SetMeta(int a_RelX, int a_RelY, int a_RelZ, NIBBLETYPE a_Meta)
+
+	/** Set a meta value, with the option of not informing the client and / or not marking dirty.
+	Used for setting metas that are of little value for saving to disk and / or for sending to the client,
+	such as leaf decay flags. */
+	inline void SetMeta(int a_RelX, int a_RelY, int a_RelZ, NIBBLETYPE a_Meta, bool a_ShouldMarkDirty = true, bool a_ShouldInformClient = true)
 	{
 			bool hasChanged = m_ChunkData.SetMeta(a_RelX, a_RelY, a_RelZ, a_Meta);
 			if (hasChanged)
 			{
-				MarkDirty();
 				m_IsRedstoneDirty = true;
-
-				m_PendingSendBlocks.push_back(sSetBlock(m_PosX, m_PosZ, a_RelX, a_RelY, a_RelZ, GetBlock(a_RelX, a_RelY, a_RelZ), a_Meta));
+				if (a_ShouldMarkDirty)
+				{
+					MarkDirty();
+				}
+				if (a_ShouldInformClient)
+				{
+					m_PendingSendBlocks.push_back(sSetBlock(m_PosX, m_PosZ, a_RelX, a_RelY, a_RelZ, GetBlock(a_RelX, a_RelY, a_RelZ), a_Meta));
+				}
 			}
 	}
 

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1230,7 +1230,7 @@ NIBBLETYPE cChunkMap::GetBlockBlockLight(int a_BlockX, int a_BlockY, int a_Block
 
 
 
-void cChunkMap::SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_BlockMeta)
+void cChunkMap::SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_BlockMeta, bool a_ShouldMarkDirty, bool a_ShouldInformClient)
 {
 	int ChunkX, ChunkZ;
 	cChunkDef::AbsoluteToRelative(a_BlockX, a_BlockY, a_BlockZ, ChunkX, ChunkZ);
@@ -1240,7 +1240,7 @@ void cChunkMap::SetBlockMeta(int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYP
 	cChunkPtr Chunk = GetChunk(ChunkX, ChunkZ);
 	if ((Chunk != nullptr) && Chunk->IsValid())
 	{
-		Chunk->SetMeta(a_BlockX, a_BlockY, a_BlockZ, a_BlockMeta);
+		Chunk->SetMeta(a_BlockX, a_BlockY, a_BlockZ, a_BlockMeta, a_ShouldMarkDirty, a_ShouldInformClient);
 	}
 }
 

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -159,7 +159,7 @@ public:
 	NIBBLETYPE GetBlockMeta      (int a_BlockX, int a_BlockY, int a_BlockZ);
 	NIBBLETYPE GetBlockSkyLight  (int a_BlockX, int a_BlockY, int a_BlockZ);
 	NIBBLETYPE GetBlockBlockLight(int a_BlockX, int a_BlockY, int a_BlockZ);
-	void       SetBlockMeta      (int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_BlockMeta);
+	void       SetBlockMeta      (int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_BlockMeta, bool a_ShouldMarkDirty, bool a_ShouldInformClient);
 	void       SetBlock          (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_SendToClients = true);
 	bool       GetBlockTypeMeta  (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta);
 	bool       GetBlockInfo      (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2030,9 +2030,11 @@ void cWorld::SetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_Bloc
 
 
 
-void cWorld::SetBlockMeta(int a_X, int a_Y, int a_Z, NIBBLETYPE a_MetaData)
+
+
+void cWorld::SetBlockMeta(int a_X, int a_Y, int a_Z, NIBBLETYPE a_MetaData, bool a_ShouldMarkDirty, bool a_ShouldInformClient)
 {
-	m_ChunkMap->SetBlockMeta(a_X, a_Y, a_Z, a_MetaData);
+	m_ChunkMap->SetBlockMeta(a_X, a_Y, a_Z, a_MetaData, a_ShouldMarkDirty, a_ShouldInformClient);
 }
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -401,7 +401,8 @@ public:
 	{
 		return m_ChunkMap->GetBlockMeta(a_BlockX, a_BlockY, a_BlockZ);
 	}
-	void       SetBlockMeta      (int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_MetaData);
+
+	void       SetBlockMeta      (int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_MetaData, bool a_ShouldMarkDirty = true, bool a_ShouldInformClient = true);
 	NIBBLETYPE GetBlockSkyLight  (int a_BlockX, int a_BlockY, int a_BlockZ);
 	NIBBLETYPE GetBlockBlockLight(int a_BlockX, int a_BlockY, int a_BlockZ);
 


### PR DESCRIPTION
This PR resolves the grass underground spread issue  (#2850), also, it stops leaves decay checks from sending needless packets to the client and needless writing to disk. This is part of the solution for #3110.

Closes #2850.