### PR TITLE
Proper respawn packets on dimension travel

### DIFF
--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -369,6 +369,9 @@ public:  // tolua_export
 	bool IsPlayerChunkSent();
 
 private:
+	/** The dimension that was last sent to a player in a Respawn or Login packet.
+	Used to avoid Respawning into the same dimension, which confuses the client. */
+	eDimension m_LastSentDimension;
 
 	friend class cServer;  // Needs access to SetSelf()
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1433,19 +1433,22 @@ bool cEntity::DetectPortal()
 				}
 				m_PortalCooldownData.m_TicksDelayed = 0;
 
+				// Nether portal in the nether
 				if (GetWorld()->GetDimension() == dimNether)
 				{
 					if (GetWorld()->GetLinkedOverworldName().empty())
 					{
 						return false;
 					}
+					cWorld * DestinationWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
+					eDimension DestionationDim = DestinationWorld->GetDimension();
 
 					m_PortalCooldownData.m_ShouldPreventTeleportation = true;  // Stop portals from working on respawn
 
 					if (IsPlayer())
 					{
 						// Send a respawn packet before world is loaded / generated so the client isn't left in limbo
-						(reinterpret_cast<cPlayer *>(this))->GetClientHandle()->SendRespawn(dimOverworld);
+						(reinterpret_cast<cPlayer *>(this))->GetClientHandle()->SendRespawn(DestionationDim);
 					}
 
 					Vector3d TargetPos = GetPosition();
@@ -1454,23 +1457,30 @@ bool cEntity::DetectPortal()
 
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
-					LOGD("Jumping nether -> overworld");
+					LOGD("Jumping %s -> %s", DimensionToString(dimNether).c_str(), DimensionToString(DestionationDim).c_str());
 					new cNetherPortalScanner(this, TargetWorld, TargetPos, 256);
 					return true;
 				}
+				// Nether portal in the overworld
 				else
 				{
 					if (GetWorld()->GetLinkedNetherWorldName().empty())
 					{
 						return false;
 					}
+					cWorld * DestinationWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedNetherWorldName());
+					eDimension DestionationDim = DestinationWorld->GetDimension();
 
 					m_PortalCooldownData.m_ShouldPreventTeleportation = true;
 
 					if (IsPlayer())
 					{
-						reinterpret_cast<cPlayer *>(this)->AwardAchievement(achEnterPortal);
-						reinterpret_cast<cPlayer *>(this)->GetClientHandle()->SendRespawn(dimNether);
+						if (DestionationDim == dimNether)
+						{
+							reinterpret_cast<cPlayer *>(this)->AwardAchievement(achEnterPortal);
+						}
+
+						reinterpret_cast<cPlayer *>(this)->GetClientHandle()->SendRespawn(DestionationDim);
 					}
 
 					Vector3d TargetPos = GetPosition();
@@ -1479,7 +1489,7 @@ bool cEntity::DetectPortal()
 
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedNetherWorldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
-					LOGD("Jumping overworld -> nether");
+					LOGD("Jumping %s -> %s", DimensionToString(dimOverworld).c_str(), DimensionToString(DestionationDim).c_str());
 					new cNetherPortalScanner(this, TargetWorld, TargetPos, 128);
 					return true;
 				}
@@ -1491,6 +1501,7 @@ bool cEntity::DetectPortal()
 					return false;
 				}
 
+				// End portal in the end
 				if (GetWorld()->GetDimension() == dimEnd)
 				{
 
@@ -1498,37 +1509,55 @@ bool cEntity::DetectPortal()
 					{
 						return false;
 					}
+					cWorld * DestinationWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
+					eDimension DestionationDim = DestinationWorld->GetDimension();
+
 
 					m_PortalCooldownData.m_ShouldPreventTeleportation = true;
 
 					if (IsPlayer())
 					{
 						cPlayer * Player = reinterpret_cast<cPlayer *>(this);
-						Player->TeleportToCoords(Player->GetLastBedPos().x, Player->GetLastBedPos().y, Player->GetLastBedPos().z);
-						Player->GetClientHandle()->SendRespawn(dimOverworld);
+						if (Player->GetBedWorld() == DestinationWorld)
+						{
+							Player->TeleportToCoords(Player->GetLastBedPos().x, Player->GetLastBedPos().y, Player->GetLastBedPos().z);
+						}
+						else
+						{
+							Player->TeleportToCoords(DestinationWorld->GetSpawnX(), DestinationWorld->GetSpawnY(), DestinationWorld->GetSpawnZ());
+						}
+						Player->GetClientHandle()->SendRespawn(DestionationDim);
 					}
 
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
+					LOGD("Jumping %s -> %s", DimensionToString(dimEnd).c_str(), DimensionToString(DestionationDim).c_str());
 					return MoveToWorld(TargetWorld, false);
 				}
+				// End portal in the overworld
 				else
 				{
 					if (GetWorld()->GetLinkedEndWorldName().empty())
 					{
 						return false;
 					}
+					cWorld * DestinationWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedEndWorldName());
+					eDimension DestionationDim = DestinationWorld->GetDimension();
 
 					m_PortalCooldownData.m_ShouldPreventTeleportation = true;
 
 					if (IsPlayer())
 					{
-						reinterpret_cast<cPlayer *>(this)->AwardAchievement(achEnterTheEnd);
-						reinterpret_cast<cPlayer *>(this)->GetClientHandle()->SendRespawn(dimEnd);
+						if (DestionationDim == dimEnd)
+						{
+							reinterpret_cast<cPlayer *>(this)->AwardAchievement(achEnterTheEnd);
+						}
+						reinterpret_cast<cPlayer *>(this)->GetClientHandle()->SendRespawn(DestionationDim);
 					}
 
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedEndWorldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
+					LOGD("Jumping %s -> %s", DimensionToString(dimOverworld).c_str(), DimensionToString(DestionationDim).c_str());
 					return MoveToWorld(TargetWorld, false);
 				}
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -893,6 +893,15 @@ void cPlayer::SetBedPos(const Vector3i & a_Pos, cWorld * a_World)
 
 
 
+cWorld * cPlayer::GetBedWorld()
+{
+	return m_SpawnWorld;
+}
+
+
+
+
+
 void cPlayer::SetFlying(bool a_IsFlying)
 {
 	if (a_IsFlying == m_IsFlying)

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -467,6 +467,9 @@ public:
 
 	// tolua_end
 
+	// TODO lua export GetBedPos and GetBedWorld
+	cWorld * GetBedWorld();
+
 	/** Update movement-related statistics. */
 	void UpdateMovementStats(const Vector3d & a_DeltaPos, bool a_PreviousIsOnGround);
 

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -114,7 +114,7 @@ public:
 	virtual void SendPluginMessage              (const AString & a_Channel, const AString & a_Message) = 0;
 	virtual void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID) = 0;
 	virtual void SendResetTitle                 (void) = 0;
-	virtual void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks) = 0;
+	virtual void SendRespawn                    (eDimension a_Dimension) = 0;
 	virtual void SendExperience                 (void) = 0;
 	virtual void SendExperienceOrb              (const cExpOrb & a_ExpOrb) = 0;
 	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) = 0;

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -107,8 +107,7 @@ cProtocol180::cProtocol180(cClientHandle * a_Client, const AString & a_ServerAdd
 	m_ServerPort(a_ServerPort),
 	m_State(a_State),
 	m_ReceivedData(32 KiB),
-	m_IsEncrypted(false),
-	m_LastSentDimension(dimNotSet)
+	m_IsEncrypted(false)
 {
 
 	// BungeeCord handling:
@@ -626,7 +625,6 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 		Pkt.WriteString("default");  // Level type - wtf?
 		Pkt.WriteBool(false);  // Reduced Debug Info - wtf?
 	}
-	m_LastSentDimension = a_World.GetDimension();
 
 	// Send the spawn position:
 	{
@@ -1084,13 +1082,8 @@ void cProtocol180::SendResetTitle(void)
 
 
 
-void cProtocol180::SendRespawn(eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks)
+void cProtocol180::SendRespawn(eDimension a_Dimension)
 {
-	if ((m_LastSentDimension == a_Dimension) && !a_ShouldIgnoreDimensionChecks)
-	{
-		// Must not send a respawn for the world with the same dimension, the client goes cuckoo if we do (unless we are respawning from death)
-		return;
-	}
 
 	cPacketizer Pkt(*this, 0x07);  // Respawn packet
 	cPlayer * Player = m_Client->GetPlayer();
@@ -1098,7 +1091,6 @@ void cProtocol180::SendRespawn(eDimension a_Dimension, bool a_ShouldIgnoreDimens
 	Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
 	Pkt.WriteBEUInt8(static_cast<Byte>(Player->GetEffectiveGameMode()));
 	Pkt.WriteString("default");
-	m_LastSentDimension = a_Dimension;
 }
 
 

--- a/src/Protocol/Protocol18x.h
+++ b/src/Protocol/Protocol18x.h
@@ -110,7 +110,7 @@ public:
 	virtual void SendPluginMessage              (const AString & a_Channel, const AString & a_Message) override;
 	virtual void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID) override;
 	virtual void SendResetTitle                 (void) override;
-	virtual void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks) override;
+	virtual void SendRespawn                    (eDimension a_Dimension) override;
 	virtual void SendSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch) override;
 	virtual void SendExperience                 (void) override;
 	virtual void SendExperienceOrb              (const cExpOrb & a_ExpOrb) override;
@@ -176,11 +176,6 @@ protected:
 
 	/** The logfile where the comm is logged, when g_ShouldLogComm is true */
 	cFile m_CommLogFile;
-
-	/** The dimension that was last sent to a player in a Respawn or Login packet.
-	Used to avoid Respawning into the same dimension, which confuses the client. */
-	eDimension m_LastSentDimension;
-
 
 	/** Adds the received (unencrypted) data to m_ReceivedData, parses complete packets */
 	void AddReceivedData(const char * a_Data, size_t a_Size);

--- a/src/Protocol/Protocol19x.cpp
+++ b/src/Protocol/Protocol19x.cpp
@@ -117,8 +117,7 @@ cProtocol190::cProtocol190(cClientHandle * a_Client, const AString & a_ServerAdd
 	m_ServerPort(a_ServerPort),
 	m_State(a_State),
 	m_ReceivedData(32 KiB),
-	m_IsEncrypted(false),
-	m_LastSentDimension(dimNotSet)
+	m_IsEncrypted(false)
 {
 
 	// BungeeCord handling:
@@ -640,7 +639,6 @@ void cProtocol190::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 		Pkt.WriteString("default");  // Level type - wtf?
 		Pkt.WriteBool(false);  // Reduced Debug Info - wtf?
 	}
-	m_LastSentDimension = a_World.GetDimension();
 
 	// Send the spawn position:
 	{
@@ -1110,21 +1108,14 @@ void cProtocol190::SendResetTitle(void)
 
 
 
-void cProtocol190::SendRespawn(eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks)
+void cProtocol190::SendRespawn(eDimension a_Dimension)
 {
-	if ((m_LastSentDimension == a_Dimension) && !a_ShouldIgnoreDimensionChecks)
-	{
-		// Must not send a respawn for the world with the same dimension, the client goes cuckoo if we do (unless we are respawning from death)
-		return;
-	}
-
 	cPacketizer Pkt(*this, 0x33);  // Respawn packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Dimension));
 	Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
 	Pkt.WriteBEUInt8(static_cast<Byte>(Player->GetEffectiveGameMode()));
 	Pkt.WriteString("default");
-	m_LastSentDimension = a_Dimension;
 }
 
 
@@ -4058,7 +4049,6 @@ void cProtocol191::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 		Pkt.WriteString("default");  // Level type - wtf?
 		Pkt.WriteBool(false);  // Reduced Debug Info - wtf?
 	}
-	m_LastSentDimension = a_World.GetDimension();
 
 	// Send the spawn position:
 	{

--- a/src/Protocol/Protocol19x.h
+++ b/src/Protocol/Protocol19x.h
@@ -116,7 +116,7 @@ public:
 	virtual void SendPluginMessage              (const AString & a_Channel, const AString & a_Message) override;
 	virtual void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID) override;
 	virtual void SendResetTitle                 (void) override;
-	virtual void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks) override;
+	virtual void SendRespawn                    (eDimension a_Dimension) override;
 	virtual void SendSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch) override;
 	virtual void SendExperience                 (void) override;
 	virtual void SendExperienceOrb              (const cExpOrb & a_ExpOrb) override;
@@ -182,11 +182,6 @@ protected:
 
 	/** The logfile where the comm is logged, when g_ShouldLogComm is true */
 	cFile m_CommLogFile;
-
-	/** The dimension that was last sent to a player in a Respawn or Login packet.
-	Used to avoid Respawning into the same dimension, which confuses the client. */
-	eDimension m_LastSentDimension;
-
 
 	/** Adds the received (unencrypted) data to m_ReceivedData, parses complete packets */
 	void AddReceivedData(const char * a_Data, size_t a_Size);

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -635,10 +635,10 @@ void cProtocolRecognizer::SendResetTitle(void)
 
 
 
-void cProtocolRecognizer::SendRespawn(eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks)
+void cProtocolRecognizer::SendRespawn(eDimension a_Dimension)
 {
 	ASSERT(m_Protocol != nullptr);
-	m_Protocol->SendRespawn(a_Dimension, a_ShouldIgnoreDimensionChecks);
+	m_Protocol->SendRespawn(a_Dimension);
 }
 
 

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -100,7 +100,7 @@ public:
 	virtual void SendPluginMessage              (const AString & a_Channel, const AString & a_Message) override;
 	virtual void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID) override;
 	virtual void SendResetTitle                 (void) override;
-	virtual void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks) override;
+	virtual void SendRespawn                    (eDimension a_Dimension) override;
 	virtual void SendExperience                 (void) override;
 	virtual void SendExperienceOrb              (const cExpOrb & a_ExpOrb) override;
 	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) override;


### PR DESCRIPTION
Closes #2547
Closes #2405
Closes #3352
Replaces #3350
Replaces #3114
Completes the "[Stable world travel](https://github.com/cuberite/cuberite/milestone/20?closed=1)" milestone :)

Minecraft clients do not like respawning to the same dimension, unless the player dies. This PR takes this into account when teleporting between dimensions. If one is teleporting from a world of dimension A to a world of dimension A, a dummy respawn packet of some dimension B is sent first, and the real respawn packet of dimension A is sent afterwards.

Also, the cEntity teleportation code used to falsely assume that a linked world's dimension always has correspondance to the portal type and the current world. For instance, it assumed that when stepping into a Nether portal from the Overworld, one always ends up in a Nether. This caused the wrong respawn packets to be sent. The PR fixes this as well.