### PR TITLE
Initialize m_bIsInBed in cPlayer constructor.

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -84,6 +84,7 @@ cPlayer::cPlayer(cClientHandlePtr a_Client, const AString & a_PlayerName) :
 	m_BowCharge(0),
 	m_FloaterID(cEntity::INVALID_ID),
 	m_Team(nullptr),
+	m_bIsInBed(false),
 	m_TicksUntilNextSave(PLAYER_INVENTORY_SAVE_INTERVAL),
 	m_bIsTeleporting(false),
 	m_UUID((a_Client != nullptr) ? a_Client->GetUUID() : ""),


### PR DESCRIPTION
This fixes an issue where the return value from the IsInBed method of
the cPlayer class in the lua API would not return a boolean value.