### PR TITLE
Entities now bail out of ticks if destroyed (TNT fix)

### DIFF
--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -180,6 +180,11 @@ void cArrowEntity::CollectedBy(cPlayer & a_Dest)
 void cArrowEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	m_Timer += a_Dt;
 
 	if (m_bIsCollected)

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -102,6 +102,11 @@ void cBoat::OnRightClicked(cPlayer & a_Player)
 void cBoat::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	BroadcastMovementUpdate();
 
 	SetSpeed(GetSpeed() * 0.97);  // Slowly decrease the speed

--- a/src/Entities/FireworkEntity.cpp
+++ b/src/Entities/FireworkEntity.cpp
@@ -65,6 +65,11 @@ void cFireworkEntity::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_C
 void cFireworkEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (m_TicksToExplosion <= 0)
 	{

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1264,6 +1264,11 @@ void cMinecartWithFurnace::OnRightClicked(cPlayer & a_Player)
 void cMinecartWithFurnace::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (m_IsFueled)
 	{

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -111,7 +111,11 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	m_World->ForEachEntityInBox(cBoundingBox(GetPosition(), GetWidth(), GetHeight()), Callback);
 
 	super::Tick(a_Dt, a_Chunk);
-
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	HandleFalling();
 }
 

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -116,6 +116,11 @@ void cPickup::SpawnOn(cClientHandle & a_Client)
 void cPickup::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	BroadcastMovementUpdate();  // Notify clients of position
 
 	m_Timer += a_Dt;

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -369,6 +369,11 @@ AString cProjectileEntity::GetMCAClassName(void) const
 void cProjectileEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	BroadcastMovementUpdate();
 }
 

--- a/src/Entities/TNTEntity.cpp
+++ b/src/Entities/TNTEntity.cpp
@@ -57,6 +57,11 @@ void cTNTEntity::Explode(void)
 void cTNTEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	BroadcastMovementUpdate();
 
 	m_FuseTicks -= 1;

--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -52,6 +52,11 @@ void cAggressiveMonster::EventSeePlayer(cEntity * a_Entity, cChunk & a_Chunk)
 void cAggressiveMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (m_EMState == CHASING)
 	{

--- a/src/Mobs/CaveSpider.cpp
+++ b/src/Mobs/CaveSpider.cpp
@@ -19,6 +19,11 @@ cCaveSpider::cCaveSpider(void) :
 void cCaveSpider::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	m_EMPersonality = (GetWorld()->GetTimeOfDay() < (12000 + 1000)) ? PASSIVE : AGGRESSIVE;
 }

--- a/src/Mobs/Chicken.cpp
+++ b/src/Mobs/Chicken.cpp
@@ -23,6 +23,11 @@ cChicken::cChicken(void) :
 void cChicken::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (IsBaby())
 	{

--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -26,6 +26,11 @@ cCreeper::cCreeper(void) :
 void cCreeper::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if ((GetTarget() == nullptr) || (!TargetIsInRange() && !m_BurnedWithFlintAndSteel))
 	{

--- a/src/Mobs/Enderman.cpp
+++ b/src/Mobs/Enderman.cpp
@@ -189,6 +189,11 @@ bool cEnderman::CheckLight()
 void cEnderman::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	// TODO take damage in rain
 

--- a/src/Mobs/Horse.cpp
+++ b/src/Mobs/Horse.cpp
@@ -35,6 +35,11 @@ cHorse::cHorse(int Type, int Color, int Style, int TameTimes) :
 void cHorse::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (!m_bIsMouthOpen)
 	{

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -231,6 +231,11 @@ void cMonster::StopMovingToPosition()
 void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	GET_AND_VERIFY_CURRENT_CHUNK(Chunk, POSX_TOINT, POSZ_TOINT);
 
 	ASSERT((GetTarget() == nullptr) || (GetTarget()->IsPawn() && (GetTarget()->GetWorld() == GetWorld())));

--- a/src/Mobs/PassiveMonster.cpp
+++ b/src/Mobs/PassiveMonster.cpp
@@ -81,6 +81,11 @@ void cPassiveMonster::Destroyed()
 void cPassiveMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (m_EMState == ESCAPING)
 	{

--- a/src/Mobs/Pig.cpp
+++ b/src/Mobs/Pig.cpp
@@ -85,6 +85,11 @@ void cPig::OnRightClicked(cPlayer & a_Player)
 void cPig::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	// If the attachee player is holding a carrot-on-stick, let them drive this pig:
 	if (m_bIsSaddled && (m_Attachee != nullptr))

--- a/src/Mobs/Sheep.cpp
+++ b/src/Mobs/Sheep.cpp
@@ -88,6 +88,11 @@ void cSheep::OnRightClicked(cPlayer & a_Player)
 void cSheep::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	int PosX = POSX_TOINT;
 	int PosY = POSY_TOINT - 1;
 	int PosZ = POSZ_TOINT;

--- a/src/Mobs/SnowGolem.cpp
+++ b/src/Mobs/SnowGolem.cpp
@@ -30,6 +30,11 @@ void cSnowGolem::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 void cSnowGolem::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 	if (IsBiomeNoDownfall(m_World->GetBiomeAt(POSX_TOINT, POSZ_TOINT)))
 	{
 		TakeDamage(*this);

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -54,6 +54,11 @@ bool cVillager::DoTakeDamage(TakeDamageInfo & a_TDI)
 void cVillager::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (m_ActionCountDown > -1)
 	{

--- a/src/Mobs/Wither.cpp
+++ b/src/Mobs/Wither.cpp
@@ -69,6 +69,11 @@ bool cWither::DoTakeDamage(TakeDamageInfo & a_TDI)
 void cWither::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	super::Tick(a_Dt, a_Chunk);
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
 
 	if (m_WitherInvulnerableTicks > 0)
 	{

--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -263,6 +263,12 @@ void cWolf::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		super::Tick(a_Dt, a_Chunk);
 	}
 
+	if (!IsTicking())
+	{
+		// The base class tick destroyed us
+		return;
+	}
+
 	if (GetTarget() == nullptr)
 	{
 		cPlayer * a_Closest_Player = m_World->FindClosestPlayer(GetPosition(), static_cast<float>(m_SightDistance));


### PR DESCRIPTION
Closes #3358, and prevents future double-destroy bugs.