### PR TITLE
Delay EntityChangedWorld players' callback until Entity fully linked …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Makefile
 *.a
 *.d
 *.so
+tests/*/*-exe
 BuildInfo.h
 CMakeCache.txt
 CMakeFiles

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1827,8 +1827,7 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 			ParentChunk->GetPosX(), ParentChunk->GetPosZ()
 		);
 		ParentChunk->RemoveEntity(this);
-		a_World->AddPlayer(this);
-		cRoot::Get()->GetPluginManager()->CallHookEntityChangedWorld(*this, a_OldWorld);
+		a_World->AddPlayer(this, &a_OldWorld);  // New world will appropriate and announce client at his next tick
 	});
 	return true;
 }

--- a/src/World.h
+++ b/src/World.h
@@ -61,6 +61,7 @@ class cBroadcaster;
 
 
 typedef std::list< cPlayer * > cPlayerList;
+typedef std::list< std::pair< cPlayer *, cWorld * > > cAwaitingPlayerList;
 
 typedef SharedPtr<cSetChunkData> cSetChunkDataPtr;  // TODO: Change to unique_ptr once we go C++11
 typedef std::vector<cSetChunkDataPtr> cSetChunkDataPtrs;
@@ -262,8 +263,9 @@ public:
 
 	/** Adds the player to the world.
 	Uses a queue to store the player object until the Tick thread processes the addition event.
-	Also adds the player as an entity in the chunkmap, and the player's ClientHandle, if any, for ticking. */
-	void AddPlayer(cPlayer * a_Player);
+	Also adds the player as an entity in the chunkmap, and the player's ClientHandle, if any, for ticking.
+	If a_OldWorld is provided, a corresponding ENTITY_CHANGED_WORLD event is triggerred after the addition. */
+	void AddPlayer(cPlayer * a_Player, cWorld * a_OldWorld = nullptr);
 
 	/** Removes the player from the world.
 	Removes the player from the addition queue, too, if appropriate.
@@ -1006,7 +1008,7 @@ private:
 	cCriticalSection m_CSPlayersToAdd;
 
 	/** List of players that are scheduled for adding, waiting for the Tick thread to add them. */
-	cPlayerList m_PlayersToAdd;
+	cAwaitingPlayerList m_PlayersToAdd;
 
 	/** CS protecting m_SetChunkDataQueue. */
 	cCriticalSection m_CSSetChunkDataQueue;


### PR DESCRIPTION
…to world

Otherwise, some API call just don't seems to happen
gitignore tweak for test executables