### PR TITLE
Close chest window if minecart is destroyed

### DIFF
--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1206,6 +1206,7 @@ void cMinecartWithChest::OpenNewWindow()
 
 void cMinecartWithChest::Destroyed()
 {
+	GetWindow()->OwnerDestroyed();
 	cItems Pickups;
 	m_Contents.CopyToItems(Pickups);
 	GetWorld()->SpawnItemPickups(Pickups, GetPosX(), GetPosY() + 1, GetPosZ(), 4);


### PR DESCRIPTION
This fixes a part of #2934, by closing the window if the minecart chest gets destroyed.

For the block chest, is the method `cChunkMap::DoExplosionAt` a good place to add code to destroy block entites to fix the whole issue?