### PR TITLE
Fix cWorld:QueueTask() Lua's binding

### DIFF
--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -478,8 +478,7 @@ static int tolua_cWorld_QueueTask(lua_State * tolua_S)
 	cLuaState L(tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
-		!L.CheckParamNumber  (2) ||
-		!L.CheckParamFunction(3)
+		!L.CheckParamFunction(2)
 	)
 	{
 		return 0;


### PR DESCRIPTION
Manual binding expect three parameters : self, a number, a function
And then read self and a function...
Removing the extra check for the broken second argument