### PR TITLE
Add {} around easyinstall.sh

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+{
+
+set -e
+
 PLATFORM=$(uname -m)
 
 echo "Identifying platform: $PLATFORM"
@@ -15,3 +19,5 @@ curl -s $DOWNLOADURL | tar -xzf -
 echo "Done."
 
 echo "Cuberite is now installed, run using 'cd Server; ./Cuberite'."
+
+}


### PR DESCRIPTION
This makes piping the download to sh safer.