### PR TITLE
HTTP: Fixed empty headers parsing.

### DIFF
--- a/src/HTTP/EnvelopeParser.cpp
+++ b/src/HTTP/EnvelopeParser.cpp
@@ -118,7 +118,14 @@ bool cEnvelopeParser::ParseLine(const char * a_Data, size_t a_Size)
 		if (a_Data[i] == ':')
 		{
 			m_LastKey.assign(a_Data, i);
-			m_LastValue.assign(a_Data + i + 2, a_Size - i - 2);
+			if (a_Size > i + 1)
+			{
+				m_LastValue.assign(a_Data + i + 2, a_Size - i - 2);
+			}
+			else
+			{
+				m_LastValue.clear();
+			}
 			return true;
 		}
 	}  // for i - a_Data[]

--- a/tests/HTTP/CMakeLists.txt
+++ b/tests/HTTP/CMakeLists.txt
@@ -44,11 +44,22 @@ endif()
 
 
 
+set (TEST_DATA_FILES
+	HTTPRequest1.data
+	HTTPRequest2.data
+	HTTPResponse1.data
+	HTTPResponse2.data
+)
+
+source_group("Data Files" FILES ${TEST_DATA_FILES})
+
+
+
 
 # Define individual test executables:
 
 # HTTPMessageParser_file: Feed file contents into a cHTTPResponseParser and print the callbacks as they're called:
-add_executable(HTTPMessageParser_file-exe HTTPMessageParser_file.cpp)
+add_executable(HTTPMessageParser_file-exe HTTPMessageParser_file.cpp ${TEST_DATA_FILES})
 target_link_libraries(HTTPMessageParser_file-exe HTTP Network OSSupport)
 
 # UrlClientTest: Tests the UrlClient class by requesting a few things off the internet:

--- a/tests/HTTP/HTTPRequest1.data
+++ b/tests/HTTP/HTTPRequest1.data
@@ -1,5 +1,8 @@
 GET /some/url HTTP/1.1
 Note: This is a test of a regular request
 Content-Length: 3
+Empty-Header:
+Almost-Empty-Header: a
+Two-Char-Header: 12
 
 bla

--- a/tests/HTTP/HTTPResponse1.data
+++ b/tests/HTTP/HTTPResponse1.data
@@ -6,5 +6,6 @@ Note3: The data is 2 bytes longer than the actual request, parser should indicat
 Header1: Value1
 Header2: Value2
 Content-Length: 3
+Empty-Header:
 
 bla

--- a/tests/HTTP/HTTPResponse2.data
+++ b/tests/HTTP/HTTPResponse2.data
@@ -2,6 +2,7 @@ HTTP/1.0 200 OK
 Note: This is a Chunked transfer encoding test
 Header2: Value2
 Transfer-Encoding: chunked
+Empty-Header:
 
 4
 Wiki


### PR DESCRIPTION
Empty HTTP headers would cause a crash before this fix.