### PR TITLE
Added gdb to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+    - gdb
 
 script: ./CIbuild.sh
 
@@ -26,3 +27,10 @@ branches:
   only:
     - coverity_scan
     - master
+
+after_failure:
+- cat /proc/sys/kernel/core_pattern
+- COREFILE=$(find Server -maxdepth 1 -name "core*" | head -n 1) # find core file
+- echo $COREFILE # print path of core file
+- echo `pwd` # print path of working directory
+- if [[ -f "$COREFILE" ]]; then gdb -c "$COREFILE" $CUBERITE_PATH -ex "info threads" -ex "thread apply all bt" -ex "set pagination 0" -batch; fi

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -218,6 +218,12 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 		// Save the current time
 		m_StartTime = std::chrono::steady_clock::now();
 
+		int test = 5;
+		if (test > 0)
+		{
+			abort();
+		}
+
 		#ifdef _WIN32
 			EnableMenuItem(ConsoleMenu, SC_CLOSE, MF_ENABLED);  // Re-enable close button
 		#endif


### PR DESCRIPTION
Retry of #2585.

Added gdb and script commands.
Also code that crashes the server after initialized, will be removed after success.

In #3364 we have `core dumped`, it looks like that core files are now generated automatically. Therefore I retry this.