### PR TITLE
Auto clean bad world linkages

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -345,6 +345,7 @@ void cClientHandle::Authenticate(const AString & a_Name, const AString & a_UUID,
 	if (World == nullptr)
 	{
 		World = cRoot::Get()->GetDefaultWorld();
+		m_Player->SetPosition(World->GetSpawnX(), World->GetSpawnY(), World->GetSpawnZ());
 	}
 
 	if (m_Player->GetGameMode() == eGameMode_NotSet)

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -410,7 +410,7 @@ void cRoot::LoadWorlds(cSettingsRepositoryInterface & a_Settings, bool a_IsNewIn
 					a_Settings.AddValue("Worlds", "World", "world_nether");
 					a_Settings.AddValue("Worlds", "World", "world_end");
 					Worlds = a_Settings.GetValues("Worlds");  // Refresh the Worlds list so that the rest of the function works as usual
-					LOG("The server detected an old default config with bad world linkages. This has been autofixed by adding \"world_nether\" and \"world_end\" to settings.ini");
+					LOG("The server detected an old default config with bad world linkages. This has been autofixed by adding \"world_nether\" and \"world_end\" to settings.ini. If you do not want this autofix to trigger, please remove the nether and / or end from settings.ini and from world/world.ini");
 				}
 			}
 		}

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -530,38 +530,36 @@ void cWorld::Start(void)
 		m_LinkedOverworldName = IniFile.GetValueSet("LinkedWorlds", "OverworldName", GetLinkedOverworldName());
 	}
 
-	// If we are linked to one or more worlds that do not exist, ask the server to stop.
-	AString BadWorlds = "";
+	// If we are linked to one or more worlds that do not exist, unlink them
 	cRoot * Root = cRoot::Get();
 	if (GetDimension() == dimOverworld)
 	{
 		if ((!m_LinkedNetherWorldName.empty()) && (Root->GetWorld(m_LinkedNetherWorldName) == nullptr))
 		{
-			BadWorlds = m_LinkedNetherWorldName;
+			IniFile.SetValue("LinkedWorlds", "NetherWorldName", "");
+			LOG("%s Is linked to a nonexisting nether world called \"%s\". The server has modified \"%s/world.ini\" and removed this invalid link.",
+				GetName().c_str(), m_LinkedNetherWorldName.c_str(), GetName().c_str());
+			m_LinkedNetherWorldName = "";
 		}
 		if ((!m_LinkedEndWorldName.empty()) && (Root->GetWorld(m_LinkedEndWorldName) == nullptr))
 		{
-			if (!(BadWorlds.empty()))
-			{
-				BadWorlds += ", ";
-			}
-			BadWorlds += m_LinkedEndWorldName;
+			IniFile.SetValue("LinkedWorlds", "EndWorldName", "");
+			LOG("%s Is linked to a nonexisting end world called \"%s\". The server has modified \"%s/world.ini\" and removed this invalid link.",
+				GetName().c_str(), m_LinkedEndWorldName.c_str(), GetName().c_str());
+			m_LinkedEndWorldName = "";
 		}
 	}
 	else
 	{
 		if ((!m_LinkedOverworldName.empty()) && (Root->GetWorld(m_LinkedOverworldName) == nullptr))
 		{
-			BadWorlds = m_LinkedOverworldName;
+			IniFile.SetValue("LinkedWorlds", "OverworldName", "");
+			LOG("%s Is linked to a nonexisting overworld called \"%s\". The server has modified \"%s/world.ini\" and removed this invalid link.",
+				GetName().c_str(), m_LinkedOverworldName.c_str(), GetName().c_str());
+			m_LinkedOverworldName = "";
 		}
 	}
-	if (!BadWorlds.empty())
-	{
-		const char * WorldName = m_WorldName.c_str();
-		LOGERROR("\n###### ERROR: \"%s\" is linked to the following nonexisting world/s:\n%s\n\nPlease edit %s/world.ini and fix this.\n\nNote that the server started enforcing proper world linkages recently. And people with older configs may naturally get this error. If you just want a working default config and don't mind losing this world, delete the folder \"%s\" and the server will receate one for you. Otherwise edit the world.ini file and fix the invalid linkages.\n\nMore help and info:\nhttps://forum.cuberite.org/thread-2366.html\n######\n",
-			WorldName, BadWorlds.c_str(), WorldName, WorldName);
-		cRoot::Get()->StopServer();
-	}
+
 
 
 	// Adjust the enum-backed variables into their respective bounds:


### PR DESCRIPTION
Right now, the server refuses to start when a `world.ini` has nonexisting worlds. This is confusing for people, and we published a [full guide](https://forum.cuberite.org/thread-2366.html). After this PR, the server will simply remove bad linkages on startup (A message will appear in the console, telling the player that the server has done this).

Justifying scenario: If an admin removes world_nether from settings.ini in an attempt to disable the nether, the server refuses to start without this PR. The admin expects it to start as usual, without the nether. After this PR, the server will "garbage collect" world_nether and remove it from every linkage it was referenced from.

In short, if a world has `LinkedWorldName=my_Deleted_world` and then  `my_deleted_world` is removed from `settings.ini`, the server sets `LinkedWorldName` to blank.