### PR TITLE
Fixed explosions not causing some blocks to drop their broken variants (such as stone dropping cobblestone)

### DIFF
--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1853,7 +1853,18 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 							// No pickups for air
 							break;
 						}
-
+						case E_BLOCK_GRASS:
+						{
+							// Change the grass block to dirt
+							area.SetBlockType(bx + x, by + y, bz + z, E_BLOCK_DIRT);
+							// Do not break, we want the default case to run so the block is destroyed
+						}
+						case E_BLOCK_STONE:
+						{
+							// Change the stone block to cobblestone
+							area.SetBlockType(bx + x, by + y, bz + z, E_BLOCK_COBBLESTONE);
+							// Do not break, we want the default case to run so the block is destroyed
+						}
 						default:
 						{
 							if (m_World->GetTickRandomNumber(100) <= 25)  // 25% chance of pickups


### PR DESCRIPTION
Fixes #3194 

Blocks included:
Stone -> Cobblestone
Grass Blocks -> Dirt