### PR TITLE
Smart chunk unloading

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ SET (SRCS
 	Logger.cpp
 	Map.cpp
 	MapManager.cpp
+	MemoryCounter.cpp
 	MemorySettingsRepository.cpp
 	MobCensus.cpp
 	MobFamilyCollecter.cpp
@@ -127,6 +128,7 @@ SET (HDRS
 	Map.h
 	MapManager.h
 	Matrix4.h
+	MemoryCounter.h
 	MemorySettingsRepository.h
 	MobCensus.h
 	MobFamilyCollecter.h

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -74,17 +74,17 @@ cChunk::cChunk(
 	cAllocationPool<cChunkData::sChunkSection> & a_Pool
 ) :
 	m_Presence(cpInvalid),
+	m_CanUnload(true),
+	m_SaveStatus(eSaveStatus::CLEAN),
 	m_ShouldGenerateIfLoadFailed(false),
 	m_IsLightValid(false),
-	m_IsDirty(false),
-	m_IsSaving(false),
 	m_HasLoadFailed(false),
 	m_StayCount(0),
 	m_PosX(a_ChunkX),
 	m_PosZ(a_ChunkZ),
 	m_World(a_World),
 	m_ChunkMap(a_ChunkMap),
-	m_ChunkData(a_Pool),
+	m_ChunkData(a_Pool, a_World->GetMemoryCounter()),
 	m_BlockTickX(0),
 	m_BlockTickY(0),
 	m_BlockTickZ(0),
@@ -113,6 +113,8 @@ cChunk::cChunk(
 	{
 		a_NeighborZP->m_NeighborZM = this;
 	}
+	m_World->GetMemoryCounter().IncrementCanUnloadCount();
+	m_World->GetMemoryCounter().IncrementApproximateChunkRAM(sizeof(cChunk));
 }
 
 
@@ -121,6 +123,9 @@ cChunk::cChunk(
 
 cChunk::~cChunk()
 {
+	ASSERT(m_CanUnload);
+	m_World->GetMemoryCounter().DecrementCanUnloadCount();
+	m_World->GetMemoryCounter().DecrementApproximateChunkRAM(sizeof(cChunk));
 	cPluginManager::Get()->CallHookChunkUnloaded(*m_World, m_PosX, m_PosZ);
 
 	// LOGINFO("### delete cChunk() (%i, %i) from %p, thread 0x%x ###", m_PosX, m_PosZ, this, GetCurrentThreadId());
@@ -179,6 +184,7 @@ void cChunk::SetPresence(cChunk::ePresence a_Presence)
 	{
 		m_World->GetChunkMap()->ChunkValidated();
 	}
+	UpdateCanUnload();
 }
 
 
@@ -212,11 +218,28 @@ void cChunk::MarkRegenerating(void)
 
 bool cChunk::CanUnload(void)
 {
-	return
-		m_LoadedByClient.empty() &&  // The chunk is not used by any client
-		!m_IsDirty &&                // The chunk has been saved properly or hasn't been touched since the load / gen
-		(m_StayCount == 0) &&        // The chunk is not in a ChunkStay
-		(m_Presence != cpQueued) ;   // The chunk is not queued for loading / generating (otherwise multi-load / multi-gen could occur)
+	return m_CanUnload;
+}
+
+
+
+
+
+bool cChunk::IsUnused()
+{
+	return m_LoadedByClient.empty() &&  // The chunk is not used by any client
+	(m_StayCount == 0) &&               // The chunk is not in a ChunkStay
+	(m_Presence != cpQueued) ;          // The chunk is not queued for loading / generating (otherwise multi-load / multi-gen could occur)
+}
+
+
+
+
+
+void cChunk::MarkQueuedSaving(void)
+{
+	ASSERT(m_SaveStatus == eSaveStatus::DIRTY);
+	m_SaveStatus = eSaveStatus::DIRTY_QUEUED_SAVING;
 }
 
 
@@ -225,7 +248,8 @@ bool cChunk::CanUnload(void)
 
 void cChunk::MarkSaving(void)
 {
-	m_IsSaving = true;
+	ASSERT(m_SaveStatus == eSaveStatus::DIRTY_QUEUED_SAVING);
+	m_SaveStatus = eSaveStatus::DIRTY_IS_SAVING;
 }
 
 
@@ -234,11 +258,9 @@ void cChunk::MarkSaving(void)
 
 void cChunk::MarkSaved(void)
 {
-	if (!m_IsSaving)
-	{
-		return;
-	}
-	m_IsDirty = false;
+	ASSERT(m_SaveStatus == eSaveStatus::DIRTY_IS_SAVING);
+	m_SaveStatus = eSaveStatus::CLEAN;
+	UpdateCanUnload();
 }
 
 
@@ -247,7 +269,7 @@ void cChunk::MarkSaved(void)
 
 void cChunk::MarkLoaded(void)
 {
-	m_IsDirty = false;
+	m_SaveStatus = eSaveStatus::CLEAN;
 	SetPresence(cpPresent);
 }
 
@@ -266,7 +288,7 @@ void cChunk::MarkLoadFailed(void)
 	}
 	else
 	{
-		m_Presence = cpInvalid;
+		SetPresence(cpInvalid);
 	}
 }
 
@@ -466,6 +488,7 @@ bool cChunk::HasBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ)
 void cChunk::Stay(bool a_Stay)
 {
 	m_StayCount += (a_Stay ? 1 : -1);
+	UpdateCanUnload();
 	ASSERT(m_StayCount >= 0);
 }
 
@@ -628,7 +651,10 @@ void cChunk::Tick(std::chrono::milliseconds a_Dt)
 	// Tick all block entities in this chunk:
 	for (cBlockEntityList::iterator itr = m_BlockEntities.begin(); itr != m_BlockEntities.end(); ++itr)
 	{
-		m_IsDirty = (*itr)->Tick(a_Dt, *this) | m_IsDirty;
+		if ((*itr)->Tick(a_Dt, *this) && (!IsDirty()))
+		{
+			m_SaveStatus = eSaveStatus::DIRTY;
+		}
 	}
 
 	for (cEntityList::iterator itr = m_Entities.begin(); itr != m_Entities.end();)
@@ -736,6 +762,29 @@ void cChunk::MoveEntityToNewChunk(cEntity * a_Entity)
 	} Mover(a_Entity);
 
 	m_ChunkMap->CompareChunkClients(this, Neighbor, Mover);
+}
+
+
+
+
+void cChunk::UpdateCanUnload()
+{
+	bool CanUnload =
+	m_LoadedByClient.empty() &&  // The chunk is not used by any client
+	(!IsDirty()) &&              // The chunk is not dirty
+	(m_StayCount == 0) &&        // The chunk is not in a ChunkStay
+	(m_Presence != cpQueued) ;   // The chunk is not queued for loading / generating (otherwise multi-load / multi-gen could occur)
+
+	if ((CanUnload == false) && (m_CanUnload == true))
+	{
+		m_CanUnload = false;
+		m_World->GetMemoryCounter().DecrementCanUnloadCount();
+	}
+	if ((CanUnload == true) && (m_CanUnload == false))
+	{
+		m_CanUnload = true;
+		m_World->GetMemoryCounter().IncrementCanUnloadCount();
+	}
 }
 
 
@@ -1833,7 +1882,7 @@ bool cChunk::AddClient(cClientHandle * a_Client)
 	}
 
 	m_LoadedByClient.push_back(a_Client);
-
+	UpdateCanUnload();
 	for (cEntityList::iterator itr = m_Entities.begin(); itr != m_Entities.end(); ++itr)
 	{
 		/*
@@ -1860,6 +1909,7 @@ void cChunk::RemoveClient(cClientHandle * a_Client)
 	ASSERT(std::distance(itr, m_LoadedByClient.end()) <= 1);
 	// Note: itr can equal m_LoadedByClient.end()
 	m_LoadedByClient.erase(itr, m_LoadedByClient.end());
+	UpdateCanUnload();
 
 	if (!a_Client->IsDestroyed())
 	{

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -82,6 +82,14 @@ public:
 		cpPresent,  /**< The chunk is present */
 	};
 
+	enum class eSaveStatus
+	{
+		CLEAN,                 // No changes were made to the chunk since last save
+		DIRTY,                 // Changes were made since last save, chunk is dirty
+		DIRTY_QUEUED_SAVING,   // Chunk is dirty, but it is queued for saving
+		DIRTY_IS_SAVING        // Chunk is dirty, but it is in the process of being saved, it will become CLEAN soon.
+	};
+
 	cChunk(
 		int a_ChunkX, int a_ChunkZ,   // Chunk coords
 		cChunkMap * a_ChunkMap, cWorld * a_World,   // Parent objects
@@ -107,10 +115,21 @@ public:
 	/** Marks all clients attached to this chunk as wanting this chunk. Also sets presence to cpQueued. */
 	void MarkRegenerating(void);
 
-	/** Returns true iff the chunk has changed since it was last saved. */
-	bool IsDirty(void) const {return m_IsDirty; }
+	/** Returns true if the chunk has changed since it was last saved.
+	If true, implies that CanUnload() is false. */
+	bool IsDirty(void) const {return m_SaveStatus != eSaveStatus::CLEAN; }
 
+	/** Returns true if the chunk is dirty, not saving, and not queued for save.
+	If true, implies that IsDirty() is true, and that CanUnload() is false. */
+	bool IsDirtyAndNotQueuedForSave(void) const {return m_SaveStatus == eSaveStatus::DIRTY; }
+
+	/** The chunk is unused and not dirty, and can therefore be unloaded.
+	If true, implies that IsUnused is true, and that ShouldBeTicked() is false. */
 	bool CanUnload(void);
+
+	/** The chunk is unused, but it may or may not be dirty.
+	Saving may be needed before unload. If true, implies that ShouldBeTicked() is false. */
+	bool IsUnused(void);
 
 	bool IsLightValid(void) const {return m_IsLightValid; }
 
@@ -121,6 +140,7 @@ public:
 	3. Mark the chunk as saved (MarkSaved())
 	If anywhere inside this sequence another thread mmodifies the chunk, the chunk will not get marked as saved in MarkSaved()
 	*/
+	void MarkQueuedSaving(void);
 	void MarkSaving(void);  // Marks the chunk as being saved.
 	void MarkSaved(void);  // Marks the chunk as saved, if it didn't change from the last call to MarkSaving()
 	void MarkLoaded(void);  // Marks the chunk as freshly loaded. Fails if the chunk is already valid
@@ -377,8 +397,11 @@ public:
 
 	inline void MarkDirty(void)
 	{
-		m_IsDirty = true;
-		m_IsSaving = false;
+		if (m_SaveStatus == eSaveStatus::CLEAN)
+		{
+			m_SaveStatus = eSaveStatus::DIRTY;
+			UpdateCanUnload();
+		}
 	}
 
 	/** Sets the blockticking to start at the specified block. Only one blocktick may be set, second call overwrites the first call */
@@ -507,11 +530,13 @@ private:
 	/** Holds the presence status of the chunk - if it is present, or in the loader / generator queue, or unloaded */
 	ePresence m_Presence;
 
+	/** Stores whether it's safe to unload this chunk. Returned by CanUnload(), modified by UpdateCanUnload(). */
+	bool m_CanUnload;
+
 	/** If the chunk fails to load, should it be queued in the generator or reset back to invalid? */
+	eSaveStatus m_SaveStatus;
 	bool m_ShouldGenerateIfLoadFailed;
 	bool m_IsLightValid;   // True if the blocklight and skylight are calculated
-	bool m_IsDirty;        // True if the chunk has changed since it was last saved
-	bool m_IsSaving;       // True if the chunk is being saved
 	bool m_HasLoadFailed;  // True if chunk failed to load and hasn't been generated yet since then
 
 	std::vector<Vector3i> m_ToTickBlocks;
@@ -591,6 +616,10 @@ private:
 
 	/** Called by Tick() when an entity moves out of this chunk into a neighbor; moves the entity and sends spawn / despawn packet to clients */
 	void MoveEntityToNewChunk(cEntity * a_Entity);
+
+	/** Checks whether the chunk can unload and updates m_CanUnload accordingly.
+	Updates the world's counter of how many chunks can be unloaded. */
+	void UpdateCanUnload();
 };
 
 typedef cChunk * cChunkPtr;

--- a/src/ChunkData.h
+++ b/src/ChunkData.h
@@ -11,13 +11,11 @@
 
 
 #include <cstring>
-
-
 #include "ChunkDef.h"
-
 #include "AllocationPool.h"
 
-
+// fwd
+class cMemoryCounter;
 
 #if __cplusplus < 201103L
 // auto_ptr style interface for memory management
@@ -37,7 +35,7 @@ public:
 
 	struct sChunkSection;
 
-	cChunkData(cAllocationPool<cChunkData::sChunkSection> & a_Pool);
+	cChunkData(cAllocationPool<cChunkData::sChunkSection> & a_Pool, cMemoryCounter & a_WorldMemoryCounter);
 	~cChunkData();
 
 	#if __cplusplus < 201103L
@@ -109,6 +107,8 @@ private:
 	// auto_ptr style interface for memory management
 	mutable bool m_IsOwner;
 	#endif
+
+	cMemoryCounter & m_WorldMemoryCounter;
 
 	sChunkSection * m_Sections[NumSections];
 

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -38,6 +38,7 @@ class cMobCensus;
 class cMobSpawner;
 class cSetChunkData;
 class cBoundingBox;
+class cFastRandom;
 
 typedef std::list<cClientHandle *>         cClientHandleList;
 typedef cChunk *                           cChunkPtr;
@@ -378,17 +379,20 @@ public:
 	/** Try to Spawn Monsters inside all Chunks */
 	void SpawnMobs(cMobSpawner & a_MobSpawner);
 
+	size_t TickAndUnload(std::chrono::milliseconds a_Dt, int a_UnloadChance);
+
 	void Tick(std::chrono::milliseconds a_Dt);
 
 	/** Ticks a single block. Used by cWorld::TickQueuedBlocks() to tick the queued blocks */
 	void TickBlock(int a_BlockX, int a_BlockY, int a_BlockZ);
 
-	void UnloadUnusedChunks(void);
-	void SaveAllChunks(void);
+	/** Saves chunks immediately. If UnusedOnly is set to true, only unused chunks are saved.
+	Otherwise, all chunks are saved. */
+	void SaveChunks(bool a_UnusedOnly);
 
 	cWorld * GetWorld(void) { return m_World; }
 
-	int GetNumChunks(void);
+	size_t GetNumChunks(void);
 
 	void ChunkValidated(void);  // Called by chunks that have become valid
 
@@ -404,6 +408,12 @@ public:
 	This function allows nesting and task-concurrency (multiple separate tasks can request ticking and as long
 	as at least one requests is active the chunk will be ticked). */
 	void SetChunkAlwaysTicked(int a_ChunkX, int a_ChunkZ, bool a_AlwaysTicked);
+
+	/** Increase the internal chunk counter. */
+	void IncreaseChunkCounter();
+
+	/** Decrease the internal chunk counter. */
+	void DecreaseChunkCounter();
 
 private:
 
@@ -435,12 +445,9 @@ private:
 		int GetX(void) const {return m_LayerX; }
 		int GetZ(void) const {return m_LayerZ; }
 
-		int GetNumChunksLoaded(void) const ;
-
 		void GetChunkStats(int & a_NumChunksValid, int & a_NumChunksDirty) const;
 
-		void Save(void);
-		void UnloadUnusedChunks(void);
+		void Save(bool a_UnusedOnly);
 
 		/** Collect a mob census, of all mobs, their megatype, their chunk and their distance o closest player */
 		void CollectMobCensus(cMobCensus & a_ToFill);
@@ -448,6 +455,7 @@ private:
 		/** Try to Spawn Monsters inside all Chunks */
 		void SpawnMobs(cMobSpawner & a_MobSpawner);
 
+		size_t TickAndUnload(std::chrono::milliseconds a_Dt, int a_UnloadChance, cFastRandom * a_Random);
 		void Tick(std::chrono::milliseconds a_Dt);
 
 		void RemoveClient(cClientHandle * a_Client);
@@ -461,15 +469,25 @@ private:
 		/** Returns true if there is an entity with the specified ID within this layer's chunks */
 		bool HasEntity(UInt32 a_EntityID);
 
+		/** Returns how many chunks this layer has. */
+		size_t GetNumChunks();
+
 	protected:
 
 		cChunkPtr m_Chunks[LAYER_SIZE * LAYER_SIZE];
 		int m_LayerX;
 		int m_LayerZ;
 		cChunkMap * m_Parent;
-		int m_NumChunksLoaded;
 
 		cAllocationPool<cChunkData::sChunkSection> & m_Pool;
+	private:
+		/** Increase the internal chunk counter. */
+		void IncreaseChunkCounter();
+
+		/** Decrease the internal chunk counter. */
+		void DecreaseChunkCounter();
+
+		size_t m_ChunkCounter;
 	};
 
 	class cStarvationCallbacks
@@ -512,6 +530,8 @@ private:
 	cEvent           m_evtChunkValid;  // Set whenever any chunk becomes valid, via ChunkValidated()
 
 	cWorld * m_World;
+
+	size_t m_ChunkCounter;
 
 	/** The cChunkStay descendants that are currently enabled in this chunkmap */
 	cChunkStays m_ChunkStays;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -224,10 +224,10 @@ void cEntity::Destroy(bool a_ShouldBroadcast)
 	cChunk * ParentChunk = GetParentChunk();
 	m_World->QueueTask([this, ParentChunk](cWorld & a_World)
 	{
-		LOGD("Destroying entity #%i (%s) from chunk (%d, %d)",
+		/* LOGD("Destroying entity #%i (%s) from chunk (%d, %d)",
 			this->GetUniqueID(), this->GetClass(),
 			ParentChunk->GetPosX(), ParentChunk->GetPosZ()
-		);
+		); */  // TODO uncomment this after testing
 		ParentChunk->RemoveEntity(this);
 		delete this;
 	});

--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -241,10 +241,10 @@ void cChunkGenerator::Execute(void)
 		// Display perf info once in a while:
 		if ((NumChunksGenerated > 512) && (clock() - LastReportTick > 2 * CLOCKS_PER_SEC))
 		{
-			LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
+			/* LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
 				static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC / (clock() - GenerationStart),
 				NumChunksGenerated
-			);
+			); */
 			LastReportTick = clock();
 		}
 

--- a/src/MemoryCounter.cpp
+++ b/src/MemoryCounter.cpp
@@ -1,0 +1,68 @@
+#include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
+#include "MemoryCounter.h"
+
+
+
+
+
+cMemoryCounter::cMemoryCounter() :
+	m_ApproximateChunkRamSize(0),
+	m_CanUnloadCount(0)
+{
+
+}
+
+
+
+
+
+void cMemoryCounter::IncrementApproximateChunkRAM(size_t a_Increment)
+{
+	m_ApproximateChunkRamSize += a_Increment;
+}
+
+
+
+
+
+void cMemoryCounter::DecrementApproximateChunkRAM(size_t a_Decrement)
+{
+	ASSERT(m_ApproximateChunkRamSize >= a_Decrement);
+	m_ApproximateChunkRamSize -= a_Decrement;
+}
+
+
+
+
+/** Increments the counter of the amount of unused chunks our world has by one. */
+void cMemoryCounter::IncrementCanUnloadCount()
+{
+	++m_CanUnloadCount;
+}
+
+
+
+
+
+void cMemoryCounter::DecrementCanUnloadCount()
+{
+	--m_CanUnloadCount;
+}
+
+
+
+
+
+size_t cMemoryCounter::GetCanUnloadCount()
+{
+	return m_CanUnloadCount;
+}
+
+
+
+
+
+size_t cMemoryCounter::GetApproximateChunkRAM()
+{
+	return static_cast<size_t>(m_ApproximateChunkRamSize / 1048576);  // Cast to MiB
+}

--- a/src/MemoryCounter.h
+++ b/src/MemoryCounter.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <atomic>
+#include <cstdlib>  // for Size_t
+
+class cMemoryCounter
+{
+
+public:
+	cMemoryCounter();
+
+	/** Increments the approximated chunk RAM consumption counter by a_Increment. Unit is bytes. */
+	void IncrementApproximateChunkRAM(size_t a_Increment);
+
+	/** Decrements the approximated chunk RAM consumption counter by a_Decrement. Unit is bytes. */
+	void DecrementApproximateChunkRAM(size_t a_Decrement);
+
+	/** Increments the counter of the amount of unused chunks our world has by one. */
+	void IncrementCanUnloadCount();
+
+	/** Decrements the conter of the amount of unused chunks our world has by one. */
+	void DecrementCanUnloadCount();
+
+	/** Returns the value of the number of chunks that can be unloaded by our world. Thread safe. */
+	size_t GetCanUnloadCount();
+
+	/** Returns the approximated chunk RAM consumption in MiB. Thread safe. */
+	size_t GetApproximateChunkRAM();
+
+private:
+	std::atomic<uint64_t> m_ApproximateChunkRamSize;
+	std::atomic<size_t> m_CanUnloadCount;
+};

--- a/src/Root.h
+++ b/src/Root.h
@@ -124,8 +124,15 @@ public:
 	/** Executes commands queued in the command queue */
 	void TickCommands(void);
 
-	/** Returns the number of chunks loaded */
-	int GetTotalChunkCount(void);  // tolua_export
+	/** Returns the number of chunks loaded. */
+	size_t GetTotalChunkCount(void);  // tolua_export
+
+	/** Returns the number of loaded chunks that can be unloaded. */
+	size_t GetTotalCanUnloadCount();
+
+	/** Returns the estimated amount of RAM being used by all worlds' chunkmaps in MiB.
+	Actual amount is higher. */
+	size_t GetApproximateChunkRAM();
 
 	/** Saves all chunks in all worlds */
 	void SaveAllChunks(void);  // tolua_export
@@ -147,6 +154,13 @@ public:
 
 	/** Broadcast Player through all worlds */
 	void BroadcastPlayerListsAddPlayer(const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
+
+	/** Returns the RAM cap that all the chunks of the worlds combined must not exceed, in MiB.
+	This value can be set by the user in settings.ini. */
+	size_t GetMaxRAMChunks();
+
+	/** Returns whether ram magement is set to minimize RAM or to use as much RAM as possible as a chunk cache. */
+	bool GetMinimizeRam();
 
 	// tolua_begin
 
@@ -215,6 +229,12 @@ private:
 
 	cHTTPServer m_HTTPServer;
 
+	/** The amount of max RAM usage allowed by the chunks of all worlds combined, in MiB. */
+	size_t m_MaxRAMChunks;
+
+	/** Stores the chunk saving scheme. If true, worlds strive for minimizing RAM.
+	If false, worlds make full use of m_MaxRAMChunks as a chunk cache. */
+	bool m_MinimizeRam;
 
 	void LoadGlobalSettings();
 

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -371,7 +371,7 @@ void cWebAdmin::HandleWebadminRequest(cHTTPServerConnection & a_Connection, cHTT
 	ReplaceString(Template, "{TITLE}",       "Cuberite");
 
 	AString NumChunks;
-	Printf(NumChunks, "%d", cRoot::Get()->GetTotalChunkCount());
+	Printf(NumChunks, SIZE_T_FMT, cRoot::Get()->GetTotalChunkCount());
 	ReplaceString(Template, "{NUMCHUNKS}", NumChunks);
 
 	cHTTPOutgoingResponse Resp;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -62,7 +62,6 @@
 #include "FastRandom.h"
 
 
-
 const int TIME_SUNSET        = 12000;
 const int TIME_NIGHT_START   = 13187;
 const int TIME_NIGHT_END     = 22812;
@@ -148,8 +147,11 @@ cWorld::cWorld(const AString & a_WorldName, eDimension a_Dimension, const AStrin
 	m_WorldAge(0),
 	m_TimeOfDay(0),
 	m_LastTimeUpdate(0),
-	m_LastUnload(0),
+	m_LastUnloadCheck(0),
 	m_LastSave(0),
+	m_LastUnusedSave(0),
+	m_UnusedSaveCountDown(5),
+	m_MemoryCounter(),
 	m_SkyDarkness(0),
 	m_GameMode(gmNotSet),
 	m_bEnabledPVP(false),
@@ -222,6 +224,9 @@ cWorld::~cWorld()
 	Serializer.Save();
 
 	m_MapManager.SaveMapData();
+
+	// Must remove all chunk layers before reset, to keep the allocation pool while removal takes place
+	// m_ChunkMap->RemoveAllLayersAndChunks();  // TODO this can assert fail in cEntity destructor
 
 	// Explicitly destroy the chunkmap, so that it's guaranteed to be destroyed before the other internals
 	// This fixes crashes on stopping the server, because chunk destructor deletes entities and those access the world.
@@ -1023,7 +1028,29 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 	// Add players waiting in the queue to be added:
 	AddQueuedPlayers();
 
-	m_ChunkMap->Tick(a_Dt);
+	if (m_WorldAge - m_LastUnloadCheck > std::chrono::seconds(2))
+	{
+		m_LastUnloadCheck = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
+		// Unused non dirty chunks unload randomly in Cuberite.
+		// This is the chance of a single unused, non dirty chunk to unload, out of CHUNK_CHANCE_ACCURACY.
+		int UnloadChance = ManageChunkUnload();  // This function also does some chunk unload bookkeeping.
+		if (UnloadChance != 0)
+		{
+			m_ChunkMap->TickAndUnload(a_Dt, UnloadChance);
+			/* size_t UnloadedAmount = m_ChunkMap->TickAndUnload(a_Dt, UnloadChance);
+			LOGD("%s: Unloaded: %zu, Chance: %d / %d", GetName().c_str(), UnloadedAmount, UnloadChance, CHUNK_CHANCE_ACCURACY); */
+
+		}
+		else
+		{
+			m_ChunkMap->Tick(a_Dt);
+		}
+	}
+	else
+	{
+		m_ChunkMap->Tick(a_Dt);
+	}
+
 	TickMobs(a_Dt);
 	m_MapManager.TickMaps();
 
@@ -1037,14 +1064,122 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 
 	if (m_WorldAge - m_LastSave > std::chrono::minutes(5))  // Save each 5 minutes
 	{
-		SaveAllChunks();
+		// LOGD("%s: ********* Saving ALL dirty chunks (periodic save)", GetName().c_str());
+		SaveChunks();
 	}
+}
 
-	if (m_WorldAge - m_LastUnload > std::chrono::seconds(10))  // Unload every 10 seconds
+
+
+
+
+int cWorld::ManageChunkUnload()
+{
+	/* #ifdef _DEBUG
+	size_t MyRam = GetMemoryCounter().GetApproximateChunkRAM();  // RAM used by our loaded chunks (approximated)
+	#endif */
+
+	cRoot * Root = cRoot::Get();
+	size_t Ram = Root->GetApproximateChunkRAM();  // RAM used by all world's loaded chunks combined (approximated) in MiB
+	size_t MaxRam = Root->GetMaxRAMChunks();      // Maximum allowed RAM use of all worlds in MiB
+
+	/* LOGD("%s: GlobalRam: %zu, myChunks: %zu, Unloadable: %zu", GetName().c_str(), Ram, GetNumChunks(), GetMemoryCounter().GetCanUnloadCount()); */
+
+	// If the setting is set to minimize ram
+	if (Root->GetMinimizeRam())
 	{
-		UnloadUnusedChunks();
+		// Save all chunks if RAM is too much
+		if (Ram > MaxRam)
+		{
+			if (m_WorldAge - m_LastSave > std::chrono::seconds(20))
+			{
+				LOGD("###### %s: Saving all unused dirty chunks", GetName().c_str());
+				SaveChunks(true);
+			}
+		}
+
+		// Unload all unused non dirty chunks anyways
+		return CHUNK_CHANCE_ACCURACY;
+		// The chance of a chunk to unload the next tick is random, and is equal to
+		// <returned value> out of CHUNK_CHANCE_ACCURACY.
+		// returning CHUNK_CHANCE_ACCURACY means all unused non dirty chunks will
+		// unload with 100% certainty.
 	}
 
+	// If we're here, then the setting is not set to minimize RAM, therefore we
+	// take advantage of the RAM we have and use it as a chunk cache.
+	// We unload as lazily as possible.
+
+	// *** The code below explained briefly ***
+	// Keeping chunks in the RAM is a good thing and RAM acts as a chunk cache.
+	// We want to unload chunks as little as possible.
+	// If maxRam is exceeded, we unload just enough to go below the limit.
+	// If we really cannot stop RAM growth because too many chunks are dirty and unloadable,
+	// then we call the save cycle.
+
+	if (Ram > MaxRam)  // If all worlds combined should free something
+	{
+		// Calculate how much RAM all worlds combined should free (MiB)
+		size_t RamFreeGoal = Root->GetApproximateChunkRAM() - Root->GetMaxRAMChunks();
+
+		// Calculate how many chunks all worlds should free, assuming all chunks consume equal RAM.
+		size_t ChunkUnloadGoal = (RamFreeGoal * Root->GetTotalChunkCount()) / Ram;
+
+		// How many unloadable chunks all worlds have
+		size_t UnloadableChunks = Root->GetTotalCanUnloadCount();
+
+		// If the chunk unload goal is bigger than the amount of unloadable chunks the worlds have,
+		// then we consider saving chunks in the following if block, and we may unload all unused
+		// non dirty chunks we have. We are patient, and we don't save straight away.
+		if (ChunkUnloadGoal > UnloadableChunks)
+		{
+			if (m_UnusedSaveCountDown > 0)
+			{
+				--m_UnusedSaveCountDown;
+				// Wait and don't save yet, in hopes that other worlds managed to free enough.
+				// We'll get back here next iteration
+			}
+			else
+			{
+				// We have waited for 5 iterations (10 seconds), and we still can't free enough,
+				// and other worlds didn't free enough. Let's resort to saving unused dirty chunks.
+
+				// Make sure we haven't saved recently.
+				if (m_WorldAge - m_LastUnusedSave > std::chrono::seconds(20))
+				{
+					// Wait randomly before saving, so that not all worlds save at once.
+					// During this wait, other worlds may save and we won't have to save if enough RAM is freed.
+					if (m_TickRand.randInt(3) == 0)
+					{
+						LOGD("###### %s: Saving unused dirty chunks to meet unload goal", GetName().c_str());
+						SaveChunks(true);
+					}
+				}
+			}
+
+			// Unload all unused non dirty chunks anyways.
+			return CHUNK_CHANCE_ACCURACY;
+		}
+		// ... Otherwise, the unload goal is attainable without a save. Just unload enough chunks.
+		else
+		{
+			m_UnusedSaveCountDown = 4;  // Reset the "save patience countdown". We won't save chunks any time soon.
+
+			// Calculate the chance for a single chunk to get freed next tick.
+			// The chance is in the range [1 to CHUNK_CHANCE_ACCURACY - 1].
+			size_t FreeChance = (CHUNK_CHANCE_ACCURACY * ChunkUnloadGoal) / UnloadableChunks;
+			return static_cast<int>(FreeChance);
+		}
+	}
+	else
+	{
+		// Reset the "save patience countdown". We won't save chunks any time soon.
+		m_UnusedSaveCountDown = 4;
+	}
+
+	// If we're here, it means nothing should be unloaded because RAM is smaller than maxRam
+	// Return an unload chance of zero (Unload chance per chunk per tick is <returned value> / CHUNK_CHANCE_ACCURACY)
+	return 0;
 }
 
 
@@ -2786,10 +2921,11 @@ void cWorld::SetChunkData(cSetChunkData & a_SetChunkData)
 	// If a client is requesting this chunk, send it to them:
 	int ChunkX = a_SetChunkData.GetChunkX();
 	int ChunkZ = a_SetChunkData.GetChunkZ();
+	bool ShouldMarkDirty = a_SetChunkData.ShouldMarkDirty();
 	cChunkSender & ChunkSender = m_ChunkSender;
 	DoWithChunk(
 		ChunkX, ChunkZ,
-		[&ChunkSender] (cChunk & a_Chunk) -> bool
+		[&ChunkSender, ShouldMarkDirty] (cChunk & a_Chunk) -> bool
 		{
 			if (a_Chunk.HasAnyClients())
 			{
@@ -2800,12 +2936,16 @@ void cWorld::SetChunkData(cSetChunkData & a_SetChunkData)
 					a_Chunk.GetAllClients()
 				);
 			}
+			if (ShouldMarkDirty)
+			{
+				a_Chunk.MarkQueuedSaving();
+			}
 			return true;
 		}
 	);
 
 	// Save the chunk right after generating, so that we don't have to generate it again on next run
-	if (a_SetChunkData.ShouldMarkDirty())
+	if (ShouldMarkDirty)
 	{
 		m_Storage.QueueSaveChunk(ChunkX, ChunkZ);
 	}
@@ -2867,25 +3007,6 @@ bool cWorld::IsChunkValid(int a_ChunkX, int a_ChunkZ) const
 bool cWorld::HasChunkAnyClients(int a_ChunkX, int a_ChunkZ) const
 {
 	return m_ChunkMap->HasChunkAnyClients(a_ChunkX, a_ChunkZ);
-}
-
-
-
-
-
-void cWorld::UnloadUnusedChunks(void)
-{
-	m_LastUnload = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
-	m_ChunkMap->UnloadUnusedChunks();
-}
-
-
-
-
-
-void cWorld::QueueUnloadUnusedChunks(void)
-{
-	QueueTask([](cWorld & a_World) { a_World.UnloadUnusedChunks(); });
 }
 
 
@@ -3392,10 +3513,14 @@ bool cWorld::ForEachLoadedChunk(std::function<bool(int, int)> a_Callback)
 
 
 
-void cWorld::SaveAllChunks(void)
+void cWorld::SaveChunks(bool a_UnusedOnly)
 {
-	m_LastSave = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
-	m_ChunkMap->SaveAllChunks();
+	m_LastUnusedSave = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);;
+	if (!a_UnusedOnly)
+	{
+		m_LastSave = m_LastUnusedSave;
+	}
+	m_ChunkMap->SaveChunks(a_UnusedOnly);
 }
 
 
@@ -3404,7 +3529,7 @@ void cWorld::SaveAllChunks(void)
 
 void cWorld::QueueSaveAllChunks(void)
 {
-	QueueTask([](cWorld & a_World) { a_World.SaveAllChunks(); });
+	QueueTask([](cWorld & a_World) { a_World.SaveChunks(); });
 }
 
 
@@ -3486,9 +3611,13 @@ unsigned int cWorld::GetNumPlayers(void)
 
 
 
-int cWorld::GetNumChunks(void) const
+size_t cWorld::GetNumChunks(void) const
 {
-	return m_ChunkMap->GetNumChunks();
+	if (m_ChunkMap.get() != nullptr)
+	{
+		return m_ChunkMap->GetNumChunks();
+	}
+	return 0;
 }
 
 
@@ -3531,6 +3660,14 @@ void cWorld::TickQueuedBlocks(void)
 	}  // for itr - m_BlockTickQueueCopy[]
 }
 
+
+
+
+
+cMemoryCounter & cWorld::GetMemoryCounter()
+{
+	return m_MemoryCounter;
+}
 
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -29,7 +29,7 @@
 #include "ClientHandle.h"
 #include "EffectID.h"
 #include <functional>
-
+#include "MemoryCounter.h"
 
 
 class cFireSimulator;
@@ -79,7 +79,7 @@ typedef cItemCallback<cFlowerPotEntity>    cFlowerPotCallback;
 
 
 
-
+const int CHUNK_CHANCE_ACCURACY = 100000;
 
 
 // tolua_begin
@@ -254,9 +254,6 @@ public:
 	bool IsChunkValid(int a_ChunkX, int a_ChunkZ) const;
 
 	bool HasChunkAnyClients(int a_ChunkX, int a_ChunkZ) const;
-
-	/** Queues a task to unload unused chunks onto the tick thread. The prefferred way of unloading. */
-	void QueueUnloadUnusedChunks(void);  // tolua_export
 
 	void CollectPickupsByPlayer(cPlayer & a_Player);
 
@@ -661,8 +658,9 @@ public:
 
 	// tolua_end
 
-	/** Saves all chunks immediately. Dangerous interface, may deadlock, use QueueSaveAllChunks() instead */
-	void SaveAllChunks(void);
+	/** Saves chunks immediately. Dangerous interface, may deadlock, use QueueSaveAllChunks() instead.
+	If UnusedOnly is set to true, only unused chunks are saved. Otherwise, all chunks are saved. */
+	void SaveChunks(bool a_UnusedOnly = false);
 
 	/** Queues a task to save all chunks onto the tick thread. The prefferred way of saving chunks from external sources */
 	void QueueSaveAllChunks(void);  // tolua_export
@@ -673,10 +671,10 @@ public:
 	/** Queues a lambda task onto the tick thread, with the specified delay. */
 	void ScheduleTask(int a_DelayTicks, std::function<void(cWorld &)> a_Task);
 
-	/** Returns the number of chunks loaded	 */
-	int GetNumChunks() const;  // tolua_export
+	/** Returns the number of chunks loaded.	 */
+	size_t GetNumChunks() const;  // tolua_export
 
-	/** Returns the number of chunks loaded and dirty, and in the lighting queue */
+	/** Returns the number of chunks loaded and dirty, and in the lighting queue. */
 	void GetChunkStats(int & a_NumValid, int & a_NumDirty, int & a_NumInLightingQueue);
 
 	// Various queues length queries (cannot be const, they lock their CS):
@@ -697,6 +695,9 @@ public:
 
 	/** Processes the blocks queued for ticking with a delay (m_BlockTickQueue[]) */
 	void TickQueuedBlocks(void);
+
+	/** Returns the memory counter owned by this world. */
+	cMemoryCounter & GetMemoryCounter();
 
 	struct BlockTickQueueItem
 	{
@@ -880,8 +881,17 @@ private:
 	std::chrono::milliseconds  m_WorldAge;
 	std::chrono::milliseconds  m_TimeOfDay;
 	cTickTimeLong  m_LastTimeUpdate;    // The tick in which the last time update has been sent.
-	cTickTimeLong  m_LastUnload;        // The last WorldAge (in ticks) in which unloading was triggerred
+	cTickTimeLong  m_LastUnloadCheck;        // The last WorldAge (in ticks) in which we checked if we need to unlad
 	cTickTimeLong  m_LastSave;          // The last WorldAge (in ticks) in which save-all was triggerred
+	cTickTimeLong  m_LastUnusedSave;    // The last WorldAge (in ticks) in which only unused chunks were saved.
+
+	// If too many chunks are loaded and we cannot free enough, this starts decreaminting once every
+	// 2 seconds. When it reaches zero, we save unused chunks in an attempt to free them.
+	// We do not do this immediately because we hope other worlds have freed enough chunks in the meantime.
+	int m_UnusedSaveCountDown;
+
+	cMemoryCounter m_MemoryCounter;
+
 	std::map<cMonster::eFamily, cTickTimeLong> m_LastSpawnMonster;  // The last WorldAge (in ticks) in which a monster was spawned (for each megatype of monster)  // MG TODO : find a way to optimize without creating unmaintenability (if mob IDs are becoming unrowed)
 
 	NIBBLETYPE m_SkyDarkness;
@@ -1011,6 +1021,22 @@ private:
 
 	void Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_LastTickDurationMSec);
 
+	/** Analyses various server meters, and determines how many chunks this world should unload
+	in order to maintain the proper amount of RAM.
+	Converts the result into a chance for a single chunk to unload during the following tick
+	and returns that. The returned chance is a fraction of the constant CHUNK_CHANCE_ACCURACY.
+
+	For instance:
+	- if 0 is returned, then no chunks should unload during the following tick.
+	- If CHUNK_CHANCE_ACCURACY / 2 is returned, then about half the unloadable chunks
+	should unload during the following tick.
+	- If CHUNK_CHANCE_ACCURACY is returned, then all chunks that can unload should unload
+	during the following tick.
+
+	Side effects:
+	May call cWorld::SaveChunks(true) if it estimates that we cannot unload enough chunks without saving. */
+	int ManageChunkUnload();
+
 	/** Handles the weather in each tick */
 	void TickWeather(float a_Dt);
 
@@ -1022,9 +1048,6 @@ private:
 
 	/** Ticks all clients that are in this world */
 	void TickClients(float a_Dt);
-
-	/** Unloads all chunks immediately. */
-	void UnloadUnusedChunks(void);
 
 	void UpdateSkyDarkness(void);
 

--- a/tests/ChunkData/ArraytoCoord.cpp
+++ b/tests/ChunkData/ArraytoCoord.cpp
@@ -1,102 +1,103 @@
 
 #include "Globals.h"
 #include "ChunkData.h"
-
+#include "MemoryCounter.h"
 
 
 int main(int argc, char** argv)
 {
+	cMemoryCounter Dummy;
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
+	{
 		virtual cChunkData::sChunkSection * Allocate()
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
+
 		virtual void Free(cChunkData::sChunkSection * a_Ptr)
 		{
 			delete a_Ptr;
 		}
 	} Pool;
 	{
-	
+
 		// Test first segment
-		cChunkData buffer(Pool);
+		cChunkData buffer(Pool, Dummy);
 
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		memset(SrcBlockBuffer, 0x00, sizeof(SrcBlockBuffer));
 		SrcBlockBuffer[7 + (4 * 16) + (5 * 16 * 16)] = 0xcd;
 		buffer.SetBlockTypes(SrcBlockBuffer);
 		testassert(buffer.GetBlock(7, 5, 4) == 0xcd);
-	
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (2 * 16 * 16)) / 2] = 0xe;
 		buffer.SetMetas(SrcNibbleBuffer);
 		testassert(buffer.GetMeta(6, 2, 1) == 0xe);
-	
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (2 * 16 * 16)) / 2] = 0xe;
 		buffer.SetBlockLight(SrcNibbleBuffer);
 		testassert(buffer.GetBlockLight(6, 2, 1) == 0xe);
-	
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (2 * 16 * 16)) / 2] = 0xe;
 		buffer.SetSkyLight(SrcNibbleBuffer);
 		testassert(buffer.GetSkyLight(6, 2, 1) == 0xe);
 	}
-	
+
 	{
 		// test following segment
-		cChunkData buffer(Pool);
+		cChunkData buffer(Pool, Dummy);
 
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		memset(SrcBlockBuffer, 0x00, sizeof(SrcBlockBuffer));
 		SrcBlockBuffer[7 + (4 * 16) + (24 * 16 * 16)] = 0xcd;
 		buffer.SetBlockTypes(SrcBlockBuffer);
 		testassert(buffer.GetBlock(7, 24, 4) == 0xcd);
-	
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (24 * 16 * 16)) / 2] = 0xe;
 		buffer.SetMetas(SrcNibbleBuffer);
 		testassert(buffer.GetMeta(6, 24, 1) == 0xe);
-	
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + 1 * 16 + 24 * 16 * 16) / 2] = 0xe;
 		buffer.SetBlockLight(SrcNibbleBuffer);
 		testassert(buffer.GetBlockLight(6, 24, 1) == 0xe);
-	
+
 		memset(SrcNibbleBuffer, 0xff, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (24 * 16 * 16)) / 2] = 0xe;
 		buffer.SetSkyLight(SrcNibbleBuffer);
 		testassert(buffer.GetSkyLight(6, 24, 1) == 0xe);
 	}
-	
+
 	{
 		// test zeros
-		cChunkData buffer(Pool);
+		cChunkData buffer(Pool, Dummy);
 
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		memset(SrcBlockBuffer, 0x00, sizeof(SrcBlockBuffer));
 		buffer.SetBlockTypes(SrcBlockBuffer);
 		testassert(buffer.GetBlock(7, 24, 4) == 0x00);
-	
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		buffer.SetMetas(SrcNibbleBuffer);
 		testassert(buffer.GetMeta(6, 24, 1) == 0x0);
-	
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		buffer.SetBlockLight(SrcNibbleBuffer);
 		testassert(buffer.GetBlockLight(6, 24, 1) == 0x0);
-	
+
 		memset(SrcNibbleBuffer, 0xff, sizeof(SrcNibbleBuffer));
 		buffer.SetSkyLight(SrcNibbleBuffer);
 		testassert(buffer.GetSkyLight(6, 24, 1) == 0xf);
 	}
-	
+
 	// All tests passed:
 	return 0;
 }

--- a/tests/ChunkData/CMakeLists.txt
+++ b/tests/ChunkData/CMakeLists.txt
@@ -7,11 +7,12 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	add_flags_cxx("-Wno-error=old-style-cast")
 	set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ChunkData.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=sign-conversion")
 	set_source_files_properties(${CMAKE_SOURCE_DIR}/src/StringUtils.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=conversion")
+	set_source_files_properties(${CMAKE_SOURCE_DIR}/src/MemoryCounter.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=conversion")
 endif()
 
 
 add_definitions(-DTEST_GLOBALS=1)
-add_library(ChunkBuffer ${CMAKE_SOURCE_DIR}/src/ChunkData.cpp ${CMAKE_SOURCE_DIR}/src/StringUtils.cpp)
+add_library(ChunkBuffer ${CMAKE_SOURCE_DIR}/src/ChunkData.cpp ${CMAKE_SOURCE_DIR}/src/StringUtils.cpp ${CMAKE_SOURCE_DIR}/src/MemoryCounter.cpp)
 
 
 add_executable(creatable-exe creatable.cpp)

--- a/tests/ChunkData/Coordinates.cpp
+++ b/tests/ChunkData/Coordinates.cpp
@@ -1,11 +1,12 @@
 
 #include "Globals.h"
 #include "ChunkData.h"
-
+#include "MemoryCounter.h"
 
 
 int main(int argc, char** argv)
 {
+	cMemoryCounter Dummy;
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
 	{
@@ -20,7 +21,7 @@ int main(int argc, char** argv)
 		}
 	} Pool;
 	{
-		cChunkData buffer(Pool);
+		cChunkData buffer(Pool, Dummy);
 
 		// Empty chunks
 		buffer.SetBlock(0, 0, 0, 0xAB);
@@ -93,7 +94,7 @@ int main(int argc, char** argv)
 	}
 
 	{
-		cChunkData buffer(Pool);
+		cChunkData buffer(Pool, Dummy);
 
 		// Zero's
 		buffer.SetBlock(0, 0, 0, 0x0);
@@ -110,9 +111,9 @@ int main(int argc, char** argv)
 
 	{
 		// Operator =
-		cChunkData buffer(Pool);
+		cChunkData buffer(Pool, Dummy);
 		buffer.SetBlock(0, 0, 0, 0x42);
-		cChunkData copy(Pool);
+		cChunkData copy(Pool, Dummy);
 		copy = std::move(buffer);
 		testassert(copy.GetBlock(0, 0, 0) == 0x42);
 	}

--- a/tests/ChunkData/Copies.cpp
+++ b/tests/ChunkData/Copies.cpp
@@ -1,34 +1,35 @@
 
 #include "Globals.h"
 #include "ChunkData.h"
-
+#include "MemoryCounter.h"
 
 
 int main(int argc, char** argv)
 {
+	cMemoryCounter Dummy;
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
+	{
 		virtual cChunkData::sChunkSection * Allocate()
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
+
 		virtual void Free(cChunkData::sChunkSection * a_Ptr)
 		{
 			delete a_Ptr;
 		}
 	} Pool;
 	{
-		cChunkData buffer(Pool);
-	
+		cChunkData buffer(Pool, Dummy);
+
 		buffer.SetBlock(3, 1, 4, 0xDE);
 		buffer.SetMeta(3, 1, 4, 0xA);
-	
+
 		cChunkData copy = buffer.Copy();
 		testassert(copy.GetBlock(3, 1, 4) == 0xDE);
 		testassert(copy.GetMeta(3, 1, 4) == 0xA);
-	
+
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		for (int i = 0; i < 16 * 16 * 256; i += 4)
 		{
@@ -37,21 +38,21 @@ int main(int argc, char** argv)
 			SrcBlockBuffer[i + 2] = 0xbe;
 			SrcBlockBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetBlockTypes(SrcBlockBuffer);
 		BLOCKTYPE DstBlockBuffer[16 * 16 * 256];
 		buffer.CopyBlockTypes(DstBlockBuffer);
 		testassert(memcmp(SrcBlockBuffer, DstBlockBuffer, (16 * 16 * 256) - 1) == 0);
-		
+
 		memset(SrcBlockBuffer, 0x00, 16 * 16 * 256);
 		buffer.SetBlockTypes(SrcBlockBuffer);
 		buffer.CopyBlockTypes(DstBlockBuffer);
 		testassert(memcmp(SrcBlockBuffer, DstBlockBuffer, (16 * 16 * 256) - 1) == 0);
 	}
-	
+
 	{
-		cChunkData buffer(Pool);
-	
+		cChunkData buffer(Pool, Dummy);
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		for (int i = 0; i < 16 * 16 * 256 / 2; i += 4)
 		{
@@ -60,21 +61,21 @@ int main(int argc, char** argv)
 			SrcNibbleBuffer[i + 2] = 0xbe;
 			SrcNibbleBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetMetas(SrcNibbleBuffer);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256/ 2];
 		buffer.CopyMetas(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-		
+
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 /2);
 		buffer.SetMetas(SrcNibbleBuffer);
 		buffer.CopyMetas(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
 	}
-	
+
 	{
-		cChunkData buffer(Pool);
-		
+		cChunkData buffer(Pool, Dummy);
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		for (int i = 0; i < 16 * 16 * 256 / 2; i += 4)
 		{
@@ -83,21 +84,21 @@ int main(int argc, char** argv)
 			SrcNibbleBuffer[i + 2] = 0xbe;
 			SrcNibbleBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetBlockLight(SrcNibbleBuffer);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256 / 2];
 		buffer.CopyBlockLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 /2) - 1) == 0);
-		
+
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 /2);
 		buffer.SetBlockLight(SrcNibbleBuffer);
 		buffer.CopyBlockLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 /2) - 1) == 0);
 	}
-	
+
 	{
-		cChunkData buffer(Pool);
-		
+		cChunkData buffer(Pool, Dummy);
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		for (int i = 0; i < 16 * 16 * 256 / 2; i += 4)
 		{
@@ -106,42 +107,42 @@ int main(int argc, char** argv)
 			SrcNibbleBuffer[i + 2] = 0xbe;
 			SrcNibbleBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetSkyLight(SrcNibbleBuffer);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256/ 2];
 		buffer.CopySkyLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-	
+
 		memset(SrcNibbleBuffer, 0xFF, 16 * 16 * 256 / 2);
 		buffer.SetSkyLight(SrcNibbleBuffer);
 		buffer.CopySkyLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
 	}
-	
+
 	{
-		cChunkData buffer(Pool);
-		
+		cChunkData buffer(Pool, Dummy);
+
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		memset(SrcBlockBuffer, 0x00, 16 * 16 * 256);
 		BLOCKTYPE DstBlockBuffer[16 * 16 * 256];
 		buffer.CopyBlockTypes(DstBlockBuffer);
 		testassert(memcmp(SrcBlockBuffer, DstBlockBuffer, (16 * 16 * 256) - 1) == 0);
-	
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 / 2);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256 / 2];
 		buffer.CopyMetas(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-	
+
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 / 2);
 		buffer.CopyBlockLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-	
+
 		memset(SrcNibbleBuffer, 0xFF, 16 * 16 * 256 / 2);
 		buffer.CopySkyLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
 	}
-	
+
 	// All tests successful:
 	return 0;
 }

--- a/tests/ChunkData/CopyBlocks.cpp
+++ b/tests/ChunkData/CopyBlocks.cpp
@@ -9,28 +9,29 @@
 
 #include "Globals.h"
 #include "ChunkData.h"
-
+#include "MemoryCounter.h"
 
 
 
 
 int main(int argc, char ** argv)
 {
+	cMemoryCounter Dummy;
 	// Set up a cChunkData with known contents - all blocks 0x01, all metas 0x02:
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
+	{
 		virtual cChunkData::sChunkSection * Allocate()
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
+
 		virtual void Free(cChunkData::sChunkSection * a_Ptr)
 		{
 			delete a_Ptr;
 		}
 	} Pool;
-	cChunkData Data(Pool);
+	cChunkData Data(Pool, Dummy);
 	cChunkDef::BlockTypes   BlockTypes;
 	cChunkDef::BlockNibbles BlockMetas;
 	memset(BlockTypes, 0x01, sizeof(BlockTypes));

--- a/tests/ChunkData/creatable.cpp
+++ b/tests/ChunkData/creatable.cpp
@@ -1,22 +1,24 @@
 
 #include "Globals.h"
 #include "ChunkData.h"
+#include "MemoryCounter.h"
 
 int main(int argc, char** argv)
 {
+	cMemoryCounter Dummy;
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
+	{
 		virtual cChunkData::sChunkSection * Allocate()
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
+
 		virtual void Free(cChunkData::sChunkSection * a_Ptr)
 		{
 			delete a_Ptr;
 		}
 	} Pool;
-	cChunkData buffer(Pool);
+	cChunkData buffer(Pool, Dummy);
 	return 0;
 }

--- a/tests/LoadablePieces/CMakeLists.txt
+++ b/tests/LoadablePieces/CMakeLists.txt
@@ -13,6 +13,7 @@ set (SHARED_SRCS
 	${CMAKE_SOURCE_DIR}/src/BlockArea.cpp
 	${CMAKE_SOURCE_DIR}/src/Cuboid.cpp
 	${CMAKE_SOURCE_DIR}/src/ChunkData.cpp
+	${CMAKE_SOURCE_DIR}/src/MemoryCounter.cpp
 	${CMAKE_SOURCE_DIR}/src/StringCompression.cpp
 	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
 
@@ -42,6 +43,7 @@ set (SHARED_HDRS
 	${CMAKE_SOURCE_DIR}/src/BlockArea.h
 	${CMAKE_SOURCE_DIR}/src/Cuboid.h
 	${CMAKE_SOURCE_DIR}/src/ChunkData.h
+	${CMAKE_SOURCE_DIR}/src/MemoryCounter.h
 	${CMAKE_SOURCE_DIR}/src/Globals.h
 	${CMAKE_SOURCE_DIR}/src/StringCompression.h
 	${CMAKE_SOURCE_DIR}/src/StringUtils.h


### PR DESCRIPTION
Work in progress. This is a smarter replacement for #3142

- The server has  a `MaxChunkRAM` setting, configurable in `settings.ini` (default: 30 MiB)
- The server has a `MinimizeRam` setting, configurable in `settings.ini` (default: 1)

**Terminology:**
Dirtiness:
- Clean chunk: No changes were made, no need to save to disk before unloading.
- Dirty chunk: A chunk which underwent changes. Must save to disk before unloading.

Usage:

- Unused chunk: A chunk with no players (nor chunkStay, etc.) nearby, the server may unload this.
- Used chunk: A chunk which is actively used by the game. The server must not unload this.

Other:

- Saving a chunk: Turns dirty chunks into clean chunks by saving them to disk. After a save, the chunk is no longer dirty and the server may unload it.
- Unloading a chunk: Removing a chunk from RAM and freeing that RAM. We can only unload chunks that are both unused and clean.

The server has two saving/unloading strategies.

**Strategy 1: `MinimizeRam` is 0:**
 The server is RAM-greedy, and uses all the RAM specified in `MaxChunkRAM` as a chunk cache in order to improve performance. Chunks are saved/unloaded as late as possible. Disk I/O is significantly reduced. Performance is improved. RAM usage is typically static and will not go below or above  `MaxChunkRAM`.
 - Dirty chunks are saved in 5 minute intervals to avoid data loss in case of a crash.
 - If current RAM usage exceeds `MaxChunkRAM`, a minimum amount of clean unused chunks is unloaded in order to preserve the `MaxChunkRAM` limit. The chunks are chosen randomly.
 - If there are no clean unused chunks left to unload and `MaxChunkRAM` still cannot be maintained, a save cycle is forced, allowing more chunks to be unloaded.
 - Other than the above three scenarios, chunks are never unloaded or saved.
 - The amount of RAM used by chunks is normally static and equals `MaxChunkRAM`
 - If the activity is too high and the `MaxChunkRAM` limit cannot be maintained even after all measures were taken, the "agressive" strategy is used. This happens when the RAM required by the **used chunks** exceeds `MaxChunkRAM`.

**Strategy 2: `MinimizeRam` is 1:** (Might remove this strategy)
 The server is RAM-economic, attempts to never reach `MaxChunkRAM`. Clean unused Chunks are unloaded as soon as possible.
 - Dirty chunks are saved in 5 minute intervals to avoid data loss in case of a crash.
 - Clean unused chunks are unloaded as soon as possible, making `MaxChunkRAM` much harder to reach in comparison with the previous scheme.
 - If current RAM usage exceeds `MaxChunkRAM`, a save cycle is forced, allowing more chunks to be unloaded.
 - Other than the three above scenarios, chunks are never unloaded or saved.
 - If the activity is too high and the `MaxChunkRAM` limit cannot be maintained, the "agressive" strategy is used. This happens when the RAM required by the **used chunks** exceeds `MaxChunkRAM`.

**"Agressive" strategy**:
 - Dirty chunks are saved in 5 minute intervals to avoid data loss in case of a crash.
 - Whenever a chunk becomes unused, it is unloaded asap (and saved if dirty).
 - The agressive strategy is technically nonexistent and does not have its own code. It's just what happens when the server is constantly above `MaxChunkRAM` in either strategy.

Additionally, this closes #3166 