### PR TITLE
Lua tracked ref

### DIFF
--- a/src/Bindings/LuaNameLookup.cpp
+++ b/src/Bindings/LuaNameLookup.cpp
@@ -10,9 +10,8 @@
 
 
 
-cLuaNameLookup::cLuaNameLookup(const AString & a_Query, cPluginLua & a_Plugin, int a_CallbacksTableStackPos):
-	m_Plugin(a_Plugin),
-	m_Callbacks(cPluginLua::cOperation(a_Plugin)(), a_CallbacksTableStackPos),
+cLuaNameLookup::cLuaNameLookup(const AString & a_Query, cLuaState::cTableRefPtr && a_Callbacks):
+	m_Callbacks(std::move(a_Callbacks)),
 	m_Query(a_Query)
 {
 }
@@ -23,20 +22,7 @@ cLuaNameLookup::cLuaNameLookup(const AString & a_Query, cPluginLua & a_Plugin, i
 
 void cLuaNameLookup::OnNameResolved(const AString & a_Name, const AString & a_IP)
 {
-	// Check if we're still valid:
-	if (!m_Callbacks.IsValid())
-	{
-		return;
-	}
-
-	// Call the callback:
-	cPluginLua::cOperation Op(m_Plugin);
-	if (!Op().Call(cLuaState::cTableRef(m_Callbacks, "OnNameResolved"), a_Name, a_IP))
-	{
-		LOGINFO("cNetwork name lookup OnNameResolved callback failed in plugin %s looking up %s. %s resolves to %s.",
-			m_Plugin.GetName().c_str(), m_Query.c_str(), a_Name.c_str(), a_IP.c_str()
-		);
-	}
+	m_Callbacks->CallTableFn("OnNameResolved", a_Name, a_IP);
 }
 
 
@@ -45,20 +31,7 @@ void cLuaNameLookup::OnNameResolved(const AString & a_Name, const AString & a_IP
 
 void cLuaNameLookup::OnError(int a_ErrorCode, const AString & a_ErrorMsg)
 {
-	// Check if we're still valid:
-	if (!m_Callbacks.IsValid())
-	{
-		return;
-	}
-
-	// Call the callback:
-	cPluginLua::cOperation Op(m_Plugin);
-	if (!Op().Call(cLuaState::cTableRef(m_Callbacks, "OnError"), m_Query, a_ErrorCode, a_ErrorMsg))
-	{
-		LOGINFO("cNetwork name lookup OnError callback failed in plugin %s looking up %s. The error is %d (%s)",
-			m_Plugin.GetName().c_str(), m_Query.c_str(), a_ErrorCode, a_ErrorMsg.c_str()
-		);
-	}
+	m_Callbacks->CallTableFn("OnError", m_Query, a_ErrorCode, a_ErrorMsg);
 }
 
 
@@ -67,20 +40,7 @@ void cLuaNameLookup::OnError(int a_ErrorCode, const AString & a_ErrorMsg)
 
 void cLuaNameLookup::OnFinished(void)
 {
-	// Check if we're still valid:
-	if (!m_Callbacks.IsValid())
-	{
-		return;
-	}
-
-	// Call the callback:
-	cPluginLua::cOperation Op(m_Plugin);
-	if (!Op().Call(cLuaState::cTableRef(m_Callbacks, "OnFinished"), m_Query))
-	{
-		LOGINFO("cNetwork name lookup OnFinished callback failed in plugin %s, looking up %s.",
-			m_Plugin.GetName().c_str(), m_Query.c_str()
-		);
-	}
+	m_Callbacks->CallTableFn("OnFinished", m_Query);
 }
 
 

--- a/src/Bindings/LuaNameLookup.h
+++ b/src/Bindings/LuaNameLookup.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "../OSSupport/Network.h"
-#include "PluginLua.h"
+#include "LuaState.h"
 
 
 
@@ -21,15 +21,12 @@ class cLuaNameLookup:
 {
 public:
 	/** Creates a new instance of the lookup callbacks for the specified query,
-	attached to the specified lua plugin and wrapping the callbacks that are in a table at the specified stack pos. */
-	cLuaNameLookup(const AString & a_Query, cPluginLua & a_Plugin, int a_CallbacksTableStackPos);
+	using the callbacks that are in the specified table. */
+	cLuaNameLookup(const AString & a_Query, cLuaState::cTableRefPtr && a_Callbacks);
 
 protected:
-	/** The plugin for which the query is created. */
-	cPluginLua & m_Plugin;
-
 	/** The Lua table that holds the callbacks to be invoked. */
-	cLuaState::cRef m_Callbacks;
+	cLuaState::cTableRefPtr m_Callbacks;
 
 	/** The query used to start the lookup (either hostname or IP). */
 	AString m_Query;

--- a/src/Bindings/LuaServerHandle.h
+++ b/src/Bindings/LuaServerHandle.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "../OSSupport/Network.h"
-#include "PluginLua.h"
+#include "LuaState.h"
 
 
 
@@ -31,8 +31,8 @@ class cLuaServerHandle:
 {
 public:
 	/** Creates a new instance of the server handle,
-	attached to the specified lua plugin and wrapping the (listen-) callbacks that are in a table at the specified stack pos. */
-	cLuaServerHandle(UInt16 a_Port, cPluginLua & a_Plugin, int a_CallbacksTableStackPos);
+	wrapping the (listen-) callbacks that are in the specified table. */
+	cLuaServerHandle(UInt16 a_Port, cLuaState::cTableRefPtr && a_Callbacks);
 
 	~cLuaServerHandle();
 
@@ -54,11 +54,8 @@ public:
 	void Release(void);
 
 protected:
-	/** The plugin for which the server is created. */
-	cPluginLua & m_Plugin;
-
 	/** The Lua table that holds the callbacks to be invoked. */
-	cLuaState::cRef m_Callbacks;
+	cLuaState::cTableRefPtr m_Callbacks;
 
 	/** The port on which the server is listening.
 	Used mainly for better error reporting. */

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -122,9 +122,9 @@ cLuaStateTracker & cLuaStateTracker::Get(void)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// cLuaState::cCallback:
+// cLuaState::cTrackedRef:
 
-cLuaState::cCallback::cCallback(void):
+cLuaState::cTrackedRef::cTrackedRef(void):
 	m_CS(nullptr)
 {
 }
@@ -133,20 +133,14 @@ cLuaState::cCallback::cCallback(void):
 
 
 
-bool cLuaState::cCallback::RefStack(cLuaState & a_LuaState, int a_StackPos)
+bool cLuaState::cTrackedRef::RefStack(cLuaState & a_LuaState, int a_StackPos)
 {
-	// Check if the stack contains a function:
-	if (!lua_isfunction(a_LuaState, a_StackPos))
-	{
-		return false;
-	}
-
 	// Clear any previous callback:
 	Clear();
 
 	// Add self to LuaState's callback-tracking:
 	auto canonState = a_LuaState.QueryCanonLuaState();
-	canonState->TrackCallback(*this);
+	canonState->TrackRef(*this);
 
 	// Store the new callback:
 	m_CS = &(canonState->m_CS);
@@ -158,9 +152,9 @@ bool cLuaState::cCallback::RefStack(cLuaState & a_LuaState, int a_StackPos)
 
 
 
-void cLuaState::cCallback::Clear(void)
+void cLuaState::cTrackedRef::Clear(void)
 {
-	// Free the callback reference:
+	// Free the reference:
 	lua_State * luaState = nullptr;
 	{
 		auto cs = m_CS;
@@ -175,20 +169,21 @@ void cLuaState::cCallback::Clear(void)
 			m_Ref.UnRef();
 		}
 	}
+	m_CS = nullptr;
 
 	// Remove from LuaState's callback-tracking:
 	if (luaState == nullptr)
 	{
 		return;
 	}
-	cLuaState(luaState).UntrackCallback(*this);
+	cLuaState(luaState).UntrackRef(*this);
 }
 
 
 
 
 
-bool cLuaState::cCallback::IsValid(void)
+bool cLuaState::cTrackedRef::IsValid(void)
 {
 	auto cs = m_CS;
 	if (cs == nullptr)
@@ -203,7 +198,7 @@ bool cLuaState::cCallback::IsValid(void)
 
 
 
-bool cLuaState::cCallback::IsSameLuaState(cLuaState & a_LuaState)
+bool cLuaState::cTrackedRef::IsSameLuaState(cLuaState & a_LuaState)
 {
 	auto cs = m_CS;
 	if (cs == nullptr)
@@ -227,7 +222,7 @@ bool cLuaState::cCallback::IsSameLuaState(cLuaState & a_LuaState)
 
 
 
-void cLuaState::cCallback::Invalidate(void)
+void cLuaState::cTrackedRef::Invalidate(void)
 {
 	auto cs = m_CS;
 	if (cs == nullptr)
@@ -244,6 +239,43 @@ void cLuaState::cCallback::Invalidate(void)
 		return;
 	}
 	m_Ref.UnRef();
+	m_CS = nullptr;
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cLuaState::cCallback:
+
+bool cLuaState::cCallback::RefStack(cLuaState & a_LuaState, int a_StackPos)
+{
+	// Check if the stack contains a function:
+	if (!lua_isfunction(a_LuaState, a_StackPos))
+	{
+		return false;
+	}
+
+	return Super::RefStack(a_LuaState, a_StackPos);
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cLuaState::cTableRef:
+
+bool cLuaState::cTableRef::RefStack(cLuaState & a_LuaState, int a_StackPos)
+{
+	// Check if the stack contains a table:
+	if (!lua_istable(a_LuaState, a_StackPos))
+	{
+		return false;
+	}
+
+	return Super::RefStack(a_LuaState, a_StackPos);
 }
 
 
@@ -365,12 +397,12 @@ void cLuaState::Close(void)
 		return;
 	}
 
-	// Invalidate all callbacks:
+	// Invalidate all tracked refs:
 	{
-		cCSLock Lock(m_CSTrackedCallbacks);
-		for (auto & c: m_TrackedCallbacks)
+		cCSLock Lock(m_CSTrackedRefs);
+		for (auto & r: m_TrackedRefs)
 		{
-			c->Invalidate();
+			r->Invalidate();
 		}
 	}
 
@@ -592,22 +624,28 @@ bool cLuaState::PushFunction(const cRef & a_FnRef)
 
 
 
-bool cLuaState::PushFunction(const cTableRef & a_TableRef)
+bool cLuaState::PushFunction(const cRef & a_TableRef, const char * a_FnName)
 {
 	ASSERT(IsValid());
 	ASSERT(m_NumCurrentFunctionArgs == -1);  // If not, there's already something pushed onto the stack
 
+	if (!a_TableRef.IsValid())
+	{
+		return false;
+	}
+
 	// Push the error handler for lua_pcall()
 	lua_pushcfunction(m_LuaState, &ReportFnCallErrors);
 
-	lua_rawgeti(m_LuaState, LUA_REGISTRYINDEX, a_TableRef.GetTableRef());  // Get the table ref
+	// Get the function from the table:
+	lua_rawgeti(m_LuaState, LUA_REGISTRYINDEX, static_cast<int>(a_TableRef));
 	if (!lua_istable(m_LuaState, -1))
 	{
 		// Not a table, bail out
 		lua_pop(m_LuaState, 2);
 		return false;
 	}
-	lua_getfield(m_LuaState, -1, a_TableRef.GetFnName());
+	lua_getfield(m_LuaState, -1, a_FnName);
 	if (lua_isnil(m_LuaState, -1) || !lua_isfunction(m_LuaState, -1))
 	{
 		// Not a valid function, bail out
@@ -618,7 +656,7 @@ bool cLuaState::PushFunction(const cTableRef & a_TableRef)
 	// Pop the table off the stack:
 	lua_remove(m_LuaState, -2);
 
-	Printf(m_CurrentFunctionName, "<table-callback %s>", a_TableRef.GetFnName());
+	Printf(m_CurrentFunctionName, "<table-callback %s>", a_FnName);
 	m_NumCurrentFunctionArgs = 0;
 	return true;
 }
@@ -1061,6 +1099,28 @@ bool cLuaState::GetStackValue(int a_StackPos, cCallbackSharedPtr & a_Callback)
 
 
 
+bool cLuaState::GetStackValue(int a_StackPos, cTableRef & a_TableRef)
+{
+	return a_TableRef.RefStack(*this, a_StackPos);
+}
+
+
+
+
+
+bool cLuaState::GetStackValue(int a_StackPos, cTableRefPtr & a_TableRef)
+{
+	if (a_TableRef == nullptr)
+	{
+		a_TableRef = cpp14::make_unique<cTableRef>();
+	}
+	return a_TableRef->RefStack(*this, a_StackPos);
+}
+
+
+
+
+
 bool cLuaState::GetStackValue(int a_StackPos, cPluginManager::CommandResult & a_Result)
 {
 	if (lua_isnumber(m_LuaState, a_StackPos))
@@ -1079,6 +1139,41 @@ bool cLuaState::GetStackValue(int a_StackPos, cRef & a_Ref)
 {
 	a_Ref.RefStack(*this, a_StackPos);
 	return true;
+}
+
+
+
+
+
+bool cLuaState::GetStackValue(int a_StackPos, cTrackedRef & a_Ref)
+{
+	return a_Ref.RefStack(*this, a_StackPos);
+}
+
+
+
+
+
+bool cLuaState::GetStackValue(int a_StackPos, cTrackedRefPtr & a_Ref)
+{
+	if (a_Ref == nullptr)
+	{
+		a_Ref = cpp14::make_unique<cTrackedRef>();
+	}
+	return a_Ref->RefStack(*this, a_StackPos);
+}
+
+
+
+
+
+bool cLuaState::GetStackValue(int a_StackPos, cTrackedRefSharedPtr & a_Ref)
+{
+	if (a_Ref == nullptr)
+	{
+		a_Ref = std::make_shared<cTrackedRef>();
+	}
+	return a_Ref->RefStack(*this, a_StackPos);
 }
 
 
@@ -1930,7 +2025,7 @@ int cLuaState::BreakIntoDebugger(lua_State * a_LuaState)
 
 
 
-void cLuaState::TrackCallback(cCallback & a_Callback)
+void cLuaState::TrackRef(cTrackedRef & a_Ref)
 {
 	// Get the CanonLuaState global from Lua:
 	auto canonState = QueryCanonLuaState();
@@ -1941,15 +2036,15 @@ void cLuaState::TrackCallback(cCallback & a_Callback)
 	}
 
 	// Add the callback:
-	cCSLock Lock(canonState->m_CSTrackedCallbacks);
-	canonState->m_TrackedCallbacks.push_back(&a_Callback);
+	cCSLock Lock(canonState->m_CSTrackedRefs);
+	canonState->m_TrackedRefs.push_back(&a_Ref);
 }
 
 
 
 
 
-void cLuaState::UntrackCallback(cCallback & a_Callback)
+void cLuaState::UntrackRef(cTrackedRef & a_Ref)
 {
 	// Get the CanonLuaState global from Lua:
 	auto canonState = QueryCanonLuaState();
@@ -1960,12 +2055,12 @@ void cLuaState::UntrackCallback(cCallback & a_Callback)
 	}
 
 	// Remove the callback:
-	cCSLock Lock(canonState->m_CSTrackedCallbacks);
-	auto & trackedCallbacks = canonState->m_TrackedCallbacks;
-	trackedCallbacks.erase(std::remove_if(trackedCallbacks.begin(), trackedCallbacks.end(),
-		[&a_Callback](cCallback * a_StoredCallback)
+	cCSLock Lock(canonState->m_CSTrackedRefs);
+	auto & trackedRefs = canonState->m_TrackedRefs;
+	trackedRefs.erase(std::remove_if(trackedRefs.begin(), trackedRefs.end(),
+		[&a_Ref](cTrackedRef * a_StoredRef)
 		{
-			return (a_StoredCallback == &a_Callback);
+			return (a_StoredRef == &a_Ref);
 		}
 	));
 }

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -120,46 +120,84 @@ public:
 	} ;
 
 
-	/** Used for calling functions stored in a reference-stored table */
-	class cTableRef
+	/** Represents a reference to a Lua object that has a tracked lifetime -
+	- when the Lua state to which it belongs is closed, the object is kept alive, but invalidated.
+	Is thread-safe and unload-safe.
+	To receive the cTrackedRef instance from the Lua side, use RefStack() or (better) cLuaState::GetStackValue().
+	Note that instances of this class are tracked in the canon LuaState instance, so that
+	they can be invalidated when the LuaState is unloaded; due to multithreading issues they can only be tracked
+	by-ptr, which has an unfortunate effect of disabling the copy and move constructors. */
+	class cTrackedRef
 	{
-		int m_TableRef;
-		const char * m_FnName;
+		friend class ::cLuaState;
 	public:
-		cTableRef(int a_TableRef, const char * a_FnName) :
-			m_TableRef(a_TableRef),
-			m_FnName(a_FnName)
+		/** Creates an unbound ref instance. */
+		cTrackedRef(void);
+
+		~cTrackedRef()
 		{
+			Clear();
 		}
 
-		cTableRef(const cRef & a_TableRef, const char * a_FnName) :
-			m_TableRef(static_cast<int>(a_TableRef)),
-			m_FnName(a_FnName)
-		{
-		}
+		/** Set the contained reference to the object at the specified Lua state's stack position.
+		If another reference has been previously contained, it is freed first. */
+		bool RefStack(cLuaState & a_LuaState, int a_StackPos);
 
-		int GetTableRef(void) const { return m_TableRef; }
-		const char * GetFnName(void) const { return m_FnName; }
-	} ;
+		/** Frees the contained reference, if any. */
+		void Clear(void);
+
+		/** Returns true if the contained reference is valid. */
+		bool IsValid(void);
+
+		/** Returns true if the reference resides in the specified Lua state.
+		Internally, compares the reference's canon Lua state. */
+		bool IsSameLuaState(cLuaState & a_LuaState);
+
+	protected:
+		friend class cLuaState;
+
+		/** The mutex protecting m_Ref against multithreaded access */
+		cCriticalSection * m_CS;
+
+		/** Reference to the Lua callback */
+		cRef m_Ref;
 
 
-	/** Represents a callback to Lua that C++ code can call.
+		/** Invalidates the callback, without untracking it from the cLuaState.
+		Called only from cLuaState when closing the Lua state. */
+		void Invalidate(void);
+
+		/** Returns the internal reference.
+		Only to be used when the cLuaState's CS is held and the cLuaState is known to be valid. */
+		cRef & GetRef() { return m_Ref; }
+
+		/** This class cannot be copied, because it is tracked in the LuaState by-ptr.
+		Use a smart pointer for a copyable object. */
+		cTrackedRef(const cTrackedRef &) = delete;
+
+		/** This class cannot be moved, because it is tracked in the LuaState by-ptr.
+		Use a smart pointer for a copyable object. */
+		cTrackedRef(cTrackedRef &&) = delete;
+	};
+	typedef UniquePtr<cTrackedRef> cTrackedRefPtr;
+	typedef SharedPtr<cTrackedRef> cTrackedRefSharedPtr;
+
+
+	/** Represents a stored callback to Lua that C++ code can call.
 	Is thread-safe and unload-safe.
 	When the Lua state is unloaded, the callback returns an error instead of calling into non-existent code.
 	To receive the callback instance from the Lua side, use RefStack() or (better) cLuaState::GetStackValue()
 	with a cCallbackPtr. Note that instances of this class are tracked in the canon LuaState instance, so that
 	they can be invalidated when the LuaState is unloaded; due to multithreading issues they can only be tracked
 	by-ptr, which has an unfortunate effect of disabling the copy and move constructors. */
-	class cCallback
+	class cCallback:
+		public cTrackedRef
 	{
-	public:
-		/** Creates an unbound callback instance. */
-		cCallback(void);
+		typedef cTrackedRef Super;
 
-		~cCallback()
-		{
-			Clear();
-		}
+	public:
+
+		cCallback(void) {}
 
 		/** Calls the Lua callback, if still available.
 		Returns true if callback has been called.
@@ -181,32 +219,11 @@ public:
 		}
 
 		/** Set the contained callback to the function in the specified Lua state's stack position.
-		If a callback has been previously contained, it is freed first. */
+		If a callback has been previously contained, it is unreferenced first.
+		Returns true on success, false on failure (not a function at the specified stack pos). */
 		bool RefStack(cLuaState & a_LuaState, int a_StackPos);
 
-		/** Frees the contained callback, if any. */
-		void Clear(void);
-
-		/** Returns true if the contained callback is valid. */
-		bool IsValid(void);
-
-		/** Returns true if the callback resides in the specified Lua state.
-		Internally, compares the callback's canon Lua state. */
-		bool IsSameLuaState(cLuaState & a_LuaState);
-
 	protected:
-		friend class cLuaState;
-
-		/** The mutex protecting m_Ref against multithreaded access */
-		cCriticalSection * m_CS;
-
-		/** Reference to the Lua callback */
-		cRef m_Ref;
-
-
-		/** Invalidates the callback, without untracking it from the cLuaState.
-		Called only from cLuaState when closing the Lua state. */
-		void Invalidate(void);
 
 		/** This class cannot be copied, because it is tracked in the LuaState by-ptr.
 		Use cCallbackPtr for a copyable object. */
@@ -218,6 +235,47 @@ public:
 	};
 	typedef UniquePtr<cCallback> cCallbackPtr;
 	typedef SharedPtr<cCallback> cCallbackSharedPtr;
+
+
+	/** Represents a stored Lua table with callback functions that C++ code can call.
+	Is thread-safe and unload-safe.
+	When Lua state is unloaded, the CallFn() will return failure instead of calling into non-existent code.
+	To receive the callback instance from the Lua side, use RefStack() or (better) cLuaState::GetStackValue()
+	with a cCallbackPtr. Note that instances of this class are tracked in the canon LuaState instance, so that
+	they can be invalidated when the LuaState is unloaded; due to multithreading issues they can only be tracked
+	by-ptr, which has an unfortunate effect of disabling the copy and move constructors. */
+	class cTableRef:
+		public cTrackedRef
+	{
+		typedef cTrackedRef Super;
+	public:
+		cTableRef(void) {}
+
+		/** Calls the Lua function stored under the specified name in the referenced table, if still available.
+		Returns true if callback has been called.
+		Returns false if the Lua state isn't valid anymore, or the function doesn't exist. */
+		template <typename... Args>
+		bool CallTableFn(const char * a_FnName, Args &&... args)
+		{
+			auto cs = m_CS;
+			if (cs == nullptr)
+			{
+				return false;
+			}
+			cCSLock Lock(*cs);
+			if (!m_Ref.IsValid())
+			{
+				return false;
+			}
+			return cLuaState(m_Ref.GetLuaState()).CallTableFn(m_Ref, a_FnName, std::forward<Args>(args)...);
+		}
+
+		/** Set the contained reference to the table in the specified Lua state's stack position.
+		If another table has been previously contained, it is unreferenced first.
+		Returns true on success, false on failure (not a table at the specified stack pos). */
+		bool RefStack(cLuaState & a_LuaState, int a_StackPos);
+	};
+	typedef UniquePtr<cTableRef> cTableRefPtr;
 
 
 	/** A dummy class that's used only to delimit function args from return values for cLuaState::Call() */
@@ -381,8 +439,13 @@ public:
 	bool GetStackValue(int a_StackPos, cCallback & a_Callback);
 	bool GetStackValue(int a_StackPos, cCallbackPtr & a_Callback);
 	bool GetStackValue(int a_StackPos, cCallbackSharedPtr & a_Callback);
+	bool GetStackValue(int a_StackPos, cTableRef & a_TableRef);
+	bool GetStackValue(int a_StackPos, cTableRefPtr & a_TableRef);
 	bool GetStackValue(int a_StackPos, cPluginManager::CommandResult & a_Result);
 	bool GetStackValue(int a_StackPos, cRef & a_Ref);
+	bool GetStackValue(int a_StackPos, cTrackedRef & a_Ref);
+	bool GetStackValue(int a_StackPos, cTrackedRefPtr & a_Ref);
+	bool GetStackValue(int a_StackPos, cTrackedRefSharedPtr & a_Ref);
 	bool GetStackValue(int a_StackPos, double & a_Value);
 	bool GetStackValue(int a_StackPos, eBlockFace & a_Value);
 	bool GetStackValue(int a_StackPos, eWeather & a_Value);
@@ -583,14 +646,29 @@ protected:
 	/** Number of arguments currently pushed (for the Push / Call chain) */
 	int m_NumCurrentFunctionArgs;
 
-	/** The tracked callbacks.
-	This object will invalidate all of these when it is about to be closed.
-	Protected against multithreaded access by m_CSTrackedCallbacks. */
-	std::vector<cCallback *> m_TrackedCallbacks;
+	/** The tracked references.
+	The cLuaState will invalidate all of these when it is about to be closed.
+	Protected against multithreaded access by m_CSTrackedRefs. */
+	std::vector<cTrackedRef *> m_TrackedRefs;
 
-	/** Protects m_TrackedTallbacks against multithreaded access. */
-	cCriticalSection m_CSTrackedCallbacks;
+	/** Protects m_TrackedRefs against multithreaded access. */
+	cCriticalSection m_CSTrackedRefs;
 
+
+	/** Call the Lua function specified by name in the table stored as a reference.
+	Returns true if call succeeded, false if there was an error (not a table ref, function name not found).
+	A special param of cRet & signifies the end of param list and the start of return values.
+	Example call: CallTableFn(TableRef, "FnName", Param1, Param2, Param3, cLuaState::Return, Ret1, Ret2) */
+	template <typename... Args>
+	bool CallTableFn(const cRef & a_TableRef, const char * a_FnName, Args &&... args)
+	{
+		if (!PushFunction(a_TableRef, a_FnName))
+		{
+			// Pushing the function failed
+			return false;
+		}
+		return PushCallPop(std::forward<Args>(args)...);
+	}
 
 	/** Variadic template terminator: If there's nothing more to push / pop, just call the function.
 	Note that there are no return values either, because those are prefixed by a cRet value, so the arg list is never empty. */
@@ -646,10 +724,9 @@ protected:
 	*/
 	bool PushFunction(const cRef & a_FnRef);
 
-	/** Pushes a function that is stored in a referenced table by name
-	Returns true if successful. Logs a warning on failure
-	*/
-	bool PushFunction(const cTableRef & a_TableRef);
+	/** Pushes a function that is stored under the specified name in a table that has been saved as a reference.
+	Returns true if successful. */
+	bool PushFunction(const cRef & a_TableRef, const char * a_FnName);
 
 	/** Pushes a usertype of the specified class type onto the stack */
 	// void PushUserType(void * a_Object, const char * a_Type);
@@ -667,13 +744,13 @@ protected:
 	/** Tries to break into the MobDebug debugger, if it is installed. */
 	static int BreakIntoDebugger(lua_State * a_LuaState);
 
-	/** Adds the specified callback to tracking.
-	The callback will be invalidated when this Lua state is about to be closed. */
-	void TrackCallback(cCallback & a_Callback);
+	/** Adds the specified reference to tracking.
+	The reference will be invalidated when this Lua state is about to be closed. */
+	void TrackRef(cTrackedRef & a_Ref);
 
-	/** Removes the specified callback from tracking.
-	The callback will no longer be invalidated when this Lua state is about to be closed. */
-	void UntrackCallback(cCallback & a_Callback);
+	/** Removes the specified reference from tracking.
+	The reference will no longer be invalidated when this Lua state is about to be closed. */
+	void UntrackRef(cTrackedRef & a_Ref);
 } ;
 
 

--- a/src/Bindings/LuaTCPLink.h
+++ b/src/Bindings/LuaTCPLink.h
@@ -10,8 +10,8 @@
 #pragma once
 
 #include "../OSSupport/Network.h"
-#include "PluginLua.h"
 #include "../PolarSSL++/SslContext.h"
+#include "LuaState.h"
 
 
 
@@ -30,11 +30,11 @@ class cLuaTCPLink:
 	public cTCPLink::cCallbacks
 {
 public:
-	/** Creates a new instance of the link, attached to the specified plugin and wrapping the callbacks that are in a table at the specified stack pos. */
-	cLuaTCPLink(cPluginLua & a_Plugin, int a_CallbacksTableStackPos);
+	/** Creates a new instance of the link, wrapping the callbacks that are in the specified table. */
+	cLuaTCPLink(cLuaState::cTableRefPtr && a_Callbacks);
 
 	/** Creates a new instance of the link, attached to the specified plugin and wrapping the callbacks that are in the specified referenced table. */
-	cLuaTCPLink(cPluginLua & a_Plugin, cLuaState::cRef && a_CallbacksTableRef, cLuaServerHandleWPtr a_Server);
+	cLuaTCPLink(cLuaState::cTableRefPtr && a_Callbacks, cLuaServerHandleWPtr a_Server);
 
 	~cLuaTCPLink();
 
@@ -139,11 +139,8 @@ protected:
 	};
 
 
-	/** The plugin for which the link is created. */
-	cPluginLua & m_Plugin;
-
 	/** The Lua table that holds the callbacks to be invoked. */
-	cLuaState::cRef m_Callbacks;
+	cLuaState::cTableRefPtr m_Callbacks;
 
 	/** The underlying link representing the connection.
 	May be nullptr. */

--- a/src/Bindings/LuaUDPEndpoint.h
+++ b/src/Bindings/LuaUDPEndpoint.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "../OSSupport/Network.h"
-#include "PluginLua.h"
+#include "LuaState.h"
 
 
 
@@ -28,8 +28,8 @@ class cLuaUDPEndpoint:
 	public cUDPEndpoint::cCallbacks
 {
 public:
-	/** Creates a new instance of the endpoint, attached to the specified plugin and wrapping the callbacks that are in a table at the specified stack pos. */
-	cLuaUDPEndpoint(cPluginLua & a_Plugin, int a_CallbacksTableStackPos);
+	/** Creates a new instance of the endpoint, wrapping the callbacks that are in the specified table. */
+	cLuaUDPEndpoint(cLuaState::cTableRefPtr && a_Callbacks);
 
 	~cLuaUDPEndpoint();
 
@@ -58,11 +58,8 @@ public:
 	void Release(void);
 
 protected:
-	/** The plugin for which the link is created. */
-	cPluginLua & m_Plugin;
-
 	/** The Lua table that holds the callbacks to be invoked. */
-	cLuaState::cRef m_Callbacks;
+	cLuaState::cTableRefPtr m_Callbacks;
 
 	/** SharedPtr to self, so that the object can keep itself alive for as long as it needs (for Lua). */
 	cLuaUDPEndpointPtr m_Self;

--- a/src/OSSupport/IPLookup.cpp
+++ b/src/OSSupport/IPLookup.cpp
@@ -103,7 +103,13 @@ bool cNetwork::IPToHostName(
 {
 	auto res = std::make_shared<cIPLookup>(a_Callbacks);
 	cNetworkSingleton::Get().AddIPLookup(res);
-	return res->Lookup(a_IP);
+	if (!res->Lookup(a_IP))
+	{
+		// Lookup failed early on, remove the object completely:
+		cNetworkSingleton::Get().RemoveIPLookup(res.get());
+		return false;
+	}
+	return true;
 }
 
 


### PR DESCRIPTION
This adds the same treatment as `cLuaState::cCallback` (tracking, reset when plugin unloads) to a separate `cTrackedRef` class that can hold a reference to any Lua object. This is in turn used for the Lua callback tables in `cTableRef`.