### PR TITLE
TNT explosion rate limit

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ SET (SRCS
 	Cuboid.cpp
 	DeadlockDetect.cpp
 	Enchantments.cpp
+	ExplosionLimiter.cpp
 	FastRandom.cpp
 	FurnaceRecipe.cpp
 	Globals.cpp
@@ -108,6 +109,7 @@ SET (HDRS
 	EffectID.h
 	Enchantments.h
 	Endianness.h
+	ExplosionLimiter.h
 	FastRandom.h
 	ForEachChunkProvider.h
 	FurnaceRecipe.h

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1711,26 +1711,29 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 			return;
 		}
 
-		for (int radius = 1; radius <= ExplosionSizeInt; ++radius)
+		// Loop a sphere, inside out
+		// We scan the surface of a cube. The cube increases in size each iteration
+		for (int CubeSize = 1; CubeSize <= ExplosionSizeInt; ++CubeSize)
 		{
-			for (int x = -radius; x <= radius; x++)
+			for (int x = -CubeSize; x <= CubeSize; x++)
 			{
-				for (int y = -radius; y <= radius; y++)
+				for (int y = -CubeSize; y <= CubeSize; y++)
 				{
 					if ((by + y >= cChunkDef::Height) || (by + y < 0))
 					{
 						// Outside of the world
 						continue;
 					}
-					for (int z = -radius; z <= radius; z++)
+					for (int z = -CubeSize; z <= CubeSize; z++)
 					{
 						if ((x * x + y * y + z * z) > ExplosionSizeSq)
 						{
-							// Too far away
+							// Outside the sphere
 							continue;
 						}
-						if ((abs(x) != radius) && (abs(y) != radius) && (abs(z) != radius))
+						if ((abs(x) != CubeSize) && (abs(y) != CubeSize) && (abs(z) != CubeSize))
 						{
+							// Not on the surface of the cube
 							continue;
 						}
 
@@ -1811,7 +1814,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 					}  // for z
 				}  // for y
 			}  // for x
-		} // for radius
+		}  // for radius
 		area.Write(m_World, bx - ExplosionSizeInt, MinY, bz - ExplosionSizeInt);
 	}
 

--- a/src/ExplosionLimiter.cpp
+++ b/src/ExplosionLimiter.cpp
@@ -1,0 +1,34 @@
+#include "ExplosionLimiter.h"
+cExplosionLimiter::cExplosionLimiter()
+	: m_ExplosionsAllowedPerSecond()
+{
+
+}
+
+void cExplosionLimiter::SetExplosionsAllowedPerSecond(unsigned int a_ExplosionsAllowedPerSecond)
+{
+	m_ExplosionsAllowedPerSecond = a_ExplosionsAllowedPerSecond;
+}
+
+
+
+
+
+void cExplosionLimiter::ResetExplosionLimit()
+{
+	m_ExplosionsAllowedThisSecond = m_ExplosionsAllowedPerSecond;
+}
+
+
+
+
+
+bool cExplosionLimiter::RequestExplosion()
+{
+	if (m_ExplosionsAllowedThisSecond > 0)
+	{
+		m_ExplosionsAllowedThisSecond -= 1;
+		return true;
+	}
+	return false;
+}

--- a/src/ExplosionLimiter.cpp
+++ b/src/ExplosionLimiter.cpp
@@ -1,3 +1,6 @@
+
+#include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
+
 #include "ExplosionLimiter.h"
 cExplosionLimiter::cExplosionLimiter()
 	: m_ExplosionsAllowedPerSecond()

--- a/src/ExplosionLimiter.h
+++ b/src/ExplosionLimiter.h
@@ -1,0 +1,19 @@
+class cExplosionLimiter
+{
+public:
+	cExplosionLimiter();
+
+	/** Set the number of allowed TNT explosions caused by other TNTS per second. */
+	void SetExplosionsAllowedPerSecond(unsigned int a_ExplosionsAllowedPerSecond);
+
+	/** Reset the explosion limit. Called once a second from cWorld. */
+	void ResetExplosionLimit();
+
+	/** Check whether a TNT is allowed to explode other TNTs.
+	Returns false if explosion is denied and true if allowed. */
+	bool RequestExplosion();
+
+private:
+	unsigned int m_ExplosionsAllowedThisSecond;
+	unsigned int m_ExplosionsAllowedPerSecond;
+};

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -148,8 +148,8 @@ cWorld::cWorld(const AString & a_WorldName, eDimension a_Dimension, const AStrin
 	m_IsDaylightCycleEnabled(true),
 	m_WorldAge(0),
 	m_TimeOfDay(0),
+	m_TickCount(0),
 	m_LastTimeUpdate(0),
-	m_LastChunkCheck(0),
 	m_LastSave(0),
 	m_SkyDarkness(0),
 	m_GameMode(gmNotSet),
@@ -165,6 +165,7 @@ cWorld::cWorld(const AString & a_WorldName, eDimension a_Dimension, const AStrin
 	m_RedstoneSimulator(nullptr),
 	m_MaxPlayers(10),
 	m_ChunkMap(),
+	m_ExplosionLimiter(),
 	m_bAnimals(true),
 	m_Weather(eWeather_Sunny),
 	m_WeatherInterval(24000),  // Guaranteed 1 game-day of sunshine at server start :)
@@ -309,6 +310,15 @@ void cWorld::ChangeWeather(void)
 {
 	// In the next tick the weather will be changed
 	m_WeatherInterval = 0;
+}
+
+
+
+
+
+cExplosionLimiter & cWorld::GetExplosionLimiter()
+{
+	return m_ExplosionLimiter;
 }
 
 
@@ -460,6 +470,8 @@ void cWorld::Start(void)
 		IniFile.SetValueI("General", "UnusedChunkCap", UnusedDirtyChunksCap);
 	}
 	m_UnusedDirtyChunksCap = static_cast<size_t>(UnusedDirtyChunksCap);
+	m_ExplosionLimiter.SetExplosionsAllowedPerSecond(
+				static_cast<unsigned int>(IniFile.GetValueSetI("General", "ExplosionPerSecCap", 15)));
 
 	m_BroadcastDeathMessages = IniFile.GetValueSetB("Broadcasting", "BroadcastDeathMessages", true);
 	m_BroadcastAchievementMessages = IniFile.GetValueSetB("Broadcasting", "BroadcastAchievementMessages", true);
@@ -1064,7 +1076,8 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 
 	TickWeather(static_cast<float>(a_Dt.count()));
 
-	if (m_WorldAge - m_LastChunkCheck > std::chrono::seconds(10))
+	// Perform chunk unloading and saving every 10 seconds
+	if ((m_TickCount % (10 * 20)) == 0)
 	{
 		// Unload every 10 seconds
 		UnloadUnusedChunks();
@@ -1079,6 +1092,17 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 			// Save if we have too many dirty unused chunks
 			SaveAllChunks();
 		}
+	}
+
+	if ((m_TickCount % (1 * 20)) == 0)
+	{
+		GetExplosionLimiter().ResetExplosionLimit();
+	}
+
+	m_TickCount += 1;
+	if (m_TickCount == 10000)
+	{
+		m_TickCount = 0;
 	}
 }
 
@@ -2977,7 +3001,6 @@ bool cWorld::HasChunkAnyClients(int a_ChunkX, int a_ChunkZ) const
 
 void cWorld::UnloadUnusedChunks(void)
 {
-	m_LastChunkCheck = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
 	m_ChunkMap->UnloadUnusedChunks();
 }
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -471,7 +471,7 @@ void cWorld::Start(void)
 	}
 	m_UnusedDirtyChunksCap = static_cast<size_t>(UnusedDirtyChunksCap);
 	m_ExplosionLimiter.SetExplosionsAllowedPerSecond(
-				static_cast<unsigned int>(IniFile.GetValueSetI("General", "ExplosionPerSecCap", 15)));
+		static_cast<unsigned int>(IniFile.GetValueSetI("General", "ExplosionPerSecCap", 15)));
 
 	m_BroadcastDeathMessages = IniFile.GetValueSetB("Broadcasting", "BroadcastDeathMessages", true);
 	m_BroadcastAchievementMessages = IniFile.GetValueSetB("Broadcasting", "BroadcastAchievementMessages", true);

--- a/src/World.h
+++ b/src/World.h
@@ -29,6 +29,7 @@
 #include "ClientHandle.h"
 #include "EffectID.h"
 #include <functional>
+#include "ExplosionLimiter.h"
 
 
 
@@ -775,9 +776,11 @@ public:
 
 	// tolua_end
 
-	cChunkGenerator & GetGenerator(void) { return m_Generator; }
-	cWorldStorage &   GetStorage  (void) { return m_Storage; }
-	cChunkMap *       GetChunkMap (void) { return m_ChunkMap.get(); }
+	cChunkGenerator &   GetGenerator(void) { return m_Generator; }
+	cWorldStorage &     GetStorage  (void) { return m_Storage; }
+	cChunkMap *         GetChunkMap (void) { return m_ChunkMap.get(); }
+	cExplosionLimiter & GetExplosionLimiter();
+
 
 	/** Sets the blockticking to start at the specified block. Only one blocktick per chunk may be set, second call overwrites the first call */
 	void SetNextBlockTick(int a_BlockX, int a_BlockY, int a_BlockZ);  // tolua_export
@@ -896,10 +899,11 @@ private:
 	// std::chrono::milliseconds is guaranteed to be good for 292 years by the standard.
 	std::chrono::milliseconds  m_WorldAge;
 	std::chrono::milliseconds  m_TimeOfDay;
-	cTickTimeLong  m_LastTimeUpdate;    // The tick in which the last time update has been sent.
-	cTickTimeLong  m_LastChunkCheck;        // The last WorldAge (in ticks) in which unloading and possibly saving was triggered
-	cTickTimeLong  m_LastSave;          // The last WorldAge (in ticks) in which save-all was triggerred
+	unsigned int  m_TickCount;        // The number of ticks we've ever ticked. Wraps to 0 every 10000 ticks
+	cTickTimeLong  m_LastTimeUpdate;  // The tick in which the last time update has been sent.
+	cTickTimeLong  m_LastSave;        // The last WorldAge (in ticks) in which save-all was triggerred
 	std::map<cMonster::eFamily, cTickTimeLong> m_LastSpawnMonster;  // The last WorldAge (in ticks) in which a monster was spawned (for each megatype of monster)  // MG TODO : find a way to optimize without creating unmaintenability (if mob IDs are becoming unrowed)
+
 
 	NIBBLETYPE m_SkyDarkness;
 
@@ -927,6 +931,7 @@ private:
 	unsigned int m_MaxPlayers;
 
 	std::unique_ptr<cChunkMap> m_ChunkMap;
+	cExplosionLimiter m_ExplosionLimiter;
 
 	bool m_bAnimals;
 	std::set<eMonsterType> m_AllowedMobs;


### PR DESCRIPTION
Main change: TNT explosion rate limit
Secondary change to cWorld:
cWorld now has a tick variable. I did that to avoid adding yet another m_LastX, and because I want the explosion rate to be tick-dependent and not time-dependent. That way, if the world lags, the explosion rate per tick does not increase.

Secondary change to the explosion  loop:
I made the explosion loop scan inside-out. This prevents chain explosions from having a single preferred general direction on low explosion rates.
