### PR TITLE
ChunkLayers now stored in std::map

### DIFF
--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -12,7 +12,6 @@
 
 
 
-
 class cWorld;
 class cWorldInterface;
 class cItem;
@@ -68,7 +67,6 @@ public:
 	static const int LAYER_SIZE = 32;
 
 	cChunkMap(cWorld * a_World);
-	~cChunkMap();
 
 	// Broadcast respective packets to all clients of the chunk where the event is taking place
 	// (Please keep these alpha-sorted)
@@ -424,6 +422,8 @@ private:
 		);
 		~cChunkLayer();
 
+		cChunkLayer(const cChunkLayer & a_That) = delete;
+
 		/** Always returns an assigned chunkptr, but the chunk needn't be valid (loaded / generated) - callers must check */
 		cChunkPtr GetChunk( int a_ChunkX, int a_ChunkZ);
 
@@ -506,7 +506,7 @@ private:
 	void RemoveLayer(cChunkLayer * a_Layer);
 
 	cCriticalSection m_CSLayers;
-	cChunkLayerList  m_Layers;
+	std::map<std::pair<int, int>, cChunkLayer>  m_Layers;
 	cEvent           m_evtChunkValid;  // Set whenever any chunk becomes valid, via ChunkValidated()
 
 	cWorld * m_World;


### PR DESCRIPTION
This is just an exploratory alternative to #2565. I have no idea if it's better, it might be not.
- #2565 has a map of chunks in cChunkMap
- This has a map of chunkLayers in cChunkMap. It means there are a thousand (64*64) times less items at best in the map at any given time.

If #2565 uses an unordered_map instead, it *might* outperform both. But we may need to tweak it to minimize rehashing and collisions.