### PR TITLE
Save chunks more often to reduce RAM usage

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -215,7 +215,6 @@ bool cChunk::CanUnload(void)
 {
 	return
 		m_LoadedByClient.empty() &&  // The chunk is not used by any client
-		!m_IsDirty &&                // The chunk has been saved properly or hasn't been touched since the load / gen
 		(m_StayCount == 0) &&        // The chunk is not in a ChunkStay
 		(m_Presence != cpQueued) ;   // The chunk is not queued for loading / generating (otherwise multi-load / multi-gen could occur)
 }


### PR DESCRIPTION
Please discuss!

In Cuberite, a dirty chunk is a chunk which has changes that are yet unsaved to storage.
Every 300 seconds, there is a save cycle: chunks are scanned, dirty chunks are saved to disk and become non dirty.
Every 10 seconds, there is an unload cycle: chunks are scanned, unused, non-dirty chunks are freed from ram.

There's a problem here: An **unused dirty** chunk that wants to unload has to wait in RAM for up to 300 seconds until the save cycle, only then it may unload.

I made a simple change:
- Used chunks are saved every 300 seconds in the save cycle, just like before.
- Unused chunks are saved immediately in the unload cycle and then get unloaded, rather than waiting for the save cycle.

The result was astounding. I had a player fly in a straight line in standard for a while and test both cases.

**Case 1: The master branch. (Debug mode)**
Upon login, there were ~300 loaded chunks. As I flied in a straight line, loaded chunks accumilated until reaching ~3000, then 5 minutes passed and the save cycle triggered, my pc lagged for 20 seconds, and then there was a rapid drop in loaded chunks until settling back at ~300.
Ram usage peak was ~320 MB.

Here is a gif of the accumilation, and an image of the sudden drop.
![bad](https://cloud.githubusercontent.com/assets/5030488/14527738/aa956076-0254-11e6-9005-927e3726f927.gif)
![thedrop](https://cloud.githubusercontent.com/assets/5030488/14527739/ac8becce-0254-11e6-9f8c-5fb0e87c1985.png)

**Case 2: My PR. (Debug mode)**
Upon login, there were ~300 loaded chunks. Flying never changed that significantly, the amount of loaded chunks never surpassed 630. Ram usage peaked at about 100MB.

Here is a gif of the lack of accumilation.
![good](https://cloud.githubusercontent.com/assets/5030488/14527756/c33dbf10-0254-11e6-9bfa-6f797c265377.gif)


- Note that in both test cases, RAM usage would have been far less in release mode.
- The difference would have been bigger for faster flying speeds.