### PR TITLE
Fix tab list sometimes not updating after a player leaves.

### DIFF
--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2548,7 +2548,7 @@ void cWorld::BroadcastPlayerListRemovePlayer(const cPlayer & a_Player, const cCl
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
 	{
 		cClientHandle * ch = (*itr)->GetClientHandle();
-		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn() || ch->IsDestroyed())
+		if ((ch == a_Exclude) || (ch == nullptr) || !ch->IsLoggedIn())
 		{
 			continue;
 		}


### PR DESCRIPTION
When a player leaves the game, their client handle has its state
changed to csDestroyed.

This should fix issue #3138 

@madmaxoft how did this even work in the first place? Is there an error in the logic somewhere else?