### PR TITLE
Fixed SendUnloadChunk bug

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1886,7 +1886,7 @@ void cClientHandle::RemoveFromWorld(void)
 	}
 	for (auto && Chunk : Chunks)
 	{
-		m_Protocol->SendUnloadChunk(Chunk.m_ChunkX, Chunk.m_ChunkZ);
+		SendUnloadChunk(Chunk.m_ChunkX, Chunk.m_ChunkZ);
 	}  // for itr - Chunks[]
 
 	// Here, we set last streamed values to bogus ones so everything is resent


### PR DESCRIPTION
Someone please doublecheck this. I am not too familiar with cClientHandle.
`this->SendUnloadChunk` does bookkeeping for `m_SentChunks`, invoking `m_Protocol->SendUnloadChunk` doesn't do that, and therefore `m_SentChunk` would have stale stuff unless we use `this->SendUnloadChunk`