### PR TITLE
remove usage of 256 as magical number for the height of a chunk

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3698,11 +3698,13 @@ end
 				},
 				Clear =
 				{
+					Returns = "self",
 					Notes = "Removes all parts from this object",
 				},
 				constructor =
 				{
 					{
+						Returns = { {Type = "cCompositeChat"} },
 						Notes = "Creates an empty chat message",
 					},
 					{
@@ -3718,6 +3720,7 @@ end
 								IsOptional = true,
 							},
 						},
+						Returns = { {Type = "cCompositeChat"} },
 						Notes = "Creates a chat message containing the specified text, parsed by the ParseText() function. This allows easy migration from old chat messages.",
 					},
 				},
@@ -10100,7 +10103,7 @@ a_Player:OpenWindow(Window);
 					{
 						{
 							Name = "MobType",
-							Type = "Globals#eMobType",
+							Type = "Globals#eMonsterType",
 						},
 					},
 					Returns =
@@ -10110,7 +10113,7 @@ a_Player:OpenWindow(Window);
 							Type = "cMonster#eFamily",
 						},
 					},
-					Notes = "Returns the mob family ({{cMonster#eFamily|mfXXX}} constants) based on the mob type ({{Globals#eMobType|mtXXX}} constants)",
+					Notes = "Returns the mob family ({{cMonster#eFamily|mfXXX}} constants) based on the mob type ({{Globals#eMonsterType|mtXXX}} constants)",
 				},
 				GetAge =
 				{
@@ -10149,10 +10152,10 @@ a_Player:OpenWindow(Window);
 					{
 						{
 							Name = "MobType",
-							Type = "Globals#eMobType",
+							Type = "Globals#eMonsterType",
 						},
 					},
-					Notes = "Returns the type of this mob ({{Globals#eMobType|mtXXX}} constant)",
+					Notes = "Returns the type of this mob ({{Globals#eMonsterType|mtXXX}} constant)",
 				},
 				GetRelativeWalkSpeed =
 				{
@@ -10219,7 +10222,7 @@ a_Player:OpenWindow(Window);
 					{
 						{
 							Name = "MobType",
-							Type = "Globals#eMobType",
+							Type = "Globals#eMonsterType",
 						},
 					},
 					Returns =
@@ -10228,7 +10231,7 @@ a_Player:OpenWindow(Window);
 							Type = "string",
 						},
 					},
-					Notes = "Returns the string representing the given mob type ({{Globals#eMobType|mtXXX}} constant), or empty string if unknown type.",
+					Notes = "Returns the string representing the given mob type ({{Globals#eMonsterType|mtXXX}} constant), or empty string if unknown type.",
 				},
 				MobTypeToVanillaName =
 				{
@@ -10317,10 +10320,10 @@ a_Player:OpenWindow(Window);
 					{
 						{
 							Name = "MobType",
-							Type = "Globals#eMobType",
+							Type = "Globals#eMonsterType",
 						},
 					},
-					Notes = "Returns the mob type ({{Globals#eMobType|mtXXX}} constant) parsed from the string type (\"creeper\"), or mtInvalidType if unrecognized.",
+					Notes = "Returns the mob type ({{Globals#eMonsterType|mtXXX}} constant) parsed from the string type (\"creeper\"), or mtInvalidType if unrecognized.",
 				},
 			},
 			Constants =
@@ -18497,6 +18500,66 @@ World:ForEachEntity(
 				{
 					Notes = "A wither skull explosion. The SourceData param is the {{cWitherSkullEntity|wither skull entity}} object.",
 				},
+				mtCustom =
+				{
+					Notes = "Send raw data without any processing",
+				},
+				mtDeath =
+				{
+					Notes = "Denotes death of player",
+				},
+				mtError =
+				{
+					Notes = "Something could not be done (i.e. command not executed due to insufficient privilege)",
+				},
+				mtFail =
+				{
+					Notes = "Something could not be done (i.e. command not executed due to insufficient privilege)",
+				},
+				mtFailure =
+				{
+					Notes = "Something could not be done (i.e. command not executed due to insufficient privilege)",
+				},
+				mtFatal =
+				{
+					Notes = "Something catastrophic occured (i.e. plugin crash)",
+				},
+				mtInfo =
+				{
+					Notes = "Informational message (i.e. command usage)",
+				},
+				mtInformation =
+				{
+					Notes = "Informational message (i.e. command usage)",
+				},
+				mtJoin =
+				{
+					Notes = "A player has joined the server",
+				},
+				mtLeave =
+				{
+					Notes = "A player has left the server",
+				},
+				mtMaxPlusOne =
+				{
+					Notes = "The first invalid type, used for checking on LuaAPI boundaries",
+				},
+				mtPM =
+				{
+					Notes = "Player to player messaging identifier",
+				},
+				mtPrivateMessage =
+				{
+					Notes = "Player to player messaging identifier",
+				},
+				mtSuccess =
+				{
+					Notes = "Something executed successfully",
+				},
+				mtWarning =
+				{
+					Notes = "Something concerning (i.e. reload) is about to happen",
+				},
 			},
 			ConstantGroups =
 			{
@@ -18590,11 +18653,70 @@ World:ForEachEntity(
 						StringToBiome() function that can convert a string into one of these constants.
 					]],
 				},
-				eMobType =
+				eMessageType =
+				{
+					-- Need to be specified explicitly, because there's also eMonsterType using the same "mt" prefix
+					Include =
+					{
+						"mtCustom",
+						"mtDeath",
+						"mtError",
+						"mtFail",
+						"mtFailure",
+						"mtFatal",
+						"mtInfo",
+						"mtInformation",
+						"mtJoin",
+						"mtLeave",
+						"mtMaxPlusOne",
+						"mtPrivateMessage",
+						"mtPM",
+						"mtSuccess",
+						"mtWarning",
+					},
+					TextBefore = [[
+						These constants are used together with messaging functions and classes, they specify the type of
+						message being sent. The server can be configured to modify the message text (add prefixes) based
+						on the message's type.
+					]],
+				},
+				eMonsterType =
 				{
 					Include =
 					{
-						"^mt.*",
+						"mtInvalidType",
+						"mtBat",
+						"mtBlaze",
+						"mtCaveSpider",
+						"mtChicken",
+						"mtCow",
+						"mtCreeper",
+						"mtEnderDragon",
+						"mtEnderman",
+						"mtGhast",
+						"mtGiant",
+						"mtGuardian",
+						"mtHorse",
+						"mtIronGolem",
+						"mtMagmaCube",
+						"mtMooshroom",
+						"mtOcelot",
+						"mtPig",
+						"mtRabbit",
+						"mtSheep",
+						"mtSilverfish",
+						"mtSkeleton",
+						"mtSlime",
+						"mtSnowGolem",
+						"mtSpider",
+						"mtSquid",
+						"mtVillager",
+						"mtWitch",
+						"mtWither",
+						"mtWolf",
+						"mtZombie",
+						"mtZombiePigman",
+						"mtMax",
 					},
 					TextBefore = [[
 						The following constants are used for distinguishing between the individual mob types:
@@ -18604,7 +18726,7 @@ World:ForEachEntity(
 				{
 					Include = "^sl.*",
 					TextBefore = [[
-						The following constants define the block types  that are propelled outwards after an explosion.
+						The following constants define the block types that are propelled outwards after an explosion.
 					]],
 				},
 				eSpreadSource =

--- a/Server/Plugins/InfoDump.lua
+++ b/Server/Plugins/InfoDump.lua
@@ -35,11 +35,20 @@ end
 
 
 
+--- Removes any whitespace at the beginning and end of the string
+local function TrimString(a_Str)
+	return (string.match(a_Str, "^%s*(.-)%s*$"))
+end
+
+
+
+
+
 --- Replaces generic formatting with forum-specific formatting
 -- Also removes the single line-ends
 local function ForumizeString(a_Str)
 	assert(type(a_Str) == "string")
-	
+
 	-- Remove the indentation, unless in the code tag:
 	-- Only one code or /code tag per line is supported!
 	local IsInCode = false
@@ -55,24 +64,24 @@ local function ForumizeString(a_Str)
 		end
 	end
 	a_Str = a_Str:gsub("(.-)\n", RemoveIndentIfNotInCode)
-	
+
 	-- Replace multiple line ends with {%p} and single line ends with a space,
 	-- so that manual word-wrap in the Info.lua file doesn't wrap in the forum.
 	a_Str = a_Str:gsub("\n\n", "{%%p}")
 	a_Str = a_Str:gsub("\n", " ")
-	
+
 	-- Replace the generic formatting:
 	a_Str = a_Str:gsub("{%%p}", "\n\n")
 	a_Str = a_Str:gsub("{%%b}", "[b]"):gsub("{%%/b}", "[/b]")
 	a_Str = a_Str:gsub("{%%i}", "[i]"):gsub("{%%/i}", "[/i]")
 	a_Str = a_Str:gsub("{%%list}", "\n[list]"):gsub("{%%/list}", "[/list]")
 	a_Str = a_Str:gsub("{%%li}", "\n[*]"):gsub("{%%/li}", "\n")
-	
+
 	-- Process links: {%a LinkDestination}LinkText{%/a}
 	a_Str = a_Str:gsub("{%%a%s([^}]*)}([^{]*){%%/a}", "[url=%1]%2[/url]")
-	
+
 	-- TODO: Other formatting
-	
+
 	return a_Str
 end
 
@@ -84,7 +93,7 @@ end
 -- Also removes the single line-ends
 local function GithubizeString(a_Str)
 	assert(type(a_Str) == "string")
-	
+
 	-- Remove the indentation, unless in the code tag:
 	-- Only one code or /code tag per line is supported!
 	local IsInCode = false
@@ -100,12 +109,12 @@ local function GithubizeString(a_Str)
 		end
 	end
 	a_Str = a_Str:gsub("(.-)\n", RemoveIndentIfNotInCode)
-	
+
 	-- Replace multiple line ends with {%p} and single line ends with a space,
 	-- so that manual word-wrap in the Info.lua file doesn't wrap in the forum.
 	a_Str = a_Str:gsub("\n\n", "{%%p}")
 	a_Str = a_Str:gsub("\n", " ")
-	
+
 	-- Replace the generic formatting:
 	a_Str = a_Str:gsub("{%%p}", "\n\n")
 	a_Str = a_Str:gsub("{%%b}", "**"):gsub("{%%/b}", "**")
@@ -115,9 +124,9 @@ local function GithubizeString(a_Str)
 
 	-- Process links: {%a LinkDestination}LinkText{%/a}
 	a_Str = a_Str:gsub("{%%a%s([^}]*)}([^{]*){%%/a}", "[%2](%1)")
-	
+
 	-- TODO: Other formatting
-	
+
 	return a_Str
 end
 
@@ -133,7 +142,7 @@ local function BuildCategories(a_PluginInfo)
 	-- The returned result
 	-- This will contain both an array and a dict of the categories, to allow fast search
 	local res = {}
-	
+
 	-- For each command add a reference to it into all of its categories:
 	local function AddCommands(a_CmdPrefix, a_Commands)
 		for cmd, info in pairs(a_Commands or {}) do
@@ -142,7 +151,7 @@ local function BuildCategories(a_PluginInfo)
 				CommandString = a_CmdPrefix .. cmd,
 				Info = info,
 			}
-			
+
 			if ((info.HelpString ~= nil) and (info.HelpString ~= "")) then
 				-- Add to each specified category:
 				local Category = info.Category
@@ -162,16 +171,16 @@ local function BuildCategories(a_PluginInfo)
 					end
 				end  -- for idx, cat - Category[]
 			end  -- if (HelpString valid)
-			
+
 			-- Recurse all subcommands:
 			if (info.Subcommands ~= nil) then
 				AddCommands(a_CmdPrefix .. cmd .. " ", info.Subcommands)
 			end
 		end  -- for cmd, info - a_Commands[]
 	end  -- AddCommands()
-	
+
 	AddCommands("", a_PluginInfo.Commands)
-	
+
 	-- Assign descriptions to categories:
 	for name, desc in pairs(a_PluginInfo.Categories or {}) do
 		local CatEntry = res[name]
@@ -180,7 +189,7 @@ local function BuildCategories(a_PluginInfo)
 			CatEntry.Description = desc.Description
 		end
 	end
-	
+
 	-- Alpha-sort each category's command list:
 	for idx, cat in ipairs(res) do
 		table.sort(cat.Commands,
@@ -189,7 +198,7 @@ local function BuildCategories(a_PluginInfo)
 			end
 		)
 	end
-	
+
 	return res
 end
 
@@ -220,7 +229,7 @@ local function GetCommandRefGithub(a_CommandName, a_CommandParams)
 	if (a_CommandParams == nil) then
 		return "`" .. a_CommandName .. "`"
 	end
-	
+
 	assert(type(a_CommandParams) == "table")
 	if ((a_CommandParams.Params == nil) or (a_CommandParams.Params == "")) then
 		return "`" .. a_CommandName .. "`"
@@ -239,12 +248,12 @@ local function WriteCommandParameterCombinationsForum(a_CmdString, a_ParameterCo
 	assert(type(a_CmdString) == "string")
 	assert(type(a_ParameterCombinations) == "table")
 	assert(f ~= nil)
-	
+
 	if (#a_ParameterCombinations == 0) then
 		-- No explicit parameter combinations to write
 		return
 	end
-	
+
 	f:write("The following parameter combinations are recognized:\n")
 	for idx, combination in ipairs(a_ParameterCombinations) do
 		f:write("[color=blue]", a_CmdString, "[/color] [color=green]", combination.Params or "", "[/color]")
@@ -267,12 +276,12 @@ local function WriteCommandParameterCombinationsGithub(a_CmdString, a_ParameterC
 	assert(type(a_CmdString) == "string")
 	assert(type(a_ParameterCombinations) == "table")
 	assert(f ~= nil)
-	
+
 	if (#a_ParameterCombinations == 0) then
 		-- No explicit parameter combinations to write
 		return
 	end
-	
+
 	f:write("The following parameter combinations are recognized:\n\n")
 	for idx, combination in ipairs(a_ParameterCombinations) do
 		f:write(GetCommandRefGithub(a_CmdString, combination))
@@ -298,12 +307,12 @@ local function WriteCommandsCategoryForum(a_Category, f)
 		CategoryName = "General"
 	end
 	f:write("\n[size=Large]", ForumizeString(a_Category.DisplayName or CategoryName), "[/size]\n")
-	
+
 	-- Write description:
 	if (a_Category.Description ~= "") then
 		f:write(ForumizeString(a_Category.Description), "\n")
 	end
-	
+
 	-- Write commands:
 	f:write("\n[list]")
 	for idx2, cmd in ipairs(a_Category.Commands) do
@@ -333,15 +342,15 @@ local function WriteCommandsCategoryGithub(a_Category, f)
 		CategoryName = "General"
 	end
 	f:write("\n### ", GithubizeString(a_Category.DisplayName or CategoryName), "\n")
-	
+
 	-- Write description:
 	if (a_Category.Description ~= "") then
 		f:write(GithubizeString(a_Category.Description), "\n\n")
 	end
-	
+
 	f:write("| Command | Permission | Description |\n")
 	f:write("| ------- | ---------- | ----------- |\n")
-	
+
 	-- Write commands:
 	for idx2, cmd in ipairs(a_Category.Commands) do
 		f:write("|", cmd.CommandString, " | ", cmd.Info.Permission or "", " | ", GithubizeString(cmd.Info.HelpString or "UNDOCUMENTED"), "|\n")
@@ -356,18 +365,18 @@ end
 local function DumpCommandsForum(a_PluginInfo, f)
 	-- Copy all Categories from a dictionary into an array:
 	local Categories = BuildCategories(a_PluginInfo)
-	
+
 	-- Sort the categories by name:
 	table.sort(Categories,
 		function(cat1, cat2)
 			return (string.lower(cat1.Name) < string.lower(cat2.Name))
 		end
 	)
-	
+
 	if (#Categories == 0) then
 		return
 	end
-	
+
 	f:write("\n[size=X-Large]Commands[/size]\n")
 
 	-- Dump per-category commands:
@@ -383,18 +392,18 @@ end
 local function DumpCommandsGithub(a_PluginInfo, f)
 	-- Copy all Categories from a dictionary into an array:
 	local Categories = BuildCategories(a_PluginInfo)
-	
+
 	-- Sort the categories by name:
 	table.sort(Categories,
 		function(cat1, cat2)
 			return (string.lower(cat1.Name) < string.lower(cat2.Name))
 		end
 	)
-	
+
 	if (#Categories == 0) then
 		return
 	end
-	
+
 	f:write("\n# Commands\n")
 
 	-- Dump per-category commands:
@@ -413,7 +422,7 @@ local function DumpAdditionalInfoForum(a_PluginInfo, f)
 		-- There is no AdditionalInfo in a_PluginInfo
 		return
 	end
-	
+
 	for idx, info in ipairs(a_PluginInfo.AdditionalInfo) do
 		if ((info.Title ~= nil) and (info.Contents ~= nil)) then
 			f:write("\n[size=X-Large]", ForumizeString(info.Title), "[/size]\n")
@@ -432,7 +441,7 @@ local function DumpAdditionalInfoGithub(a_PluginInfo, f)
 		-- There is no AdditionalInfo in a_PluginInfo
 		return
 	end
-	
+
 	for idx, info in ipairs(a_PluginInfo.AdditionalInfo) do
 		if ((info.Title ~= nil) and (info.Contents ~= nil)) then
 			f:write("\n# ", GithubizeString(info.Title), "\n")
@@ -472,7 +481,7 @@ local function BuildPermissions(a_PluginInfo)
 					table.insert(Permission.CommandsAffected, CommandString)
 				end
 			end
-			
+
 			-- Process the command param combinations for permissions:
 			local ParamCombinations = info.ParameterCombinations or {}
 			for idx, comb in ipairs(ParamCombinations) do
@@ -485,7 +494,7 @@ local function BuildPermissions(a_PluginInfo)
 					table.insert(Permission.CommandsAffected, {Name = CommandString, Params = comb.Params})
 				end
 			end
-			
+
 			-- Process subcommands:
 			if (info.Subcommands ~= nil) then
 				CollectPermissions(CommandString .. " ", info.Subcommands)
@@ -493,13 +502,13 @@ local function BuildPermissions(a_PluginInfo)
 		end
 	end
 	CollectPermissions("", a_PluginInfo.Commands)
-	
+
 	-- Copy the list of permissions to an array:
 	local PermArray = {}
 	for name, perm in pairs(Permissions) do
 		table.insert(PermArray, {Name = name, Info = perm})
 	end
-	
+
 	-- Sort the permissions array:
 	table.sort(PermArray,
 		function(p1, p2)
@@ -619,7 +628,7 @@ local function DumpPluginInfoGithub(a_PluginFolder, a_PluginInfo)
 	-- Check the params:
 	assert(type(a_PluginFolder) == "string")
 	assert(type(a_PluginInfo) == "table")
-	
+
 	-- Open the output file:
 	local f, msg = io.open(a_PluginFolder .. "/README.md", "w")
 	if (f == nil) then
@@ -628,7 +637,7 @@ local function DumpPluginInfoGithub(a_PluginFolder, a_PluginInfo)
 	end
 
 	-- Write the description:
-	f:write(GithubizeString(a_PluginInfo.Description), "\n")
+	f:write(TrimString(GithubizeString(a_PluginInfo.Description)), "\n")
 	DumpAdditionalInfoGithub(a_PluginInfo, f)
 	DumpCommandsGithub(a_PluginInfo, f)
 	DumpPermissionsGithub(a_PluginInfo, f)
@@ -649,7 +658,7 @@ local function LoadPluginInfo(a_FolderName)
 	if (cfg == nil) then
 		return nil, "Cannot open 'Info.lua': " .. err
 	end
-	
+
 	-- Execute the loaded file in a sandbox:
 	-- This is Lua-5.1-specific and won't work in Lua 5.2!
 	local Sandbox = {}
@@ -658,7 +667,7 @@ local function LoadPluginInfo(a_FolderName)
 	if not(isSuccess) then
 		return nil, "Cannot load Info.lua: " .. (errMsg or "<unknown error>")
 	end
-	
+
 	if (Sandbox.g_PluginInfo == nil) then
 		return nil, "Info.lua doesn't contain the g_PluginInfo declaration"
 	end
@@ -677,14 +686,14 @@ local function ProcessPluginFolder(a_FolderName)
 	if (PluginInfo == nil) then
 		return nil, "Cannot load info for plugin " .. a_FolderName .. ": " .. (Msg or "<unknown error>")
 	end
-	
+
 	-- Dump the forum format:
 	local isSuccess
 	isSuccess, Msg = DumpPluginInfoForum(a_FolderName, PluginInfo)
 	if not(isSuccess) then
 		return nil, "Cannot dump forum info for plugin " .. a_FolderName .. ": " .. (Msg or "<unknown error>")
 	end
-	
+
 	-- Dump the GitHub format:
 	isSuccess, Msg = DumpPluginInfoGithub(a_FolderName, PluginInfo)
 	if not(isSuccess) then
@@ -720,7 +729,7 @@ local function LoadLFS()
 		sudo apt-get install luarocks (Ubuntu / Debian)
 	On windows, a binary distribution can be downloaded from the LuaRocks homepage, http://luarocks.org/en/Download
 	]])
-		
+
 		print("Original error text: ", err)
 		return nil
 	end

--- a/Server/Plugins/InfoReg.lua
+++ b/Server/Plugins/InfoReg.lua
@@ -159,7 +159,9 @@ function RegisterPluginInfoCommands()
 	end
 
 	-- Loop through all commands in the plugin info, register each:
-	RegisterSubcommands("", g_PluginInfo.Commands, 1)
+	if (g_PluginInfo.Commands) then
+		RegisterSubcommands("", g_PluginInfo.Commands, 1)
+	end
 end
 
 
@@ -190,7 +192,9 @@ function RegisterPluginInfoConsoleCommands()
 	end
 
 	-- Loop through all commands in the plugin info, register each:
-	RegisterSubcommands("", g_PluginInfo.ConsoleCommands, 1)
+	if (g_PluginInfo.ConsoleCommands) then
+		RegisterSubcommands("", g_PluginInfo.ConsoleCommands, 1)
+	end
 end
 
 

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -1910,20 +1910,17 @@ static int tolua_sha1HexString(lua_State * tolua_S)
 
 
 
-static int tolua_push_StringStringMap(lua_State* tolua_S, std::map< std::string, std::string >& a_StringStringMap)
+static int tolua_get_HTTPRequest_Params(lua_State * a_LuaState)
 {
-	lua_newtable(tolua_S);
-	int top = lua_gettop(tolua_S);
-
-	for (std::map<std::string, std::string>::iterator it = a_StringStringMap.begin(); it != a_StringStringMap.end(); ++it)
+	cLuaState L(a_LuaState);
+	HTTPRequest * self;
+	if (!L.GetStackValues(1, self))
 	{
-		const char * key = it->first.c_str();
-		const char * value = it->second.c_str();
-		lua_pushstring(tolua_S, key);
-		lua_pushstring(tolua_S, value);
-		lua_settable(tolua_S, top);
+		tolua_Error err;
+		tolua_error(a_LuaState, "Invalid self parameter, expected a HTTPRequest instance", &err);
+		return 0;
 	}
-
+	L.Push(self->Params);
 	return 1;
 }
 
@@ -1931,40 +1928,44 @@ static int tolua_push_StringStringMap(lua_State* tolua_S, std::map< std::string,
 
 
 
-static int tolua_get_HTTPRequest_Params(lua_State* tolua_S)
+static int tolua_get_HTTPRequest_PostParams(lua_State * a_LuaState)
 {
-	HTTPRequest * self = reinterpret_cast<HTTPRequest *>(tolua_tousertype(tolua_S, 1, nullptr));
-	return tolua_push_StringStringMap(tolua_S, self->Params);
-}
-
-
-
-
-
-static int tolua_get_HTTPRequest_PostParams(lua_State* tolua_S)
-{
-	HTTPRequest * self = reinterpret_cast<HTTPRequest *>(tolua_tousertype(tolua_S, 1, nullptr));
-	return tolua_push_StringStringMap(tolua_S, self->PostParams);
-}
-
-
-
-
-
-static int tolua_get_HTTPRequest_FormData(lua_State* tolua_S)
-{
-	HTTPRequest * self = reinterpret_cast<HTTPRequest *>(tolua_tousertype(tolua_S, 1, nullptr));
-	std::map<std::string, HTTPFormData> & FormData = self->FormData;
-
-	lua_newtable(tolua_S);
-	int top = lua_gettop(tolua_S);
-
-	for (std::map<std::string, HTTPFormData>::iterator it = FormData.begin(); it != FormData.end(); ++it)
+	cLuaState L(a_LuaState);
+	HTTPRequest * self;
+	if (!L.GetStackValues(1, self))
 	{
-		lua_pushstring(tolua_S, it->first.c_str());
-		tolua_pushusertype(tolua_S, &(it->second), "HTTPFormData");
-		// lua_pushlstring(tolua_S, it->second.Value.c_str(), it->second.Value.size());  // Might contain binary data
-		lua_settable(tolua_S, top);
+		tolua_Error err;
+		tolua_error(a_LuaState, "Invalid self parameter, expected a HTTPRequest instance", &err);
+		return 0;
+	}
+	L.Push(self->PostParams);
+	return 1;
+}
+
+
+
+
+
+static int tolua_get_HTTPRequest_FormData(lua_State* a_LuaState)
+{
+	cLuaState L(a_LuaState);
+	HTTPRequest * self;
+	if (!L.GetStackValues(1, self))
+	{
+		tolua_Error err;
+		tolua_error(a_LuaState, "Invalid self parameter, expected a HTTPRequest instance", &err);
+		return 0;
+	}
+
+	const auto & FormData = self->FormData;
+	lua_newtable(a_LuaState);
+	int top = lua_gettop(a_LuaState);
+	for (auto itr = FormData.cbegin(); itr != FormData.cend(); ++itr)
+	{
+		lua_pushstring(a_LuaState, itr->first.c_str());
+		tolua_pushusertype(a_LuaState, const_cast<void *>(reinterpret_cast<const void *>(&(itr->second))), "HTTPFormData");
+		// lua_pushlstring(a_LuaState, it->second.Value.c_str(), it->second.Value.size());  // Might contain binary data
+		lua_settable(a_LuaState, top);
 	}
 
 	return 1;

--- a/src/Blocks/BlockLeaves.h
+++ b/src/Blocks/BlockLeaves.h
@@ -166,7 +166,7 @@ bool HasNearLog(cBlockArea & a_Area, int a_BlockX, int a_BlockY, int a_BlockZ)
 	a_Area.SetBlockType(a_BlockX, a_BlockY, a_BlockZ, E_BLOCK_SPONGE);
 	for (int i = 0; i < LEAVES_CHECK_DISTANCE; i++)
 	{
-		for (int y = std::max(a_BlockY - i, 0); y <= std::min(a_BlockY + i, 255); y++)
+		for (int y = std::max(a_BlockY - i, 0); y <= std::min(a_BlockY + i, cChunkDef::Height - 1); y++)
 		{
 			for (int z = a_BlockZ - i; z <= a_BlockZ + i; z++)
 			{

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -213,7 +213,7 @@ AString cClientHandle::FormatChatPrefix(bool ShouldAppendChatPrefixes, AString a
 
 
 
-AString cClientHandle::FormatMessageType(bool ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString &a_AdditionalData)
+AString cClientHandle::FormatMessageType(bool ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData)
 {
 	switch (a_ChatPrefix)
 	{
@@ -237,11 +237,9 @@ AString cClientHandle::FormatMessageType(bool ShouldAppendChatPrefixes, eMessage
 				return Printf("%s: %s", a_AdditionalData.c_str(), cChatColor::LightBlue);
 			}
 		}
+		case mtMaxPlusOne: break;
 	}
-	ASSERT(!"Unhandled chat prefix type!");
-	#ifndef __clang__
-		return "";
-	#endif
+	return "";
 }
 
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -77,11 +77,11 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 	m_BlockDigAnimStage(-1),
 	m_BlockDigAnimSpeed(0),
 	m_BlockDigAnimX(0),
-	m_BlockDigAnimY(256),  // Invalid Y, so that the coords don't get picked up
+	m_BlockDigAnimY(cChunkDef::Height + 1),  // Invalid Y, so that the coords don't get picked up
 	m_BlockDigAnimZ(0),
 	m_HasStartedDigging(false),
 	m_LastDigBlockX(0),
-	m_LastDigBlockY(256),  // Invalid Y, so that the coords don't get picked up
+	m_LastDigBlockY(cChunkDef::Height + 1),  // Invalid Y, so that the coords don't get picked up
 	m_LastDigBlockZ(0),
 	m_State(csConnected),
 	m_ShouldCheckDownloaded(false),

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -282,11 +282,10 @@ cLogger::eLogLevel cCompositeChat::MessageTypeToLogLevel(eMessageType a_MessageT
 		case mtPrivateMessage: return cLogger::llRegular;
 		case mtJoin:           return cLogger::llRegular;
 		case mtLeave:          return cLogger::llRegular;
+		case mtMaxPlusOne: break;
 	}
 	ASSERT(!"Unhandled MessageType");
-	#ifndef __clang__
-		return cLogger::llError;
-	#endif
+	return cLogger::llError;
 }
 
 

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -122,24 +122,22 @@ public:
 
 	typedef std::vector<cBasePart *> cParts;
 
-	// tolua_begin
-
-	/** Creates a new empty chat message */
+	/** Creates a new empty chat message.
+	Exported manually due to the other overload needing a manual export. */
 	cCompositeChat(void);
 
 	/** Creates a new chat message and parses the text into parts.
 	Recognizes "http:" and "https:" links and @color-codes.
-	Uses ParseText() for the actual parsing. */
+	Uses ParseText() for the actual parsing.
+	Exported manually due to ToLua++ generating extra output parameter. */
 	cCompositeChat(const AString & a_ParseText, eMessageType a_MessageType = mtCustom);
 
-	~cCompositeChat();
+	~cCompositeChat();  // tolua_export
+
+	// The following are exported in ManualBindings in order to support chaining - they return "self" in Lua (#755)
 
 	/** Removes all parts from the object. */
 	void Clear(void);
-
-	// tolua_end
-
-	// The following are exported in ManualBindings in order to support chaining - they return *this in Lua (#755)
 
 	/** Adds a plain text part, with optional style.
 	The default style is plain white text. */
@@ -147,8 +145,6 @@ public:
 
 	/** Adds a part that is translated client-side, with the formatting parameters and optional style. */
 	void AddClientTranslatedPart(const AString & a_TranslationID, const AStringVector & a_Parameters, const AString & a_Style = "");
-
-	// tolua_begin
 
 	/** Adds a part that opens an URL when clicked.
 	The default style is underlined light blue text. */
@@ -171,13 +167,13 @@ public:
 	Recognizes "http:" and "https:" URLs and @color-codes. */
 	void ParseText(const AString & a_ParseText);
 
-	/** Sets the message type, which is indicated by prefixes added to the message when serializing
-	Takes optional AdditionalMessageTypeData to set m_AdditionalMessageTypeData. See said variable for more documentation.
-	*/
-	void SetMessageType(eMessageType a_MessageType, const AString & a_AdditionalMessageTypeData = "");
-
 	/** Adds the "underline" style to each part that is an URL. */
 	void UnderlineUrls(void);
+
+	/** Sets the message type, which is indicated by prefixes added to the message when serializing
+	Takes optional AdditionalMessageTypeData to set m_AdditionalMessageTypeData. See said variable for more documentation.
+	Exported manually, because ToLua++ would generate extra return values. */
+	void SetMessageType(eMessageType a_MessageType, const AString & a_AdditionalMessageTypeData = "");
 
 	// tolua_begin
 

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -557,7 +557,7 @@ inline void AddFaceDirection(int & a_BlockX, unsigned char & a_BlockY, int & a_B
 {
 	int Y = a_BlockY;
 	AddFaceDirection(a_BlockX, Y, a_BlockZ, a_BlockFace, a_bInverse);
-	a_BlockY = Clamp<unsigned char>(static_cast<unsigned char>(Y), 0, 255);
+	a_BlockY = Clamp<unsigned char>(static_cast<unsigned char>(Y), 0, cChunkDef::Height - 1);
 }
 
 

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -641,6 +641,7 @@ enum eMessageType
 	mtPrivateMessage,  // Player to player messaging identifier
 	mtJoin,            // A player has joined the server
 	mtLeave,           // A player has left the server
+	mtMaxPlusOne,      // The first invalid type, used for checking on LuaAPI boundaries
 
 	// Common aliases:
 	mtFail  = mtFailure,

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1458,7 +1458,7 @@ bool cEntity::DetectPortal()
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedOverworldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
 					LOGD("Jumping %s -> %s", DimensionToString(dimNether).c_str(), DimensionToString(DestionationDim).c_str());
-					new cNetherPortalScanner(this, TargetWorld, TargetPos, 256);
+					new cNetherPortalScanner(this, TargetWorld, TargetPos, cChunkDef::Height);
 					return true;
 				}
 				// Nether portal in the overworld

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1490,7 +1490,7 @@ bool cEntity::DetectPortal()
 					cWorld * TargetWorld = cRoot::Get()->GetWorld(GetWorld()->GetLinkedNetherWorldName());
 					ASSERT(TargetWorld != nullptr);  // The linkage checker should have prevented this at startup. See cWorld::start()
 					LOGD("Jumping %s -> %s", DimensionToString(dimOverworld).c_str(), DimensionToString(DestionationDim).c_str());
-					new cNetherPortalScanner(this, TargetWorld, TargetPos, 128);
+					new cNetherPortalScanner(this, TargetWorld, TargetPos, (cChunkDef::Height / 2));
 					return true;
 				}
 			}

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -517,7 +517,7 @@ void cFinishGenTallGrass::GenFinish(cChunkDesc & a_ChunkDesc)
 			// Get the top block + 1. This is the place where the grass would finaly be placed:
 			int y = a_ChunkDesc.GetHeight(x, z) + 1;
 
-			if (y >= 255)
+			if (y >= cChunkDef::Height - 1)
 			{
 				continue;
 			}
@@ -1221,7 +1221,7 @@ void cFinishGenPreSimulator::StationarizeFluid(
 
 cFinishGenFluidSprings::cFinishGenFluidSprings(int a_Seed, BLOCKTYPE a_Fluid, cIniFile & a_IniFile, eDimension a_Dimension) :
 	m_Noise(a_Seed + a_Fluid * 100),  // Need to take fluid into account, otherwise water and lava springs generate next to each other
-	m_HeightDistribution(255),
+	m_HeightDistribution(cChunkDef::Height - 1),
 	m_Fluid(a_Fluid)
 {
 	bool IsWater = (a_Fluid == E_BLOCK_WATER);

--- a/src/WorldStorage/MapSerializer.cpp
+++ b/src/WorldStorage/MapSerializer.cpp
@@ -163,7 +163,7 @@ bool cMapSerializer::LoadMapFromNBT(const cParsedNBT & a_NBT)
 	if ((CurrLine >= 0) && (a_NBT.GetType(CurrLine) == TAG_Short))
 	{
 		unsigned int Height = static_cast<unsigned int>(a_NBT.GetShort(CurrLine));
-		if (Height >= 256)
+		if (Height >= cChunkDef::Height)
 		{
 			return false;
 		}

--- a/src/WorldStorage/SchematicFileSerializer.cpp
+++ b/src/WorldStorage/SchematicFileSerializer.cpp
@@ -164,7 +164,7 @@ bool cSchematicFileSerializer::LoadFromSchematicNBT(cBlockArea & a_BlockArea, cP
 	int SizeX = a_NBT.GetShort(TSizeX);
 	int SizeY = a_NBT.GetShort(TSizeY);
 	int SizeZ = a_NBT.GetShort(TSizeZ);
-	if ((SizeX < 1) || (SizeX > 65535) || (SizeY < 1) || (SizeY > 256) || (SizeZ < 1) || (SizeZ > 65535))
+	if ((SizeX < 1) || (SizeX > 65535) || (SizeY < 1) || (SizeY > cChunkDef::Height) || (SizeZ < 1) || (SizeZ > 65535))
 	{
 		LOG("Dimensions are invalid in the schematic file: %d, %d, %d", SizeX, SizeY, SizeZ);
 		return false;


### PR DESCRIPTION
I replaced all appearances, that i found, of numbers with cChunkDef::Height, where it made sense to me. Maybe I didn't catch everything in the generating folder since I'm not all to familiar with the generation-process.

src\Blocks\blockleaves.h(169) 255 -> height - 1
src\Entities\Entity.cpp(1461): 256 -> height
src\Entities\Entity.cpp(1493): 128 -> height / 2
src\Generating\FinishGen.cpp(520): 255 -> height - 1
src\Generating\FinishGen.cpp(1224): 255 -> height - 1
src\Defines.h(560): 255 -> height - 1
src\WorldStorage\MapSerializer.cpp(166): 256 -> height
src\WorldStorage\SchematicFileSerializer.cpp(167): 256 -> height
src\ClientHandle.cpp(80): 256 -> height + 1 for a invalid Y
src\ClientHandle.cpp(84): 256 -> height + 1 for a invalid Y

In hope it's of any help,
Spark