### PR TITLE
Fix comparator segfaults

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneComparatorHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneComparatorHandler.h
@@ -54,7 +54,14 @@ public:
 
 			virtual bool Item(cBlockEntity * a_BlockEntity) override
 			{
-				auto & Contents = static_cast<cBlockEntityWithItems *>(a_BlockEntity)->GetContents();
+				// Skip BlockEntities that don't have slots
+				auto BlockEntityWithItems = dynamic_cast<cBlockEntityWithItems *>(a_BlockEntity);
+				if (BlockEntityWithItems == nullptr)
+				{
+					return false;
+				}
+
+				auto & Contents = BlockEntityWithItems->GetContents();
 				float Fullness = 0;  // Is a floating-point type to allow later calculation to produce a non-truncated value
 
 				for (int Slot = 0; Slot != Contents.GetNumSlots(); ++Slot)


### PR DESCRIPTION
The handler would get called for any BlockEntity, but not every BlockEntity is a BlockEntityWithItems. Downcasting with static_cast is UB on fail.

fixes #3417 