### PR TITLE
Add UrlClient API

### DIFF
--- a/Server/Plugins/Debuggers/Info.lua
+++ b/Server/Plugins/Debuggers/Info.lua
@@ -224,6 +224,12 @@ g_PluginInfo =
 			HelpString = "Performs cBoundingBox API tests",
 		},
 		
+		["download"] =
+		{
+			Handler = HandleConsoleDownload,
+			HelpString = "Downloads a file from a specified URL",
+		},
+		
 		["hash"] =
 		{
 			Handler = HandleConsoleHash,
@@ -276,6 +282,12 @@ g_PluginInfo =
 		{
 			Handler = HandleConsoleTestTracer,
 			HelpString = "Tests the cLineBlockTracer",
+		},
+		
+		["testurlclient"] =
+		{
+			Handler = HandleConsoleTestUrlClient,
+			HelpString = "Tests the cUrlClient",
 		},
 		
 		["testurlparser"] =

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -2139,6 +2139,17 @@ cLuaState * cLuaState::QueryCanonLuaState(void)
 
 
 
+void cLuaState::LogApiCallParamFailure(const char * a_FnName, const char * a_ParamNames)
+{
+	LOGWARNING("%s: Cannot read params: %s, bailing out.", a_FnName, a_ParamNames);
+	LogStackTrace();
+	LogStackValues("Values on the stack");
+}
+
+
+
+
+
 int cLuaState::ReportFnCallErrors(lua_State * a_LuaState)
 {
 	LOGWARNING("LUA: %s", lua_tostring(a_LuaState, -1));

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -301,6 +301,26 @@ public:
 			return cLuaState(m_Ref.GetLuaState()).CallTableFn(m_Ref, a_FnName, std::forward<Args>(args)...);
 		}
 
+		/** Calls the Lua function stored under the specified name in the referenced table, if still available.
+		A "self" parameter is injected in front of all the given parameters and is set to the callback table.
+		Returns true if callback has been called.
+		Returns false if the Lua state isn't valid anymore, or the function doesn't exist. */
+		template <typename... Args>
+		bool CallTableFnWithSelf(const char * a_FnName, Args &&... args)
+		{
+			auto cs = m_CS;
+			if (cs == nullptr)
+			{
+				return false;
+			}
+			cCSLock Lock(*cs);
+			if (!m_Ref.IsValid())
+			{
+				return false;
+			}
+			return cLuaState(m_Ref.GetLuaState()).CallTableFn(m_Ref, a_FnName, m_Ref, std::forward<Args>(args)...);
+		}
+
 		/** Set the contained reference to the table in the specified Lua state's stack position.
 		If another table has been previously contained, it is unreferenced first.
 		Returns true on success, false on failure (not a table at the specified stack pos). */
@@ -740,6 +760,10 @@ public:
 	/** Returns the canon Lua state (the primary cLuaState instance that was used to create, rather than attach, the lua_State structure).
 	Returns nullptr if the canon Lua state cannot be queried. */
 	cLuaState * QueryCanonLuaState(void);
+
+	/** Outputs to log a warning about API call being unable to read its parameters from the stack,
+	logs the stack trace and stack values. */
+	void LogApiCallParamFailure(const char * a_FnName, const char * a_ParamNames);
 
 protected:
 

--- a/src/Bindings/LuaTCPLink.h
+++ b/src/Bindings/LuaTCPLink.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "../OSSupport/Network.h"
-#include "../PolarSSL++/SslContext.h"
 #include "LuaState.h"
 
 
@@ -90,54 +89,6 @@ public:
 	);
 
 protected:
-	// fwd:
-	class cLinkSslContext;
-	typedef SharedPtr<cLinkSslContext> cLinkSslContextPtr;
-	typedef WeakPtr<cLinkSslContext> cLinkSslContextWPtr;
-
-	/** Wrapper around cSslContext that is used when this link is being encrypted by SSL. */
-	class cLinkSslContext :
-		public cSslContext
-	{
-		cLuaTCPLink & m_Link;
-
-		/** Buffer for storing the incoming encrypted data until it is requested by the SSL decryptor. */
-		AString m_EncryptedData;
-
-		/** Buffer for storing the outgoing cleartext data until the link has finished handshaking. */
-		AString m_CleartextData;
-
-		/** Shared ownership of self, so that this object can keep itself alive for as long as it needs. */
-		cLinkSslContextWPtr m_Self;
-
-	public:
-		cLinkSslContext(cLuaTCPLink & a_Link);
-
-		/** Shares ownership of self, so that this object can keep itself alive for as long as it needs. */
-		void SetSelf(cLinkSslContextWPtr a_Self);
-
-		/** Removes the self ownership so that we can detect the SSL closure. */
-		void ResetSelf(void);
-
-		/** Stores the specified block of data into the buffer of the data to be decrypted (incoming from remote).
-		Also flushes the SSL buffers by attempting to read any data through the SSL context. */
-		void StoreReceivedData(const char * a_Data, size_t a_NumBytes);
-
-		/** Tries to read any cleartext data available through the SSL, reports it in the link. */
-		void FlushBuffers(void);
-
-		/** Tries to finish handshaking the SSL. */
-		void TryFinishHandshaking(void);
-
-		/** Sends the specified cleartext data over the SSL to the remote peer.
-		If the handshake hasn't been completed yet, queues the data for sending when it completes. */
-		void Send(const AString & a_Data);
-
-		// cSslContext overrides:
-		virtual int ReceiveEncrypted(unsigned char * a_Buffer, size_t a_NumBytes) override;
-		virtual int SendEncrypted(const unsigned char * a_Buffer, size_t a_NumBytes) override;
-	};
-
 
 	/** The Lua table that holds the callbacks to be invoked. */
 	cLuaState::cTableRefPtr m_Callbacks;
@@ -148,11 +99,6 @@ protected:
 
 	/** The server that is responsible for this link, if any. */
 	cLuaServerHandleWPtr m_Server;
-
-	/** The SSL context used for encryption, if this link uses SSL.
-	If valid, the link uses encryption through this context. */
-	cLinkSslContextPtr m_SslContext;
-
 
 	/** Common code called when the link is considered as terminated.
 	Releases m_Link, m_Callbacks and this from m_Server, each when applicable. */

--- a/src/HTTP/CMakeLists.txt
+++ b/src/HTTP/CMakeLists.txt
@@ -13,6 +13,7 @@ SET (SRCS
 	NameValueParser.cpp
 	SslHTTPServerConnection.cpp
 	TransferEncodingParser.cpp
+	UrlClient.cpp
 	UrlParser.cpp
 )
 
@@ -27,6 +28,7 @@ SET (HDRS
 	NameValueParser.h
 	SslHTTPServerConnection.h
 	TransferEncodingParser.h
+	UrlClient.h
 	UrlParser.h
 )
 

--- a/src/HTTP/HTTPMessageParser.h
+++ b/src/HTTP/HTTPMessageParser.h
@@ -31,7 +31,8 @@ public:
 		/** Called when an error has occured while parsing. */
 		virtual void OnError(const AString & a_ErrorDescription) = 0;
 
-		/** Called when the first line (request / status) is fully parsed. */
+		/** Called when the first line of the request or response is fully parsed.
+		Doesn't check the validity of the line, only extracts the first complete line. */
 		virtual void OnFirstLine(const AString & a_FirstLine) = 0;
 
 		/** Called when a single header line is parsed. */

--- a/src/HTTP/UrlClient.cpp
+++ b/src/HTTP/UrlClient.cpp
@@ -1,0 +1,611 @@
+
+// UrlClient.cpp
+
+// Implements the cUrlClient class for high-level URL interaction
+
+#include "Globals.h"
+#include "UrlClient.h"
+#include "UrlParser.h"
+#include "HTTPMessageParser.h"
+
+
+
+
+
+// fwd:
+class cSchemeHandler;
+typedef SharedPtr<cSchemeHandler> cSchemeHandlerPtr;
+
+
+
+
+
+class cUrlClientRequest:
+	public cNetwork::cConnectCallbacks,
+	public cTCPLink::cCallbacks
+{
+	friend class cHttpSchemeHandler;
+
+public:
+	static std::pair<bool, AString> Request(
+		const AString & a_Method,
+		const AString & a_URL,
+		cUrlClient::cCallbacks & a_Callbacks,
+		AStringMap && a_Headers,
+		const AString & a_Body,
+		AStringMap && a_Options
+	)
+	{
+		// Create a new instance of cUrlClientRequest, wrapped in a SharedPtr, so that it has a controlled lifetime.
+		// Cannot use std::make_shared, because the constructor is not public
+		SharedPtr<cUrlClientRequest> ptr (new cUrlClientRequest(
+			a_Method, a_URL, a_Callbacks, std::move(a_Headers), a_Body, std::move(a_Options)
+		));
+		return ptr->DoRequest(ptr);
+	}
+
+
+	/** Calls the error callback with the specified message, if it exists, and terminates the request. */
+	void CallErrorCallback(const AString & a_ErrorMessage)
+	{
+		// Call the error callback:
+		m_Callbacks.OnError(a_ErrorMessage);
+
+		// Terminate the request's TCP link:
+		auto link = m_Link;
+		if (link != nullptr)
+		{
+			link->Close();
+		}
+		m_Self.reset();
+	}
+
+
+	cUrlClient::cCallbacks & GetCallbacks() { return m_Callbacks; }
+
+	void RedirectTo(const AString & a_RedirectUrl);
+
+	bool ShouldAllowRedirects() const;
+
+
+protected:
+
+	/** Method to be used for the request */
+	AString m_Method;
+
+	/** URL that will be requested. */
+	AString m_Url;
+
+	/** Individual components of the URL that will be requested. */
+	AString m_UrlScheme, m_UrlUsername, m_UrlPassword, m_UrlHost, m_UrlPath, m_UrlQuery, m_UrlFragment;
+	UInt16 m_UrlPort;
+
+	/** Callbacks that report progress and results of the request. */
+	cUrlClient::cCallbacks & m_Callbacks;
+
+	/** Extra headers to be sent with the request (besides the normal ones). */
+	AStringMap m_Headers;
+
+	/** Body to be sent with the request, if any. */
+	AString m_Body;
+
+	/** Extra options to be used for the request. */
+	AStringMap m_Options;
+
+	/** SharedPtr to self, so that this object can keep itself alive for as long as it needs,
+	and pass self as callbacks to cNetwork functions. */
+	SharedPtr<cUrlClientRequest> m_Self;
+
+	/** The handler that "talks" the protocol specified in m_UrlScheme, handles all the sending and receiving. */
+	SharedPtr<cSchemeHandler> m_SchemeHandler;
+
+	/** The link handling the request. */
+	cTCPLinkPtr m_Link;
+
+	/** The number of redirect attempts that will still be followed.
+	If the response specifies a redirect and this is nonzero, the redirect is followed.
+	If the response specifies a redirect and this is zero, a redirect loop is reported as an error. */
+	int m_NumRemainingRedirects;
+
+
+	cUrlClientRequest(
+		const AString & a_Method,
+		const AString & a_Url,
+		cUrlClient::cCallbacks & a_Callbacks,
+		AStringMap && a_Headers,
+		const AString & a_Body,
+		AStringMap && a_Options
+	):
+		m_Method(a_Method),
+		m_Url(a_Url),
+		m_Callbacks(a_Callbacks),
+		m_Headers(std::move(a_Headers)),
+		m_Body(a_Body),
+		m_Options(std::move(a_Options))
+	{
+		m_NumRemainingRedirects = GetStringMapInteger(m_Options, "MaxRedirects", 30);
+	}
+
+
+	std::pair<bool, AString> DoRequest(SharedPtr<cUrlClientRequest> a_Self);
+
+
+	// cNetwork::cConnectCallbacks override: TCP link connected:
+	virtual void OnConnected(cTCPLink & a_Link) override;
+
+	// cNetwork::cConnectCallbacks override: An error has occurred:
+	virtual void OnError(int a_ErrorCode, const AString & a_ErrorMsg) override
+	{
+		m_Callbacks.OnError(Printf("Network error %d (%s)", a_ErrorCode, a_ErrorMsg.c_str()));
+		m_Self.reset();
+	}
+
+
+	// cTCPLink::cCallbacks override: TCP link created
+	virtual void OnLinkCreated(cTCPLinkPtr a_Link) override
+	{
+		m_Link = a_Link;
+	}
+
+
+	/** Called when there's data incoming from the remote peer. */
+	virtual void OnReceivedData(const char * a_Data, size_t a_Length) override;
+
+
+	/** Called when the remote end closes the connection.
+	The link is still available for connection information query (IP / port).
+	Sending data on the link is not an error, but the data won't be delivered. */
+	virtual void OnRemoteClosed(void) override;
+};
+
+
+
+
+
+/** Represents a base class for an object that "talks" a specified URL protocol, such as HTTP or FTP.
+Also provides a static factory method for creating an instance based on the scheme.
+A descendant of this class is created for each request and handles all of the request's aspects,
+from right after connecting to the TCP link till the link is closed.
+For an example of a specific handler, see the cHttpSchemeHandler class. */
+class cSchemeHandler abstract
+{
+public:
+	cSchemeHandler(cUrlClientRequest & a_ParentRequest):
+		m_ParentRequest(a_ParentRequest)
+	{
+	}
+
+	// Force a virtual destructor in all descendants
+	virtual ~cSchemeHandler() {}
+
+	/** Creates and returns a new handler for the specified scheme.
+	a_ParentRequest is the request which is to be handled by the handler. */
+	static cSchemeHandlerPtr Create(const AString & a_Scheme, cUrlClientRequest & a_ParentRequest);
+
+	/** Called when the link gets established. */
+	virtual void OnConnected(cTCPLink & a_Link) = 0;
+
+	/** Called when there's data incoming from the remote peer. */
+	virtual void OnReceivedData(const char * a_Data, size_t a_Length) = 0;
+
+	/** Called when the remote end closes the connection.
+	The link is still available for connection information query (IP / port).
+	Sending data on the link is not an error, but the data won't be delivered. */
+	virtual void OnRemoteClosed(void) = 0;
+
+protected:
+	cUrlClientRequest & m_ParentRequest;
+};
+
+
+
+
+
+/** cSchemeHandler descendant that handles HTTP (and HTTPS) requests. */
+class cHttpSchemeHandler:
+	public cSchemeHandler,
+	protected cHTTPMessageParser::cCallbacks
+{
+	typedef cSchemeHandler Super;
+
+public:
+	cHttpSchemeHandler(cUrlClientRequest & a_ParentRequest, bool a_IsTls):
+		Super(a_ParentRequest),
+		m_Parser(*this),
+		m_IsTls(a_IsTls),
+		m_IsRedirect(false)
+	{
+	}
+
+
+	virtual void OnConnected(cTCPLink & a_Link) override
+	{
+		m_Link = &a_Link;
+		if (m_IsTls)
+		{
+			// TODO: Start TLS
+		}
+		else
+		{
+			SendRequest();
+		}
+	}
+
+	void SendRequest()
+	{
+		// Send the request:
+		auto requestLine = m_ParentRequest.m_UrlPath;
+		if (requestLine.empty())
+		{
+			requestLine = "/";
+		}
+		if (!m_ParentRequest.m_UrlQuery.empty())
+		{
+			requestLine.push_back('?');
+			requestLine.append(m_ParentRequest.m_UrlQuery);
+		}
+		m_Link->Send(Printf("%s %s HTTP/1.1\r\n", m_ParentRequest.m_Method.c_str(), requestLine.c_str()));
+		m_Link->Send(Printf("Host: %s\r\n", m_ParentRequest.m_UrlHost.c_str()));
+		m_Link->Send(Printf("Content-Length: %u\r\n", static_cast<unsigned>(m_ParentRequest.m_Body.size())));
+		for (auto itr = m_ParentRequest.m_Headers.cbegin(), end = m_ParentRequest.m_Headers.cend(); itr != end; ++itr)
+		{
+			m_Link->Send(Printf("%s: %s\r\n", itr->first.c_str(), itr->second.c_str()));
+		}  // for itr - m_Headers[]
+		m_Link->Send("\r\n", 2);
+		m_Link->Send(m_ParentRequest.m_Body);
+
+		// Notify the callbacks that the request has been sent:
+		m_ParentRequest.GetCallbacks().OnRequestSent();
+	}
+
+
+	virtual void OnReceivedData(const char * a_Data, size_t a_Length) override
+	{
+		auto res = m_Parser.Parse(a_Data, a_Length);
+		if (res == AString::npos)
+		{
+			m_ParentRequest.CallErrorCallback("Failed to parse HTTP response");
+			return;
+		}
+	}
+
+
+	virtual void OnRemoteClosed(void) override
+	{
+		m_Link = nullptr;
+	}
+
+
+	// cHTTPResponseParser::cCallbacks overrides:
+	virtual void OnError(const AString & a_ErrorDescription) override
+	{
+		m_ParentRequest.CallErrorCallback(a_ErrorDescription);
+		m_Link = nullptr;
+	}
+
+
+	virtual void OnFirstLine(const AString & a_FirstLine) override
+	{
+		// Find the first space, parse the result code between it and the second space:
+		auto idxFirstSpace = a_FirstLine.find(' ');
+		if (idxFirstSpace == AString::npos)
+		{
+			m_ParentRequest.CallErrorCallback(Printf("Failed to parse HTTP status line \"%s\", no space delimiter.", a_FirstLine.c_str()));
+			return;
+		}
+		auto idxSecondSpace = a_FirstLine.find(' ', idxFirstSpace + 1);
+		if (idxSecondSpace == AString::npos)
+		{
+			m_ParentRequest.CallErrorCallback(Printf("Failed to parse HTTP status line \"%s\", missing second space delimiter.", a_FirstLine.c_str()));
+			return;
+		}
+		int resultCode;
+		auto resultCodeStr = a_FirstLine.substr(idxFirstSpace + 1, idxSecondSpace - idxFirstSpace - 1);
+		if (!StringToInteger(resultCodeStr, resultCode))
+		{
+			m_ParentRequest.CallErrorCallback(Printf("Failed to parse HTTP result code from response \"%s\"", resultCodeStr.c_str()));
+			return;
+		}
+
+		// Check for redirects, follow if allowed by the options:
+		switch (resultCode)
+		{
+			case cUrlClient::HTTP_STATUS_MULTIPLE_CHOICES:
+			case cUrlClient::HTTP_STATUS_MOVED_PERMANENTLY:
+			case cUrlClient::HTTP_STATUS_FOUND:
+			case cUrlClient::HTTP_STATUS_SEE_OTHER:
+			case cUrlClient::HTTP_STATUS_TEMPORARY_REDIRECT:
+			{
+				m_IsRedirect = true;
+				return;
+			}
+		}
+		m_ParentRequest.GetCallbacks().OnStatusLine(a_FirstLine.substr(1, idxFirstSpace), resultCode, a_FirstLine.substr(idxSecondSpace + 1));
+	}
+
+
+	virtual void OnHeaderLine(const AString & a_Key, const AString & a_Value) override
+	{
+		if (m_IsRedirect)
+		{
+			if (a_Key == "Location")
+			{
+				m_RedirectLocation = a_Value;
+			}
+		}
+		else
+		{
+			m_ParentRequest.GetCallbacks().OnHeader(a_Key, a_Value);
+		}
+	}
+
+
+	/** Called when all the headers have been parsed. */
+	virtual void OnHeadersFinished(void) override
+	{
+		if (!m_IsRedirect)
+		{
+			m_ParentRequest.GetCallbacks().OnHeadersFinished();
+		}
+	}
+
+
+	/** Called for each chunk of the incoming body data. */
+	virtual void OnBodyData(const void * a_Data, size_t a_Size) override
+	{
+		if (!m_IsRedirect)
+		{
+			m_ParentRequest.GetCallbacks().OnBodyData(a_Data, a_Size);
+		}
+	}
+
+
+	/** Called when the entire body has been reported by OnBodyData(). */
+	virtual void OnBodyFinished(void) override
+	{
+		if (m_IsRedirect)
+		{
+			if (m_RedirectLocation.empty())
+			{
+				m_ParentRequest.CallErrorCallback("Invalid redirect, there's no location to redirect to");
+			}
+			else
+			{
+				m_ParentRequest.RedirectTo(m_RedirectLocation);
+			}
+		}
+		else
+		{
+			m_ParentRequest.GetCallbacks().OnBodyFinished();
+		}
+	}
+
+protected:
+
+	/** The network link. */
+	cTCPLink * m_Link;
+
+	/** If true, the TLS should be started on the link before sending the request (used for https). */
+	bool m_IsTls;
+
+	/** Parser of the HTTP response message. */
+	cHTTPMessageParser m_Parser;
+
+	/** Set to true if the first line contains a redirecting HTTP status code and the options specify to follow redirects.
+	If true, and the parent request allows redirects, neither headers not the body contents are reported through the callbacks,
+	and after the entire request is parsed, the redirect is attempted. */
+	bool m_IsRedirect;
+
+	/** The Location where the request should be redirected.
+	Only used when m_IsRedirect is true. */
+	AString m_RedirectLocation;
+};
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cSchemeHandler:
+
+cSchemeHandlerPtr cSchemeHandler::Create(const AString & a_Scheme, cUrlClientRequest & a_ParentRequest)
+{
+	auto lowerScheme = StrToLower(a_Scheme);
+	if (lowerScheme == "http")
+	{
+		return std::make_shared<cHttpSchemeHandler>(a_ParentRequest, false);
+	}
+	else if (lowerScheme == "https")
+	{
+		return std::make_shared<cHttpSchemeHandler>(a_ParentRequest, true);
+	}
+
+	return nullptr;
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cUrlClientRequest:
+
+void cUrlClientRequest::RedirectTo(const AString & a_RedirectUrl)
+{
+	// Check that redirection is allowed:
+	m_Callbacks.OnRedirecting(a_RedirectUrl);
+	if (!ShouldAllowRedirects())
+	{
+		CallErrorCallback(Printf("Redirect to \"%s\" not allowed", a_RedirectUrl.c_str()));
+		return;
+	}
+
+	// Do the actual redirect:
+	m_Link->Close();
+	m_Url = a_RedirectUrl;
+	m_NumRemainingRedirects = m_NumRemainingRedirects - 1;
+	auto res = DoRequest(m_Self);
+	if (!res.first)
+	{
+		m_Callbacks.OnError(Printf("Redirection failed: %s", res.second.c_str()));
+		return;
+	}
+}
+
+
+
+
+
+bool cUrlClientRequest::ShouldAllowRedirects() const
+{
+	return (m_NumRemainingRedirects > 0);
+}
+
+
+
+
+
+void cUrlClientRequest::OnConnected(cTCPLink & a_Link)
+{
+	m_Callbacks.OnConnected(a_Link);
+	m_SchemeHandler->OnConnected(a_Link);
+}
+
+
+
+
+
+void cUrlClientRequest::OnReceivedData(const char * a_Data, size_t a_Length)
+{
+	auto handler = m_SchemeHandler;
+	if (handler != nullptr)
+	{
+		handler->OnReceivedData(a_Data, a_Length);
+	}
+}
+
+
+
+
+
+void cUrlClientRequest::OnRemoteClosed()
+{
+	// Notify the callback:
+	auto handler = m_SchemeHandler;
+	if (handler != nullptr)
+	{
+		handler->OnRemoteClosed();
+	}
+
+	// Let ourselves be deleted
+	m_Self.reset();
+}
+
+
+
+
+
+std::pair<bool, AString> cUrlClientRequest::DoRequest(SharedPtr<cUrlClientRequest> a_Self)
+{
+	// We need a shared pointer to self, care must be taken not to pass any other ptr:
+	ASSERT(a_Self.get() == this);
+
+	m_Self = a_Self;
+
+	// Parse the URL:
+	auto res = cUrlParser::Parse(m_Url, m_UrlScheme, m_UrlUsername, m_UrlPassword, m_UrlHost, m_UrlPort, m_UrlPath, m_UrlQuery, m_UrlFragment);
+	if (!res.first)
+	{
+		return res;
+	}
+
+	// Get a handler that will work with the specified scheme:
+	m_SchemeHandler = cSchemeHandler::Create(m_UrlScheme, *this);
+	if (m_SchemeHandler == nullptr)
+	{
+		return std::make_pair(false, Printf("Unknown Url scheme: %s", m_UrlScheme.c_str()));
+	}
+
+	if (!cNetwork::Connect(m_UrlHost, m_UrlPort, m_Self, m_Self))
+	{
+		return std::make_pair(false, "Network connection failed");
+	}
+	return std::make_pair(true, AString());
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cUrlClient:
+
+std::pair<bool, AString> cUrlClient::Request(
+	const AString & a_Method,
+	const AString & a_URL,
+	cCallbacks & a_Callbacks,
+	AStringMap && a_Headers,
+	AString && a_Body,
+	AStringMap && a_Options
+)
+{
+	return cUrlClientRequest::Request(
+		a_Method, a_URL, a_Callbacks, std::move(a_Headers), std::move(a_Body), std::move(a_Options)
+	);
+}
+
+
+
+
+
+std::pair<bool, AString> cUrlClient::Get(
+	const AString & a_URL,
+	cCallbacks & a_Callbacks,
+	AStringMap a_Headers,
+	AString a_Body,
+	AStringMap a_Options
+)
+{
+	return cUrlClientRequest::Request(
+		"GET", a_URL, a_Callbacks, std::move(a_Headers), std::move(a_Body), std::move(a_Options)
+	);
+}
+
+
+
+
+
+std::pair<bool, AString> cUrlClient::Post(
+	const AString & a_URL,
+	cCallbacks & a_Callbacks,
+	AStringMap && a_Headers,
+	AString && a_Body,
+	AStringMap && a_Options
+)
+{
+	return cUrlClientRequest::Request(
+		"POST", a_URL, a_Callbacks, std::move(a_Headers), std::move(a_Body), std::move(a_Options)
+	);
+}
+
+
+
+
+
+std::pair<bool, AString> cUrlClient::Put(
+	const AString & a_URL,
+	cCallbacks & a_Callbacks,
+	AStringMap && a_Headers,
+	AString && a_Body,
+	AStringMap && a_Options
+)
+{
+	return cUrlClientRequest::Request(
+		"PUT", a_URL, a_Callbacks, std::move(a_Headers), std::move(a_Body), std::move(a_Options)
+	);
+}
+
+
+
+
+

--- a/src/HTTP/UrlClient.h
+++ b/src/HTTP/UrlClient.h
@@ -5,7 +5,10 @@
 
 /*
 Options that can be set via the Options parameter to the cUrlClient calls:
-"MaxRedirects": The maximum number of allowed redirects before the client refuses a redirect with an error
+"MaxRedirects":       The maximum number of allowed redirects before the client refuses a redirect with an error
+"OwnCert":            The client certificate to use, if requested by the server. Any string that can be parsed by cX509Cert.
+"OwnPrivKey":         The private key appropriate for OwnCert. Any string that can be parsed by cCryptoKey.
+"OwnPrivKeyPassword": The password for OwnPrivKey. If not present or empty, no password is assumed.
 
 Behavior:
 - If a redirect is received, and redirection is allowed, the redirection is reported via OnRedirecting() callback
@@ -34,8 +37,11 @@ public:
 	class cCallbacks
 	{
 	public:
+		// Force a virtual destructor in descendants:
+		virtual ~cCallbacks() {}
+
 		/** Called when the TCP connection is established. */
-		virtual void OnConnected(cTCPLink & a_Link) {};
+		virtual void OnConnected(cTCPLink & a_Link) {}
 
 		/** Called for TLS connections, when the server certificate is received.
 		Return true to continue with the request, false to abort.
@@ -43,30 +49,34 @@ public:
 		TODO: The certificate parameter needs a representation! */
 		virtual bool OnCertificateReceived() { return true; }
 
+		/** Called for TLS connections, when the TLS handshake has been completed.
+		An empty default implementation is provided so that clients don't need to reimplement it unless they are interested in the event. */
+		virtual void OnTlsHandshakeCompleted() { }
+
 		/** Called after the entire request has been sent to the remote peer. */
-		virtual void OnRequestSent() {};
+		virtual void OnRequestSent() {}
 
 		/** Called after the first line of the response is parsed, unless the response is an allowed redirect. */
 		virtual void OnStatusLine(const AString & a_HttpVersion, int a_StatusCode, const AString & a_Rest) {}
 
 		/** Called when a single HTTP header is received and parsed, unless the response is an allowed redirect
 		Called once for each incoming header. */
-		virtual void OnHeader(const AString & a_Key, const AString & a_Value) {};
+		virtual void OnHeader(const AString & a_Key, const AString & a_Value) {}
 
 		/** Called when the HTTP headers have been fully parsed, unless the response is an allowed redirect.
 		There will be no more OnHeader() calls. */
-		virtual void OnHeadersFinished() {};
+		virtual void OnHeadersFinished() {}
 
 		/** Called when the next fragment of the response body is received, unless the response is an allowed redirect.
 		This can be called multiple times, as data arrives over the network. */
-		virtual void OnBodyData(const void * a_Data, size_t a_Size) {};
+		virtual void OnBodyData(const void * a_Data, size_t a_Size) {}
 
 		/** Called after the response body has been fully reported by OnBody() calls, unless the response is an allowed redirect.
 		There will be no more OnBody() calls. */
-		virtual void OnBodyFinished() {};
+		virtual void OnBodyFinished() {}
 
 		/** Called when an asynchronous error is encountered. */
-		virtual void OnError(const AString & a_ErrorMsg) {};
+		virtual void OnError(const AString & a_ErrorMsg) {}
 
 		/** Called when a redirect is to be followed.
 		This is called even if the redirecting is prohibited by the options; in such an event, this call will be
@@ -74,7 +84,7 @@ public:
 		If a response indicates a redirect (and the request allows redirecting), the regular callbacks
 		OnStatusLine(), OnHeader(), OnHeadersFinished(), OnBodyData() and OnBodyFinished() are not called
 		for such a response; instead, the redirect is silently attempted. */
-		virtual void OnRedirecting(const AString & a_NewLocation) {};
+		virtual void OnRedirecting(const AString & a_NewLocation) {}
 	};
 
 

--- a/src/HTTP/UrlClient.h
+++ b/src/HTTP/UrlClient.h
@@ -86,6 +86,7 @@ public:
 		for such a response; instead, the redirect is silently attempted. */
 		virtual void OnRedirecting(const AString & a_NewLocation) {}
 	};
+	typedef UniquePtr<cCallbacks> cCallbacksPtr;
 
 
 	/** Used for HTTP status codes. */
@@ -112,7 +113,7 @@ public:
 	static std::pair<bool, AString> Request(
 		const AString & a_Method,
 		const AString & a_URL,
-		cCallbacks & a_Callbacks,
+		cCallbacksPtr && a_Callbacks,
 		AStringMap && a_Headers,
 		AString && a_Body,
 		AStringMap && a_Options
@@ -121,7 +122,7 @@ public:
 	/** Alias for Request("GET", ...) */
 	static std::pair<bool, AString> Get(
 		const AString & a_URL,
-		cCallbacks & a_Callbacks,
+		cCallbacksPtr && a_Callbacks,
 		AStringMap a_Headers = AStringMap(),
 		AString a_Body = AString(),
 		AStringMap a_Options = AStringMap()
@@ -130,7 +131,7 @@ public:
 	/** Alias for Request("POST", ...) */
 	static std::pair<bool, AString> Post(
 		const AString & a_URL,
-		cCallbacks & a_Callbacks,
+		cCallbacksPtr && a_Callbacks,
 		AStringMap && a_Headers,
 		AString && a_Body,
 		AStringMap && a_Options
@@ -139,7 +140,7 @@ public:
 	/** Alias for Request("PUT", ...) */
 	static std::pair<bool, AString> Put(
 		const AString & a_URL,
-		cCallbacks & a_Callbacks,
+		cCallbacksPtr && a_Callbacks,
 		AStringMap && a_Headers,
 		AString && a_Body,
 		AStringMap && a_Options

--- a/src/HTTP/UrlClient.h
+++ b/src/HTTP/UrlClient.h
@@ -1,0 +1,141 @@
+
+// UrlClient.h
+
+// Declares the cUrlClient class for high-level URL interaction
+
+/*
+Options that can be set via the Options parameter to the cUrlClient calls:
+"MaxRedirects": The maximum number of allowed redirects before the client refuses a redirect with an error
+
+Behavior:
+- If a redirect is received, and redirection is allowed, the redirection is reported via OnRedirecting() callback
+and the request is restarted at the redirect URL, without reporting any of the redirect's headers nor body
+- If a redirect is received and redirection is not allowed (maximum redirection attempts have been reached),
+the OnRedirecting() callback is called with the redirect URL and then the request terminates with an OnError() callback,
+without reporting the redirect's headers nor body.
+*/
+
+
+
+
+
+#pragma once
+
+#include "../OSSupport/Network.h"
+
+
+
+
+
+class cUrlClient
+{
+public:
+	/** Callbacks that are used for progress and result reporting. */
+	class cCallbacks
+	{
+	public:
+		/** Called when the TCP connection is established. */
+		virtual void OnConnected(cTCPLink & a_Link) {};
+
+		/** Called for TLS connections, when the server certificate is received.
+		Return true to continue with the request, false to abort.
+		The default implementation does nothing and continues with the request.
+		TODO: The certificate parameter needs a representation! */
+		virtual bool OnCertificateReceived() { return true; }
+
+		/** Called after the entire request has been sent to the remote peer. */
+		virtual void OnRequestSent() {};
+
+		/** Called after the first line of the response is parsed, unless the response is an allowed redirect. */
+		virtual void OnStatusLine(const AString & a_HttpVersion, int a_StatusCode, const AString & a_Rest) {}
+
+		/** Called when a single HTTP header is received and parsed, unless the response is an allowed redirect
+		Called once for each incoming header. */
+		virtual void OnHeader(const AString & a_Key, const AString & a_Value) {};
+
+		/** Called when the HTTP headers have been fully parsed, unless the response is an allowed redirect.
+		There will be no more OnHeader() calls. */
+		virtual void OnHeadersFinished() {};
+
+		/** Called when the next fragment of the response body is received, unless the response is an allowed redirect.
+		This can be called multiple times, as data arrives over the network. */
+		virtual void OnBodyData(const void * a_Data, size_t a_Size) {};
+
+		/** Called after the response body has been fully reported by OnBody() calls, unless the response is an allowed redirect.
+		There will be no more OnBody() calls. */
+		virtual void OnBodyFinished() {};
+
+		/** Called when an asynchronous error is encountered. */
+		virtual void OnError(const AString & a_ErrorMsg) {};
+
+		/** Called when a redirect is to be followed.
+		This is called even if the redirecting is prohibited by the options; in such an event, this call will be
+		followed by OnError().
+		If a response indicates a redirect (and the request allows redirecting), the regular callbacks
+		OnStatusLine(), OnHeader(), OnHeadersFinished(), OnBodyData() and OnBodyFinished() are not called
+		for such a response; instead, the redirect is silently attempted. */
+		virtual void OnRedirecting(const AString & a_NewLocation) {};
+	};
+
+
+	/** Used for HTTP status codes. */
+	enum eHTTPStatus
+	{
+		HTTP_STATUS_OK                 = 200,
+		HTTP_STATUS_MULTIPLE_CHOICES   = 300,  // MAY have a redirect using the "Location" header
+		HTTP_STATUS_MOVED_PERMANENTLY  = 301,  // redirect using the "Location" header
+		HTTP_STATUS_FOUND              = 302,  // redirect using the "Location" header
+		HTTP_STATUS_SEE_OTHER          = 303,  // redirect using the "Location" header
+		HTTP_STATUS_TEMPORARY_REDIRECT = 307,  // redirect using the "Location" header
+	};
+
+
+	/** Makes a network request to the specified URL, using the specified method (if applicable).
+	The response is reported via the a_ResponseCallback callback, in a single call.
+	The metadata about the response (HTTP headers) are reported via a_InfoCallback before the a_ResponseCallback call.
+	If there is an asynchronous error, it is reported in via the a_ErrorCallback.
+	If there is an immediate error (misformatted URL etc.), the function returns false and an error message.
+	a_Headers contains additional headers to use for the request.
+	a_Body specifies optional body to include with the request, if applicable.
+	a_Options contains various options for the request that govern the request behavior, but aren't sent to the server,
+	such as the proxy server, whether to follow redirects, and client certificate for TLS. */
+	static std::pair<bool, AString> Request(
+		const AString & a_Method,
+		const AString & a_URL,
+		cCallbacks & a_Callbacks,
+		AStringMap && a_Headers,
+		AString && a_Body,
+		AStringMap && a_Options
+	);
+
+	/** Alias for Request("GET", ...) */
+	static std::pair<bool, AString> Get(
+		const AString & a_URL,
+		cCallbacks & a_Callbacks,
+		AStringMap a_Headers = AStringMap(),
+		AString a_Body = AString(),
+		AStringMap a_Options = AStringMap()
+	);
+
+	/** Alias for Request("POST", ...) */
+	static std::pair<bool, AString> Post(
+		const AString & a_URL,
+		cCallbacks & a_Callbacks,
+		AStringMap && a_Headers,
+		AString && a_Body,
+		AStringMap && a_Options
+	);
+
+	/** Alias for Request("PUT", ...) */
+	static std::pair<bool, AString> Put(
+		const AString & a_URL,
+		cCallbacks & a_Callbacks,
+		AStringMap && a_Headers,
+		AString && a_Body,
+		AStringMap && a_Options
+	);
+};
+
+
+
+

--- a/src/OSSupport/Network.h
+++ b/src/OSSupport/Network.h
@@ -20,6 +20,11 @@ typedef std::vector<cTCPLinkPtr> cTCPLinkPtrs;
 class cServerHandle;
 typedef SharedPtr<cServerHandle> cServerHandlePtr;
 typedef std::vector<cServerHandlePtr> cServerHandlePtrs;
+class cCryptoKey;
+typedef SharedPtr<cCryptoKey> cCryptoKeyPtr;
+class cX509Cert;
+typedef SharedPtr<cX509Cert> cX509CertPtr;
+
 
 
 
@@ -48,6 +53,10 @@ public:
 		The link is still available for connection information query (IP / port).
 		Sending data on the link is not an error, but the data won't be delivered. */
 		virtual void OnRemoteClosed(void) = 0;
+
+		/** Called when the TLS handshake has been completed and communication can continue regularly.
+		Has an empty default implementation, so that link callback descendants don't need to specify TLS handlers when they don't use TLS at all. */
+		virtual void OnTlsHandshakeCompleted(void) {}
 
 		/** Called when an error is detected on the connection. */
 		virtual void OnError(int a_ErrorCode, const AString & a_ErrorMsg) = 0;
@@ -89,6 +98,30 @@ public:
 	/** Drops the connection without any more processing.
 	Sends the RST packet, queued outgoing and incoming data is lost. */
 	virtual void Close(void) = 0;
+
+	/** Starts a TLS handshake as a client connection.
+	If a client certificate should be used for the connection, set the certificate into a_OwnCertData and
+	its corresponding private key to a_OwnPrivKeyData. If both are empty, no client cert is presented.
+	a_OwnPrivKeyPassword is the password to be used for decoding PrivKey, empty if not passworded.
+	Returns empty string on success, non-empty error description on failure. */
+	virtual AString StartTLSClient(
+		cX509CertPtr a_OwnCert,
+		cCryptoKeyPtr a_OwnPrivKey
+	) = 0;
+
+	/** Starts a TLS handshake as a server connection.
+	Set the server certificate into a_CertData and its corresponding private key to a_OwnPrivKeyData.
+	a_OwnPrivKeyPassword is the password to be used for decoding PrivKey, empty if not passworded.
+	a_StartTLSData is any data that should be pushed into the TLS before reading more data from the remote.
+	This is used mainly for protocols starting TLS in the middle of communication, when the TLS start command
+	can be received together with the TLS Client Hello message in one OnReceivedData() call, to re-queue the
+	Client Hello message into the TLS handshake buffer.
+	Returns empty string on success, non-empty error description on failure. */
+	virtual AString StartTLSServer(
+		cX509CertPtr a_OwnCert,
+		cCryptoKeyPtr a_OwnPrivKey,
+		const AString & a_StartTLSData
+	) = 0;
 
 	/** Returns the callbacks that are used. */
 	cCallbacksPtr GetCallbacks(void) const { return m_Callbacks; }

--- a/src/OSSupport/TCPLinkImpl.cpp
+++ b/src/OSSupport/TCPLinkImpl.cpp
@@ -48,6 +48,9 @@ cTCPLinkImpl::cTCPLinkImpl(evutil_socket_t a_Socket, cTCPLink::cCallbacksPtr a_L
 
 cTCPLinkImpl::~cTCPLinkImpl()
 {
+	// If the TLS context still exists, free it:
+	m_TlsContext.reset();
+
 	bufferevent_free(m_BufferEvent);
 }
 
@@ -129,7 +132,16 @@ bool cTCPLinkImpl::Send(const void * a_Data, size_t a_Length)
 		LOGD("%s: Cannot send data, the link is already shut down.", __FUNCTION__);
 		return false;
 	}
-	return (bufferevent_write(m_BufferEvent, a_Data, a_Length) == 0);
+
+	// If running in TLS mode, push the data into the TLS context instead:
+	if (m_TlsContext != nullptr)
+	{
+		m_TlsContext->Send(a_Data, a_Length);
+		return true;
+	}
+
+	// Send the data:
+	return SendRaw(a_Data, a_Length);
 }
 
 
@@ -138,6 +150,14 @@ bool cTCPLinkImpl::Send(const void * a_Data, size_t a_Length)
 
 void cTCPLinkImpl::Shutdown(void)
 {
+	// If running in TLS mode, notify the TLS layer:
+	if (m_TlsContext != nullptr)
+	{
+		m_TlsContext->NotifyClose();
+		m_TlsContext->ResetSelf();
+		m_TlsContext.reset();
+	}
+
 	// If there's no outgoing data, shutdown the socket directly:
 	if (evbuffer_get_length(bufferevent_get_output(m_BufferEvent)) == 0)
 	{
@@ -155,6 +175,14 @@ void cTCPLinkImpl::Shutdown(void)
 
 void cTCPLinkImpl::Close(void)
 {
+	// If running in TLS mode, notify the TLS layer:
+	if (m_TlsContext != nullptr)
+	{
+		m_TlsContext->NotifyClose();
+		m_TlsContext->ResetSelf();
+		m_TlsContext.reset();
+	}
+
 	// Disable all events on the socket, but keep it alive:
 	bufferevent_disable(m_BufferEvent, EV_READ | EV_WRITE);
 	if (m_Server == nullptr)
@@ -173,18 +201,98 @@ void cTCPLinkImpl::Close(void)
 
 
 
+AString cTCPLinkImpl::StartTLSClient(
+	cX509CertPtr a_OwnCert,
+	cCryptoKeyPtr a_OwnPrivKey
+)
+{
+	// Check preconditions:
+	if (m_TlsContext != nullptr)
+	{
+		return "TLS is already active on this link";
+	}
+	if (
+		((a_OwnCert == nullptr) && (a_OwnPrivKey != nullptr)) ||
+		((a_OwnCert != nullptr) && (a_OwnPrivKey != nullptr))
+	)
+	{
+		return "Either provide both the certificate and private key, or neither";
+	}
+
+	// Create the TLS context:
+	m_TlsContext.reset(new cLinkTlsContext(*this));
+	m_TlsContext->Initialize(true);
+	if (a_OwnCert != nullptr)
+	{
+		m_TlsContext->SetOwnCert(a_OwnCert, a_OwnPrivKey);
+	}
+	m_TlsContext->SetSelf(cLinkTlsContextWPtr(m_TlsContext));
+
+	// Start the handshake:
+	m_TlsContext->Handshake();
+	return "";
+}
+
+
+
+
+
+AString cTCPLinkImpl::StartTLSServer(
+	cX509CertPtr a_OwnCert,
+	cCryptoKeyPtr a_OwnPrivKey,
+	const AString & a_StartTLSData
+)
+{
+	// Check preconditions:
+	if (m_TlsContext != nullptr)
+	{
+		return "TLS is already active on this link";
+	}
+	if ((a_OwnCert == nullptr)  || (a_OwnPrivKey == nullptr))
+	{
+		return "Provide the server certificate and private key";
+	}
+
+	// Create the TLS context:
+	m_TlsContext.reset(new cLinkTlsContext(*this));
+	m_TlsContext->Initialize(false);
+	m_TlsContext->SetOwnCert(a_OwnCert, a_OwnPrivKey);
+	m_TlsContext->SetSelf(cLinkTlsContextWPtr(m_TlsContext));
+
+	// Push the initial data:
+	m_TlsContext->StoreReceivedData(a_StartTLSData.data(), a_StartTLSData.size());
+
+	// Start the handshake:
+	m_TlsContext->Handshake();
+	return "";
+}
+
+
+
+
+
 void cTCPLinkImpl::ReadCallback(bufferevent * a_BufferEvent, void * a_Self)
 {
 	ASSERT(a_Self != nullptr);
 	cTCPLinkImpl * Self = static_cast<cTCPLinkImpl *>(a_Self);
+	ASSERT(Self->m_BufferEvent == a_BufferEvent);
 	ASSERT(Self->m_Callbacks != nullptr);
 
 	// Read all the incoming data, in 1024-byte chunks:
 	char data[1024];
 	size_t length;
+	auto tlsContext = Self->m_TlsContext;
 	while ((length = bufferevent_read(a_BufferEvent, data, sizeof(data))) > 0)
 	{
-		Self->m_Callbacks->OnReceivedData(data, length);
+		if (tlsContext != nullptr)
+		{
+			ASSERT(tlsContext->IsLink(Self));
+			tlsContext->StoreReceivedData(data, length);
+		}
+		else
+		{
+			Self->ReceivedCleartextData(data, length);
+		}
 	}
 }
 
@@ -262,6 +370,13 @@ void cTCPLinkImpl::EventCallback(bufferevent * a_BufferEvent, short a_What, void
 	// If the connection has been closed, call the link callback and remove the connection:
 	if (a_What & BEV_EVENT_EOF)
 	{
+		// If running in TLS mode and there's data left in the TLS contect, report it:
+		auto tlsContext = Self->m_TlsContext;
+		if (tlsContext != nullptr)
+		{
+			tlsContext->FlushBuffers();
+		}
+
 		Self->m_Callbacks->OnRemoteClosed();
 		if (Self->m_Server != nullptr)
 		{
@@ -351,6 +466,178 @@ void cTCPLinkImpl::DoActualShutdown(void)
 		shutdown(bufferevent_getfd(m_BufferEvent), SHUT_WR);
 	#endif
 	bufferevent_disable(m_BufferEvent, EV_WRITE);
+}
+
+
+
+
+
+bool cTCPLinkImpl::SendRaw(const void * a_Data, size_t a_Length)
+{
+	return (bufferevent_write(m_BufferEvent, a_Data, a_Length) == 0);
+}
+
+
+
+
+
+void cTCPLinkImpl::ReceivedCleartextData(const char * a_Data, size_t a_Length)
+{
+	ASSERT(m_Callbacks != nullptr);
+	m_Callbacks->OnReceivedData(a_Data, a_Length);
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cTCPLinkImpl::cLinkTlsContext:
+
+cTCPLinkImpl::cLinkTlsContext::cLinkTlsContext(cTCPLinkImpl & a_Link):
+	m_Link(a_Link)
+{
+}
+
+
+
+
+
+void cTCPLinkImpl::cLinkTlsContext::SetSelf(cLinkTlsContextWPtr a_Self)
+{
+	m_Self = a_Self;
+}
+
+
+
+
+
+void cTCPLinkImpl::cLinkTlsContext::ResetSelf(void)
+{
+	m_Self.reset();
+}
+
+
+
+
+
+void cTCPLinkImpl::cLinkTlsContext::StoreReceivedData(const char * a_Data, size_t a_NumBytes)
+{
+	// Hold self alive for the duration of this function
+	cLinkTlsContextPtr Self(m_Self);
+
+	m_EncryptedData.append(a_Data, a_NumBytes);
+
+	// Try to finish a pending handshake:
+	TryFinishHandshaking();
+
+	// Flush any cleartext data that can be "received":
+	FlushBuffers();
+}
+
+
+
+
+
+void cTCPLinkImpl::cLinkTlsContext::FlushBuffers(void)
+{
+	// Hold self alive for the duration of this function
+	cLinkTlsContextPtr Self(m_Self);
+
+	// If the handshake didn't complete yet, bail out:
+	if (!HasHandshaken())
+	{
+		return;
+	}
+
+	char Buffer[1024];
+	int NumBytes;
+	while ((NumBytes = ReadPlain(Buffer, sizeof(Buffer))) > 0)
+	{
+		m_Link.ReceivedCleartextData(Buffer, static_cast<size_t>(NumBytes));
+		if (m_Self.expired())
+		{
+			// The callback closed the SSL context, bail out
+			return;
+		}
+	}
+}
+
+
+
+
+
+void cTCPLinkImpl::cLinkTlsContext::TryFinishHandshaking(void)
+{
+	// Hold self alive for the duration of this function
+	cLinkTlsContextPtr Self(m_Self);
+
+	// If the handshake hasn't finished yet, retry:
+	if (!HasHandshaken())
+	{
+		Handshake();
+		// If the handshake succeeded, write all the queued plaintext data:
+		if (HasHandshaken())
+		{
+			m_Link.GetCallbacks()->OnTlsHandshakeCompleted();
+			WritePlain(m_CleartextData.data(), m_CleartextData.size());
+			m_CleartextData.clear();
+		}
+	}
+}
+
+
+
+
+
+void cTCPLinkImpl::cLinkTlsContext::Send(const void * a_Data, size_t a_Length)
+{
+	// Hold self alive for the duration of this function
+	cLinkTlsContextPtr Self(m_Self);
+
+	// If the handshake hasn't completed yet, queue the data:
+	if (!HasHandshaken())
+	{
+		m_CleartextData.append(reinterpret_cast<const char *>(a_Data), a_Length);
+		TryFinishHandshaking();
+		return;
+	}
+
+	// The connection is all set up, write the cleartext data into the SSL context:
+	WritePlain(a_Data, a_Length);
+	FlushBuffers();
+}
+
+
+
+
+
+int cTCPLinkImpl::cLinkTlsContext::ReceiveEncrypted(unsigned char * a_Buffer, size_t a_NumBytes)
+{
+	// Hold self alive for the duration of this function
+	cLinkTlsContextPtr Self(m_Self);
+
+	// If there's nothing queued in the buffer, report empty buffer:
+	if (m_EncryptedData.empty())
+	{
+		return POLARSSL_ERR_NET_WANT_READ;
+	}
+
+	// Copy as much data as possible to the provided buffer:
+	size_t BytesToCopy = std::min(a_NumBytes, m_EncryptedData.size());
+	memcpy(a_Buffer, m_EncryptedData.data(), BytesToCopy);
+	m_EncryptedData.erase(0, BytesToCopy);
+	return static_cast<int>(BytesToCopy);
+}
+
+
+
+
+
+int cTCPLinkImpl::cLinkTlsContext::SendEncrypted(const unsigned char * a_Buffer, size_t a_NumBytes)
+{
+	m_Link.SendRaw(a_Buffer, a_NumBytes);
+	return static_cast<int>(a_NumBytes);
 }
 
 

--- a/src/OSSupport/TCPLinkImpl.cpp
+++ b/src/OSSupport/TCPLinkImpl.cpp
@@ -322,6 +322,11 @@ void cTCPLinkImpl::EventCallback(bufferevent * a_BufferEvent, short a_What, void
 {
 	ASSERT(a_Self != nullptr);
 	cTCPLinkImplPtr Self = static_cast<cTCPLinkImpl *>(a_Self)->m_Self;
+	if (Self == nullptr)
+	{
+		// The link has already been freed
+		return;
+	}
 
 	// If an error is reported, call the error callback:
 	if (a_What & BEV_EVENT_ERROR)

--- a/src/OSSupport/TCPLinkImpl.h
+++ b/src/OSSupport/TCPLinkImpl.h
@@ -14,6 +14,7 @@
 #include "Network.h"
 #include <event2/event.h>
 #include <event2/bufferevent.h>
+#include "../PolarSSL++/SslContext.h"
 
 
 
@@ -64,8 +65,72 @@ public:
 	virtual UInt16 GetRemotePort(void) const override { return m_RemotePort; }
 	virtual void Shutdown(void) override;
 	virtual void Close(void) override;
+	virtual AString StartTLSClient(
+		cX509CertPtr a_OwnCert,
+		cCryptoKeyPtr a_OwnPrivKey
+	) override;
+	virtual AString StartTLSServer(
+		cX509CertPtr a_OwnCert,
+		cCryptoKeyPtr a_OwnPrivKey,
+		const AString & a_StartTLSData
+	) override;
 
 protected:
+
+	// fwd:
+	class cLinkTlsContext;
+	typedef SharedPtr<cLinkTlsContext> cLinkTlsContextPtr;
+	typedef WeakPtr<cLinkTlsContext> cLinkTlsContextWPtr;
+
+	/** Wrapper around cSslContext that is used when this link is being encrypted by SSL. */
+	class cLinkTlsContext :
+		public cSslContext
+	{
+		cTCPLinkImpl & m_Link;
+
+		/** Buffer for storing the incoming encrypted data until it is requested by the SSL decryptor. */
+		AString m_EncryptedData;
+
+		/** Buffer for storing the outgoing cleartext data until the link has finished handshaking. */
+		AString m_CleartextData;
+
+		/** Shared ownership of self, so that this object can keep itself alive for as long as it needs. */
+		cLinkTlsContextWPtr m_Self;
+
+	public:
+		cLinkTlsContext(cTCPLinkImpl & a_Link);
+
+		/** Shares ownership of self, so that this object can keep itself alive for as long as it needs. */
+		void SetSelf(cLinkTlsContextWPtr a_Self);
+
+		/** Removes the self ownership so that we can detect the SSL closure. */
+		void ResetSelf(void);
+
+		/** Stores the specified block of data into the buffer of the data to be decrypted (incoming from remote).
+		Also flushes the SSL buffers by attempting to read any data through the SSL context. */
+		void StoreReceivedData(const char * a_Data, size_t a_NumBytes);
+
+		/** Tries to read any cleartext data available through the SSL, reports it in the link. */
+		void FlushBuffers(void);
+
+		/** Tries to finish handshaking the SSL. */
+		void TryFinishHandshaking(void);
+
+		/** Sends the specified cleartext data over the SSL to the remote peer.
+		If the handshake hasn't been completed yet, queues the data for sending when it completes. */
+		void Send(const void * a_Data, size_t a_Length);
+
+		// cSslContext overrides:
+		virtual int ReceiveEncrypted(unsigned char * a_Buffer, size_t a_NumBytes) override;
+		virtual int SendEncrypted(const unsigned char * a_Buffer, size_t a_NumBytes) override;
+
+		/** Returns true if the context's associated TCP link is the same link as a_Link. */
+		bool IsLink(cTCPLinkImpl * a_Link)
+		{
+			return (a_Link == &m_Link);
+		}
+	};
+
 
 	/** Callbacks to call when the connection is established.
 	May be NULL if not used. Only used for outgoing connections (cNetwork::Connect()). */
@@ -99,6 +164,10 @@ protected:
 	data is sent to the OS TCP stack, the socket gets shut down. */
 	bool m_ShouldShutdown;
 
+	/** The SSL context used for encryption, if this link uses SSL.
+	If valid, the link uses encryption through this context. */
+	cLinkTlsContextPtr m_TlsContext;
+
 
 	/** Creates a new link to be queued to connect to a specified host:port.
 	Used for outgoing connections created using cNetwork::Connect().
@@ -127,6 +196,12 @@ protected:
 	/** Calls shutdown on the link and disables LibEvent writing.
 	Called after all data from LibEvent buffers is sent to the OS TCP stack and shutdown() has been called before. */
 	void DoActualShutdown(void);
+
+	/** Sends the data directly to the socket (without the optional TLS). */
+	bool SendRaw(const void * a_Data, size_t a_Length);
+
+	/** Called by the TLS when it has decoded a piece of incoming cleartext data from the socket. */
+	void ReceivedCleartextData(const char * a_Data, size_t a_Length);
 };
 
 

--- a/tests/HTTP/CMakeLists.txt
+++ b/tests/HTTP/CMakeLists.txt
@@ -2,6 +2,7 @@ enable_testing()
 
 include_directories(${CMAKE_SOURCE_DIR}/src/)
 include_directories(${CMAKE_SOURCE_DIR}/lib/libevent/include)
+include_directories(${CMAKE_SOURCE_DIR}/lib/polarssl/include)
 
 add_definitions(-DTEST_GLOBALS=1)
 
@@ -74,6 +75,9 @@ add_test(NAME HTTPMessageParser_file-test3-2 COMMAND HTTPMessageParser_file-exe 
 
 # Test parsing the request file in 512-byte chunks (should process everything in a single call):
 add_test(NAME HTTPMessageParser_file-test4-512 COMMAND HTTPMessageParser_file-exe ${CMAKE_CURRENT_SOURCE_DIR}/HTTPRequest1.data 512)
+
+# Test the URLClient
+add_test(NAME UrlClient-test COMMAND UrlClientTest-exe)
 
 
 

--- a/tests/HTTP/CMakeLists.txt
+++ b/tests/HTTP/CMakeLists.txt
@@ -11,6 +11,8 @@ set (HTTP_SRCS
 	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessage.cpp
 	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessageParser.cpp
 	${CMAKE_SOURCE_DIR}/src/HTTP/TransferEncodingParser.cpp
+	${CMAKE_SOURCE_DIR}/src/HTTP/UrlClient.cpp
+	${CMAKE_SOURCE_DIR}/src/HTTP/UrlParser.cpp
 	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
 )
 
@@ -19,13 +21,20 @@ set (HTTP_HDRS
 	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessage.h
 	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessageParser.h
 	${CMAKE_SOURCE_DIR}/src/HTTP/TransferEncodingParser.h
+	${CMAKE_SOURCE_DIR}/src/HTTP/UrlClient.h
+	${CMAKE_SOURCE_DIR}/src/HTTP/UrlParser.h
 	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+)
+
+set (SHARED_SRCS
+	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
 )
 
 add_library(HTTP
 	${HTTP_SRCS}
 	${HTTP_HDRS}
 )
+target_link_libraries(HTTP Network OSSupport)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	add_flags_cxx("-Wno-error=conversion -Wno-error=old-style-cast")
@@ -35,11 +44,21 @@ endif()
 
 
 
-# Define individual tests:
+# Define individual test executables:
 
 # HTTPMessageParser_file: Feed file contents into a cHTTPResponseParser and print the callbacks as they're called:
 add_executable(HTTPMessageParser_file-exe HTTPMessageParser_file.cpp)
-target_link_libraries(HTTPMessageParser_file-exe HTTP)
+target_link_libraries(HTTPMessageParser_file-exe HTTP Network OSSupport)
+
+# UrlClientTest: Tests the UrlClient class by requesting a few things off the internet:
+add_executable(UrlClientTest-exe UrlClientTest.cpp)
+target_link_libraries(UrlClientTest-exe HTTP)
+
+
+
+
+
+# Define individual tests:
 
 # Test parsing the response file in 2-byte chunks (should go from response line parsing through headers parsing to body parsing, each within a different step):
 add_test(NAME HTTPMessageParser_file-test1-2 COMMAND HTTPMessageParser_file-exe ${CMAKE_CURRENT_SOURCE_DIR}/HTTPResponse1.data 2)
@@ -63,7 +82,8 @@ add_test(NAME HTTPMessageParser_file-test4-512 COMMAND HTTPMessageParser_file-ex
 # Put all the tests into a solution folder (MSVC):
 set_target_properties(
 	HTTPMessageParser_file-exe
-	PROPERTIES FOLDER Tests
+	UrlClientTest-exe
+	PROPERTIES FOLDER Tests/HTTP
 )
 set_target_properties(
 	HTTP

--- a/tests/HTTP/UrlClientTest.cpp
+++ b/tests/HTTP/UrlClientTest.cpp
@@ -1,0 +1,162 @@
+
+#include "Globals.h"
+#include "HTTP/UrlClient.h"
+#include "OSSupport/NetworkSingleton.h"
+
+
+
+
+
+class cCallbacks:
+	public cUrlClient::cCallbacks
+{
+public:
+	cCallbacks(cEvent & a_Event):
+		m_Event(a_Event)
+	{
+	}
+
+	virtual void OnConnected(cTCPLink & a_Link) override
+	{
+		LOG("Link connected to %s:%u", a_Link.GetRemoteIP().c_str(), a_Link.GetRemotePort());
+	}
+
+	virtual bool OnCertificateReceived() override
+	{
+		LOG("Server certificate received");
+		return true;
+	}
+
+	virtual void OnRequestSent() override
+	{
+		LOG("Request has been sent");
+	}
+
+	virtual void OnHeader(const AString & a_Key, const AString & a_Value) override
+	{
+		LOG("HTTP Header: \"%s\" -> \"%s\"", a_Key.c_str(), a_Value.c_str());
+	}
+
+	virtual void OnHeadersFinished() override
+	{
+		LOG("HTTP headers finished.");
+	}
+
+	virtual void OnBodyData(const void * a_Data, size_t a_Size) override
+	{
+		AString body(reinterpret_cast<const char *>(a_Data), a_Size);
+		LOG("Body part:\n%s", body.c_str());
+	}
+
+	/** Called after the response body has been fully reported by OnBody() calls.
+	There will be no more OnBody() calls. */
+	virtual void OnBodyFinished() override
+	{
+		LOG("Body finished.");
+		m_Event.Set();
+	}
+
+	virtual void OnRedirecting(const AString & a_RedirectUrl) override
+	{
+		LOG("Redirecting to \"%s\".", a_RedirectUrl.c_str());
+	}
+
+	virtual void OnError(const AString & a_ErrorMsg) override
+	{
+		LOG("Error: %s", a_ErrorMsg.c_str());
+		m_Event.Set();
+	}
+
+protected:
+	cEvent & m_Event;
+};
+
+
+
+
+
+int TestRequest1()
+{
+	LOG("Running test 1");
+	cEvent evtFinished;
+	cCallbacks callbacks(evtFinished);
+	AStringMap options;
+	options["MaxRedirects"] = "0";
+	auto res = cUrlClient::Get("http://github.com", callbacks, AStringMap(), AString(), options);
+	if (res.first)
+	{
+		evtFinished.Wait();
+	}
+	else
+	{
+		LOG("Immediate error: %s", res.second.c_str());
+		return 1;
+	}
+	return 0;
+}
+
+
+
+
+
+int TestRequest2()
+{
+	LOG("Running test 2");
+	cEvent evtFinished;
+	cCallbacks callbacks(evtFinished);
+	auto res = cUrlClient::Get("http://github.com", callbacks);
+	if (res.first)
+	{
+		evtFinished.Wait();
+	}
+	else
+	{
+		LOG("Immediate error: %s", res.second.c_str());
+		return 1;
+	}
+	return 0;
+}
+
+
+
+
+
+int TestRequests()
+{
+	auto res = TestRequest1();
+	if (res != 0)
+	{
+		return res;
+	}
+	res = TestRequest2();
+	if (res != 0)
+	{
+		return res;
+	}
+	return 0;
+}
+
+
+
+
+
+int main()
+{
+	LOGD("Test started");
+
+	LOGD("Initializing cNetwork...");
+	cNetworkSingleton::Get().Initialise();
+
+	LOGD("Testing...");
+	auto res = TestRequests();
+
+	LOGD("Terminating cNetwork...");
+	cNetworkSingleton::Get().Terminate();
+	LOGD("cUrlClient test finished");
+
+	return res;
+}
+
+
+
+

--- a/tests/HTTP/UrlClientTest.cpp
+++ b/tests/HTTP/UrlClientTest.cpp
@@ -106,10 +106,10 @@ static int TestRequest1()
 {
 	LOG("Running test 1");
 	cEvent evtFinished;
-	cCallbacks callbacks(evtFinished);
+	auto callbacks = cpp14::make_unique<cCallbacks>(evtFinished);
 	AStringMap options;
 	options["MaxRedirects"] = "0";
-	auto res = cUrlClient::Get("http://github.com", callbacks, AStringMap(), AString(), options);
+	auto res = cUrlClient::Get("http://github.com", std::move(callbacks), AStringMap(), AString(), options);
 	if (res.first)
 	{
 		evtFinished.Wait();
@@ -130,8 +130,8 @@ static int TestRequest2()
 {
 	LOG("Running test 2");
 	cEvent evtFinished;
-	cCallbacks callbacks(evtFinished);
-	auto res = cUrlClient::Get("http://github.com", callbacks);
+	auto callbacks = cpp14::make_unique<cCallbacks>(evtFinished);
+	auto res = cUrlClient::Get("http://github.com", std::move(callbacks));
 	if (res.first)
 	{
 		evtFinished.Wait();
@@ -152,10 +152,10 @@ static int TestRequest3()
 {
 	LOG("Running test 3");
 	cEvent evtFinished;
-	cCallbacks callbacks(evtFinished);
+	auto callbacks = cpp14::make_unique<cCallbacks>(evtFinished);
 	AStringMap options;
 	options["MaxRedirects"] = "0";
-	auto res = cUrlClient::Get("https://github.com", callbacks, AStringMap(), AString(), options);
+	auto res = cUrlClient::Get("https://github.com", std::move(callbacks), AStringMap(), AString(), options);
 	if (res.first)
 	{
 		evtFinished.Wait();
@@ -176,8 +176,8 @@ static int TestRequest4()
 {
 	LOG("Running test 4");
 	cEvent evtFinished;
-	cCallbacks callbacks(evtFinished);
-	auto res = cUrlClient::Get("https://github.com", callbacks);
+	auto callbacks = cpp14::make_unique<cCallbacks>(evtFinished);
+	auto res = cUrlClient::Get("https://github.com", std::move(callbacks));
 	if (res.first)
 	{
 		evtFinished.Wait();

--- a/tests/HTTP/UrlClientTest.cpp
+++ b/tests/HTTP/UrlClientTest.cpp
@@ -7,6 +7,7 @@
 
 
 
+/** Simple callbacks that dump the events to the console and signalize a cEvent when the request is finished. */
 class cCallbacks:
 	public cUrlClient::cCallbacks
 {
@@ -14,12 +15,21 @@ public:
 	cCallbacks(cEvent & a_Event):
 		m_Event(a_Event)
 	{
+		LOGD("Created a cCallbacks instance at %p", reinterpret_cast<void *>(this));
 	}
+
+
+	~cCallbacks()
+	{
+		LOGD("Deleting the cCallbacks instance at %p", reinterpret_cast<void *>(this));
+	}
+
 
 	virtual void OnConnected(cTCPLink & a_Link) override
 	{
 		LOG("Link connected to %s:%u", a_Link.GetRemoteIP().c_str(), a_Link.GetRemotePort());
 	}
+
 
 	virtual bool OnCertificateReceived() override
 	{
@@ -27,39 +37,56 @@ public:
 		return true;
 	}
 
+
+	virtual void OnTlsHandshakeCompleted() override
+	{
+		LOG("TLS handshake has completed.");
+	}
+
+
 	virtual void OnRequestSent() override
 	{
 		LOG("Request has been sent");
 	}
+
 
 	virtual void OnHeader(const AString & a_Key, const AString & a_Value) override
 	{
 		LOG("HTTP Header: \"%s\" -> \"%s\"", a_Key.c_str(), a_Value.c_str());
 	}
 
+
 	virtual void OnHeadersFinished() override
 	{
 		LOG("HTTP headers finished.");
 	}
 
+
 	virtual void OnBodyData(const void * a_Data, size_t a_Size) override
 	{
-		AString body(reinterpret_cast<const char *>(a_Data), a_Size);
-		LOG("Body part:\n%s", body.c_str());
+		#if 0
+			// Output the whole received data blob:
+			AString body(reinterpret_cast<const char *>(a_Data), a_Size);
+			LOG("Body part:\n%s", body.c_str());
+		#else
+			// Output only the data size, to keep the log short:
+			LOG("Body part: %u bytes", static_cast<unsigned>(a_Size));
+		#endif
 	}
 
-	/** Called after the response body has been fully reported by OnBody() calls.
-	There will be no more OnBody() calls. */
+
 	virtual void OnBodyFinished() override
 	{
 		LOG("Body finished.");
 		m_Event.Set();
 	}
 
+
 	virtual void OnRedirecting(const AString & a_RedirectUrl) override
 	{
 		LOG("Redirecting to \"%s\".", a_RedirectUrl.c_str());
 	}
+
 
 	virtual void OnError(const AString & a_ErrorMsg) override
 	{
@@ -75,7 +102,7 @@ protected:
 
 
 
-int TestRequest1()
+static int TestRequest1()
 {
 	LOG("Running test 1");
 	cEvent evtFinished;
@@ -99,7 +126,7 @@ int TestRequest1()
 
 
 
-int TestRequest2()
+static int TestRequest2()
 {
 	LOG("Running test 2");
 	cEvent evtFinished;
@@ -121,17 +148,69 @@ int TestRequest2()
 
 
 
-int TestRequests()
+static int TestRequest3()
 {
-	auto res = TestRequest1();
-	if (res != 0)
+	LOG("Running test 3");
+	cEvent evtFinished;
+	cCallbacks callbacks(evtFinished);
+	AStringMap options;
+	options["MaxRedirects"] = "0";
+	auto res = cUrlClient::Get("https://github.com", callbacks, AStringMap(), AString(), options);
+	if (res.first)
 	{
-		return res;
+		evtFinished.Wait();
 	}
-	res = TestRequest2();
-	if (res != 0)
+	else
 	{
-		return res;
+		LOG("Immediate error: %s", res.second.c_str());
+		return 1;
+	}
+	return 0;
+}
+
+
+
+
+
+static int TestRequest4()
+{
+	LOG("Running test 4");
+	cEvent evtFinished;
+	cCallbacks callbacks(evtFinished);
+	auto res = cUrlClient::Get("https://github.com", callbacks);
+	if (res.first)
+	{
+		evtFinished.Wait();
+	}
+	else
+	{
+		LOG("Immediate error: %s", res.second.c_str());
+		return 1;
+	}
+	return 0;
+}
+
+
+
+
+
+static int TestRequests()
+{
+	std::function<int(void)> tests[] =
+	{
+		&TestRequest1,
+		&TestRequest2,
+		&TestRequest3,
+		&TestRequest4,
+	};
+	for (const auto & test: tests)
+	{
+		LOG("%s", AString(60, '-').c_str());
+		auto res = test();
+		if (res != 0)
+		{
+			return res;
+		}
 	}
 	return 0;
 }

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -2,6 +2,7 @@ enable_testing()
 
 include_directories(${CMAKE_SOURCE_DIR}/src/)
 include_directories(${CMAKE_SOURCE_DIR}/lib/libevent/include)
+include_directories(${CMAKE_SOURCE_DIR}/lib/polarssl/include)
 
 add_definitions(-DTEST_GLOBALS=1)
 
@@ -15,6 +16,11 @@ set (Network_SRCS
 	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkSingleton.cpp
 	${CMAKE_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.cpp
 	${CMAKE_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.cpp
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/CtrDrbgContext.cpp
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/CryptoKey.cpp
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/EntropyContext.cpp
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/SslContext.cpp
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/X509Cert.cpp
 	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
 )
 
@@ -27,6 +33,11 @@ set (Network_HDRS
 	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkSingleton.h
 	${CMAKE_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.h
 	${CMAKE_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.h
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/CtrDrbgContext.h
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/CryptoKey.h
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/EntropyContext.h
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/SslContext.h
+	${CMAKE_SOURCE_DIR}/src/PolarSSL++/X509Cert.h
 	${CMAKE_SOURCE_DIR}/src/StringUtils.h
 )
 
@@ -35,7 +46,7 @@ add_library(Network
 	${Network_HDRS}
 )
 
-target_link_libraries(Network event_core event_extra)
+target_link_libraries(Network event_core event_extra mbedtls)
 if (MSVC)
 	target_link_libraries(Network ws2_32.lib)
 endif()


### PR DESCRIPTION
Adds a new API, cUrlClient, for simplifying HTTP(S) requests to other servers.
 - [x] C++ API class `cUrlClient` wrapping the HTTP parser
 - [x] TLS support for the API
 - [x] Export the new class to Lua