### PR TITLE
Travis CI: updated to Trusty's image and ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,29 @@
 language: cpp
-sudo: false
+
+sudo: required
+dist: trusty
 
 compiler:
 - clang
 - gcc
 
+cache:
+  ccache
+
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
 
-script: ./CIbuild.sh
+before_install:
+  - |
+    if [ "$CC" = "clang" ]; then
+      export CCACHE_CPP2=yes;
+      sudo ln -s ../../bin/ccache /usr/lib/ccache/clang;
+      sudo ln -s ../../bin/ccache /usr/lib/ccache/clang++;
+    fi
+
+script:
+  ./CIbuild.sh
 
 env:
   - TRAVIS_CUBERITE_BUILD_TYPE=RELEASE CUBERITE_PATH=./Cuberite
@@ -22,7 +33,9 @@ notifications:
   email:
     on_success: change
     on_failure: always
+
 branches:
   only:
     - coverity_scan
     - master
+

--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -6,16 +6,14 @@ export CUBERITE_BUILD_SERIES_NAME="Travis $CC $TRAVIS_CUBERITE_BUILD_TYPE"
 export CUBERITE_BUILD_ID=$TRAVIS_JOB_NUMBER
 export CUBERITE_BUILD_DATETIME=`date`
 
-if [ "$CXX" == "g++" ]; then
-	# This is a temporary workaround to allow the identification of GCC-4.8 by CMake, required for C++11 features
-	# Travis Docker containers don't allow sudo, which update-alternatives needs, and it seems no alternative to this command is provided, hence:
-	export CXX="/usr/bin/g++-4.8"
-fi
 cmake . -DBUILD_TOOLS=1 -DSELF_TEST=1;
 
 echo "Building..."
-make -j 2;
-make -j 2 test ARGS="-V";
+make -j 3;
+echo "Ccache statistics"
+ccache -s;
+
+make test ARGS="-V";
 
 echo "Testing..."
 cd Server/;

--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -113,6 +113,10 @@ macro(set_flags)
 		# We use a signed char (fixes #640 on RasPi)
 		add_flags_cxx("-fsigned-char")
 
+		# Ubuntu gcc-defaults package bug #1228201
+		if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+			add_flags_lnk("-Wl,--no-as-needed")
+		endif()
 	endif()
 
 
@@ -299,7 +303,7 @@ macro(set_exe_flags)
 					add_flags_cxx("-Wno-double-promotion")
 				endif()
 			endif()
-			add_flags_cxx("-Wno-error=unused-command-line-argument")
+			add_flags_cxx("-Qunused-arguments")
 		endif()
 	endif()
 


### PR DESCRIPTION
Add ccache support to build phase.
Work-around Cmake specifying -lpthread before linked files.

What https://github.com/cuberite/cuberite/pull/3334 was supposed to be...
