### PR TITLE
Fixed data race in SpawnPrepare.cpp

### DIFF
--- a/src/SpawnPrepare.h
+++ b/src/SpawnPrepare.h
@@ -21,7 +21,7 @@ protected:
 	int m_PrepareDistance;
 
 	/** The index of the next chunk to be queued in the lighting thread. */
-	int m_NextIdx;
+	std::atomic<int> m_NextIdx;
 
 	/** The maximum index of the prepared chunks. Queueing stops when m_NextIdx reaches this number. */
 	int m_MaxIdx;


### PR DESCRIPTION
I think the info below is enough :)



SpawnPrepare.cpp:107(read): `if (m_NextIdx < m_MaxIdx)`
SpawnPrepare.cpp:112(write): `m_NextIdx += 1;`

```
  Read of size 4 at 0x7ffcd5ea6f3c by main thread (mutexes: write M544):
    #0 cSpawnPrepare::PreparedChunkCallback(int, int) /home/lukas/cpp/cuberite/src/SpawnPrepare.cpp:107:6 (Cuberite+0x0000006b561a)
    #1 cSpawnPrepareCallback::Call(int, int, bool) /home/lukas/cpp/cuberite/src/SpawnPrepare.cpp:25:18 (Cuberite+0x0000006b593f)
    #2 cChunkMap::PrepareChunk(int, int, std::unique_ptr<cChunkCoordCallback, std::default_delete<cChunkCoordCallback> >) /home/lukas/cpp/cuberite/src/ChunkMap.cpp:2255:15 (Cuberite+0x000000635947)
    #3 cWorld::PrepareChunk(int, int, std::unique_ptr<cChunkCoordCallback, std::default_delete<cChunkCoordCallback> >) /home/lukas/cpp/cuberite/src/World.cpp:3327:14 (Cuberite+0x0000006dd886)
    #4 cSpawnPrepare::PrepareChunks(cWorld&, int, int, int) /home/lukas/cpp/cuberite/src/SpawnPrepare.cpp:63:11 (Cuberite+0x0000006b5448)
    #5 cWorld::InitializeSpawn() /home/lukas/cpp/cuberite/src/World.cpp:376:2 (Cuberite+0x0000006cc62d)
    #6 cRoot::StartWorlds() /home/lukas/cpp/cuberite/src/Root.cpp:514:16 (Cuberite+0x00000069fe79)
    #7 cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface, std::default_delete<cSettingsRepositoryInterface> >) /home/lukas/cpp/cuberite/src/Root.cpp:188 (Cuberite+0x00000069fe79)
    #8 UniversalMain(std::unique_ptr<cSettingsRepositoryInterface, std::default_delete<cSettingsRepositoryInterface> >) /home/lukas/cpp/cuberite/src/main.cpp:231:8 (Cuberite+0x0000006e99f3)
    #9 main /home/lukas/cpp/cuberite/src/main.cpp:548:4 (Cuberite+0x0000006e72a7)

  Previous write of size 4 at 0x7ffcd5ea6f3c by thread T4:
    #0 cSpawnPrepare::PreparedChunkCallback(int, int) /home/lukas/cpp/cuberite/src/SpawnPrepare.cpp:112:13 (Cuberite+0x0000006b570f)
    #1 cSpawnPrepareCallback::Call(int, int, bool) /home/lukas/cpp/cuberite/src/SpawnPrepare.cpp:25:18 (Cuberite+0x0000006b593f)
    #2 cLightingThread::LightChunk(cLightingThread::cLightingChunkStay&) /home/lukas/cpp/cuberite/src/LightingThread.cpp:327:27 (Cuberite+0x000000679bf6)
    #3 cLightingThread::Execute() /home/lukas/cpp/cuberite/src/LightingThread.cpp:228:3 (Cuberite+0x000000679647)
    #4 cIsThread::DoExecute() /home/lukas/cpp/cuberite/src/OSSupport/IsThread.cpp:74:2 (Cuberite+0x0000006fb0a6)
    #5 void std::__invoke_impl<void, void (cIsThread::* const&)(), cIsThread*>(std::__invoke_memfun_deref, void (cIsThread::* const&)(), cIsThread*&&) /usr/lib/gcc/x86_64-linux-gnu/6.1.1/../../../../include/c++/6.1.1/functional:235:14 (Cuberite+0x0000006fb3a4)
    #6 std::result_of<void (cIsThread::* const&(cIsThread*&&))()>::type std::__invoke<void (cIsThread::* const&)(), cIsThread*>(void (cIsThread::* const&)(), cIsThread*&&) /usr/lib/gcc/x86_64-linux-gnu/6.1.1/../../../../include/c++/6.1.1/functional:259 (Cuberite+0x0000006fb3a4)
    #7 _ZNKSt12_Mem_fn_baseIM9cIsThreadFvvELb1EEclIJPS0_EEEDTclsr3stdE8__invokedtdefpT6_M_pmfspclsr3stdE7forwardIT_Efp_EEEDpOS6_ /usr/lib/gcc/x86_64-linux-gnu/6.1.1/../../../../include/c++/6.1.1/functional:613 (Cuberite+0x0000006fb3a4)
    #8 void std::_Bind_simple<std::_Mem_fn<void (cIsThread::*)()> (cIsThread*)>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/lib/gcc/x86_64-linux-gnu/6.1.1/../../../../include/c++/6.1.1/functional:1399 (Cuberite+0x0000006fb3a4)
    #9 std::_Bind_simple<std::_Mem_fn<void (cIsThread::*)()> (cIsThread*)>::operator()() /usr/lib/gcc/x86_64-linux-gnu/6.1.1/../../../../include/c++/6.1.1/functional:1389 (Cuberite+0x0000006fb3a4)
    #10 std::thread::_State_impl<std::_Bind_simple<std::_Mem_fn<void (cIsThread::*)()> (cIsThread*)> >::_M_run() /usr/lib/gcc/x86_64-linux-gnu/6.1.1/../../../../include/c++/6.1.1/thread:196 (Cuberite+0x0000006fb3a4)
    #11 <null> <null> (libstdc++.so.6+0x0000000b998e)
	
SUMMARY: ThreadSanitizer: data race /home/lukas/cpp/cuberite/src/SpawnPrepare.cpp:107:6 in cSpawnPrepare::PreparedChunkCallback(int, int)
```