### PR TITLE
Don't let redstone blocks power adjacent blocks.

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
@@ -36,7 +36,7 @@ cRedstoneHandler * cIncrementalRedstoneSimulator::CreateComponent(cWorld & a_Wor
 	{
 		case E_BLOCK_ACTIVATOR_RAIL:
 		case E_BLOCK_DETECTOR_RAIL:
-		case E_BLOCK_POWERED_RAIL: 
+		case E_BLOCK_POWERED_RAIL:
 		{
 			static cPoweredRailHandler ComponentHandler(a_World);
 			return &ComponentHandler;

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneBlockHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneBlockHandler.h
@@ -23,8 +23,7 @@ public:
 		UNUSED(a_BlockType);
 		UNUSED(a_Meta);
 		UNUSED(a_QueryPosition);
-		UNUSED(a_QueryBlockType);
-		return 15;
+		return cIncrementalRedstoneSimulator::IsMechanism(a_QueryBlockType) ? 15 : 0;
 	}
 
 	virtual unsigned char GetPowerLevel(const Vector3i & a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) override


### PR DESCRIPTION
This fixes issue #2966