### PR TITLE
Added API export for LuaCheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,4 @@ CPackSourceConfig.cmake
 Server/cuberite_api.lua
 Server/official_undocumented.lua
 Server/NewlyUndocumented.lua
-
+Server/.luacheckrc

--- a/Server/Plugins/APIDump/main_APIDump.lua
+++ b/Server/Plugins/APIDump/main_APIDump.lua
@@ -1635,6 +1635,75 @@ end
 
 
 
+local function DumpLuaCheck(a_API)
+	LOG("Creating file .luacheckrc...")
+	local file = io.open(".luacheckrc", "w")
+	
+	file:write([[
+-- This file is the config file for the tool named Luacheck
+-- Documentation: http://luacheck.readthedocs.io/en/stable/index.html
+
+-- Ignore unused function and loop arguments
+unused_args = false
+
+-- Allow self defined globals
+allow_defined = true
+
+-- Ignore this functions
+ignore =
+{
+	"Initialize",  -- Plugin
+	"OnDisable",  -- Plugin
+	"RegisterPluginInfoCommands",  -- InfoReg.lua
+	"RegisterPluginInfoConsoleCommands",  -- InfoReg.lua
+	"g_PluginInfo",  -- Info.lua
+}
+
+-- Ignore files / directories
+exclude_files =
+{
+	"tests/" -- CuberitePluginChecker
+}
+
+-- All globals from cuberite (classes, enums, functions)
+globals =
+{
+]])
+	
+	-- Export all global symbols
+	for _, cls in ipairs(a_API) do
+		if cls.Name == "Globals" then
+			-- Global functions
+			for _, func in ipairs(cls.Functions) do
+				file:write("\t\"", func.Name, "\",\n")
+			end
+			
+			-- Global constants
+			for _, const in ipairs(cls.Constants) do
+				file:write("\t\"", const.Name, "\",\n")
+			end
+			
+			-- Global constants from all groups
+			for _, group in pairs(cls.ConstantGroups) do
+				for _, const in pairs(group.Constants) do
+					file:write("\t\"", const.Name, "\",\n")
+				end
+			end
+		else
+			file:write("\t\"", cls.Name, "\",\n")
+		end
+	end
+	
+	file:write("}\n")
+	file:close()
+	
+	LOG("Config file .luacheckrc created...")
+end
+
+
+
+
+
 --- Returns true if a_Descendant is declared to be a (possibly indirect) descendant of a_Base
 local function IsDeclaredDescendant(a_DescendantName, a_BaseName, a_API)
 	-- Check params:
@@ -1803,6 +1872,9 @@ local function DumpApi()
 
 	-- Dump all available API objects in format used by ZeroBraneStudio API descriptions:
 	DumpAPIZBS(API)
+	
+	-- Export the API in a format used by LuaCheck
+	DumpLuaCheck(API)
 
 	LOG("APIDump finished");
 	return true
@@ -2062,3 +2134,4 @@ function Initialize(Plugin)
 
 	return true
 end
+


### PR DESCRIPTION
This is a step required for [CuberitePluginChecker/#26](https://github.com/cuberite/CuberitePluginChecker/issues/26)

The plugin APIDump will create the file `Server/.luacheckrc`. Here a link how it currently looks [.luacheckrc](https://gist.github.com/Seadragon91/5560cefb67d8cf412934833bea646655)

 The current code is not good and needs to be rewritten. The table `globals` should contain:
* ~Class names that have constructors e.g. `cItem`~
* ~Class names that have static functions / constants~
* Add all class names, much simpler and there are not many
* All global constants / functions from http://api-docs.cuberite.org/Globals.html

Would need a few pointers how I can do that better.

