### PR TITLE
Fixed minecart destruction using deallocated memory.

### DIFF
--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1250,10 +1250,15 @@ void cMinecartWithChest::Destroyed()
 	m_Contents.CopyToItems(Pickups);
 
 
-	// This makes the command not execute if the world is in the midst of destruction :)
-	GetWorld()->ScheduleTask(1, [this, Pickups](cWorld & World)
+	// Schedule the pickups creation for the next world tick
+	// This avoids a deadlock when terminating the world
+	// Note that the scheduled task may be run when this object is no longer valid, we need to store everything in the task's captured variables
+	auto posX = GetPosX();
+	auto posY = GetPosY() + 1;
+	auto posZ = GetPosZ();
+	GetWorld()->ScheduleTask(1, [Pickups, posX, posY, posZ](cWorld & World)
 	{
-		World.SpawnItemPickups(Pickups, GetPosX(), GetPosY() + 1, GetPosZ(), 4);
+		World.SpawnItemPickups(Pickups, posX, posY, posZ, 4);
 	});
 }
 

--- a/src/WorldStorage/WorldStorage.cpp
+++ b/src/WorldStorage/WorldStorage.cpp
@@ -142,6 +142,8 @@ size_t cWorldStorage::GetSaveQueueLength(void)
 
 void cWorldStorage::QueueLoadChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * a_Callback)
 {
+	ASSERT((a_ChunkX > -0x08000000) && (a_ChunkX < 0x08000000));
+	ASSERT((a_ChunkZ > -0x08000000) && (a_ChunkZ < 0x08000000));
 	ASSERT(m_World->IsChunkQueued(a_ChunkX, a_ChunkZ));
 
 	m_LoadQueue.EnqueueItem(cChunkCoordsWithCallback(a_ChunkX, a_ChunkZ, a_Callback));


### PR DESCRIPTION
The scheduled task was accessing memory that could have already been freed. As a result, the chunk loader was asked to load chunk at coords [0x80000000, 0x80000000].