### PR TITLE
Fixing string literal catching word letter as hexa-digit

### DIFF
--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -2714,7 +2714,7 @@ void cProtocol180::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Brand);
 		m_Client->SetClientBrand(Brand);
 		// Send back our brand, including the length:
-		SendPluginMessage("MC|Brand", "\x08Cuberite");
+		SendPluginMessage("MC|Brand", "\x08""Cuberite");
 		return;
 	}
 	else if (a_Channel == "MC|Beacon")

--- a/src/Protocol/Protocol19x.cpp
+++ b/src/Protocol/Protocol19x.cpp
@@ -2819,7 +2819,7 @@ void cProtocol190::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Brand);
 		m_Client->SetClientBrand(Brand);
 		// Send back our brand, including the length:
-		SendPluginMessage("MC|Brand", "\x08Cuberite");
+		SendPluginMessage("MC|Brand", "\x08""Cuberite");
 		return;
 	}
 	else if (a_Channel == "MC|Beacon")


### PR DESCRIPTION
Was sending "\x08C""uberite" as plugin identifier, aka a String of lenght (Varint 0x8c 0x75 ->) 14988 characters but only 7 provided
Now sending "\x08""Cuberite" as plugin identifier, aka a String of lenght (Varint 0x08 ->) 8 characters, with 8 provided
Fix BungeeCord compatibility