### PR TITLE
Improved world travel API and portal travel

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -5462,7 +5462,7 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 								Type = "boolean",
 							},
 						},
-						Notes = "Removes the entity from this world and starts moving it to the specified world's spawn point. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. ShouldSendRespawn is used only for players, it specifies whether the player should be sent a Respawn packet upon leaving the world (The client handles respawns only between different dimensions). <b>OBSOLETE</b>, use ScheduleMoveToWorld() instead.",
+						Notes = "Removes the entity from this world and starts moving it to the specified world's spawn point. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. ShouldSendRespawn is used only for players, it specifies whether the player should be sent a Respawn packet upon leaving the world. If the value is true, the server will automatically decide what packet or sequence of respawn packets to send. Otherwise, no respawn packets are sent. Returns true on success, false otherwise. Attempts to move to the same world will be ignored, and the entity's position will not change.",
 					},
 					{
 						Params =
@@ -5483,7 +5483,47 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 								Type = "boolean",
 							},
 						},
-						Notes = "Removes the entity from this world and starts moving it to the specified world's spawn point. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. ShouldSendRespawn is used only for players, it specifies whether the player should be sent a Respawn packet upon leaving the world (The client handles respawns only between different dimensions). <b>OBSOLETE</b>, use ScheduleMoveToWorld() instead.",
+						Notes = "Removes the entity from this world and starts moving it to the specified world's spawn point. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. ShouldSendRespawn is used only for players, it specifies whether the player should be sent a Respawn packet upon leaving the world. If the value is true, the server will automatically decide what packet or sequence of respawn packets to send. Otherwise, no respawn packets are sent. Returns true on success, false otherwise. Attempts to move to the same world will be ignored, and the entity's position will not change.",
+					},
+					{
+						Params =
+						{
+							{
+								Name = "World",
+								Type = "cWorld",
+							},
+							{
+								Name = "Position",
+								Type = "Vector3d",
+							},
+						},
+						Returns =
+						{
+							{
+								Type = "boolean",
+							},
+						},
+						Notes = "Removes the entity from this world and starts moving it to the specified world. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. Returns true on success, false otherwise. Attempts to move to the same world will be ignored, and the entity's position will not change.",
+					},
+					{
+						Params =
+						{
+							{
+								Name = "WorldName",
+								Type = "string",
+							},
+							{
+								Name = "Position",
+								Type = "Vector3d",
+							},
+						},
+						Returns =
+						{
+							{
+								Type = "boolean",
+							},
+						},
+						Notes = "Removes the entity from this world and starts moving it to the specified world. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. Returns true on success, false otherwise. Attempts to move to the same world will be ignored, and the entity's position will not change.",
 					},
 					{
 						Params =
@@ -5507,28 +5547,32 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 								Type = "boolean",
 							},
 						},
-						Notes = "Removes the entity from this world and starts moving it to the specified world. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. ShouldSendRespawn is used only for players, it specifies whether the player should be sent a Respawn packet upon leaving the world (The client handles respawns only between different dimensions). The Position parameter specifies the location that the entity should be placed in, in the new world. <b>OBSOLETE</b>, use ScheduleMoveToWorld() instead.",
+						Notes = "Removes the entity from this world and starts moving it to the specified world. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. ShouldSendRespawn is used only for players, it specifies whether the player should be sent a Respawn packet upon leaving the world. If the value is true, the server will automatically decide what packet or sequence of respawn packets to send. Otherwise, no respawn packets are sent. Returns true on success, false otherwise. Attempts to move to the same world will be ignored, and the entity's position will not change.",
 					},
-				},
-				ScheduleMoveToWorld =
-				{
-					Params =
 					{
+						Params =
 						{
-							Name = "World",
-							Type = "cWorld",
+							{
+								Name = "WorldName",
+								Type = "string",
+							},
+							{
+								Name = "ShouldSendRespawn",
+								Type = "boolean",
+							},
+							{
+								Name = "Position",
+								Type = "Vector3d",
+							},
 						},
+						Returns =
 						{
-							Name = "NewPosition",
-							Type = "Vector3d",
+							{
+								Type = "boolean",
+							},
 						},
-						{
-							Name = "ShouldSetPortalCooldown",
-							Type = "boolean",
-							IsOptional = true,
-						},
+						Notes = "Removes the entity from this world and starts moving it to the specified world. Note that to avoid deadlocks, the move is asynchronous - the entity is moved into a queue and will be moved from that queue into the destination world at some (unpredictable) time in the future. ShouldSendRespawn is used only for players, it specifies whether the player should be sent a Respawn packet upon leaving the world. If the value is true, the server will automatically decide what packet or sequence of respawn packets to send. Otherwise, no respawn packets are sent. Returns true on success, false otherwise. Attempts to move to the same world will be ignored, and the entity's position will not change.",
 					},
-					Notes = "Schedules a MoveToWorld call to occur on the next Tick of the entity. If ShouldSetPortalCooldown is false (default), doesn't set any portal cooldown, if it is true, the default portal cooldown is applied to the entity.",
 				},
 				SetGravity =
 				{

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -407,20 +407,25 @@ public:
 	/** Teleports to the coordinates specified */
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
 
-	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
-	void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false);
-
-	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
-
-	/** Moves entity to specified world, taking a world pointer */
+	/** Moves entity to specified world, taking a world pointer, and put it in spawnpoint */
 	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn = true);
 
-	/** Moves entity to specified world, taking a world name */
+	/** Moves entity to specified world, taking a world name, and put it in spawnpoint */
 	bool MoveToWorld(const AString & a_WorldName, bool a_ShouldSendRespawn = true);
 
-	// tolua_end
+	/** Moves entity to specified world, taking a world pointer, and put it in a_NewPosition */
+	bool MoveToWorld(cWorld * a_World, Vector3d a_NewPosition);
 
-	virtual bool DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
+	/** Moves entity to specified world, taking a world pointer, and put it in a_NewPosition */
+	bool MoveToWorld(const AString & a_WorldName, Vector3d a_NewPosition);
+
+	/** Moves entity to specified world, taking a world pointer, and put it in a_NewPosition */
+	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
+
+	/** Moves entity to specified world, taking a world pointer, and put it in a_NewPosition */
+	bool MoveToWorld(const AString & a_WorldName, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
+
+	// tolua_end
 
 	/** Updates clients of changes in the entity. */
 	virtual void BroadcastMovementUpdate(const cClientHandle * a_Exclude = nullptr);
@@ -503,6 +508,9 @@ public:
 	void SetIsTicking(bool a_IsTicking);
 
 protected:
+
+	virtual bool DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
+
 	/** Structure storing the portal delay timer and cooldown boolean */
 	struct sPortalCooldownData
 	{

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -340,8 +340,8 @@ void cPlayer::TickFreezeCode()
 				{
 					// If we find a position with enough space for the player
 					if (
-						(Chunk->GetBlock(Rel.x, NewY, Rel.z) == E_BLOCK_AIR) &&
-						(Chunk->GetBlock(Rel.x, NewY + 1, Rel.z) == E_BLOCK_AIR)
+						(!cBlockInfo::IsSolid(Chunk->GetBlock(Rel.x, NewY, Rel.z))) &&
+						(!cBlockInfo::IsSolid(Chunk->GetBlock(Rel.x, NewY + 1, Rel.z)))
 					)
 					{
 						// If the found position is not the same as the original
@@ -1770,89 +1770,6 @@ void cPlayer::TossItems(const cItems & a_Items)
 
 
 
-bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
-{
-	ASSERT(a_World != nullptr);
-	ASSERT(IsTicking());
-
-	if (GetWorld() == a_World)
-	{
-		// Don't move to same world
-		return false;
-	}
-
-	//  Ask the plugins if the player is allowed to change the world
-	if (cRoot::Get()->GetPluginManager()->CallHookEntityChangingWorld(*this, *a_World))
-	{
-		// A Plugin doesn't allow the player to change the world
-		return false;
-	}
-
-	GetWorld()->QueueTask([this, a_World, a_ShouldSendRespawn, a_NewPosition](cWorld & a_OldWorld)
-	{
-		// The clienthandle caches the coords of the chunk we're standing at. Invalidate this.
-		GetClientHandle()->InvalidateCachedSentChunk();
-
-		// Prevent further ticking in this world
-		SetIsTicking(false);
-
-		// Tell others we are gone
-		GetWorld()->BroadcastDestroyEntity(*this);
-
-		// Remove player from world
-		GetWorld()->RemovePlayer(this, false);
-
-		// Set position to the new position
-		SetPosition(a_NewPosition);
-		FreezeInternal(a_NewPosition, false);
-
-		// Stop all mobs from targeting this player
-		StopEveryoneFromTargetingMe();
-
-		cClientHandle * ch = this->GetClientHandle();
-		if (ch != nullptr)
-		{
-			// Send the respawn packet:
-			if (a_ShouldSendRespawn)
-			{
-				m_ClientHandle->SendRespawn(a_World->GetDimension());
-			}
-
-
-			// Update the view distance.
-			ch->SetViewDistance(m_ClientHandle->GetRequestedViewDistance());
-
-			// Send current weather of target world to player
-			if (a_World->GetDimension() == dimOverworld)
-			{
-				ch->SendWeather(a_World->GetWeather());
-			}
-		}
-
-		// Broadcast the player into the new world.
-		a_World->BroadcastSpawnEntity(*this);
-
-		// Queue add to new world and removal from the old one
-
-		SetWorld(a_World);  // Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value
-		cChunk * ParentChunk = this->GetParentChunk();
-
-		LOGD("Warping player \"%s\" from world \"%s\" to \"%s\". Source chunk: (%d, %d) ",
-			this->GetName().c_str(),
-			a_OldWorld.GetName().c_str(), a_World->GetName().c_str(),
-			ParentChunk->GetPosX(), ParentChunk->GetPosZ()
-		);
-		ParentChunk->RemoveEntity(this);
-		a_World->AddPlayer(this, &a_OldWorld);  // New world will take over and announce client at its next tick
-	});
-
-	return true;
-}
-
-
-
-
-
 bool cPlayer::LoadFromDisk(cWorldPtr & a_World)
 {
 	LoadRank();
@@ -2566,4 +2483,90 @@ void cPlayer::FreezeInternal(const Vector3d & a_Location, bool a_ManuallyFrozen)
 	m_SprintingMaxSpeed = SprintMaxSpeed;
 	m_FlyingMaxSpeed = FlyingMaxpeed;
 	m_IsFlying = IsFlying;
+}
+
+
+
+
+
+bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
+{
+	ASSERT(a_World != nullptr);
+	ASSERT(IsTicking());
+
+	if (GetWorld() == a_World)
+	{
+		// Don't move to same world
+		return false;
+	}
+
+	//  Ask the plugins if the player is allowed to change the world
+	if (cRoot::Get()->GetPluginManager()->CallHookEntityChangingWorld(*this, *a_World))
+	{
+		// A Plugin doesn't allow the player to change the world
+		return false;
+	}
+
+	GetWorld()->QueueTask([this, a_World, a_ShouldSendRespawn, a_NewPosition](cWorld & a_OldWorld)
+	{
+		// The clienthandle caches the coords of the chunk we're standing at. Invalidate this.
+		GetClientHandle()->InvalidateCachedSentChunk();
+
+		// Prevent further ticking in this world
+		SetIsTicking(false);
+
+		// Tell others we are gone
+		GetWorld()->BroadcastDestroyEntity(*this);
+
+		// Remove player from world
+		GetWorld()->RemovePlayer(this, false);
+
+		// Set position to the new position
+		SetPosition(a_NewPosition);
+		FreezeInternal(a_NewPosition, false);
+
+		// Stop all mobs from targeting this player
+		StopEveryoneFromTargetingMe();
+
+		cClientHandle * ch = this->GetClientHandle();
+		if (ch != nullptr)
+		{
+			// Send the respawn packet:
+			if (a_ShouldSendRespawn)
+			{
+				m_ClientHandle->SendRespawn(a_World->GetDimension());
+			}
+
+
+			// Update the view distance.
+			ch->SetViewDistance(m_ClientHandle->GetRequestedViewDistance());
+
+			// Send current weather of target world to player
+			if (a_World->GetDimension() == dimOverworld)
+			{
+				ch->SendWeather(a_World->GetWeather());
+			}
+		}
+
+		// Broadcast the player into the new world.
+		a_World->BroadcastSpawnEntity(*this);
+
+		// Prevent the player from teleporting back immediately, in case the destination is a portal
+		m_PortalCooldownData.m_ShouldPreventTeleportation = true;
+
+		// Queue add to new world and removal from the old one
+
+		SetWorld(a_World);  // Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value
+		cChunk * ParentChunk = this->GetParentChunk();
+
+		LOGD("Warping player \"%s\" from world \"%s\" to \"%s\". Source chunk: (%d, %d) ",
+			this->GetName().c_str(),
+			a_OldWorld.GetName().c_str(), a_World->GetName().c_str(),
+			ParentChunk->GetPosX(), ParentChunk->GetPosZ()
+		);
+		ParentChunk->RemoveEntity(this);
+		a_World->AddPlayer(this, &a_OldWorld);  // New world will take over and announce client at its next tick
+	});
+
+	return true;
 }

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -366,10 +366,6 @@ public:
 	void SetVisible( bool a_bVisible);  // tolua_export
 	bool IsVisible(void) const { return m_bVisible; }  // tolua_export
 
-	/** Moves the player to the specified world.
-	Returns true if successful, false on failure (world not found). */
-	virtual bool DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition) override;
-
 	/** Saves all player data, such as inventory, to JSON */
 	bool SaveToDisk(void);
 
@@ -705,4 +701,8 @@ private:
 	/** Pins the player to a_Location until Unfreeze() is called.
 	If ManuallyFrozen is false, the player will unfreeze when the chunk is loaded. */
 	void FreezeInternal(const Vector3d & a_Location, bool a_ManuallyFrozen);
+
+	/** Moves the player to the specified world.
+	Returns true if successful, false on failure (world not found). */
+	virtual bool DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition) override;
 } ;  // tolua_export

--- a/src/NetherPortalScanner.cpp
+++ b/src/NetherPortalScanner.cpp
@@ -290,7 +290,7 @@ void cNetherPortalScanner::OnDisabled(void)
 	}
 
 	LOGD("Placing player at {%f, %f, %f}", Position.x, Position.y, Position.z);
-	m_Entity->ScheduleMoveToWorld(m_World, Position, true);
+	m_Entity->MoveToWorld(m_World, Position);
 	delete this;
 }
 

--- a/src/NetherPortalScanner.h
+++ b/src/NetherPortalScanner.h
@@ -40,7 +40,7 @@ private:
 	static const int SearchSolidBaseWidth = 3;
 
 	/** Where to place the player out from the face and across the face */
-	const double OutOffset = 2;
+	const double OutOffset = 0.5;
 	const double AcrossOffset = 0.5;
 
 	/** Builds a portal. */


### PR DESCRIPTION
MoveToWorld changes:
- Use `MoveToWorld(world)` to teleport to a world's spawnpoint, or `MoveToWorld(world, position)`, where `world` can either be a world pointer or a string. No need to deal with `ShouldSendRespawn`
- All `MoveToWorld` overrides now have a `cWorld` pointer version and a world name version.
- Completely backward-compatible with previous variants of `MoveToWorld`. Those who want `ShouldSendRespawn` can still use it.

Removed `ScheduleMoveToWorld`. It is unlikely that anyone is using it, since it did not send respawn packets.

Players now spawn inside the destination portal, not outside of it, without experiencing teleportation loops.
