### PR TITLE
Fix crash on world travel

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -364,7 +364,7 @@ void cPlayer::TickFreezeCode()
 	}
 	else
 	{
-		if (!GetClientHandle()->IsPlayerChunkSent())
+		if (!GetClientHandle()->IsPlayerChunkSent() || (!GetParentChunk()->IsValid()))
 		{
 			FreezeInternal(GetPosition(), false);
 		}


### PR DESCRIPTION
@tigerw you mentioned that you believe the player's tick sometimes does not bail out when the parent chunk is not valid, causing an assert failure in `cPlayer line 259`, but you weren't sure. This appears to be correct. I guess it's some quirk with cClientHandle or cChunkSender. This workaround should resolve it. But I really want to take a deep look at `cClientHandle` and `cChunkSender` later. They seem to be causing lots of trouble.