### PR TITLE
Support for the 1.11 protocol

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -2909,7 +2909,7 @@ void cChunk::BroadcastBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 
 
 
-void cChunk::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude)
+void cChunk::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count, const cClientHandle * a_Exclude)
 {
 	for (auto itr = m_LoadedByClient.begin(); itr != m_LoadedByClient.end(); ++itr)
 	{
@@ -2917,7 +2917,7 @@ void cChunk::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_
 		{
 			continue;
 		}
-		(*itr)->SendCollectEntity(a_Entity, a_Player);
+		(*itr)->SendCollectEntity(a_Entity, a_Player, a_Count);
 	}  // for itr - LoadedByClient[]
 }
 

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -348,7 +348,7 @@ public:
 	void BroadcastBlockAction        (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastBlockEntity        (int a_BlockX, int a_BlockY, int a_BlockZ, const cClientHandle * a_Exclude = nullptr);
-	void BroadcastCollectEntity      (const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
+	void BroadcastCollectEntity      (const cEntity & a_Entity, const cPlayer & a_Player, int a_Count, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastDestroyEntity      (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastDetachEntity       (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);
 	void BroadcastEntityEffect       (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration, const cClientHandle * a_Exclude = nullptr);

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -332,7 +332,7 @@ void cChunkMap::BroadcastBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 
 
-void cChunkMap::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude)
+void cChunkMap::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count, const cClientHandle * a_Exclude)
 {
 	cCSLock Lock(m_CSChunks);
 	cChunkPtr Chunk = GetChunkNoGen(a_Entity.GetChunkX(), a_Entity.GetChunkZ());
@@ -341,7 +341,7 @@ void cChunkMap::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer &
 		return;
 	}
 	// It's perfectly legal to broadcast packets even to invalid chunks!
-	Chunk->BroadcastCollectEntity(a_Entity, a_Player, a_Exclude);
+	Chunk->BroadcastCollectEntity(a_Entity, a_Player, a_Count, a_Exclude);
 }
 
 

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -75,7 +75,7 @@ public:
 	void BroadcastBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, const cClientHandle * a_Exclude);
-	void BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
+	void BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastDestroyEntity(const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastDetachEntity(const cEntity & a_Entity, const cEntity & a_PreviousVehicle);
 	void BroadcastEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration, const cClientHandle * a_Exclude = nullptr);

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2426,9 +2426,9 @@ void cClientHandle::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializ
 
 
 
-void cClientHandle::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player)
+void cClientHandle::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count)
 {
-	m_Protocol->SendCollectEntity(a_Entity, a_Player);
+	m_Protocol->SendCollectEntity(a_Entity, a_Player, a_Count);
 }
 
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -164,7 +164,7 @@ public:  // tolua_export
 	void SendChatSystem                 (const AString & a_Message, eMessageType a_ChatPrefix, const AString & a_AdditionalData = "");
 	void SendChatSystem                 (const cCompositeChat & a_Message);
 	void SendChunkData                  (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer);
-	void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player);
+	void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player, int a_Count);
 	void SendDestroyEntity              (const cEntity & a_Entity);
 	void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);
 	void SendDisconnect                 (const AString & a_Reason);

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -406,7 +406,14 @@ AString cCompositeChat::CreateJsonString(bool a_ShouldUseChatPrefixes) const
 		msg["extra"].append(Part);
 	}  // for itr - Parts[]
 
-	return msg.toStyledString();
+	#if 1
+		// Serialize as machine-readable string (no whitespace):
+		Json::FastWriter writer;
+		return writer.write(msg);
+	#else
+		// Serialize as human-readable string (pretty-printed):
+		return msg.toStyledString();
+	#endif
 }
 
 

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -167,7 +167,7 @@ void cArrowEntity::CollectedBy(cPlayer & a_Dest)
 			}
 		}
 
-		GetWorld()->BroadcastCollectEntity(*this, a_Dest);
+		GetWorld()->BroadcastCollectEntity(*this, a_Dest, 1);
 		GetWorld()->BroadcastSoundEffect("random.pop", GetPosX(), GetPosY(), GetPosZ(), 0.5, static_cast<float>(0.75 + (static_cast<float>((GetUniqueID() * 23) % 32)) / 64));
 		m_bIsCollected = true;
 	}

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -234,7 +234,7 @@ bool cPickup::CollectedBy(cPlayer & a_Dest)
 		}
 
 		m_Item.m_ItemCount -= NumAdded;
-		m_World->BroadcastCollectEntity(*this, a_Dest);
+		m_World->BroadcastCollectEntity(*this, a_Dest, NumAdded);
 
 		// Also send the "pop" sound effect with a somewhat random pitch (fast-random using EntityID ;)
 		m_World->BroadcastSoundEffect("random.pop", GetPosX(), GetPosY(), GetPosZ(), 0.5, (0.75f + (static_cast<float>((GetUniqueID() * 23) % 32)) / 64));

--- a/src/Protocol/CMakeLists.txt
+++ b/src/Protocol/CMakeLists.txt
@@ -7,9 +7,10 @@ SET (SRCS
 	ChunkDataSerializer.cpp
 	MojangAPI.cpp
 	Packetizer.cpp
-	Protocol18x.cpp
-	Protocol19x.cpp
-	Protocol110x.cpp
+	Protocol_1_8.cpp
+	Protocol_1_9.cpp
+	Protocol_1_10.cpp
+	Protocol_1_11.cpp
 	ProtocolRecognizer.cpp
 )
 
@@ -19,16 +20,17 @@ SET (HDRS
 	MojangAPI.h
 	Packetizer.h
 	Protocol.h
-	Protocol18x.h
-	Protocol19x.h
-	Protocol110x.h
+	Protocol_1_8.h
+	Protocol_1_9.h
+	Protocol_1_10.h
+	Protocol_1_11.h
 	ProtocolRecognizer.h
 )
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	set_source_files_properties(Protocol19x.cpp  PROPERTIES COMPILE_FLAGS "-Wno-error=switch-enum -Wno-error=switch")
-	set_source_files_properties(Protocol18x.cpp  PROPERTIES COMPILE_FLAGS "-Wno-error=switch-enum -Wno-error=switch")
-	set_source_files_properties(Protocol110x.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=switch")
+	set_source_files_properties(Protocol_1_9.cpp  PROPERTIES COMPILE_FLAGS "-Wno-error=switch-enum -Wno-error=switch")
+	set_source_files_properties(Protocol_1_8.cpp  PROPERTIES COMPILE_FLAGS "-Wno-error=switch-enum -Wno-error=switch")
+	set_source_files_properties(Protocol_1_10.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=switch")
 endif()
 
 if (NOT MSVC)

--- a/src/Protocol/ChunkDataSerializer.cpp
+++ b/src/Protocol/ChunkDataSerializer.cpp
@@ -9,8 +9,8 @@
 #include "ChunkDataSerializer.h"
 #include "zlib/zlib.h"
 #include "ByteBuffer.h"
-#include "Protocol18x.h"
-#include "Protocol19x.h"
+#include "Protocol_1_8.h"
+#include "Protocol_1_9.h"
 
 
 
@@ -111,7 +111,7 @@ void cChunkDataSerializer::Serialize47(AString & a_Data, int a_ChunkX, int a_Chu
 	cByteBuffer Buffer(20);
 	if (PacketData.size() >= 256)
 	{
-		if (!cProtocol180::CompressPacket(PacketData, a_Data))
+		if (!cProtocol_1_8_0::CompressPacket(PacketData, a_Data))
 		{
 			ASSERT(!"Packet compression failed.");
 			a_Data.clear();
@@ -254,7 +254,7 @@ void cChunkDataSerializer::Serialize107(AString & a_Data, int a_ChunkX, int a_Ch
 	cByteBuffer Buffer(20);
 	if (PacketData.size() >= 256)
 	{
-		if (!cProtocol190::CompressPacket(PacketData, a_Data))
+		if (!cProtocol_1_9_0::CompressPacket(PacketData, a_Data))
 		{
 			ASSERT(!"Packet compression failed.");
 			a_Data.clear();
@@ -400,7 +400,7 @@ void cChunkDataSerializer::Serialize110(AString & a_Data, int a_ChunkX, int a_Ch
 	cByteBuffer Buffer(20);
 	if (PacketData.size() >= 256)
 	{
-		if (!cProtocol190::CompressPacket(PacketData, a_Data))
+		if (!cProtocol_1_9_0::CompressPacket(PacketData, a_Data))
 		{
 			ASSERT(!"Packet compression failed.");
 			a_Data.clear();

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -74,7 +74,7 @@ public:
 	virtual void SendChat                       (const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes) = 0;
 	virtual void SendChatRaw                    (const AString & a_MessageRaw, eChatType a_Type) = 0;
 	virtual void SendChunkData                  (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer) = 0;
-	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player) = 0;
+	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player, int a_Count) = 0;
 	virtual void SendDestroyEntity              (const cEntity & a_Entity) = 0;
 	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) = 0;
 	virtual void SendDisconnect                 (const AString & a_Reason) = 0;

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -7,9 +7,10 @@
 #include "Globals.h"
 
 #include "ProtocolRecognizer.h"
-#include "Protocol18x.h"
-#include "Protocol19x.h"
-#include "Protocol110x.h"
+#include "Protocol_1_8.h"
+#include "Protocol_1_9.h"
+#include "Protocol_1_10.h"
+#include "Protocol_1_11.h"
 #include "Packetizer.h"
 #include "../ClientHandle.h"
 #include "../Root.h"
@@ -53,7 +54,8 @@ AString cProtocolRecognizer::GetVersionTextFromInt(int a_ProtocolVersion)
 		case PROTO_VERSION_1_9_1:   return "1.9.1";
 		case PROTO_VERSION_1_9_2:   return "1.9.2";
 		case PROTO_VERSION_1_9_4:   return "1.9.4";
-		case PROTO_VERSION_1_10_0: return "1.10";
+		case PROTO_VERSION_1_10_0:  return "1.10";
+		case PROTO_VERSION_1_11_0:  return "1.11";
 	}
 	ASSERT(!"Unknown protocol version");
 	return Printf("Unknown protocol (%d)", a_ProtocolVersion);
@@ -220,10 +222,10 @@ void cProtocolRecognizer::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSe
 
 
 
-void cProtocolRecognizer::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player)
+void cProtocolRecognizer::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count)
 {
 	ASSERT(m_Protocol != nullptr);
-	m_Protocol->SendCollectEntity(a_Entity, a_Player);
+	m_Protocol->SendCollectEntity(a_Entity, a_Player, a_Count);
 }
 
 
@@ -978,8 +980,7 @@ void cProtocolRecognizer::SendData(const char * a_Data, size_t a_Size)
 
 bool cProtocolRecognizer::TryRecognizeProtocol(void)
 {
-	// NOTE: If a new protocol is added or an old one is removed, adjust MCS_CLIENT_VERSIONS and
-	// MCS_PROTOCOL_VERSIONS macros in the header file, as well as PROTO_VERSION_LATEST macro
+	// NOTE: If a new protocol is added or an old one is removed, adjust MCS_CLIENT_VERSIONS and MCS_PROTOCOL_VERSIONS macros in the header file
 
 	// Lengthed protocol, try if it has the entire initial handshake packet:
 	UInt32 PacketLen;
@@ -1045,37 +1046,42 @@ bool cProtocolRecognizer::TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRema
 		case PROTO_VERSION_1_8_0:
 		{
 			m_Buffer.CommitRead();
-			m_Protocol = new cProtocol180(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol = new cProtocol_1_8_0(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		case PROTO_VERSION_1_9_0:
 		{
-			m_Protocol = new cProtocol190(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol = new cProtocol_1_9_0(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		case PROTO_VERSION_1_9_1:
 		{
-			m_Protocol = new cProtocol191(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol = new cProtocol_1_9_1(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		case PROTO_VERSION_1_9_2:
 		{
-			m_Protocol = new cProtocol192(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol = new cProtocol_1_9_2(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		case PROTO_VERSION_1_9_4:
 		{
-			m_Protocol = new cProtocol194(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol = new cProtocol_1_9_4(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		case PROTO_VERSION_1_10_0:
 		{
-			m_Protocol = new cProtocol1100(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol = new cProtocol_1_10_0(m_Client, ServerAddress, ServerPort, NextState);
+			return true;
+		}
+		case PROTO_VERSION_1_11_0:
+		{
+			m_Protocol = new cProtocol_1_11_0(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		default:
 		{
-			LOGINFO("Client \"%s\" uses an unsupported protocol (lengthed, version %u (0x%x))",
+			LOGD("Client \"%s\" uses an unsupported protocol (lengthed, version %u (0x%x))",
 				m_Client->GetIPString().c_str(), ProtocolVersion, ProtocolVersion
 			);
 			if (NextState != 1)

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -18,8 +18,8 @@
 
 
 // Adjust these if a new protocol is added or an old one is removed:
-#define MCS_CLIENT_VERSIONS "1.8.x, 1.9.x, 1.10.x"
-#define MCS_PROTOCOL_VERSIONS "47, 107, 108, 109, 110, 210"
+#define MCS_CLIENT_VERSIONS "1.8.x, 1.9.x, 1.10.x, 1.11"
+#define MCS_PROTOCOL_VERSIONS "47, 107, 108, 109, 110, 210, 315"
 
 
 
@@ -39,6 +39,7 @@ public:
 		PROTO_VERSION_1_9_2  = 109,
 		PROTO_VERSION_1_9_4  = 110,
 		PROTO_VERSION_1_10_0 = 210,
+		PROTO_VERSION_1_11_0 = 315,
 	} ;
 
 	cProtocolRecognizer(cClientHandle * a_Client);
@@ -61,7 +62,7 @@ public:
 	virtual void SendChat                       (const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes) override;
 	virtual void SendChatRaw                    (const AString & a_MessageRaw, eChatType a_Type) override;
 	virtual void SendChunkData                  (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer) override;
-	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player) override;
+	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player, int a_Count) override;
 	virtual void SendDestroyEntity              (const cEntity & a_Entity) override;
 	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
 	virtual void SendDisconnect                 (const AString & a_Reason) override;

--- a/src/Protocol/Protocol_1_10.cpp
+++ b/src/Protocol/Protocol_1_10.cpp
@@ -1,15 +1,14 @@
 
-// Protocol110x.cpp
+// Protocol_1_10.cpp
 
 /*
-Implements the 1.10.x protocol classes:
-	- cProtocol1100
-		- release 1.10.0 protocol (#210)
-(others may be added later in the future for the 1.10 release series)
+Implements the 1.10 protocol classes:
+	- cProtocol_1_10_0
+		- release 1.10 protocol (#210), also used by 1.10.1 and 1.10.2
 */
 
 #include "Globals.h"
-#include "Protocol110x.h"
+#include "Protocol_1_10.h"
 #include "Packetizer.h"
 
 #include "json/json.h"
@@ -283,7 +282,7 @@ namespace Metadata
 
 
 
-cProtocol1100::cProtocol1100(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
+cProtocol_1_10_0::cProtocol_1_10_0(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
 	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
 {
 }
@@ -292,7 +291,7 @@ cProtocol1100::cProtocol1100(cClientHandle * a_Client, const AString &a_ServerAd
 
 
 
-void cProtocol1100::SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch)
+void cProtocol_1_10_0::SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -310,7 +309,7 @@ void cProtocol1100::SendSoundEffect(const AString & a_SoundName, double a_X, dou
 
 
 
-void cProtocol1100::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_10_0::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 {
 	cServer * Server = cRoot::Get()->GetServer();
 	AString ServerDescription = Server->GetDescription();
@@ -355,7 +354,7 @@ void cProtocol1100::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol1100::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
 {
 	using namespace Metadata;
 
@@ -552,7 +551,7 @@ void cProtocol1100::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_E
 
 
 
-void cProtocol1100::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_10_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 {
 	using namespace Metadata;
 

--- a/src/Protocol/Protocol_1_10.h
+++ b/src/Protocol/Protocol_1_10.h
@@ -1,11 +1,10 @@
 
-// Protocol110x.h
+// Protocol_1_10.h
 
 /*
-Declares the 1.10.x protocol classes:
-	- cProtocol1100
-		- release 1.10.0 protocol (#210)
-(others may be added later in the future for the 1.10 release series)
+Declares the 1.10 protocol classes:
+	- cProtocol_1_10
+		- release 1.10 protocol (#210), also used by 1.10.1 and 1.10.2
 */
 
 
@@ -14,15 +13,19 @@ Declares the 1.10.x protocol classes:
 
 #pragma once
 
-#include "Protocol19x.h"
+#include "Protocol_1_9.h"
 
-class cProtocol1100 :
-	public cProtocol194
+
+
+
+
+class cProtocol_1_10_0 :
+	public cProtocol_1_9_4
 {
-	typedef cProtocol194 super;
+	typedef cProtocol_1_9_4 super;
 
 public:
-	cProtocol1100(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
+	cProtocol_1_10_0(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
 	virtual void SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch) override;
 

--- a/src/Protocol/Protocol_1_11.cpp
+++ b/src/Protocol/Protocol_1_11.cpp
@@ -1,0 +1,189 @@
+
+// Protocol_1_11.cpp
+
+/*
+Implements the 1.11 protocol classes:
+	- cProtocol_1_11_0
+		- release 1.11 protocol (#315)
+(others may be added later in the future for the 1.11 release series)
+*/
+
+#include "Globals.h"
+#include "Protocol_1_11.h"
+#include "ProtocolRecognizer.h"
+#include "Packetizer.h"
+
+#include "../Root.h"
+#include "../Server.h"
+#include "../ClientHandle.h"
+#include "../CompositeChat.h"
+#include "../Bindings/PluginManager.h"
+#include "../Entities/Player.h"
+#include "../Mobs/Monster.h"
+
+
+
+
+
+#define HANDLE_READ(ByteBuf, Proc, Type, Var) \
+	Type Var; \
+	if (!ByteBuf.Proc(Var))\
+	{\
+		return;\
+	}
+
+
+
+
+
+cProtocol_1_11_0::cProtocol_1_11_0(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
+	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
+{
+}
+
+
+
+
+
+void cProtocol_1_11_0::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x0d);  // Collect Item packet
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Player.GetUniqueID());
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_Count));
+}
+
+
+
+
+
+void cProtocol_1_11_0::SendHideTitle(void)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x45);  // Title packet
+	Pkt.WriteVarInt32(4);  // Hide title
+}
+
+
+
+
+
+void cProtocol_1_11_0::SendResetTitle(void)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x45);  // Title packet
+	Pkt.WriteVarInt32(5);  // Reset title
+}
+
+
+
+
+
+void cProtocol_1_11_0::SendSpawnMob(const cMonster & a_Mob)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x0f);  // Spawn Mob packet
+	Pkt.WriteVarInt32(a_Mob.GetUniqueID());
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_Mob.GetMobType()));
+	Pkt.WriteFPInt(a_Mob.GetPosX());
+	Pkt.WriteFPInt(a_Mob.GetPosY());
+	Pkt.WriteFPInt(a_Mob.GetPosZ());
+	Pkt.WriteByteAngle(a_Mob.GetPitch());
+	Pkt.WriteByteAngle(a_Mob.GetHeadYaw());
+	Pkt.WriteByteAngle(a_Mob.GetYaw());
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Mob.GetSpeedX() * 400));
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Mob.GetSpeedY() * 400));
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Mob.GetSpeedZ() * 400));
+	WriteEntityMetadata(Pkt, a_Mob);
+	Pkt.WriteBEUInt8(0x7f);  // Metadata terminator
+}
+
+
+
+
+
+void cProtocol_1_11_0::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x45);  // Title packet
+	Pkt.WriteVarInt32(3);  // Set title display times
+	Pkt.WriteBEInt32(a_FadeInTicks);
+	Pkt.WriteBEInt32(a_DisplayTicks);
+	Pkt.WriteBEInt32(a_FadeOutTicks);
+}
+
+
+
+
+
+
+void cProtocol_1_11_0::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
+{
+	int BlockX, BlockY, BlockZ;
+	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
+	{
+		return;
+	}
+
+	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Face);
+	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Hand);
+	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, CursorX);
+	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, CursorY);
+	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, CursorZ);
+	m_Client->HandleRightClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), FloorC(CursorX * 16), FloorC(CursorY * 16), FloorC(CursorZ * 16), m_Client->GetPlayer()->GetEquippedItem());
+}
+
+
+
+
+
+void cProtocol_1_11_0::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
+{
+	cServer * Server = cRoot::Get()->GetServer();
+	AString ServerDescription = Server->GetDescription();
+	int NumPlayers = Server->GetNumPlayers();
+	int MaxPlayers = Server->GetMaxPlayers();
+	AString Favicon = Server->GetFaviconData();
+	cRoot::Get()->GetPluginManager()->CallHookServerPing(*m_Client, ServerDescription, NumPlayers, MaxPlayers, Favicon);
+
+	// Version:
+	Json::Value Version;
+	Version["name"] = "Cuberite 1.11";
+	Version["protocol"] = cProtocolRecognizer::PROTO_VERSION_1_11_0;
+
+	// Players:
+	Json::Value Players;
+	Players["online"] = NumPlayers;
+	Players["max"] = MaxPlayers;
+	// TODO: Add "sample"
+
+	// Description:
+	Json::Value Description;
+	Description["text"] = ServerDescription.c_str();
+
+	// Create the response:
+	Json::Value ResponseValue;
+	ResponseValue["version"] = Version;
+	ResponseValue["players"] = Players;
+	ResponseValue["description"] = Description;
+	if (!Favicon.empty())
+	{
+		ResponseValue["favicon"] = Printf("data:image/png;base64,%s", Favicon.c_str());
+	}
+
+	// Serialize the response into a packet:
+	Json::FastWriter Writer;
+	cPacketizer Pkt(*this, 0x00);  // Response packet
+	Pkt.WriteString(Writer.write(ResponseValue));
+}
+
+
+
+
+

--- a/src/Protocol/Protocol_1_11.h
+++ b/src/Protocol/Protocol_1_11.h
@@ -1,0 +1,41 @@
+
+// Protocol_1_11.h
+
+/*
+Declares the 1.11 protocol classes:
+	- cProtocol_1_11_0
+		- release 1.11 protocol (#315)
+(others may be added later in the future for the 1.11 release series)
+*/
+
+
+
+
+
+#pragma once
+
+#include "Protocol_1_10.h"
+
+
+
+
+
+class cProtocol_1_11_0 :
+	public cProtocol_1_10_0
+{
+	typedef cProtocol_1_10_0 super;
+
+public:
+	cProtocol_1_11_0(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
+
+	virtual void SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count) override;
+	virtual void SendHideTitle    (void) override;
+	virtual void SendResetTitle   (void) override;
+	virtual void SendSpawnMob     (const cMonster & a_Mob) override;
+	virtual void SendTitleTimes   (int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks) override;
+
+protected:
+
+	virtual void HandlePacketBlockPlace   (cByteBuffer & a_ByteBuffer) override;
+	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
+};

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1,22 +1,15 @@
 
-// Protocol19x.cpp
+// Protocol_1_8.cpp
 
 /*
-Implements the 1.9.x protocol classes:
-	- cProtocol190
-		- release 1.9.0 protocol (#107)
-	- cProtocol191
-		- release 1.9.1 protocol (#108)
-	- cProtocol192
-		- release 1.9.2 protocol (#109)
-	- cProtocol194
-		- release 1.9.4 protocol (#110)
-(others may be added later in the future for the 1.9 release series)
+Implements the 1.8 protocol classes:
+	- cProtocol_1_8_0
+		- release 1.8 protocol (#47)
 */
 
 #include "Globals.h"
 #include "json/json.h"
-#include "Protocol19x.h"
+#include "Protocol_1_8.h"
 #include "ChunkDataSerializer.h"
 #include "PolarSSL++/Sha1Checksum.h"
 #include "Packetizer.h"
@@ -33,7 +26,6 @@ Implements the 1.9.x protocol classes:
 #include "../WorldStorage/FastNBT.h"
 #include "../WorldStorage/EnchantmentSerializer.h"
 
-#include "../Entities/Boat.h"
 #include "../Entities/ExpOrb.h"
 #include "../Entities/Minecart.h"
 #include "../Entities/FallingBlock.h"
@@ -43,9 +35,6 @@ Implements the 1.9.x protocol classes:
 #include "../Entities/ItemFrame.h"
 #include "../Entities/ArrowEntity.h"
 #include "../Entities/FireworkEntity.h"
-#include "../Entities/SplashPotionEntity.h"
-
-#include "../Items/ItemSpawnEgg.h"
 
 #include "../Mobs/IncludeAllMonsters.h"
 #include "../UI/Window.h"
@@ -109,9 +98,9 @@ extern bool g_ShouldLogCommIn, g_ShouldLogCommOut;
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// cProtocol190:
+// cProtocol_1_8_0:
 
-cProtocol190::cProtocol190(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
+cProtocol_1_8_0::cProtocol_1_8_0(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
 	super(a_Client),
 	m_ServerAddress(a_ServerAddress),
 	m_ServerPort(a_ServerPort),
@@ -156,7 +145,7 @@ cProtocol190::cProtocol190(cClientHandle * a_Client, const AString & a_ServerAdd
 
 
 
-void cProtocol190::DataReceived(const char * a_Data, size_t a_Size)
+void cProtocol_1_8_0::DataReceived(const char * a_Data, size_t a_Size)
 {
 	if (m_IsEncrypted)
 	{
@@ -180,24 +169,25 @@ void cProtocol190::DataReceived(const char * a_Data, size_t a_Size)
 
 
 
-void cProtocol190::SendAttachEntity(const cEntity & a_Entity, const cEntity & a_Vehicle)
+void cProtocol_1_8_0::SendAttachEntity(const cEntity & a_Entity, const cEntity & a_Vehicle)
 {
 	ASSERT(m_State == 3);  // In game mode?
-	cPacketizer Pkt(*this, 0x40);  // Set passangers packet
-	Pkt.WriteVarInt32(a_Vehicle.GetUniqueID());
-	Pkt.WriteVarInt32(1);  // 1 passenger
-	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+
+	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Vehicle.GetUniqueID());
+	Pkt.WriteBool(false);
 }
 
 
 
 
 
-void cProtocol190::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType)
+void cProtocol_1_8_0::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0a);  // Block Action packet
+	cPacketizer Pkt(*this, 0x24);  // Block Action packet
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 	Pkt.WriteBEInt8(a_Byte1);
 	Pkt.WriteBEInt8(a_Byte2);
@@ -208,11 +198,11 @@ void cProtocol190::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, cha
 
 
 
-void cProtocol190::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
+void cProtocol_1_8_0::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x08);  // Block Break Animation packet
+	cPacketizer Pkt(*this, 0x25);  // Block Break Animation packet
 	Pkt.WriteVarInt32(a_EntityID);
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 	Pkt.WriteBEInt8(a_Stage);
@@ -222,11 +212,11 @@ void cProtocol190::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_Blo
 
 
 
-void cProtocol190::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
+void cProtocol_1_8_0::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0b);  // Block Change packet
+	cPacketizer Pkt(*this, 0x23);  // Block Change packet
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 	Pkt.WriteVarInt32((static_cast<UInt32>(a_BlockType) << 4) | (static_cast<UInt32>(a_BlockMeta) & 15));
 }
@@ -235,11 +225,11 @@ void cProtocol190::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLO
 
 
 
-void cProtocol190::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes)
+void cProtocol_1_8_0::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x10);  // Multi Block Change packet
+	cPacketizer Pkt(*this, 0x22);  // Multi Block Change packet
 	Pkt.WriteBEInt32(a_ChunkX);
 	Pkt.WriteBEInt32(a_ChunkZ);
 	Pkt.WriteVarInt32(static_cast<UInt32>(a_Changes.size()));
@@ -255,9 +245,9 @@ void cProtocol190::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockV
 
 
 
-void cProtocol190::SendCameraSetTo(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendCameraSetTo(const cEntity & a_Entity)
 {
-	cPacketizer Pkt(*this, 0x36);  // Camera Packet (Attach the camera of a player at another entity in spectator mode)
+	cPacketizer Pkt(*this, 0x43);  // Camera Packet (Attach the camera of a player at another entity in spectator mode)
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 }
 
@@ -265,40 +255,34 @@ void cProtocol190::SendCameraSetTo(const cEntity & a_Entity)
 
 
 
-void cProtocol190::SendChat(const AString & a_Message, eChatType a_Type)
+void cProtocol_1_8_0::SendChat(const AString & a_Message, eChatType a_Type)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0f);  // Chat Message packet
-	Pkt.WriteString(Printf("{\"text\":\"%s\"}", EscapeString(a_Message).c_str()));
-	Pkt.WriteBEInt8(a_Type);
+	SendChatRaw(Printf("{\"text\":\"%s\"}", EscapeString(a_Message).c_str()), a_Type);
 }
 
 
 
 
 
-void cProtocol190::SendChat(const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes)
+void cProtocol_1_8_0::SendChat(const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-
-	// Send the message to the client:
-	cPacketizer Pkt(*this, 0x0f);  // Chat Message packet
-	Pkt.WriteString(a_Message.CreateJsonString(a_ShouldUseChatPrefixes));
-	Pkt.WriteBEInt8(a_Type);
+	SendChatRaw(a_Message.CreateJsonString(a_ShouldUseChatPrefixes), a_Type);
 }
 
 
 
 
 
-void cProtocol190::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type)
+void cProtocol_1_8_0::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	// Send the json string to the client:
-	cPacketizer Pkt(*this, 0x0f);  // Chat Message packet
+	cPacketizer Pkt(*this, 0x02);
 	Pkt.WriteString(a_MessageRaw);
 	Pkt.WriteBEInt8(a_Type);
 }
@@ -307,13 +291,13 @@ void cProtocol190::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type)
 
 
 
-void cProtocol190::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer)
+void cProtocol_1_8_0::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	// Serialize first, before creating the Packetizer (the packetizer locks a CS)
 	// This contains the flags and bitmasks, too
-	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_0, a_ChunkX, a_ChunkZ);
+	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_8_0, a_ChunkX, a_ChunkZ);
 
 	cCSLock Lock(m_CSPacket);
 	SendData(ChunkData.data(), ChunkData.size());
@@ -323,11 +307,12 @@ void cProtocol190::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerialize
 
 
 
-void cProtocol190::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player)
+void cProtocol_1_8_0::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count)
 {
+	UNUSED(a_Count);
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x49);  // Collect Item packet
+	cPacketizer Pkt(*this, 0x0d);  // Collect Item packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 }
@@ -336,11 +321,11 @@ void cProtocol190::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a
 
 
 
-void cProtocol190::SendDestroyEntity(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendDestroyEntity(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x30);  // Destroy Entities packet
+	cPacketizer Pkt(*this, 0x13);  // Destroy Entities packet
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 }
@@ -349,19 +334,21 @@ void cProtocol190::SendDestroyEntity(const cEntity & a_Entity)
 
 
 
-void cProtocol190::SendDetachEntity(const cEntity & a_Entity, const cEntity & a_PreviousVehicle)
+void cProtocol_1_8_0::SendDetachEntity(const cEntity & a_Entity, const cEntity & a_PreviousVehicle)
 {
 	ASSERT(m_State == 3);  // In game mode?
-	cPacketizer Pkt(*this, 0x40);  // Set passangers packet
-	Pkt.WriteVarInt32(a_PreviousVehicle.GetUniqueID());
-	Pkt.WriteVarInt32(0);  // No passangers
+
+	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(0);
+	Pkt.WriteBool(false);
 }
 
 
 
 
 
-void cProtocol190::SendDisconnect(const AString & a_Reason)
+void cProtocol_1_8_0::SendDisconnect(const AString & a_Reason)
 {
 	switch (m_State)
 	{
@@ -375,7 +362,7 @@ void cProtocol190::SendDisconnect(const AString & a_Reason)
 		case 3:
 		{
 			// In-game:
-			cPacketizer Pkt(*this, 0x1a);
+			cPacketizer Pkt(*this, 0x40);
 			Pkt.WriteString(Printf("{\"text\":\"%s\"}", EscapeString(a_Reason).c_str()));
 			break;
 		}
@@ -386,11 +373,11 @@ void cProtocol190::SendDisconnect(const AString & a_Reason)
 
 
 
-void cProtocol190::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
+void cProtocol_1_8_0::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2a);  // Sign Editor Open packet
+	cPacketizer Pkt(*this, 0x36);  // Sign Editor Open packet
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 }
 
@@ -398,11 +385,11 @@ void cProtocol190::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 
 
-void cProtocol190::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration)
+void cProtocol_1_8_0::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x4c);  // Entity Effect packet
+	cPacketizer Pkt(*this, 0x1D);  // Entity Effect packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_EffectID));
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Amplifier));
@@ -414,18 +401,13 @@ void cProtocol190::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, in
 
 
 
-void cProtocol190::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item)
+void cProtocol_1_8_0::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3c);  // Entity Equipment packet
+	cPacketizer Pkt(*this, 0x04);  // Entity Equipment packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	// Needs to be adjusted due to the insertion of offhand at slot 1
-	if (a_SlotNum > 0)
-	{
-		a_SlotNum++;
-	}
-	Pkt.WriteVarInt32(static_cast<UInt32>(a_SlotNum));
+	Pkt.WriteBEInt16(a_SlotNum);
 	WriteItem(Pkt, a_Item);
 }
 
@@ -433,11 +415,11 @@ void cProtocol190::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum
 
 
 
-void cProtocol190::SendEntityHeadLook(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendEntityHeadLook(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x34);  // Entity Head Look packet
+	cPacketizer Pkt(*this, 0x19);  // Entity Head Look packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetHeadYaw());
 }
@@ -446,11 +428,11 @@ void cProtocol190::SendEntityHeadLook(const cEntity & a_Entity)
 
 
 
-void cProtocol190::SendEntityLook(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendEntityLook(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x27);  // Entity Look packet
+	cPacketizer Pkt(*this, 0x16);  // Entity Look packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
@@ -461,25 +443,25 @@ void cProtocol190::SendEntityLook(const cEntity & a_Entity)
 
 
 
-void cProtocol190::SendEntityMetadata(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendEntityMetadata(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x39);  // Entity Metadata packet
+	cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	WriteEntityMetadata(Pkt, a_Entity);
-	Pkt.WriteBEUInt8(0xff);  // The termination byte
+	Pkt.WriteBEUInt8(0x7f);  // The termination byte
 }
 
 
 
 
 
-void cProtocol190::SendEntityProperties(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendEntityProperties(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x4b);  // Entity Properties packet
+	cPacketizer Pkt(*this, 0x20);  // Entity Properties packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	WriteEntityProperties(Pkt, a_Entity);
 }
@@ -488,16 +470,15 @@ void cProtocol190::SendEntityProperties(const cEntity & a_Entity)
 
 
 
-void cProtocol190::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
+void cProtocol_1_8_0::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x25);  // Entity Relative Move packet
+	cPacketizer Pkt(*this, 0x15);  // Entity Relative Move packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	// TODO: 1.9 changed these from chars to shorts, meaning that there can be more percision and data.  Other code needs to be updated for that.
-	Pkt.WriteBEInt16(a_RelX * 128);
-	Pkt.WriteBEInt16(a_RelY * 128);
-	Pkt.WriteBEInt16(a_RelZ * 128);
+	Pkt.WriteBEInt8(a_RelX);
+	Pkt.WriteBEInt8(a_RelY);
+	Pkt.WriteBEInt8(a_RelZ);
 	Pkt.WriteBool(a_Entity.IsOnGround());
 }
 
@@ -505,16 +486,15 @@ void cProtocol190::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char
 
 
 
-void cProtocol190::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
+void cProtocol_1_8_0::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x26);  // Entity Look And Relative Move packet
+	cPacketizer Pkt(*this, 0x17);  // Entity Look And Relative Move packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	// TODO: 1.9 changed these from chars to shorts, meaning that there can be more percision and data.  Other code needs to be updated for that.
-	Pkt.WriteBEInt16(a_RelX * 128);
-	Pkt.WriteBEInt16(a_RelY * 128);
-	Pkt.WriteBEInt16(a_RelZ * 128);
+	Pkt.WriteBEInt8(a_RelX);
+	Pkt.WriteBEInt8(a_RelY);
+	Pkt.WriteBEInt8(a_RelZ);
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteBool(a_Entity.IsOnGround());
@@ -524,11 +504,11 @@ void cProtocol190::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, 
 
 
 
-void cProtocol190::SendEntityStatus(const cEntity & a_Entity, char a_Status)
+void cProtocol_1_8_0::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1b);  // Entity Status packet
+	cPacketizer Pkt(*this, 0x1a);  // Entity Status packet
 	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEInt8(a_Status);
 }
@@ -537,11 +517,11 @@ void cProtocol190::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 
 
 
-void cProtocol190::SendEntityVelocity(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendEntityVelocity(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3b);  // Entity Velocity packet
+	cPacketizer Pkt(*this, 0x12);  // Entity Velocity packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	// 400 = 8000 / 20 ... Conversion from our speed in m / s to 8000 m / tick
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
@@ -553,11 +533,11 @@ void cProtocol190::SendEntityVelocity(const cEntity & a_Entity)
 
 
 
-void cProtocol190::SendExplosion(double a_BlockX, double a_BlockY, double a_BlockZ, float a_Radius, const cVector3iArray & a_BlocksAffected, const Vector3d & a_PlayerMotion)
+void cProtocol_1_8_0::SendExplosion(double a_BlockX, double a_BlockY, double a_BlockZ, float a_Radius, const cVector3iArray & a_BlocksAffected, const Vector3d & a_PlayerMotion)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1c);  // Explosion packet
+	cPacketizer Pkt(*this, 0x27);  // Explosion packet
 	Pkt.WriteBEFloat(static_cast<float>(a_BlockX));
 	Pkt.WriteBEFloat(static_cast<float>(a_BlockY));
 	Pkt.WriteBEFloat(static_cast<float>(a_BlockZ));
@@ -578,11 +558,11 @@ void cProtocol190::SendExplosion(double a_BlockX, double a_BlockY, double a_Bloc
 
 
 
-void cProtocol190::SendGameMode(eGameMode a_GameMode)
+void cProtocol_1_8_0::SendGameMode(eGameMode a_GameMode)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1e);  // Change Game State packet
+	cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
 	Pkt.WriteBEUInt8(3);  // Reason: Change game mode
 	Pkt.WriteBEFloat(static_cast<float>(a_GameMode));  // The protocol really represents the value with a float!
 }
@@ -591,11 +571,11 @@ void cProtocol190::SendGameMode(eGameMode a_GameMode)
 
 
 
-void cProtocol190::SendHealth(void)
+void cProtocol_1_8_0::SendHealth(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3e);  // Update Health packet
+	cPacketizer Pkt(*this, 0x06);  // Update Health packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEFloat(static_cast<float>(Player->GetHealth()));
 	Pkt.WriteVarInt32(static_cast<UInt32>(Player->GetFoodLevel()));
@@ -606,7 +586,7 @@ void cProtocol190::SendHealth(void)
 
 
 
-void cProtocol190::SendHideTitle(void)
+void cProtocol_1_8_0::SendHideTitle(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -618,11 +598,11 @@ void cProtocol190::SendHideTitle(void)
 
 
 
-void cProtocol190::SendInventorySlot(char a_WindowID, short a_SlotNum, const cItem & a_Item)
+void cProtocol_1_8_0::SendInventorySlot(char a_WindowID, short a_SlotNum, const cItem & a_Item)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x16);  // Set Slot packet
+	cPacketizer Pkt(*this, 0x2f);  // Set Slot packet
 	Pkt.WriteBEInt8(a_WindowID);
 	Pkt.WriteBEInt16(a_SlotNum);
 	WriteItem(Pkt, a_Item);
@@ -632,7 +612,7 @@ void cProtocol190::SendInventorySlot(char a_WindowID, short a_SlotNum, const cIt
 
 
 
-void cProtocol190::SendKeepAlive(UInt32 a_PingID)
+void cProtocol_1_8_0::SendKeepAlive(UInt32 a_PingID)
 {
 	// Drop the packet if the protocol is not in the Game state yet (caused a client crash):
 	if (m_State != 3)
@@ -641,7 +621,7 @@ void cProtocol190::SendKeepAlive(UInt32 a_PingID)
 		return;
 	}
 
-	cPacketizer Pkt(*this, 0x1f);  // Keep Alive packet
+	cPacketizer Pkt(*this, 0x00);  // Keep Alive packet
 	Pkt.WriteVarInt32(a_PingID);
 }
 
@@ -649,12 +629,12 @@ void cProtocol190::SendKeepAlive(UInt32 a_PingID)
 
 
 
-void cProtocol190::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
+void cProtocol_1_8_0::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 {
 	// Send the Join Game packet:
 	{
 		cServer * Server = cRoot::Get()->GetServer();
-		cPacketizer Pkt(*this, 0x23);  // Join Game packet
+		cPacketizer Pkt(*this, 0x01);  // Join Game packet
 		Pkt.WriteBEUInt32(a_Player.GetUniqueID());
 		Pkt.WriteBEUInt8(static_cast<UInt8>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
 		Pkt.WriteBEInt8(static_cast<Int8>(a_World.GetDimension()));
@@ -666,13 +646,13 @@ void cProtocol190::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 
 	// Send the spawn position:
 	{
-		cPacketizer Pkt(*this, 0x43);  // Spawn Position packet
+		cPacketizer Pkt(*this, 0x05);  // Spawn Position packet
 		Pkt.WritePosition64(FloorC(a_World.GetSpawnX()), FloorC(a_World.GetSpawnY()), FloorC(a_World.GetSpawnZ()));
 	}
 
 	// Send the server difficulty:
 	{
-		cPacketizer Pkt(*this, 0x0d);  // Server difficulty packet
+		cPacketizer Pkt(*this, 0x41);
 		Pkt.WriteBEInt8(1);
 	}
 
@@ -683,7 +663,7 @@ void cProtocol190::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 
 
 
-void cProtocol190::SendLoginSuccess(void)
+void cProtocol_1_8_0::SendLoginSuccess(void)
 {
 	ASSERT(m_State == 2);  // State: login?
 
@@ -706,18 +686,15 @@ void cProtocol190::SendLoginSuccess(void)
 
 
 
-void cProtocol190::SendPaintingSpawn(const cPainting & a_Painting)
+void cProtocol_1_8_0::SendPaintingSpawn(const cPainting & a_Painting)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	double PosX = a_Painting.GetPosX();
 	double PosY = a_Painting.GetPosY();
 	double PosZ = a_Painting.GetPosZ();
 
-	cPacketizer Pkt(*this, 0x04);  // Spawn Painting packet
+	cPacketizer Pkt(*this, 0x10);  // Spawn Painting packet
 	Pkt.WriteVarInt32(a_Painting.GetUniqueID());
-	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
-	Pkt.WriteBEUInt64(0);
-	Pkt.WriteBEUInt64(a_Painting.GetUniqueID());
 	Pkt.WriteString(a_Painting.GetName().c_str());
 	Pkt.WritePosition64(static_cast<Int32>(PosX), static_cast<Int32>(PosY), static_cast<Int32>(PosZ));
 	Pkt.WriteBEInt8(static_cast<Int8>(a_Painting.GetProtocolFacing()));
@@ -727,15 +704,14 @@ void cProtocol190::SendPaintingSpawn(const cPainting & a_Painting)
 
 
 
-void cProtocol190::SendMapData(const cMap & a_Map, int a_DataStartX, int a_DataStartY)
+void cProtocol_1_8_0::SendMapData(const cMap & a_Map, int a_DataStartX, int a_DataStartY)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x24);  // Map packet
+	cPacketizer Pkt(*this, 0x34);
 	Pkt.WriteVarInt32(a_Map.GetID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Map.GetScale()));
 
-	Pkt.WriteBool(true);
 	Pkt.WriteVarInt32(static_cast<UInt32>(a_Map.GetDecorators().size()));
 	for (const auto & Decorator : a_Map.GetDecorators())
 	{
@@ -759,40 +735,40 @@ void cProtocol190::SendMapData(const cMap & a_Map, int a_DataStartX, int a_DataS
 
 
 
-void cProtocol190::SendPickupSpawn(const cPickup & a_Pickup)
+void cProtocol_1_8_0::SendPickupSpawn(const cPickup & a_Pickup)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	{  // TODO Use SendSpawnObject
-		cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
+	{
+		cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
 		Pkt.WriteVarInt32(a_Pickup.GetUniqueID());
-		// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
-		Pkt.WriteBEUInt64(0);
-		Pkt.WriteBEUInt64(a_Pickup.GetUniqueID());
 		Pkt.WriteBEUInt8(2);  // Type = Pickup
-		Pkt.WriteBEDouble(a_Pickup.GetPosX());
-		Pkt.WriteBEDouble(a_Pickup.GetPosY());
-		Pkt.WriteBEDouble(a_Pickup.GetPosZ());
+		Pkt.WriteFPInt(a_Pickup.GetPosX());
+		Pkt.WriteFPInt(a_Pickup.GetPosY());
+		Pkt.WriteFPInt(a_Pickup.GetPosZ());
 		Pkt.WriteByteAngle(a_Pickup.GetYaw());
 		Pkt.WriteByteAngle(a_Pickup.GetPitch());
 		Pkt.WriteBEInt32(0);  // No object data
-		Pkt.WriteBEInt16(0);  // No velocity
-		Pkt.WriteBEInt16(0);
-		Pkt.WriteBEInt16(0);
 	}
 
-	SendEntityMetadata(a_Pickup);
+	{
+		cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
+		Pkt.WriteVarInt32(a_Pickup.GetUniqueID());
+		Pkt.WriteBEUInt8((0x05 << 5) | 10);  // Slot type + index 10
+		WriteItem(Pkt, a_Pickup.GetItem());
+		Pkt.WriteBEUInt8(0x7f);  // End of metadata
+	}
 }
 
 
 
 
 
-void cProtocol190::SendPlayerAbilities(void)
+void cProtocol_1_8_0::SendPlayerAbilities(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2b);  // Player Abilities packet
+	cPacketizer Pkt(*this, 0x39);  // Player Abilities packet
 	Byte Flags = 0;
 	cPlayer * Player = m_Client->GetPlayer();
 	if (Player->IsGameModeCreative())
@@ -817,11 +793,11 @@ void cProtocol190::SendPlayerAbilities(void)
 
 
 
-void cProtocol190::SendEntityAnimation(const cEntity & a_Entity, char a_Animation)
+void cProtocol_1_8_0::SendEntityAnimation(const cEntity & a_Entity, char a_Animation)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x06);  // Animation packet
+	cPacketizer Pkt(*this, 0x0b);  // Animation packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEInt8(a_Animation);
 }
@@ -830,12 +806,12 @@ void cProtocol190::SendEntityAnimation(const cEntity & a_Entity, char a_Animatio
 
 
 
-void cProtocol190::SendParticleEffect(const AString & a_ParticleName, float a_SrcX, float a_SrcY, float a_SrcZ, float a_OffsetX, float a_OffsetY, float a_OffsetZ, float a_ParticleData, int a_ParticleAmount)
+void cProtocol_1_8_0::SendParticleEffect(const AString & a_ParticleName, float a_SrcX, float a_SrcY, float a_SrcZ, float a_OffsetX, float a_OffsetY, float a_OffsetZ, float a_ParticleData, int a_ParticleAmount)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	int ParticleID = GetParticleID(a_ParticleName);
 
-	cPacketizer Pkt(*this, 0x22);  // Particle effect packet
+	cPacketizer Pkt(*this, 0x2A);
 	Pkt.WriteBEInt32(ParticleID);
 	Pkt.WriteBool(false);
 	Pkt.WriteBEFloat(a_SrcX);
@@ -852,12 +828,12 @@ void cProtocol190::SendParticleEffect(const AString & a_ParticleName, float a_Sr
 
 
 
-void cProtocol190::SendParticleEffect(const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, std::array<int, 2> a_Data)
+void cProtocol_1_8_0::SendParticleEffect(const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, std::array<int, 2> a_Data)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	int ParticleID = GetParticleID(a_ParticleName);
 
-	cPacketizer Pkt(*this, 0x22);  // Particle effect packet
+	cPacketizer Pkt(*this, 0x2A);
 	Pkt.WriteBEInt32(ParticleID);
 	Pkt.WriteBool(false);
 	Pkt.WriteBEFloat(a_Src.x);
@@ -896,11 +872,11 @@ void cProtocol190::SendParticleEffect(const AString & a_ParticleName, Vector3f a
 
 
 
-void cProtocol190::SendPlayerListAddPlayer(const cPlayer & a_Player)
+void cProtocol_1_8_0::SendPlayerListAddPlayer(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
 	Pkt.WriteVarInt32(0);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -933,11 +909,11 @@ void cProtocol190::SendPlayerListAddPlayer(const cPlayer & a_Player)
 
 
 
-void cProtocol190::SendPlayerListRemovePlayer(const cPlayer & a_Player)
+void cProtocol_1_8_0::SendPlayerListRemovePlayer(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
 	Pkt.WriteVarInt32(4);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -947,11 +923,11 @@ void cProtocol190::SendPlayerListRemovePlayer(const cPlayer & a_Player)
 
 
 
-void cProtocol190::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
+void cProtocol_1_8_0::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -962,14 +938,14 @@ void cProtocol190::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
 
 
 
-void cProtocol190::SendPlayerListUpdatePing(const cPlayer & a_Player)
+void cProtocol_1_8_0::SendPlayerListUpdatePing(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	auto ClientHandle = a_Player.GetClientHandlePtr();
 	if (ClientHandle != nullptr)
 	{
-		cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
+		cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
 		Pkt.WriteVarInt32(2);
 		Pkt.WriteVarInt32(1);
 		Pkt.WriteUUID(a_Player.GetUUID());
@@ -981,11 +957,11 @@ void cProtocol190::SendPlayerListUpdatePing(const cPlayer & a_Player)
 
 
 
-void cProtocol190::SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName)
+void cProtocol_1_8_0::SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
 	Pkt.WriteVarInt32(3);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -1005,11 +981,11 @@ void cProtocol190::SendPlayerListUpdateDisplayName(const cPlayer & a_Player, con
 
 
 
-void cProtocol190::SendPlayerMaxSpeed(void)
+void cProtocol_1_8_0::SendPlayerMaxSpeed(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x4b);  // Entity Properties
+	cPacketizer Pkt(*this, 0x20);  // Entity Properties
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteVarInt32(Player->GetUniqueID());
 	Pkt.WriteBEInt32(1);  // Count
@@ -1034,11 +1010,11 @@ void cProtocol190::SendPlayerMaxSpeed(void)
 
 
 
-void cProtocol190::SendPlayerMoveLook(void)
+void cProtocol_1_8_0::SendPlayerMoveLook(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2e);  // Player Position And Look packet
+	cPacketizer Pkt(*this, 0x08);  // Player Position And Look packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEDouble(Player->GetPosX());
 	Pkt.WriteBEDouble(Player->GetPosY());
@@ -1046,14 +1022,13 @@ void cProtocol190::SendPlayerMoveLook(void)
 	Pkt.WriteBEFloat(static_cast<float>(Player->GetYaw()));
 	Pkt.WriteBEFloat(static_cast<float>(Player->GetPitch()));
 	Pkt.WriteBEUInt8(0);
-	Pkt.WriteVarInt32(0);  // Teleport ID - not implemented here
 }
 
 
 
 
 
-void cProtocol190::SendPlayerPosition(void)
+void cProtocol_1_8_0::SendPlayerPosition(void)
 {
 	// There is no dedicated packet for this, send the whole thing:
 	SendPlayerMoveLook();
@@ -1063,30 +1038,35 @@ void cProtocol190::SendPlayerPosition(void)
 
 
 
-void cProtocol190::SendPlayerSpawn(const cPlayer & a_Player)
+void cProtocol_1_8_0::SendPlayerSpawn(const cPlayer & a_Player)
 {
 	// Called to spawn another player for the client
-	cPacketizer Pkt(*this, 0x05);  // Spawn Player packet
+	cPacketizer Pkt(*this, 0x0c);  // Spawn Player packet
 	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 	Pkt.WriteUUID(cMojangAPI::MakeUUIDShort(a_Player.GetUUID()));
-	Pkt.WriteBEDouble(a_Player.GetPosX());
-	Pkt.WriteBEDouble(a_Player.GetPosY() + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
-	Pkt.WriteBEDouble(a_Player.GetPosZ());
+	Pkt.WriteFPInt(a_Player.GetPosX());
+	Pkt.WriteFPInt(a_Player.GetPosY() + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
+	Pkt.WriteFPInt(a_Player.GetPosZ());
 	Pkt.WriteByteAngle(a_Player.GetYaw());
 	Pkt.WriteByteAngle(a_Player.GetPitch());
-	WriteEntityMetadata(Pkt, a_Player);
-	Pkt.WriteBEUInt8(0xff);  // Metadata: end
+	short ItemType = a_Player.GetEquippedItem().IsEmpty() ? 0 : a_Player.GetEquippedItem().m_ItemType;
+	Pkt.WriteBEInt16(ItemType);
+	Pkt.WriteBEUInt8((3 << 5) | 6);  // Metadata: float + index 6
+	Pkt.WriteBEFloat(static_cast<float>(a_Player.GetHealth()));
+	Pkt.WriteBEUInt8((4 << 5 | (2 & 0x1F)) & 0xFF);
+	Pkt.WriteString(a_Player.GetName());
+	Pkt.WriteBEUInt8(0x7f);  // Metadata: end
 }
 
 
 
 
 
-void cProtocol190::SendPluginMessage(const AString & a_Channel, const AString & a_Message)
+void cProtocol_1_8_0::SendPluginMessage(const AString & a_Channel, const AString & a_Message)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x18);  // Plugin message packet
+	cPacketizer Pkt(*this, 0x3f);
 	Pkt.WriteString(a_Channel);
 	Pkt.WriteBuf(a_Message.data(), a_Message.size());
 }
@@ -1095,11 +1075,11 @@ void cProtocol190::SendPluginMessage(const AString & a_Channel, const AString & 
 
 
 
-void cProtocol190::SendRemoveEntityEffect(const cEntity & a_Entity, int a_EffectID)
+void cProtocol_1_8_0::SendRemoveEntityEffect(const cEntity & a_Entity, int a_EffectID)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x31);  // Remove entity effect packet
+	cPacketizer Pkt(*this, 0x1e);
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_EffectID));
 }
@@ -1108,7 +1088,7 @@ void cProtocol190::SendRemoveEntityEffect(const cEntity & a_Entity, int a_Effect
 
 
 
-void cProtocol190::SendResetTitle(void)
+void cProtocol_1_8_0::SendResetTitle(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1120,9 +1100,10 @@ void cProtocol190::SendResetTitle(void)
 
 
 
-void cProtocol190::SendRespawn(eDimension a_Dimension)
+void cProtocol_1_8_0::SendRespawn(eDimension a_Dimension)
 {
-	cPacketizer Pkt(*this, 0x33);  // Respawn packet
+
+	cPacketizer Pkt(*this, 0x07);  // Respawn packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Dimension));
 	Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
@@ -1134,11 +1115,11 @@ void cProtocol190::SendRespawn(eDimension a_Dimension)
 
 
 
-void cProtocol190::SendExperience(void)
+void cProtocol_1_8_0::SendExperience(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3d);  // Experience Packet
+	cPacketizer Pkt(*this, 0x1f);  // Experience Packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEFloat(Player->GetXpPercentage());
 	Pkt.WriteVarInt32(static_cast<UInt32>(Player->GetXpLevel()));
@@ -1149,15 +1130,15 @@ void cProtocol190::SendExperience(void)
 
 
 
-void cProtocol190::SendExperienceOrb(const cExpOrb & a_ExpOrb)
+void cProtocol_1_8_0::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x01);  // Spawn experience orb packet
+	cPacketizer Pkt(*this, 0x11);
 	Pkt.WriteVarInt32(a_ExpOrb.GetUniqueID());
-	Pkt.WriteBEDouble(a_ExpOrb.GetPosX());
-	Pkt.WriteBEDouble(a_ExpOrb.GetPosY());
-	Pkt.WriteBEDouble(a_ExpOrb.GetPosZ());
+	Pkt.WriteFPInt(a_ExpOrb.GetPosX());
+	Pkt.WriteFPInt(a_ExpOrb.GetPosY());
+	Pkt.WriteFPInt(a_ExpOrb.GetPosZ());
 	Pkt.WriteBEInt16(static_cast<Int16>(a_ExpOrb.GetReward()));
 }
 
@@ -1165,11 +1146,11 @@ void cProtocol190::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 
 
 
-void cProtocol190::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
+void cProtocol_1_8_0::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3f);  // Scoreboard objective packet
+	cPacketizer Pkt(*this, 0x3b);
 	Pkt.WriteString(a_Name);
 	Pkt.WriteBEUInt8(a_Mode);
 	if ((a_Mode == 0) || (a_Mode == 2))
@@ -1183,11 +1164,11 @@ void cProtocol190::SendScoreboardObjective(const AString & a_Name, const AString
 
 
 
-void cProtocol190::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
+void cProtocol_1_8_0::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x42);  // Update score packet
+	cPacketizer Pkt(*this, 0x3c);
 	Pkt.WriteString(a_Player);
 	Pkt.WriteBEUInt8(a_Mode);
 	Pkt.WriteString(a_Objective);
@@ -1202,11 +1183,11 @@ void cProtocol190::SendScoreUpdate(const AString & a_Objective, const AString & 
 
 
 
-void cProtocol190::SendDisplayObjective(const AString & a_Objective, cScoreboard::eDisplaySlot a_Display)
+void cProtocol_1_8_0::SendDisplayObjective(const AString & a_Objective, cScoreboard::eDisplaySlot a_Display)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x38);  // Display scoreboard packet
+	cPacketizer Pkt(*this, 0x3d);
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Display));
 	Pkt.WriteString(a_Objective);
 }
@@ -1215,7 +1196,7 @@ void cProtocol190::SendDisplayObjective(const AString & a_Objective, cScoreboard
 
 
 
-void cProtocol190::SendSetSubTitle(const cCompositeChat & a_SubTitle)
+void cProtocol_1_8_0::SendSetSubTitle(const cCompositeChat & a_SubTitle)
 {
 	SendSetRawSubTitle(a_SubTitle.CreateJsonString(false));
 }
@@ -1224,7 +1205,7 @@ void cProtocol190::SendSetSubTitle(const cCompositeChat & a_SubTitle)
 
 
 
-void cProtocol190::SendSetRawSubTitle(const AString & a_SubTitle)
+void cProtocol_1_8_0::SendSetRawSubTitle(const AString & a_SubTitle)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1238,7 +1219,7 @@ void cProtocol190::SendSetRawSubTitle(const AString & a_SubTitle)
 
 
 
-void cProtocol190::SendSetTitle(const cCompositeChat & a_Title)
+void cProtocol_1_8_0::SendSetTitle(const cCompositeChat & a_Title)
 {
 	SendSetRawTitle(a_Title.CreateJsonString(false));
 }
@@ -1247,7 +1228,7 @@ void cProtocol190::SendSetTitle(const cCompositeChat & a_Title)
 
 
 
-void cProtocol190::SendSetRawTitle(const AString & a_Title)
+void cProtocol_1_8_0::SendSetRawTitle(const AString & a_Title)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1261,13 +1242,12 @@ void cProtocol190::SendSetRawTitle(const AString & a_Title)
 
 
 
-void cProtocol190::SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch)
+void cProtocol_1_8_0::SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x19);  // Named sound effect packet
+	cPacketizer Pkt(*this, 0x29);  // Sound Effect packet
 	Pkt.WriteString(a_SoundName);
-	Pkt.WriteVarInt32(0);  // Master sound category (may want to be changed to a parameter later)
 	Pkt.WriteBEInt32(static_cast<Int32>(a_X * 8.0));
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Y * 8.0));
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Z * 8.0));
@@ -1279,11 +1259,11 @@ void cProtocol190::SendSoundEffect(const AString & a_SoundName, double a_X, doub
 
 
 
-void cProtocol190::SendSoundParticleEffect(const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data)
+void cProtocol_1_8_0::SendSoundParticleEffect(const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x21);  // Effect packet
+	cPacketizer Pkt(*this, 0x28);  // Effect packet
 	Pkt.WriteBEInt32(static_cast<int>(a_EffectID));
 	Pkt.WritePosition64(a_SrcX, a_SrcY, a_SrcZ);
 	Pkt.WriteBEInt32(a_Data);
@@ -1294,19 +1274,16 @@ void cProtocol190::SendSoundParticleEffect(const EffectID a_EffectID, int a_SrcX
 
 
 
-void cProtocol190::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
+void cProtocol_1_8_0::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
+	cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
 	Pkt.WriteVarInt32(a_FallingBlock.GetUniqueID());
-	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
-	Pkt.WriteBEUInt64(0);
-	Pkt.WriteBEUInt64(a_FallingBlock.GetUniqueID());
 	Pkt.WriteBEUInt8(70);  // Falling block
-	Pkt.WriteBEDouble(a_FallingBlock.GetPosX());
-	Pkt.WriteBEDouble(a_FallingBlock.GetPosY());
-	Pkt.WriteBEDouble(a_FallingBlock.GetPosZ());
+	Pkt.WriteFPInt(a_FallingBlock.GetPosX());
+	Pkt.WriteFPInt(a_FallingBlock.GetPosY());
+	Pkt.WriteFPInt(a_FallingBlock.GetPosZ());
 	Pkt.WriteByteAngle(a_FallingBlock.GetYaw());
 	Pkt.WriteByteAngle(a_FallingBlock.GetPitch());
 	Pkt.WriteBEInt32(static_cast<Int32>(a_FallingBlock.GetBlockType()) | (static_cast<Int32>(a_FallingBlock.GetBlockMeta()) << 12));
@@ -1319,19 +1296,16 @@ void cProtocol190::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
 
 
 
-void cProtocol190::SendSpawnMob(const cMonster & a_Mob)
+void cProtocol_1_8_0::SendSpawnMob(const cMonster & a_Mob)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x03);  // Spawn Mob packet
+	cPacketizer Pkt(*this, 0x0f);  // Spawn Mob packet
 	Pkt.WriteVarInt32(a_Mob.GetUniqueID());
-	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
-	Pkt.WriteBEUInt64(0);
-	Pkt.WriteBEUInt64(a_Mob.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<Byte>(a_Mob.GetMobType()));
-	Pkt.WriteBEDouble(a_Mob.GetPosX());
-	Pkt.WriteBEDouble(a_Mob.GetPosY());
-	Pkt.WriteBEDouble(a_Mob.GetPosZ());
+	Pkt.WriteFPInt(a_Mob.GetPosX());
+	Pkt.WriteFPInt(a_Mob.GetPosY());
+	Pkt.WriteFPInt(a_Mob.GetPosZ());
 	Pkt.WriteByteAngle(a_Mob.GetPitch());
 	Pkt.WriteByteAngle(a_Mob.GetHeadYaw());
 	Pkt.WriteByteAngle(a_Mob.GetYaw());
@@ -1339,14 +1313,14 @@ void cProtocol190::SendSpawnMob(const cMonster & a_Mob)
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Mob.GetSpeedY() * 400));
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Mob.GetSpeedZ() * 400));
 	WriteEntityMetadata(Pkt, a_Mob);
-	Pkt.WriteBEUInt8(0xff);  // Metadata terminator
+	Pkt.WriteBEUInt8(0x7f);  // Metadata terminator
 }
 
 
 
 
 
-void cProtocol190::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, int a_ObjectData, Byte a_Yaw, Byte a_Pitch)
+void cProtocol_1_8_0::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, int a_ObjectData, Byte a_Yaw, Byte a_Pitch)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	double PosX = a_Entity.GetPosX();
@@ -1357,57 +1331,57 @@ void cProtocol190::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, 
 		FixItemFramePositions(a_ObjectData, PosX, PosZ, Yaw);
 	}
 
-	cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
+	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
-	Pkt.WriteBEUInt64(0);
-	Pkt.WriteBEUInt64(a_Entity.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_ObjectType));
-	Pkt.WriteBEDouble(PosX);
-	Pkt.WriteBEDouble(a_Entity.GetPosY());
-	Pkt.WriteBEDouble(PosZ);
+	Pkt.WriteFPInt(PosX);
+	Pkt.WriteFPInt(a_Entity.GetPosY());
+	Pkt.WriteFPInt(PosZ);
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteByteAngle(Yaw);
 	Pkt.WriteBEInt32(a_ObjectData);
-	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
-	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedY() * 400));
-	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedZ() * 400));
+	if (a_ObjectData != 0)
+	{
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedY() * 400));
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedZ() * 400));
+	}
 }
 
 
 
 
 
-void cProtocol190::SendSpawnVehicle(const cEntity & a_Vehicle, char a_VehicleType, char a_VehicleSubType)
+void cProtocol_1_8_0::SendSpawnVehicle(const cEntity & a_Vehicle, char a_VehicleType, char a_VehicleSubType)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
+	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
 	Pkt.WriteVarInt32(a_Vehicle.GetUniqueID());
-	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
-	Pkt.WriteBEUInt64(0);
-	Pkt.WriteBEUInt64(a_Vehicle.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_VehicleType));
-	Pkt.WriteBEDouble(a_Vehicle.GetPosX());
-	Pkt.WriteBEDouble(a_Vehicle.GetPosY());
-	Pkt.WriteBEDouble(a_Vehicle.GetPosZ());
+	Pkt.WriteFPInt(a_Vehicle.GetPosX());
+	Pkt.WriteFPInt(a_Vehicle.GetPosY());
+	Pkt.WriteFPInt(a_Vehicle.GetPosZ());
 	Pkt.WriteByteAngle(a_Vehicle.GetPitch());
 	Pkt.WriteByteAngle(a_Vehicle.GetYaw());
 	Pkt.WriteBEInt32(a_VehicleSubType);
-	Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedX() * 400));
-	Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedY() * 400));
-	Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedZ() * 400));
+	if (a_VehicleSubType != 0)
+	{
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedX() * 400));
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedY() * 400));
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedZ() * 400));
+	}
 }
 
 
 
 
 
-void cProtocol190::SendStatistics(const cStatManager & a_Manager)
+void cProtocol_1_8_0::SendStatistics(const cStatManager & a_Manager)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x07);  // Statistics packet
+	cPacketizer Pkt(*this, 0x37);
 	Pkt.WriteVarInt32(statCount);  // TODO 2014-05-11 xdot: Optimization: Send "dirty" statistics only
 
 	size_t Count = static_cast<size_t>(statCount);
@@ -1425,11 +1399,11 @@ void cProtocol190::SendStatistics(const cStatManager & a_Manager)
 
 
 
-void cProtocol190::SendTabCompletionResults(const AStringVector & a_Results)
+void cProtocol_1_8_0::SendTabCompletionResults(const AStringVector & a_Results)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0e);  // Tab-Complete packet
+	cPacketizer Pkt(*this, 0x3a);  // Tab-Complete packet
 	Pkt.WriteVarInt32(static_cast<UInt32>(a_Results.size()));
 
 	for (AStringVector::const_iterator itr = a_Results.begin(), end = a_Results.end(); itr != end; ++itr)
@@ -1442,15 +1416,15 @@ void cProtocol190::SendTabCompletionResults(const AStringVector & a_Results)
 
 
 
-void cProtocol190::SendTeleportEntity(const cEntity & a_Entity)
+void cProtocol_1_8_0::SendTeleportEntity(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x4a);  // Entity teleport packet
+	cPacketizer Pkt(*this, 0x18);
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEDouble(a_Entity.GetPosX());
-	Pkt.WriteBEDouble(a_Entity.GetPosY());
-	Pkt.WriteBEDouble(a_Entity.GetPosZ());
+	Pkt.WriteFPInt(a_Entity.GetPosX());
+	Pkt.WriteFPInt(a_Entity.GetPosY());
+	Pkt.WriteFPInt(a_Entity.GetPosZ());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteBool(a_Entity.IsOnGround());
@@ -1460,23 +1434,23 @@ void cProtocol190::SendTeleportEntity(const cEntity & a_Entity)
 
 
 
-void cProtocol190::SendThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ)
+void cProtocol_1_8_0::SendThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x02);  // Spawn Global Entity packet
+	cPacketizer Pkt(*this, 0x2c);  // Spawn Global Entity packet
 	Pkt.WriteVarInt32(0);  // EntityID = 0, always
 	Pkt.WriteBEUInt8(1);  // Type = Thunderbolt
-	Pkt.WriteBEDouble(a_BlockX);
-	Pkt.WriteBEDouble(a_BlockY);
-	Pkt.WriteBEDouble(a_BlockZ);
+	Pkt.WriteFPInt(a_BlockX);
+	Pkt.WriteFPInt(a_BlockY);
+	Pkt.WriteFPInt(a_BlockZ);
 }
 
 
 
 
 
-void cProtocol190::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks)
+void cProtocol_1_8_0::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1492,7 +1466,7 @@ void cProtocol190::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_F
 
 
 
-void cProtocol190::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_DoDaylightCycle)
+void cProtocol_1_8_0::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_DoDaylightCycle)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	if (!a_DoDaylightCycle)
@@ -1501,7 +1475,7 @@ void cProtocol190::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_Do
 		a_TimeOfDay = std::min(-a_TimeOfDay, -1LL);
 	}
 
-	cPacketizer Pkt(*this, 0x44);  // Time update packet
+	cPacketizer Pkt(*this, 0x03);
 	Pkt.WriteBEInt64(a_WorldAge);
 	Pkt.WriteBEInt64(a_TimeOfDay);
 }
@@ -1510,23 +1484,26 @@ void cProtocol190::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_Do
 
 
 
-void cProtocol190::SendUnloadChunk(int a_ChunkX, int a_ChunkZ)
+void cProtocol_1_8_0::SendUnloadChunk(int a_ChunkX, int a_ChunkZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1d);  // Unload chunk packet
+	cPacketizer Pkt(*this, 0x21);  // Chunk Data packet
 	Pkt.WriteBEInt32(a_ChunkX);
 	Pkt.WriteBEInt32(a_ChunkZ);
+	Pkt.WriteBool(true);
+	Pkt.WriteBEInt16(0);  // Primary bitmap
+	Pkt.WriteVarInt32(0);  // Data size
 }
 
 
 
 
-void cProtocol190::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
+void cProtocol_1_8_0::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x09);  // Update tile entity packet
+	cPacketizer Pkt(*this, 0x35);  // Update tile entity packet
 	Pkt.WritePosition64(a_BlockEntity.GetPosX(), a_BlockEntity.GetPosY(), a_BlockEntity.GetPosZ());
 
 	Byte Action = 0;
@@ -1548,11 +1525,11 @@ void cProtocol190::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 
 
 
-void cProtocol190::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
+void cProtocol_1_8_0::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x46);  // Update sign packet
+	cPacketizer Pkt(*this, 0x33);
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 
 	Json::StyledWriter JsonWriter;
@@ -1569,11 +1546,11 @@ void cProtocol190::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 
 
 
-void cProtocol190::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
+void cProtocol_1_8_0::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2f);  // Use bed
+	cPacketizer Pkt(*this, 0x0a);
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 }
@@ -1582,12 +1559,12 @@ void cProtocol190::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_Bloc
 
 
 
-void cProtocol190::SendWeather(eWeather a_Weather)
+void cProtocol_1_8_0::SendWeather(eWeather a_Weather)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	{
-		cPacketizer Pkt(*this, 0x1e);  // Change Game State packet
+		cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
 		Pkt.WriteBEUInt8((a_Weather == wSunny) ? 1 : 2);  // End rain / begin rain
 		Pkt.WriteBEFloat(0);  // Unused for weather
 	}
@@ -1599,11 +1576,11 @@ void cProtocol190::SendWeather(eWeather a_Weather)
 
 
 
-void cProtocol190::SendWholeInventory(const cWindow & a_Window)
+void cProtocol_1_8_0::SendWholeInventory(const cWindow & a_Window)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x14);  // Window Items packet
+	cPacketizer Pkt(*this, 0x30);  // Window Items packet
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Window.GetNumSlots()));
 	cItems Slots;
@@ -1618,11 +1595,11 @@ void cProtocol190::SendWholeInventory(const cWindow & a_Window)
 
 
 
-void cProtocol190::SendWindowClose(const cWindow & a_Window)
+void cProtocol_1_8_0::SendWindowClose(const cWindow & a_Window)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x12);  // Close window packet
+	cPacketizer Pkt(*this, 0x2e);
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 }
 
@@ -1630,7 +1607,7 @@ void cProtocol190::SendWindowClose(const cWindow & a_Window)
 
 
 
-void cProtocol190::SendWindowOpen(const cWindow & a_Window)
+void cProtocol_1_8_0::SendWindowOpen(const cWindow & a_Window)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1640,7 +1617,7 @@ void cProtocol190::SendWindowOpen(const cWindow & a_Window)
 		return;
 	}
 
-	cPacketizer Pkt(*this, 0x13);  // Open window packet
+	cPacketizer Pkt(*this, 0x2d);
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 	Pkt.WriteString(a_Window.GetWindowTypeName());
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", a_Window.GetWindowTitle().c_str()));
@@ -1671,11 +1648,11 @@ void cProtocol190::SendWindowOpen(const cWindow & a_Window)
 
 
 
-void cProtocol190::SendWindowProperty(const cWindow & a_Window, short a_Property, short a_Value)
+void cProtocol_1_8_0::SendWindowProperty(const cWindow & a_Window, short a_Property, short a_Value)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x15);  // Window Property packet
+	cPacketizer Pkt(*this, 0x31);  // Window Property packet
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(a_Property);
 	Pkt.WriteBEInt16(a_Value);
@@ -1685,7 +1662,7 @@ void cProtocol190::SendWindowProperty(const cWindow & a_Window, short a_Property
 
 
 
-bool cProtocol190::CompressPacket(const AString & a_Packet, AString & a_CompressedData)
+bool cProtocol_1_8_0::CompressPacket(const AString & a_Packet, AString & a_CompressedData)
 {
 	// Compress the data:
 	char CompressedData[MAX_COMPRESSED_PACKET_LEN];
@@ -1728,7 +1705,7 @@ bool cProtocol190::CompressPacket(const AString & a_Packet, AString & a_Compress
 
 
 
-int cProtocol190::GetParticleID(const AString & a_ParticleName)
+int cProtocol_1_8_0::GetParticleID(const AString & a_ParticleName)
 {
 	static bool IsInitialized = false;
 	static std::map<AString, int> ParticleMap;
@@ -1794,7 +1771,7 @@ int cProtocol190::GetParticleID(const AString & a_ParticleName)
 
 
 
-void cProtocol190::FixItemFramePositions(int a_ObjectData, double & a_PosX, double & a_PosZ, double & a_Yaw)
+void cProtocol_1_8_0::FixItemFramePositions(int a_ObjectData, double & a_PosX, double & a_PosZ, double & a_Yaw)
 {
 	switch (a_ObjectData)
 	{
@@ -1829,7 +1806,7 @@ void cProtocol190::FixItemFramePositions(int a_ObjectData, double & a_PosX, doub
 
 
 
-void cProtocol190::AddReceivedData(const char * a_Data, size_t a_Size)
+void cProtocol_1_8_0::AddReceivedData(const char * a_Data, size_t a_Size)
 {
 	// Write the incoming data into the comm log file:
 	if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
@@ -1959,7 +1936,7 @@ void cProtocol190::AddReceivedData(const char * a_Data, size_t a_Size)
 		if (!HandlePacket(bb, PacketType))
 		{
 			// Unknown packet, already been reported, but without the length. Log the length here:
-			LOGWARNING("Protocol 1.9: Unhandled packet: type 0x%x, state %d, length %u", PacketType, m_State, PacketLen);
+			LOGWARNING("Unhandled packet: type 0x%x, state %d, length %u", PacketType, m_State, PacketLen);
 
 			#ifdef _DEBUG
 				// Dump the packet contents into the log:
@@ -1985,7 +1962,7 @@ void cProtocol190::AddReceivedData(const char * a_Data, size_t a_Size)
 		if (bb.GetReadableSpace() != 1)
 		{
 			// Read more or less than packet length, report as error
-			LOGWARNING("Protocol 1.9: Wrong number of bytes read for packet 0x%x, state %d. Read " SIZE_T_FMT " bytes, packet contained %u bytes",
+			LOGWARNING("Protocol 1.8: Wrong number of bytes read for packet 0x%x, state %d. Read " SIZE_T_FMT " bytes, packet contained %u bytes",
 				PacketType, m_State, bb.GetUsedSpace() - bb.GetReadableSpace(), PacketLen
 			);
 
@@ -2014,7 +1991,7 @@ void cProtocol190::AddReceivedData(const char * a_Data, size_t a_Size)
 		ASSERT(m_ReceivedData.GetReadableSpace() == OldReadableSpace);
 		AString Hex;
 		CreateHexDump(Hex, AllData.data(), AllData.size(), 16);
-		m_CommLogFile.Printf("Protocol 1.9: There are " SIZE_T_FMT " (0x" SIZE_T_FMT_HEX ") bytes of non-parse-able data left in the buffer:\n%s",
+		m_CommLogFile.Printf("There are " SIZE_T_FMT " (0x" SIZE_T_FMT_HEX ") bytes of non-parse-able data left in the buffer:\n%s",
 			m_ReceivedData.GetReadableSpace(), m_ReceivedData.GetReadableSpace(), Hex.c_str()
 		);
 		m_CommLogFile.Flush();
@@ -2024,7 +2001,7 @@ void cProtocol190::AddReceivedData(const char * a_Data, size_t a_Size)
 
 
 
-bool cProtocol190::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
+bool cProtocol_1_8_0::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
 {
 	switch (m_State)
 	{
@@ -2055,36 +2032,31 @@ bool cProtocol190::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
 			// Game
 			switch (a_PacketType)
 			{
-				case 0x00: HandleConfirmTeleport              (a_ByteBuffer); return true;
-				case 0x01: HandlePacketTabComplete            (a_ByteBuffer); return true;
-				case 0x02: HandlePacketChatMessage            (a_ByteBuffer); return true;
-				case 0x03: HandlePacketClientStatus           (a_ByteBuffer); return true;
-				case 0x04: HandlePacketClientSettings         (a_ByteBuffer); return true;
-				case 0x05: break;  // Confirm transaction - not used in MCS
-				case 0x06: HandlePacketEnchantItem            (a_ByteBuffer); return true;
-				case 0x07: HandlePacketWindowClick            (a_ByteBuffer); return true;
-				case 0x08: HandlePacketWindowClose            (a_ByteBuffer); return true;
-				case 0x09: HandlePacketPluginMessage          (a_ByteBuffer); return true;
-				case 0x0a: HandlePacketUseEntity              (a_ByteBuffer); return true;
-				case 0x0b: HandlePacketKeepAlive              (a_ByteBuffer); return true;
-				case 0x0c: HandlePacketPlayerPos              (a_ByteBuffer); return true;
-				case 0x0d: HandlePacketPlayerPosLook          (a_ByteBuffer); return true;
-				case 0x0e: HandlePacketPlayerLook             (a_ByteBuffer); return true;
-				case 0x0f: HandlePacketPlayer                 (a_ByteBuffer); return true;
-				case 0x10: HandlePacketVehicleMove            (a_ByteBuffer); return true;
-				case 0x11: HandlePacketBoatSteer              (a_ByteBuffer); return true;
-				case 0x12: HandlePacketPlayerAbilities        (a_ByteBuffer); return true;
-				case 0x13: HandlePacketBlockDig               (a_ByteBuffer); return true;
-				case 0x14: HandlePacketEntityAction           (a_ByteBuffer); return true;
-				case 0x15: HandlePacketSteerVehicle           (a_ByteBuffer); return true;
-				case 0x16: break;  // Resource pack status - not yet implemented
-				case 0x17: HandlePacketSlotSelect             (a_ByteBuffer); return true;
-				case 0x18: HandlePacketCreativeInventoryAction(a_ByteBuffer); return true;
-				case 0x19: HandlePacketUpdateSign             (a_ByteBuffer); return true;
-				case 0x1a: HandlePacketAnimation              (a_ByteBuffer); return true;
-				case 0x1b: HandlePacketSpectate               (a_ByteBuffer); return true;
-				case 0x1c: HandlePacketBlockPlace             (a_ByteBuffer); return true;
-				case 0x1d: HandlePacketUseItem                (a_ByteBuffer); return true;
+				case 0x00: HandlePacketKeepAlive              (a_ByteBuffer); return true;
+				case 0x01: HandlePacketChatMessage            (a_ByteBuffer); return true;
+				case 0x02: HandlePacketUseEntity              (a_ByteBuffer); return true;
+				case 0x03: HandlePacketPlayer                 (a_ByteBuffer); return true;
+				case 0x04: HandlePacketPlayerPos              (a_ByteBuffer); return true;
+				case 0x05: HandlePacketPlayerLook             (a_ByteBuffer); return true;
+				case 0x06: HandlePacketPlayerPosLook          (a_ByteBuffer); return true;
+				case 0x07: HandlePacketBlockDig               (a_ByteBuffer); return true;
+				case 0x08: HandlePacketBlockPlace             (a_ByteBuffer); return true;
+				case 0x09: HandlePacketSlotSelect             (a_ByteBuffer); return true;
+				case 0x0a: HandlePacketAnimation              (a_ByteBuffer); return true;
+				case 0x0b: HandlePacketEntityAction           (a_ByteBuffer); return true;
+				case 0x0c: HandlePacketSteerVehicle           (a_ByteBuffer); return true;
+				case 0x0d: HandlePacketWindowClose            (a_ByteBuffer); return true;
+				case 0x0e: HandlePacketWindowClick            (a_ByteBuffer); return true;
+				case 0x0f:  // Confirm transaction - not used in MCS
+				case 0x10: HandlePacketCreativeInventoryAction(a_ByteBuffer); return true;
+				case 0x11: HandlePacketEnchantItem            (a_ByteBuffer); return true;
+				case 0x12: HandlePacketUpdateSign             (a_ByteBuffer); return true;
+				case 0x13: HandlePacketPlayerAbilities        (a_ByteBuffer); return true;
+				case 0x14: HandlePacketTabComplete            (a_ByteBuffer); return true;
+				case 0x15: HandlePacketClientSettings         (a_ByteBuffer); return true;
+				case 0x16: HandlePacketClientStatus           (a_ByteBuffer); return true;
+				case 0x17: HandlePacketPluginMessage          (a_ByteBuffer); return true;
+				case 0x18: HandlePacketSpectate               (a_ByteBuffer); return true;
 			}
 			break;
 		}
@@ -2116,7 +2088,7 @@ bool cProtocol190::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
 
 
 
-void cProtocol190::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt64, Int64, Timestamp);
 
@@ -2128,7 +2100,7 @@ void cProtocol190::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 {
 	cServer * Server = cRoot::Get()->GetServer();
 	AString ServerDescription = Server->GetDescription();
@@ -2139,8 +2111,8 @@ void cProtocol190::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 	// Version:
 	Json::Value Version;
-	Version["name"] = "Cuberite 1.9";
-	Version["protocol"] = 107;
+	Version["name"] = "Cuberite 1.8";
+	Version["protocol"] = 47;
 
 	// Players:
 	Json::Value Players;
@@ -2173,7 +2145,7 @@ void cProtocol190::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffer)
 {
 	UInt32 EncKeyLength, EncNonceLength;
 	if (!a_ByteBuffer.ReadVarInt(EncKeyLength))
@@ -2236,7 +2208,7 @@ void cProtocol190::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffe
 
 
 
-void cProtocol190::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 {
 	AString Username;
 	if (!a_ByteBuffer.ReadVarUTF8String(Username))
@@ -2273,10 +2245,8 @@ void cProtocol190::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 {
-	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Hand);
-
 	m_Client->HandleAnimation(0);  // Packet exists solely for arm-swing notification
 }
 
@@ -2284,7 +2254,7 @@ void cProtocol190::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Status);
 
@@ -2294,7 +2264,7 @@ void cProtocol190::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 		return;
 	}
 
-	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Face);
+	HANDLE_READ(a_ByteBuffer, ReadBEInt8, Int8, Face);
 	m_Client->HandleLeftClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), Status);
 }
 
@@ -2302,7 +2272,7 @@ void cProtocol190::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 {
 	int BlockX, BlockY, BlockZ;
 	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
@@ -2310,8 +2280,11 @@ void cProtocol190::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 		return;
 	}
 
-	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Face);
-	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Hand);
+	HANDLE_READ(a_ByteBuffer, ReadBEInt8, Int8, Face);
+
+	cItem Item;
+	ReadItem(a_ByteBuffer, Item, 3);
+
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorX);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorY);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorZ);
@@ -2322,30 +2295,7 @@ void cProtocol190::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketBoatSteer(cByteBuffer & a_ByteBuffer)
-{
-	HANDLE_READ(a_ByteBuffer, ReadBool, bool, RightPaddle);
-	HANDLE_READ(a_ByteBuffer, ReadBool, bool, LeftPaddle);
-
-	// Get the players vehicle
-	cPlayer * Player = m_Client->GetPlayer();
-	cEntity * Vehicle = Player->GetAttached();
-
-	if (Vehicle)
-	{
-		if (Vehicle->GetEntityType() == cEntity::etBoat)
-		{
-			auto * Boat = reinterpret_cast<cBoat *>(Vehicle);
-			Boat->UpdatePaddles(RightPaddle, LeftPaddle);
-		}
-	}
-}
-
-
-
-
-
-void cProtocol190::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Message);
 	m_Client->HandleChat(Message);
@@ -2355,14 +2305,13 @@ void cProtocol190::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Locale);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   ViewDistance);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   ChatFlags);
 	HANDLE_READ(a_ByteBuffer, ReadBool,          bool,    ChatColors);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   SkinFlags);
-	HANDLE_READ(a_ByteBuffer, ReadVarInt,        UInt32,   MainHand);
 
 	m_Client->SetLocale(Locale);
 	m_Client->SetViewDistance(ViewDistance);
@@ -2373,7 +2322,7 @@ void cProtocol190::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, ActionID);
 	switch (ActionID)
@@ -2405,17 +2354,7 @@ void cProtocol190::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandleConfirmTeleport(cByteBuffer & a_ByteBuffer)
-{
-	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, TeleportID);
-	// We don't actually validate that this packet is sent or anything yet, but it still needs to be read.
-}
-
-
-
-
-
-void cProtocol190::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
 	cItem Item;
@@ -2430,7 +2369,7 @@ void cProtocol190::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffe
 
 
 
-void cProtocol190::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt,  UInt32, PlayerID);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8,  Action);
@@ -2450,7 +2389,7 @@ void cProtocol190::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, KeepAliveID);
 	m_Client->HandleKeepAlive(KeepAliveID);
@@ -2460,7 +2399,7 @@ void cProtocol190::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketPlayer(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketPlayer(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBool, bool, IsOnGround);
 	// TODO: m_Client->HandlePlayerOnGround(IsOnGround);
@@ -2470,7 +2409,7 @@ void cProtocol190::HandlePacketPlayer(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Flags);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, FlyingSpeed);
@@ -2494,7 +2433,7 @@ void cProtocol190::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Yaw);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Pitch);
@@ -2506,7 +2445,7 @@ void cProtocol190::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosX);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
@@ -2519,7 +2458,7 @@ void cProtocol190::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosX);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
@@ -2534,7 +2473,7 @@ void cProtocol190::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Channel);
 
@@ -2565,7 +2504,7 @@ void cProtocol190::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
 	m_Client->HandleSlotSelected(SlotNum);
@@ -2575,7 +2514,7 @@ void cProtocol190::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketSpectate(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketSpectate(cByteBuffer &a_ByteBuffer)
 {
 	AString playerUUID;
 	if (!a_ByteBuffer.ReadUUID(playerUUID))
@@ -2590,7 +2529,7 @@ void cProtocol190::HandlePacketSpectate(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Sideways);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Forward);
@@ -2602,7 +2541,7 @@ void cProtocol190::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 	}
 	else if ((Flags & 0x1) != 0)
 	{
-		// TODO: Handle vehicle jump (for animals)
+		// jump
 	}
 	else
 	{
@@ -2614,10 +2553,9 @@ void cProtocol190::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Text);
-	HANDLE_READ(a_ByteBuffer, ReadBool,          bool,    AssumeCommand);
 	HANDLE_READ(a_ByteBuffer, ReadBool,          bool,    HasPosition);
 
 	if (HasPosition)
@@ -2632,7 +2570,7 @@ void cProtocol190::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 {
 	int BlockX, BlockY, BlockZ;
 	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
@@ -2641,10 +2579,15 @@ void cProtocol190::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 	}
 
 	AString Lines[4];
+	Json::Value root;
+	Json::Reader reader;
 	for (int i = 0; i < 4; i++)
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Line);
-		Lines[i] = Line;
+		if (reader.parse(Line, root, false))
+		{
+			Lines[i] = root.asString();
+		}
 	}
 
 	m_Client->HandleUpdateSign(BlockX, BlockY, BlockZ, Lines[0], Lines[1], Lines[2], Lines[3]);
@@ -2654,7 +2597,7 @@ void cProtocol190::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, EntityID);
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Type);
@@ -2663,7 +2606,6 @@ void cProtocol190::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 	{
 		case 0:
 		{
-			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand)
 			m_Client->HandleUseEntity(EntityID, false);
 			break;
 		}
@@ -2677,7 +2619,6 @@ void cProtocol190::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 			HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, TargetX);
 			HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, TargetY);
 			HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, TargetZ);
-			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand);
 
 			// TODO: Do anything
 			break;
@@ -2694,19 +2635,7 @@ void cProtocol190::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketUseItem(cByteBuffer & a_ByteBuffer)
-{
-	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt64, Hand);
-
-	// Didn't click a block - emulate old values used with place block of -1, -1, -1 (and BLOCK_FACE_NONE).
-	m_Client->HandleRightClick(-1, 255, -1, BLOCK_FACE_NONE, 0, 0, 0, m_Client->GetPlayer()->GetEquippedItem());
-}
-
-
-
-
-
-void cProtocol190::HandlePacketEnchantItem(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketEnchantItem(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, WindowID);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Enchantment);
@@ -2718,39 +2647,13 @@ void cProtocol190::HandlePacketEnchantItem(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketVehicleMove(cByteBuffer & a_ByteBuffer)
-{
-	// This handles updating the vehicles location server side
-	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, xPos);
-	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, yPos);
-	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, zPos);
-	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  yaw);
-	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  pitch);
-
-	// Get the players vehicle
-	cEntity * Vehicle = m_Client->GetPlayer()->GetAttached();
-
-	if (Vehicle)
-	{
-		Vehicle->SetPosX(xPos);
-		Vehicle->SetPosY(yPos);
-		Vehicle->SetPosZ(zPos);
-		Vehicle->SetYaw(yaw);
-		Vehicle->SetPitch(pitch);
-	}
-}
-
-
-
-
-
-void cProtocol190::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  WindowID);
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16,  Int16,  SlotNum);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  Button);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt16, UInt16, TransactionID);
-	HANDLE_READ(a_ByteBuffer, ReadVarInt32,  UInt32,  Mode);
+	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  Mode);
 	cItem Item;
 	ReadItem(a_ByteBuffer, Item);
 
@@ -2796,7 +2699,7 @@ void cProtocol190::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_8_0::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, WindowID);
 	m_Client->HandleWindowClose(WindowID);
@@ -2806,7 +2709,7 @@ void cProtocol190::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol190::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel)
+void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel)
 {
 	if (a_Channel == "MC|AdvCdm")
 	{
@@ -2871,7 +2774,7 @@ void cProtocol190::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 
 
 
-void cProtocol190::SendData(const char * a_Data, size_t a_Size)
+void cProtocol_1_8_0::SendData(const char * a_Data, size_t a_Size)
 {
 	if (m_IsEncrypted)
 	{
@@ -2895,7 +2798,7 @@ void cProtocol190::SendData(const char * a_Data, size_t a_Size)
 
 
 
-bool cProtocol190::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes)
+bool cProtocol_1_8_0::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes)
 {
 	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt16, Int16, ItemType);
 	if (ItemType == -1)
@@ -2930,7 +2833,7 @@ bool cProtocol190::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a
 
 
 
-void cProtocol190::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
+void cProtocol_1_8_0::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 {
 	// Parse into NBT:
 	cParsedNBT NBT(a_Metadata.data(), a_Metadata.size());
@@ -2987,18 +2890,6 @@ void cProtocol190::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 				{
 					cFireworkItem::ParseFromNBT(a_Item.m_FireworkItem, NBT, tag, static_cast<ENUM_ITEM_ID>(a_Item.m_ItemType));
 				}
-				else if (TagName == "EntityTag")
-				{
-					for (int entitytag = NBT.GetFirstChild(tag); entitytag >= 0; entitytag = NBT.GetNextSibling(entitytag))
-					{
-						if ((NBT.GetType(entitytag) == TAG_String) && (NBT.GetName(entitytag) == "id"))
-						{
-							eMonsterType MonsterType = cMonster::StringToMobType(NBT.GetString(entitytag));
-							// No special method here to convert to the numeric damage value; just cast to the given ID
-							a_Item.m_ItemDamage = static_cast<short>(MonsterType);
-						}
-					}
-				}
 				break;
 			}
 			case TAG_Int:
@@ -3007,122 +2898,6 @@ void cProtocol190::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 				{
 					a_Item.m_RepairCost = NBT.GetInt(tag);
 				}
-				break;
-			}
-			case TAG_String:
-			{
-				if (TagName == "Potion")
-				{
-					AString PotionEffect = NBT.GetString(tag);
-					if (PotionEffect.find("minecraft:") == AString::npos)
-					{
-						LOGD("Unknown or missing domain on potion effect name %s!", PotionEffect.c_str());
-						continue;
-					}
-
-					if (PotionEffect.find("water") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 0;
-						// Water bottles shouldn't have other bits set on them; exit early.
-						continue;
-					}
-					if (PotionEffect.find("empty") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 0;
-					}
-					else if (PotionEffect.find("mundane") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 0;
-					}
-					else if (PotionEffect.find("thick") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 20;
-					}
-					else if (PotionEffect.find("awkward") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 10;
-					}
-					else if (PotionEffect.find("regeneration") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 1;
-					}
-					else if (PotionEffect.find("swiftness") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 2;
-					}
-					else if (PotionEffect.find("fire_resistance") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 3;
-					}
-					else if (PotionEffect.find("poison") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 4;
-					}
-					else if (PotionEffect.find("healing") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 5;
-					}
-					else if (PotionEffect.find("night_vision") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 6;
-					}
-					else if (PotionEffect.find("weakness") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 8;
-					}
-					else if (PotionEffect.find("strength") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 9;
-					}
-					else if (PotionEffect.find("slowness") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 10;
-					}
-					else if (PotionEffect.find("leaping") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 11;
-					}
-					else if (PotionEffect.find("harming") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 12;
-					}
-					else if (PotionEffect.find("water_breathing") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 13;
-					}
-					else if (PotionEffect.find("invisibility") != AString::npos)
-					{
-						a_Item.m_ItemDamage = 14;
-					}
-					else
-					{
-						// Note: luck potions are not handled and will reach this location
-						LOGD("Unknown potion type for effect name %s!", PotionEffect.c_str());
-						continue;
-					}
-
-					if (PotionEffect.find("strong") != AString::npos)
-					{
-						a_Item.m_ItemDamage |= 0x20;
-					}
-					if (PotionEffect.find("long") != AString::npos)
-					{
-						a_Item.m_ItemDamage |= 0x40;
-					}
-
-					// Ugly special case with the changed splash potion ID in 1.9
-					if ((a_Item.m_ItemType == 438) || (a_Item.m_ItemType == 441))
-					{
-						// Splash or lingering potions - change the ID to the normal one and mark as splash potions
-						a_Item.m_ItemType = E_ITEM_POTION;
-						a_Item.m_ItemDamage |= 0x4000;  // Is splash potion
-					}
-					else
-					{
-						a_Item.m_ItemDamage |= 0x2000;  // Is drinkable
-					}
-				}
-				break;
 			}
 			default: LOGD("Unimplemented NBT data when parsing!"); break;
 		}
@@ -3133,7 +2908,7 @@ void cProtocol190::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 
 
 
-void cProtocol190::StartEncryption(const Byte * a_Key)
+void cProtocol_1_8_0::StartEncryption(const Byte * a_Key)
 {
 	m_Encryptor.Init(a_Key, a_Key);
 	m_Decryptor.Init(a_Key, a_Key);
@@ -3155,7 +2930,7 @@ void cProtocol190::StartEncryption(const Byte * a_Key)
 
 
 
-eBlockFace cProtocol190::FaceIntToBlockFace(Int32 a_BlockFace)
+eBlockFace cProtocol_1_8_0::FaceIntToBlockFace(Int8 a_BlockFace)
 {
 	// Normalize the blockface values returned from the protocol
 	// Anything known gets mapped 1:1, everything else returns BLOCK_FACE_NONE
@@ -3176,9 +2951,9 @@ eBlockFace cProtocol190::FaceIntToBlockFace(Int32 a_BlockFace)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// cProtocol190::cPacketizer:
+// cProtocol_1_8_0::cPacketizer:
 
-void cProtocol190::SendPacket(cPacketizer & a_Pkt)
+void cProtocol_1_8_0::SendPacket(cPacketizer & a_Pkt)
 {
 	UInt32 PacketLen = static_cast<UInt32>(m_OutPacketBuffer.GetUsedSpace());
 	AString PacketData, CompressedPacket;
@@ -3188,7 +2963,7 @@ void cProtocol190::SendPacket(cPacketizer & a_Pkt)
 	if ((m_State == 3) && (PacketLen >= 256))
 	{
 		// Compress the packet payload:
-		if (!cProtocol190::CompressPacket(PacketData, CompressedPacket))
+		if (!cProtocol_1_8_0::CompressPacket(PacketData, CompressedPacket))
 		{
 			return;
 		}
@@ -3238,7 +3013,7 @@ void cProtocol190::SendPacket(cPacketizer & a_Pkt)
 
 
 
-void cProtocol190::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
+void cProtocol_1_8_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 {
 	short ItemType = a_Item.m_ItemType;
 	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime
@@ -3254,28 +3029,11 @@ void cProtocol190::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 		return;
 	}
 
-	if ((ItemType == E_ITEM_POTION) && ((a_Item.m_ItemDamage & 0x4000) != 0))
-	{
-		// Ugly special case for splash potion ids which changed in 1.9; this can be removed when the new 1.9 ids are implemented
-		a_Pkt.WriteBEInt16(438);  // minecraft:splash_potion
-	}
-	else
-	{
-		// Normal item
-		a_Pkt.WriteBEInt16(ItemType);
-	}
+	a_Pkt.WriteBEInt16(ItemType);
 	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
-	if ((ItemType == E_ITEM_POTION) || (ItemType == E_ITEM_SPAWN_EGG))
-	{
-		// These items lost their metadata; if it is sent they don't render correctly.
-		a_Pkt.WriteBEInt16(0);
-	}
-	else
-	{
-		a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
-	}
+	a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
 
-	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (ItemType != E_ITEM_FIREWORK_ROCKET) && (ItemType != E_ITEM_FIREWORK_STAR) && !a_Item.m_ItemColor.IsValid() && (ItemType != E_ITEM_POTION) && (ItemType != E_ITEM_SPAWN_EGG))
+	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) && (a_Item.m_ItemType != E_ITEM_FIREWORK_STAR) && !a_Item.m_ItemColor.IsValid())
 	{
 		a_Pkt.WriteBEInt8(0);
 		return;
@@ -3328,76 +3086,6 @@ void cProtocol190::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 	{
 		cFireworkItem::WriteToNBTCompound(a_Item.m_FireworkItem, Writer, static_cast<ENUM_ITEM_ID>(a_Item.m_ItemType));
 	}
-	if (a_Item.m_ItemType == E_ITEM_POTION)
-	{
-		// 1.9 potions use a different format.  In the future (when only 1.9+ is supported) this should be its own class
-		AString PotionID = "empty";  // Fallback of "Uncraftable potion" for unhandled cases
-
-		cEntityEffect::eType Type = cEntityEffect::GetPotionEffectType(a_Item.m_ItemDamage);
-		if (Type != cEntityEffect::effNoEffect)
-		{
-			switch (Type)
-			{
-				case cEntityEffect::effRegeneration: PotionID = "regeneration"; break;
-				case cEntityEffect::effSpeed: PotionID = "swiftness"; break;
-				case cEntityEffect::effFireResistance: PotionID = "fire_resistance"; break;
-				case cEntityEffect::effPoison: PotionID = "poison"; break;
-				case cEntityEffect::effInstantHealth: PotionID = "healing"; break;
-				case cEntityEffect::effNightVision: PotionID = "night_vision"; break;
-				case cEntityEffect::effWeakness: PotionID = "weakness"; break;
-				case cEntityEffect::effStrength: PotionID = "strength"; break;
-				case cEntityEffect::effSlowness: PotionID = "slowness"; break;
-				case cEntityEffect::effJumpBoost: PotionID = "leaping"; break;
-				case cEntityEffect::effInstantDamage: PotionID = "harming"; break;
-				case cEntityEffect::effWaterBreathing: PotionID = "water_breathing"; break;
-				case cEntityEffect::effInvisibility: PotionID = "invisibility"; break;
-			}
-			if (cEntityEffect::GetPotionEffectIntensity(a_Item.m_ItemDamage) == 1)
-			{
-				PotionID = "strong_" + PotionID;
-			}
-			else if (a_Item.m_ItemDamage & 0x40)
-			{
-				// Extended potion bit
-				PotionID = "long_" + PotionID;
-			}
-		}
-		else
-		{
-			// Empty potions: Water bottles and other base ones
-			if (a_Item.m_ItemDamage == 0)
-			{
-				// No other bits set; thus it's a water bottle
-				PotionID = "water";
-			}
-			else
-			{
-				switch (a_Item.m_ItemDamage & 0x3f)
-				{
-					case 0x00: PotionID = "mundane"; break;
-					case 0x10: PotionID = "awkward"; break;
-					case 0x20: PotionID = "thick"; break;
-				}
-				// Default cases will use "empty" from before.
-			}
-		}
-
-		PotionID = "minecraft:" + PotionID;
-
-		Writer.AddString("Potion", PotionID.c_str());
-	}
-	if (a_Item.m_ItemType == E_ITEM_SPAWN_EGG)
-	{
-		// Convert entity ID to the name.
-		eMonsterType MonsterType = cItemSpawnEggHandler::ItemDamageToMonsterType(a_Item.m_ItemDamage);
-		if (MonsterType != eMonsterType::mtInvalidType)
-		{
-			Writer.BeginCompound("EntityTag");
-			Writer.AddString("id", cMonster::MobTypeToVanillaName(MonsterType));
-			Writer.EndCompound();
-		}
-	}
-
 	Writer.Finish();
 
 	AString Result = Writer.GetResult();
@@ -3413,7 +3101,7 @@ void cProtocol190::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 
 
 
-void cProtocol190::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity)
+void cProtocol_1_8_0::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity)
 {
 	cFastNBTWriter Writer;
 
@@ -3517,10 +3205,10 @@ void cProtocol190::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_
 
 
 
-void cProtocol190::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_8_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
 {
 	// Common metadata:
-	Int8 Flags = 0;
+	Byte Flags = 0;
 	if (a_Entity.IsOnFire())
 	{
 		Flags |= 0x01;
@@ -3541,53 +3229,35 @@ void cProtocol190::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 	{
 		Flags |= 0x20;
 	}
-	a_Pkt.WriteBEUInt8(0);  // Index 0
-	a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);  // Type
-	a_Pkt.WriteBEInt8(Flags);
+	a_Pkt.WriteBEUInt8(0);  // Byte(0) + index 0
+	a_Pkt.WriteBEUInt8(Flags);
 
 	switch (a_Entity.GetEntityType())
 	{
-		case cEntity::etPlayer:
-		{
-			auto & Player = reinterpret_cast<const cPlayer &>(a_Entity);
-
-			// TODO Set player custom name to their name.
-			// Then it's possible to move the custom name of mobs to the entities
-			// and to remove the "special" player custom name.
-			a_Pkt.WriteBEUInt8(2);  // Index 2: Custom name
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_STRING);
-			a_Pkt.WriteString(Player.GetName());
-
-			a_Pkt.WriteBEUInt8(6);  // Start metadata - Index 6: Health
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
-			a_Pkt.WriteBEFloat(static_cast<float>(Player.GetHealth()));
-			break;
-		}
+		case cEntity::etPlayer: break;  // TODO?
 		case cEntity::etPickup:
 		{
-			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+			a_Pkt.WriteBEUInt8((5 << 5) | 10);  // Slot(5) + index 10
 			WriteItem(a_Pkt, reinterpret_cast<const cPickup &>(a_Entity).GetItem());
 			break;
 		}
 		case cEntity::etMinecart:
 		{
-			a_Pkt.WriteBEUInt8(5);  // Index 5: Shaking power
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteBEUInt8(0x51);
 
 			// The following expression makes Minecarts shake more with less health or higher damage taken
+			// It gets half the maximum health, and takes it away from the current health minus the half health:
+			/*
+			Health: 5 | 3 - (5 - 3) = 1 (shake power)
+			Health: 3 | 3 - (3 - 3) = 3
+			Health: 1 | 3 - (1 - 3) = 5
+			*/
 			auto & Minecart = reinterpret_cast<const cMinecart &>(a_Entity);
-			auto maxHealth = a_Entity.GetMaxHealth();
-			auto curHealth = a_Entity.GetHealth();
-			a_Pkt.WriteVarInt32(static_cast<UInt32>((maxHealth - curHealth) * Minecart.LastDamage() * 4));
-
-			a_Pkt.WriteBEUInt8(6);  // Index 6: Shaking direction (doesn't seem to effect anything)
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(1);
-
-			a_Pkt.WriteBEUInt8(7);  // Index 7: Shake multiplier / damage taken
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
-			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));
+			a_Pkt.WriteBEInt32((((a_Entity.GetMaxHealth() / 2) - (a_Entity.GetHealth() - (a_Entity.GetMaxHealth() / 2))) * Minecart.LastDamage()) * 4);
+			a_Pkt.WriteBEUInt8(0x52);
+			a_Pkt.WriteBEInt32(1);  // Shaking direction, doesn't seem to affect anything
+			a_Pkt.WriteBEUInt8(0x73);
+			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));  // Damage taken / shake effect multiplyer
 
 			if (Minecart.GetPayload() == cMinecart::mpNone)
 			{
@@ -3595,26 +3265,20 @@ void cProtocol190::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 				const cItem & MinecartContent = RideableMinecart.GetContent();
 				if (!MinecartContent.IsEmpty())
 				{
-					a_Pkt.WriteBEUInt8(8);  // Index 8: Block ID and damage
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+					a_Pkt.WriteBEUInt8(0x54);
 					int Content = MinecartContent.m_ItemType;
 					Content |= MinecartContent.m_ItemDamage << 8;
-					a_Pkt.WriteVarInt32(static_cast<UInt32>(Content));
-
-					a_Pkt.WriteBEUInt8(9);  // Index 9: Block ID and damage
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-					a_Pkt.WriteVarInt32(static_cast<UInt32>(RideableMinecart.GetBlockHeight()));
-
-					a_Pkt.WriteBEUInt8(10);  // Index 10: Show block
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-					a_Pkt.WriteBool(true);
+					a_Pkt.WriteBEInt32(Content);
+					a_Pkt.WriteBEUInt8(0x55);
+					a_Pkt.WriteBEInt32(RideableMinecart.GetBlockHeight());
+					a_Pkt.WriteBEUInt8(0x56);
+					a_Pkt.WriteBEUInt8(1);
 				}
 			}
 			else if (Minecart.GetPayload() == cMinecart::mpFurnace)
 			{
-				a_Pkt.WriteBEUInt8(11);  // Index 11: Is powered
-				a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-				a_Pkt.WriteBool(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled());
+				a_Pkt.WriteBEUInt8(0x10);
+				a_Pkt.WriteBEUInt8(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled() ? 1 : 0);
 			}
 			break;
 		}  // case etMinecart
@@ -3626,23 +3290,15 @@ void cProtocol190::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			{
 				case cProjectileEntity::pkArrow:
 				{
-					a_Pkt.WriteBEUInt8(5);  // Index 5: Is critical
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-					a_Pkt.WriteBEInt8(reinterpret_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
+					a_Pkt.WriteBEUInt8(0x10);
+					a_Pkt.WriteBEUInt8(reinterpret_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
 					break;
 				}
 				case cProjectileEntity::pkFirework:
 				{
-					a_Pkt.WriteBEUInt8(5);  // Index 5: Firework item used for this firework
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+					a_Pkt.WriteBEUInt8(0xa8);
 					WriteItem(a_Pkt, reinterpret_cast<const cFireworkEntity &>(Projectile).GetItem());
 					break;
-				}
-				case cProjectileEntity::pkSplashPotion:
-				{
-					a_Pkt.WriteBEUInt8(5);  // Index 5: Potion item which was thrown
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
-					WriteItem(a_Pkt, reinterpret_cast<const cSplashPotionEntity &>(Projectile).GetItem());
 				}
 				default:
 				{
@@ -3658,46 +3314,13 @@ void cProtocol190::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			break;
 		}
 
-		case cEntity::etBoat:
-		{
-			auto & Boat = reinterpret_cast<const cBoat &>(a_Entity);
-
-			a_Pkt.WriteBEInt8(5);  // Index 6: Time since last hit
-			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetLastDamage());
-
-			a_Pkt.WriteBEInt8(6);  // Index 7: Forward direction
-			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetForwardDirection());
-
-			a_Pkt.WriteBEInt8(7);  // Index 8: Damage taken
-			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
-			a_Pkt.WriteBEFloat(Boat.GetDamageTaken());
-
-			a_Pkt.WriteBEInt8(8);  // Index 9: Type
-			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetType());
-
-			a_Pkt.WriteBEInt8(9);  // Index 10: Right paddle turning
-			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Boat.IsRightPaddleUsed());
-
-			a_Pkt.WriteBEInt8(10);  // Index 11: Left paddle turning
-			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Boat.IsLeftPaddleUsed());
-
-			break;
-		}  // case etBoat
-
 		case cEntity::etItemFrame:
 		{
 			auto & Frame = reinterpret_cast<const cItemFrame &>(a_Entity);
-			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+			a_Pkt.WriteBEUInt8(0xa8);
 			WriteItem(a_Pkt, Frame.GetItem());
-			a_Pkt.WriteBEUInt8(6);  // Index 6: Rotation
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Frame.GetItemRotation());
+			a_Pkt.WriteBEUInt8(0x09);
+			a_Pkt.WriteBEUInt8(Frame.GetItemRotation());
 			break;
 		}  // case etItemFrame
 
@@ -3712,23 +3335,19 @@ void cProtocol190::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 
 
 
-void cProtocol190::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_8_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 {
 	// Living Enitiy Metadata
 	if (a_Mob.HasCustomName())
 	{
-		// TODO: As of 1.9 _all_ entities can have custom names; should this be moved up?
-		a_Pkt.WriteBEUInt8(2);  // Index 2: Custom name
-		a_Pkt.WriteBEUInt8(METADATA_TYPE_STRING);
+		a_Pkt.WriteBEUInt8(0x82);
 		a_Pkt.WriteString(a_Mob.GetCustomName());
 
-		a_Pkt.WriteBEUInt8(3);  // Index 3: Custom name always visible
-		a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+		a_Pkt.WriteBEUInt8(0x03);
 		a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());
 	}
 
-	a_Pkt.WriteBEUInt8(6);  // Index 6: Health
-	a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
+	a_Pkt.WriteBEUInt8(0x66);
 	a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
 
 	switch (a_Mob.GetMobType())
@@ -3736,58 +3355,45 @@ void cProtocol190::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 		case mtBat:
 		{
 			auto & Bat = reinterpret_cast<const cBat &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Bat flags - currently only hanging
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEInt8(Bat.IsHanging() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Bat.IsHanging() ? 1 : 0);
 			break;
 		}  // case mtBat
 
 		case mtCreeper:
 		{
 			auto & Creeper = reinterpret_cast<const cCreeper &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: State (idle or "blowing")
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Creeper.IsBlowing() ? 1 : 0xffffffff);
-
-			a_Pkt.WriteBEUInt8(12);  // Index 12: Is charged
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Creeper.IsCharged());
-
-			a_Pkt.WriteBEUInt8(13);  // Index 13: Is ignited
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Creeper.IsBurnedWithFlintAndSteel());
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Creeper.IsBlowing() ? 1 : 255);
+			a_Pkt.WriteBEUInt8(0x11);
+			a_Pkt.WriteBEUInt8(Creeper.IsCharged() ? 1 : 0);
 			break;
 		}  // case mtCreeper
 
 		case mtEnderman:
 		{
 			auto & Enderman = reinterpret_cast<const cEnderman &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Carried block
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BLOCKID);
-			UInt32 Carried = 0;
-			Carried |= static_cast<UInt32>(Enderman.GetCarriedBlock() << 4);
-			Carried |= Enderman.GetCarriedMeta();
-			a_Pkt.WriteVarInt32(Carried);
-
-			a_Pkt.WriteBEUInt8(12);  // Index 12: Is screaming
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Enderman.IsScreaming());
+			a_Pkt.WriteBEUInt8(0x30);
+			a_Pkt.WriteBEInt16(static_cast<Byte>(Enderman.GetCarriedBlock()));
+			a_Pkt.WriteBEUInt8(0x11);
+			a_Pkt.WriteBEUInt8(static_cast<Byte>(Enderman.GetCarriedMeta()));
+			a_Pkt.WriteBEUInt8(0x12);
+			a_Pkt.WriteBEUInt8(Enderman.IsScreaming() ? 1 : 0);
 			break;
 		}  // case mtEnderman
 
 		case mtGhast:
 		{
 			auto & Ghast = reinterpret_cast<const cGhast &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Is attacking
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Ghast.IsCharging());
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Ghast.IsCharging());
 			break;
 		}  // case mtGhast
 
 		case mtHorse:
 		{
 			auto & Horse = reinterpret_cast<const cHorse &>(a_Mob);
-			Int8 Flags = 0;
+			int Flags = 0;
 			if (Horse.IsTame())
 			{
 				Flags |= 0x02;
@@ -3812,177 +3418,139 @@ void cProtocol190::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				Flags |= 0x80;
 			}
-			a_Pkt.WriteBEUInt8(12);  // Index 12: flags
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEInt8(Flags);
-
-			a_Pkt.WriteBEUInt8(13);  // Index 13: Variant / type
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Horse.GetHorseType()));
-
-			a_Pkt.WriteBEUInt8(14);  // Index 14: Color / style
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteBEUInt8(0x50);  // Int at index 16
+			a_Pkt.WriteBEInt32(Flags);
+			a_Pkt.WriteBEUInt8(0x13);  // Byte at index 19
+			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Horse.GetHorseType()));
+			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
 			int Appearance = 0;
 			Appearance = Horse.GetHorseColor();
 			Appearance |= Horse.GetHorseStyle() << 8;
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Appearance));
-
-			a_Pkt.WriteBEUInt8(16);  // Index 16: Armor
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Horse.GetHorseArmour()));
-
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Horse.IsBaby());
+			a_Pkt.WriteBEInt32(Appearance);
+			a_Pkt.WriteBEUInt8(0x56);  // Int at index 22
+			a_Pkt.WriteBEInt32(Horse.GetHorseArmour());
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Horse.IsBaby() ? -1 : (Horse.IsInLoveCooldown() ? 1 : 0));
 			break;
 		}  // case mtHorse
 
 		case mtMagmaCube:
 		{
 			auto & MagmaCube = reinterpret_cast<const cMagmaCube &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Size
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(MagmaCube.GetSize()));
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(static_cast<UInt8>(MagmaCube.GetSize()));
 			break;
 		}  // case mtMagmaCube
 
 		case mtOcelot:
 		{
 			auto & Ocelot = reinterpret_cast<const cOcelot &>(a_Mob);
-
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Ocelot.IsBaby());
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Ocelot.IsBaby() ? -1 : (Ocelot.IsInLoveCooldown() ? 1 : 0));
 			break;
 		}  // case mtOcelot
 
 		case mtCow:
 		{
 			auto & Cow = reinterpret_cast<const cCow &>(a_Mob);
-
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Cow.IsBaby());
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Cow.IsBaby() ? -1 : (Cow.IsInLoveCooldown() ? 1 : 0));
 			break;
 		}  // case mtCow
 
 		case mtChicken:
 		{
 			auto & Chicken = reinterpret_cast<const cChicken &>(a_Mob);
-
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Chicken.IsBaby());
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Chicken.IsBaby() ? -1 : (Chicken.IsInLoveCooldown() ? 1 : 0));
 			break;
 		}  // case mtChicken
 
 		case mtPig:
 		{
 			auto & Pig = reinterpret_cast<const cPig &>(a_Mob);
-
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Pig.IsBaby());
-
-			a_Pkt.WriteBEUInt8(12);  // Index 12: Is saddled
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Pig.IsSaddled());
-
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Pig.IsBaby() ? -1 : (Pig.IsInLoveCooldown() ? 1 : 0));
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Pig.IsSaddled() ? 1 : 0);
 			break;
 		}  // case mtPig
 
 		case mtSheep:
 		{
 			auto & Sheep = reinterpret_cast<const cSheep &>(a_Mob);
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Sheep.IsBaby() ? -1 : (Sheep.IsInLoveCooldown() ? 1 : 0));
 
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Sheep.IsBaby());
-
-			a_Pkt.WriteBEUInt8(12);  // Index 12: sheared, color
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			Int8 SheepMetadata = 0;
-			SheepMetadata = static_cast<Int8>(Sheep.GetFurColor());
+			a_Pkt.WriteBEUInt8(0x10);
+			Byte SheepMetadata = 0;
+			SheepMetadata = static_cast<Byte>(Sheep.GetFurColor());
 			if (Sheep.IsSheared())
 			{
 				SheepMetadata |= 0x10;
 			}
-			a_Pkt.WriteBEInt8(SheepMetadata);
+			a_Pkt.WriteBEUInt8(SheepMetadata);
 			break;
 		}  // case mtSheep
 
 		case mtRabbit:
 		{
 			auto & Rabbit = reinterpret_cast<const cRabbit &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Rabbit.IsBaby());
-
-			a_Pkt.WriteBEUInt8(12);  // Index 12: Type
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Rabbit.GetRabbitType()));
+			a_Pkt.WriteBEUInt8(0x12);
+			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Rabbit.GetRabbitType()));
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Rabbit.IsBaby() ? -1 : (Rabbit.IsInLoveCooldown() ? 1 : 0));
 			break;
 		}  // case mtRabbit
 
 		case mtSkeleton:
 		{
 			auto & Skeleton = reinterpret_cast<const cSkeleton &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Type
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Skeleton.IsWither() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0d);
+			a_Pkt.WriteBEUInt8(Skeleton.IsWither() ? 1 : 0);
 			break;
 		}  // case mtSkeleton
 
 		case mtSlime:
 		{
 			auto & Slime = reinterpret_cast<const cSlime &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Size
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Slime.GetSize()));
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Slime.GetSize()));
 			break;
 		}  // case mtSlime
 
 		case mtVillager:
 		{
 			auto & Villager = reinterpret_cast<const cVillager &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Villager.IsBaby());
-
-			a_Pkt.WriteBEUInt8(12);  // Index 12: Type
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Villager.GetVilType()));
+			a_Pkt.WriteBEUInt8(0x50);
+			a_Pkt.WriteBEInt32(Villager.GetVilType());
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Villager.IsBaby() ? -1 : 0);
 			break;
 		}  // case mtVillager
 
 		case mtWitch:
 		{
 			auto & Witch = reinterpret_cast<const cWitch &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is angry
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Witch.IsAngry());
+			a_Pkt.WriteBEUInt8(0x15);
+			a_Pkt.WriteBEUInt8(Witch.IsAngry() ? 1 : 0);
 			break;
 		}  // case mtWitch
 
 		case mtWither:
 		{
 			auto & Wither = reinterpret_cast<const cWither &>(a_Mob);
-			a_Pkt.WriteBEUInt8(14);  // Index 14: Invulnerable ticks
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Wither.GetWitherInvulnerableTicks());
-
-			// TODO: Use boss bar packet for health
+			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
+			a_Pkt.WriteBEInt32(static_cast<Int32>(Wither.GetWitherInvulnerableTicks()));
+			a_Pkt.WriteBEUInt8(0x66);  // Float at index 6
+			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
 			break;
 		}  // case mtWither
 
 		case mtWolf:
 		{
 			auto & Wolf = reinterpret_cast<const cWolf &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Wolf.IsBaby());
-
-			Int8 WolfStatus = 0;
+			Byte WolfStatus = 0;
 			if (Wolf.IsSitting())
 			{
 				WolfStatus |= 0x1;
@@ -3995,47 +3563,37 @@ void cProtocol190::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				WolfStatus |= 0x4;
 			}
-			a_Pkt.WriteBEUInt8(12);  // Index 12: status
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEInt8(WolfStatus);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(WolfStatus);
 
-			a_Pkt.WriteBEUInt8(14);  // Index 14: Health
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
+			a_Pkt.WriteBEUInt8(0x72);
 			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
-
-			a_Pkt.WriteBEUInt8(15);  // Index 15: Is begging
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Wolf.IsBegging());
-
-			a_Pkt.WriteBEUInt8(16);  // Index 16: Collar color
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Wolf.GetCollarColor()));
+			a_Pkt.WriteBEUInt8(0x13);
+			a_Pkt.WriteBEUInt8(Wolf.IsBegging() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x14);
+			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Wolf.GetCollarColor()));
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Wolf.IsBaby() ? -1 : 0);
 			break;
 		}  // case mtWolf
 
 		case mtZombie:
 		{
 			auto & Zombie = reinterpret_cast<const cZombie &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Zombie.IsBaby());
-
-			a_Pkt.WriteBEUInt8(12);  // Index 12: Is a villager
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Zombie.IsVillagerZombie() ? 1 : 0);  // TODO: This actually encodes the zombie villager profession, but that isn't implemented yet.
-
-			a_Pkt.WriteBEUInt8(13);  // Index 13: Is converting
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Zombie.IsConverting());
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(Zombie.IsBaby() ? 1 : -1);
+			a_Pkt.WriteBEUInt8(0x0d);
+			a_Pkt.WriteBEUInt8(Zombie.IsVillagerZombie() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0e);
+			a_Pkt.WriteBEUInt8(Zombie.IsConverting() ? 1 : 0);
 			break;
 		}  // case mtZombie
 
 		case mtZombiePigman:
 		{
 			auto & ZombiePigman = reinterpret_cast<const cZombiePigman &>(a_Mob);
-			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(ZombiePigman.IsBaby());
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEInt8(ZombiePigman.IsBaby() ? 1 : -1);
 			break;
 		}  // case mtZombiePigman
 	}  // switch (a_Mob.GetType())
@@ -4045,7 +3603,7 @@ void cProtocol190::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 
 
 
-void cProtocol190::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_8_0::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity)
 {
 	if (!a_Entity.IsMob())
 	{
@@ -4063,349 +3621,3 @@ void cProtocol190::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_
 
 
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-// cProtocol191:
-
-cProtocol191::cProtocol191(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
-	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
-{
-}
-
-
-
-
-
-void cProtocol191::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
-{
-	// Send the Join Game packet:
-	{
-		cServer * Server = cRoot::Get()->GetServer();
-		cPacketizer Pkt(*this, 0x23);  // Join Game packet
-		Pkt.WriteBEUInt32(a_Player.GetUniqueID());
-		Pkt.WriteBEUInt8(static_cast<UInt8>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
-		Pkt.WriteBEInt32(static_cast<Int32>(a_World.GetDimension()));
-		Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
-		Pkt.WriteBEUInt8(static_cast<UInt8>(Clamp<int>(Server->GetMaxPlayers(), 0, 255)));
-		Pkt.WriteString("default");  // Level type - wtf?
-		Pkt.WriteBool(false);  // Reduced Debug Info - wtf?
-	}
-
-	// Send the spawn position:
-	{
-		cPacketizer Pkt(*this, 0x43);  // Spawn Position packet
-		Pkt.WritePosition64(FloorC(a_World.GetSpawnX()), FloorC(a_World.GetSpawnY()), FloorC(a_World.GetSpawnZ()));
-	}
-
-	// Send the server difficulty:
-	{
-		cPacketizer Pkt(*this, 0x0d);  // Server difficulty packet
-		Pkt.WriteBEInt8(1);
-	}
-
-	// Send player abilities:
-	SendPlayerAbilities();
-}
-
-
-
-
-
-void cProtocol191::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
-{
-	cServer * Server = cRoot::Get()->GetServer();
-	AString ServerDescription = Server->GetDescription();
-	int NumPlayers = Server->GetNumPlayers();
-	int MaxPlayers = Server->GetMaxPlayers();
-	AString Favicon = Server->GetFaviconData();
-	cRoot::Get()->GetPluginManager()->CallHookServerPing(*m_Client, ServerDescription, NumPlayers, MaxPlayers, Favicon);
-
-	// Version:
-	Json::Value Version;
-	Version["name"] = "Cuberite 1.9.1";
-	Version["protocol"] = 108;
-
-	// Players:
-	Json::Value Players;
-	Players["online"] = NumPlayers;
-	Players["max"] = MaxPlayers;
-	// TODO: Add "sample"
-
-	// Description:
-	Json::Value Description;
-	Description["text"] = ServerDescription.c_str();
-
-	// Create the response:
-	Json::Value ResponseValue;
-	ResponseValue["version"] = Version;
-	ResponseValue["players"] = Players;
-	ResponseValue["description"] = Description;
-	if (!Favicon.empty())
-	{
-		ResponseValue["favicon"] = Printf("data:image/png;base64,%s", Favicon.c_str());
-	}
-
-	Json::StyledWriter Writer;
-	AString Response = Writer.write(ResponseValue);
-
-	cPacketizer Pkt(*this, 0x00);  // Response packet
-	Pkt.WriteString(Response);
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// cProtocol192:
-
-cProtocol192::cProtocol192(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
-	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
-{
-}
-
-
-
-
-
-void cProtocol192::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
-{
-	cServer * Server = cRoot::Get()->GetServer();
-	AString ServerDescription = Server->GetDescription();
-	int NumPlayers = Server->GetNumPlayers();
-	int MaxPlayers = Server->GetMaxPlayers();
-	AString Favicon = Server->GetFaviconData();
-	cRoot::Get()->GetPluginManager()->CallHookServerPing(*m_Client, ServerDescription, NumPlayers, MaxPlayers, Favicon);
-
-	// Version:
-	Json::Value Version;
-	Version["name"] = "Cuberite 1.9.2";
-	Version["protocol"] = 109;
-
-	// Players:
-	Json::Value Players;
-	Players["online"] = NumPlayers;
-	Players["max"] = MaxPlayers;
-	// TODO: Add "sample"
-
-	// Description:
-	Json::Value Description;
-	Description["text"] = ServerDescription.c_str();
-
-	// Create the response:
-	Json::Value ResponseValue;
-	ResponseValue["version"] = Version;
-	ResponseValue["players"] = Players;
-	ResponseValue["description"] = Description;
-	if (!Favicon.empty())
-	{
-		ResponseValue["favicon"] = Printf("data:image/png;base64,%s", Favicon.c_str());
-	}
-
-	Json::StyledWriter Writer;
-	AString Response = Writer.write(ResponseValue);
-
-	cPacketizer Pkt(*this, 0x00);  // Response packet
-	Pkt.WriteString(Response);
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// cProtocol194:
-
-cProtocol194::cProtocol194(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
-	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
-{
-}
-
-
-
-
-
-void cProtocol194::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
-{
-	cServer * Server = cRoot::Get()->GetServer();
-	AString ServerDescription = Server->GetDescription();
-	int NumPlayers = Server->GetNumPlayers();
-	int MaxPlayers = Server->GetMaxPlayers();
-	AString Favicon = Server->GetFaviconData();
-	cRoot::Get()->GetPluginManager()->CallHookServerPing(*m_Client, ServerDescription, NumPlayers, MaxPlayers, Favicon);
-
-	// Version:
-	Json::Value Version;
-	Version["name"] = "Cuberite 1.9.4";
-	Version["protocol"] = 110;
-
-	// Players:
-	Json::Value Players;
-	Players["online"] = NumPlayers;
-	Players["max"] = MaxPlayers;
-	// TODO: Add "sample"
-
-	// Description:
-	Json::Value Description;
-	Description["text"] = ServerDescription.c_str();
-
-	// Create the response:
-	Json::Value ResponseValue;
-	ResponseValue["version"] = Version;
-	ResponseValue["players"] = Players;
-	ResponseValue["description"] = Description;
-	if (!Favicon.empty())
-	{
-		ResponseValue["favicon"] = Printf("data:image/png;base64,%s", Favicon.c_str());
-	}
-
-	Json::StyledWriter Writer;
-	AString Response = Writer.write(ResponseValue);
-
-	cPacketizer Pkt(*this, 0x00);  // Response packet
-	Pkt.WriteString(Response);
-}
-
-
-
-
-
-void cProtocol194::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, 0x48);  // Collect Item packet
-	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteVarInt32(a_Player.GetUniqueID());
-}
-
-
-
-
-
-void cProtocol194::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	// Serialize first, before creating the Packetizer (the packetizer locks a CS)
-	// This contains the flags and bitmasks, too
-	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_4, a_ChunkX, a_ChunkZ);
-
-	cCSLock Lock(m_CSPacket);
-	SendData(ChunkData.data(), ChunkData.size());
-}
-
-
-
-
-
-void cProtocol194::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, 0x4b);  // Entity Effect packet
-	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEUInt8(static_cast<UInt8>(a_EffectID));
-	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Amplifier));
-	Pkt.WriteVarInt32(static_cast<UInt32>(a_Duration));
-	Pkt.WriteBool(false);  // Hide particles
-}
-
-
-
-
-
-void cProtocol194::SendEntityProperties(const cEntity & a_Entity)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-
-	cPacketizer Pkt(*this, 0x4a);  // Entity Properties packet
-	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	WriteEntityProperties(Pkt, a_Entity);
-}
-
-
-
-
-
-void cProtocol194::SendPlayerMaxSpeed(void)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, 0x4a);  // Entity Properties
-	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteVarInt32(Player->GetUniqueID());
-	Pkt.WriteBEInt32(1);  // Count
-	Pkt.WriteString("generic.movementSpeed");
-	// The default game speed is 0.1, multiply that value by the relative speed:
-	Pkt.WriteBEDouble(0.1 * Player->GetNormalMaxSpeed());
-	if (Player->IsSprinting())
-	{
-		Pkt.WriteVarInt32(1);  // Modifier count
-		Pkt.WriteBEUInt64(0x662a6b8dda3e4c1c);
-		Pkt.WriteBEUInt64(0x881396ea6097278d);  // UUID of the modifier
-		Pkt.WriteBEDouble(Player->GetSprintingMaxSpeed() - Player->GetNormalMaxSpeed());
-		Pkt.WriteBEUInt8(2);
-	}
-	else
-	{
-		Pkt.WriteVarInt32(0);  // Modifier count
-	}
-}
-
-
-
-
-
-void cProtocol194::SendTeleportEntity(const cEntity & a_Entity)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, 0x49);  // Entity teleport packet
-	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEDouble(a_Entity.GetPosX());
-	Pkt.WriteBEDouble(a_Entity.GetPosY());
-	Pkt.WriteBEDouble(a_Entity.GetPosZ());
-	Pkt.WriteByteAngle(a_Entity.GetYaw());
-	Pkt.WriteByteAngle(a_Entity.GetPitch());
-	Pkt.WriteBool(a_Entity.IsOnGround());
-}
-
-
-
-
-
-void cProtocol194::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	// 1.9.4 removed the update sign packet and now uses Update Block Entity
-	cPacketizer Pkt(*this, 0x09);  // Update tile entity packet
-	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
-	Pkt.WriteBEUInt8(9);  // Action 9 - update sign
-
-	cFastNBTWriter Writer;
-	Writer.AddInt("x",        a_BlockX);
-	Writer.AddInt("y",        a_BlockY);
-	Writer.AddInt("z",        a_BlockZ);
-	Writer.AddString("id", "Sign");
-
-	Json::StyledWriter JsonWriter;
-	Json::Value Line1;
-	Line1["text"] = a_Line1;
-	Writer.AddString("Text1", JsonWriter.write(Line1));
-	Json::Value Line2;
-	Line2["text"] = a_Line2;
-	Writer.AddString("Text2", JsonWriter.write(Line2));
-	Json::Value Line3;
-	Line3["text"] = a_Line3;
-	Writer.AddString("Text3", JsonWriter.write(Line3));
-	Json::Value Line4;
-	Line4["text"] = a_Line4;
-	Writer.AddString("Text4", JsonWriter.write(Line4));
-
-	Writer.Finish();
-	Pkt.WriteBuf(Writer.GetResult().data(), Writer.GetResult().size());
-}

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -1,17 +1,10 @@
 
-// Protocol19x.h
+// Protocol_1_8.h
 
 /*
-Declares the 1.9.x protocol classes:
-	- cProtocol190
-		- release 1.9.0 protocol (#107)
-	- cProtocol191
-		- release 1.9.1 protocol (#108)
-	- cProtocol192
-		- release 1.9.2 protocol (#109)
-	- cProtocol194
-		- release 1.9.4 protocol (#110)
-(others may be added later in the future for the 1.9 release series)
+Declares the 1.8 protocol classes:
+	- cProtocol_1_8_0
+		- release 1.8 protocol (#47)
 */
 
 
@@ -53,14 +46,14 @@ namespace Json
 
 
 
-class cProtocol190 :
+class cProtocol_1_8_0 :
 	public cProtocol
 {
 	typedef cProtocol super;
 
 public:
 
-	cProtocol190(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
+	cProtocol_1_8_0(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
 	/** Called when client sends some data: */
 	virtual void DataReceived(const char * a_Data, size_t a_Size) override;
@@ -76,7 +69,7 @@ public:
 	virtual void SendChat                       (const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes) override;
 	virtual void SendChatRaw                    (const AString & a_MessageRaw, eChatType a_Type) override;
 	virtual void SendChunkData                  (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer) override;
-	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player) override;
+	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player, int a_Count) override;
 	virtual void SendDestroyEntity              (const cEntity & a_Entity) override;
 	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
 	virtual void SendDisconnect                 (const AString & a_Reason) override;
@@ -194,8 +187,8 @@ protected:
 	bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType);
 
 	// Packet handlers while in the Status state (m_State == 1):
-	virtual void HandlePacketStatusPing(cByteBuffer & a_ByteBuffer);
-	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer);
+	void HandlePacketStatusPing(cByteBuffer & a_ByteBuffer);
+	void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer);
 
 	// Packet handlers while in the Login state (m_State == 2):
 	void HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffer);
@@ -205,11 +198,9 @@ protected:
 	void HandlePacketAnimation              (cByteBuffer & a_ByteBuffer);
 	void HandlePacketBlockDig               (cByteBuffer & a_ByteBuffer);
 	void HandlePacketBlockPlace             (cByteBuffer & a_ByteBuffer);
-	void HandlePacketBoatSteer              (cByteBuffer & a_ByteBuffer);
 	void HandlePacketChatMessage            (cByteBuffer & a_ByteBuffer);
 	void HandlePacketClientSettings         (cByteBuffer & a_ByteBuffer);
 	void HandlePacketClientStatus           (cByteBuffer & a_ByteBuffer);
-	void HandleConfirmTeleport              (cByteBuffer & a_ByteBuffer);
 	void HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer);
 	void HandlePacketEntityAction           (cByteBuffer & a_ByteBuffer);
 	void HandlePacketKeepAlive              (cByteBuffer & a_ByteBuffer);
@@ -220,14 +211,12 @@ protected:
 	void HandlePacketPlayerPosLook          (cByteBuffer & a_ByteBuffer);
 	void HandlePacketPluginMessage          (cByteBuffer & a_ByteBuffer);
 	void HandlePacketSlotSelect             (cByteBuffer & a_ByteBuffer);
-	void HandlePacketSteerVehicle           (cByteBuffer & a_ByteBuffer);
 	void HandlePacketSpectate               (cByteBuffer & a_ByteBuffer);
+	void HandlePacketSteerVehicle           (cByteBuffer & a_ByteBuffer);
 	void HandlePacketTabComplete            (cByteBuffer & a_ByteBuffer);
 	void HandlePacketUpdateSign             (cByteBuffer & a_ByteBuffer);
 	void HandlePacketUseEntity              (cByteBuffer & a_ByteBuffer);
-	void HandlePacketUseItem                (cByteBuffer & a_ByteBuffer);
 	void HandlePacketEnchantItem            (cByteBuffer & a_ByteBuffer);
-	void HandlePacketVehicleMove            (cByteBuffer & a_ByteBuffer);
 	void HandlePacketWindowClick            (cByteBuffer & a_ByteBuffer);
 	void HandlePacketWindowClose            (cByteBuffer & a_ByteBuffer);
 
@@ -256,105 +245,23 @@ protected:
 
 	/** Converts the BlockFace received by the protocol into eBlockFace constants.
 	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
-	eBlockFace FaceIntToBlockFace(Int32 a_FaceInt);
+	eBlockFace FaceIntToBlockFace(Int8 a_FaceInt);
 
 	/** Writes the item data into a packet. */
 	void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item);
 
-	/** Writes the metadata for the specified entity, not including the terminating 0xff. */
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity);
+	/** Writes the metadata for the specified entity, not including the terminating 0x7f. */
+	void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity);
 
 	/** Writes the mob-specific metadata for the specified mob */
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob);
+	void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob);
 
 	/** Writes the entity properties for the specified entity, including the Count field. */
 	void WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity);
 
 	/** Writes the block entity data for the specified block entity into the packet. */
 	void WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity);
-
-	/** Types used within metadata */
-	enum eMetadataType
-	{
-		METADATA_TYPE_BYTE              = 0,
-		METADATA_TYPE_VARINT            = 1,
-		METADATA_TYPE_FLOAT             = 2,
-		METADATA_TYPE_STRING            = 3,
-		METADATA_TYPE_CHAT              = 4,
-		METADATA_TYPE_ITEM              = 5,
-		METADATA_TYPE_BOOL              = 6,
-		METADATA_TYPE_ROTATION          = 7,
-		METADATA_TYPE_POSITION          = 8,
-		METADATA_TYPE_OPTIONAL_POSITION = 9,
-		METADATA_TYPE_DIRECTION         = 10,
-		METADATA_TYPE_OPTIONAL_UUID     = 11,
-		METADATA_TYPE_BLOCKID           = 12
-	} ;
 } ;
-
-
-
-
-
-/** The version 108 protocol, used by 1.9.1.  Uses an int rather than a byte for dimension in join game. */
-class cProtocol191 :
-	public cProtocol190
-{
-	typedef cProtocol190 super;
-
-public:
-	cProtocol191(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
-
-	// cProtocol190 overrides:
-	virtual void SendLogin(const cPlayer & a_Player, const cWorld & a_World) override;
-	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
-
-} ;
-
-
-
-
-
-/** The version 109 protocol, used by 1.9.2.  Same as 1.9.1, except the server list ping version number changed with the protocol number. */
-class cProtocol192 :
-	public cProtocol191
-{
-	typedef cProtocol191 super;
-
-public:
-	cProtocol192(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
-
-	// cProtocol190 overrides:
-	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
-
-} ;
-
-
-
-
-
-/** The version 110 protocol, used by 1.9.3 and 1.9.4. */
-class cProtocol194 :
-	public cProtocol192
-{
-	typedef cProtocol192 super;
-
-public:
-	cProtocol194(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
-
-	// cProtocol190 overrides:
-	virtual void SendCollectEntity   (const cEntity & a_Entity, const cPlayer & a_Player) override;
-	virtual void SendChunkData       (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer) override;
-	virtual void SendEntityEffect    (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration) override;
-	virtual void SendEntityProperties(const cEntity & a_Entity) override;
-	virtual void SendPlayerMaxSpeed  (void) override;
-	virtual void SendTeleportEntity  (const cEntity & a_Entity) override;
-	virtual void SendUpdateSign      (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) override;
-
-	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
-
-} ;
-
 
 
 

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -1,16 +1,21 @@
 
-// Protocol18x.cpp
+// Protocol_1_9.cpp
 
 /*
-Implements the 1.8.x protocol classes:
-	- cProtocol180
-		- release 1.8.0 protocol (#47)
-(others may be added later in the future for the 1.8 release series)
+Implements the 1.9 protocol classes:
+	- cProtocol_1_9_0
+		- release 1.9 protocol (#107)
+	- cProtocol_1_9_1
+		- release 1.9.1 protocol (#108)
+	- cProtocol_1_9_2
+		- release 1.9.2 protocol (#109)
+	- cProtocol_1_9_4
+		- release 1.9.4 protocol (#110)
 */
 
 #include "Globals.h"
 #include "json/json.h"
-#include "Protocol18x.h"
+#include "Protocol_1_9.h"
 #include "ChunkDataSerializer.h"
 #include "PolarSSL++/Sha1Checksum.h"
 #include "Packetizer.h"
@@ -27,6 +32,7 @@ Implements the 1.8.x protocol classes:
 #include "../WorldStorage/FastNBT.h"
 #include "../WorldStorage/EnchantmentSerializer.h"
 
+#include "../Entities/Boat.h"
 #include "../Entities/ExpOrb.h"
 #include "../Entities/Minecart.h"
 #include "../Entities/FallingBlock.h"
@@ -36,6 +42,9 @@ Implements the 1.8.x protocol classes:
 #include "../Entities/ItemFrame.h"
 #include "../Entities/ArrowEntity.h"
 #include "../Entities/FireworkEntity.h"
+#include "../Entities/SplashPotionEntity.h"
+
+#include "../Items/ItemSpawnEgg.h"
 
 #include "../Mobs/IncludeAllMonsters.h"
 #include "../UI/Window.h"
@@ -99,9 +108,9 @@ extern bool g_ShouldLogCommIn, g_ShouldLogCommOut;
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// cProtocol180:
+// cProtocol_1_9_0:
 
-cProtocol180::cProtocol180(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
+cProtocol_1_9_0::cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
 	super(a_Client),
 	m_ServerAddress(a_ServerAddress),
 	m_ServerPort(a_ServerPort),
@@ -146,7 +155,7 @@ cProtocol180::cProtocol180(cClientHandle * a_Client, const AString & a_ServerAdd
 
 
 
-void cProtocol180::DataReceived(const char * a_Data, size_t a_Size)
+void cProtocol_1_9_0::DataReceived(const char * a_Data, size_t a_Size)
 {
 	if (m_IsEncrypted)
 	{
@@ -170,25 +179,24 @@ void cProtocol180::DataReceived(const char * a_Data, size_t a_Size)
 
 
 
-void cProtocol180::SendAttachEntity(const cEntity & a_Entity, const cEntity & a_Vehicle)
+void cProtocol_1_9_0::SendAttachEntity(const cEntity & a_Entity, const cEntity & a_Vehicle)
 {
 	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
-	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEUInt32(a_Vehicle.GetUniqueID());
-	Pkt.WriteBool(false);
+	cPacketizer Pkt(*this, 0x40);  // Set passangers packet
+	Pkt.WriteVarInt32(a_Vehicle.GetUniqueID());
+	Pkt.WriteVarInt32(1);  // 1 passenger
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 }
 
 
 
 
 
-void cProtocol180::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType)
+void cProtocol_1_9_0::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x24);  // Block Action packet
+	cPacketizer Pkt(*this, 0x0a);  // Block Action packet
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 	Pkt.WriteBEInt8(a_Byte1);
 	Pkt.WriteBEInt8(a_Byte2);
@@ -199,11 +207,11 @@ void cProtocol180::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, cha
 
 
 
-void cProtocol180::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
+void cProtocol_1_9_0::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x25);  // Block Break Animation packet
+	cPacketizer Pkt(*this, 0x08);  // Block Break Animation packet
 	Pkt.WriteVarInt32(a_EntityID);
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 	Pkt.WriteBEInt8(a_Stage);
@@ -213,11 +221,11 @@ void cProtocol180::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_Blo
 
 
 
-void cProtocol180::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
+void cProtocol_1_9_0::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x23);  // Block Change packet
+	cPacketizer Pkt(*this, 0x0b);  // Block Change packet
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 	Pkt.WriteVarInt32((static_cast<UInt32>(a_BlockType) << 4) | (static_cast<UInt32>(a_BlockMeta) & 15));
 }
@@ -226,11 +234,11 @@ void cProtocol180::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLO
 
 
 
-void cProtocol180::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes)
+void cProtocol_1_9_0::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x22);  // Multi Block Change packet
+	cPacketizer Pkt(*this, 0x10);  // Multi Block Change packet
 	Pkt.WriteBEInt32(a_ChunkX);
 	Pkt.WriteBEInt32(a_ChunkZ);
 	Pkt.WriteVarInt32(static_cast<UInt32>(a_Changes.size()));
@@ -246,9 +254,9 @@ void cProtocol180::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockV
 
 
 
-void cProtocol180::SendCameraSetTo(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendCameraSetTo(const cEntity & a_Entity)
 {
-	cPacketizer Pkt(*this, 0x43);  // Camera Packet (Attach the camera of a player at another entity in spectator mode)
+	cPacketizer Pkt(*this, 0x36);  // Camera Packet (Attach the camera of a player at another entity in spectator mode)
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 }
 
@@ -256,40 +264,34 @@ void cProtocol180::SendCameraSetTo(const cEntity & a_Entity)
 
 
 
-void cProtocol180::SendChat(const AString & a_Message, eChatType a_Type)
+void cProtocol_1_9_0::SendChat(const AString & a_Message, eChatType a_Type)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x02);  // Chat Message packet
-	Pkt.WriteString(Printf("{\"text\":\"%s\"}", EscapeString(a_Message).c_str()));
-	Pkt.WriteBEInt8(a_Type);
+	SendChatRaw(Printf("{\"text\":\"%s\"}", EscapeString(a_Message).c_str()), a_Type);
 }
 
 
 
 
 
-void cProtocol180::SendChat(const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes)
+void cProtocol_1_9_0::SendChat(const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-
-	// Send the message to the client:
-	cPacketizer Pkt(*this, 0x02);
-	Pkt.WriteString(a_Message.CreateJsonString(a_ShouldUseChatPrefixes));
-	Pkt.WriteBEInt8(a_Type);
+	SendChatRaw(a_Message.CreateJsonString(a_ShouldUseChatPrefixes), a_Type);
 }
 
 
 
 
 
-void cProtocol180::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type)
+void cProtocol_1_9_0::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	// Send the json string to the client:
-	cPacketizer Pkt(*this, 0x02);
+	cPacketizer Pkt(*this, 0x0f);  // Chat Message packet
 	Pkt.WriteString(a_MessageRaw);
 	Pkt.WriteBEInt8(a_Type);
 }
@@ -298,13 +300,13 @@ void cProtocol180::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type)
 
 
 
-void cProtocol180::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer)
+void cProtocol_1_9_0::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	// Serialize first, before creating the Packetizer (the packetizer locks a CS)
 	// This contains the flags and bitmasks, too
-	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_8_0, a_ChunkX, a_ChunkZ);
+	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_0, a_ChunkX, a_ChunkZ);
 
 	cCSLock Lock(m_CSPacket);
 	SendData(ChunkData.data(), ChunkData.size());
@@ -314,11 +316,12 @@ void cProtocol180::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerialize
 
 
 
-void cProtocol180::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player)
+void cProtocol_1_9_0::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count)
 {
+	UNUSED(a_Count);
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0d);  // Collect Item packet
+	cPacketizer Pkt(*this, 0x49);  // Collect Item packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 }
@@ -327,11 +330,11 @@ void cProtocol180::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a
 
 
 
-void cProtocol180::SendDestroyEntity(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendDestroyEntity(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x13);  // Destroy Entities packet
+	cPacketizer Pkt(*this, 0x30);  // Destroy Entities packet
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 }
@@ -340,21 +343,19 @@ void cProtocol180::SendDestroyEntity(const cEntity & a_Entity)
 
 
 
-void cProtocol180::SendDetachEntity(const cEntity & a_Entity, const cEntity & a_PreviousVehicle)
+void cProtocol_1_9_0::SendDetachEntity(const cEntity & a_Entity, const cEntity & a_PreviousVehicle)
 {
 	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
-	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEUInt32(0);
-	Pkt.WriteBool(false);
+	cPacketizer Pkt(*this, 0x40);  // Set passangers packet
+	Pkt.WriteVarInt32(a_PreviousVehicle.GetUniqueID());
+	Pkt.WriteVarInt32(0);  // No passangers
 }
 
 
 
 
 
-void cProtocol180::SendDisconnect(const AString & a_Reason)
+void cProtocol_1_9_0::SendDisconnect(const AString & a_Reason)
 {
 	switch (m_State)
 	{
@@ -368,7 +369,7 @@ void cProtocol180::SendDisconnect(const AString & a_Reason)
 		case 3:
 		{
 			// In-game:
-			cPacketizer Pkt(*this, 0x40);
+			cPacketizer Pkt(*this, 0x1a);
 			Pkt.WriteString(Printf("{\"text\":\"%s\"}", EscapeString(a_Reason).c_str()));
 			break;
 		}
@@ -379,11 +380,11 @@ void cProtocol180::SendDisconnect(const AString & a_Reason)
 
 
 
-void cProtocol180::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
+void cProtocol_1_9_0::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x36);  // Sign Editor Open packet
+	cPacketizer Pkt(*this, 0x2a);  // Sign Editor Open packet
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 }
 
@@ -391,11 +392,11 @@ void cProtocol180::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 
 
-void cProtocol180::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration)
+void cProtocol_1_9_0::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1D);  // Entity Effect packet
+	cPacketizer Pkt(*this, 0x4c);  // Entity Effect packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_EffectID));
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Amplifier));
@@ -407,13 +408,18 @@ void cProtocol180::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, in
 
 
 
-void cProtocol180::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item)
+void cProtocol_1_9_0::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x04);  // Entity Equipment packet
+	cPacketizer Pkt(*this, 0x3c);  // Entity Equipment packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEInt16(a_SlotNum);
+	// Needs to be adjusted due to the insertion of offhand at slot 1
+	if (a_SlotNum > 0)
+	{
+		a_SlotNum++;
+	}
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_SlotNum));
 	WriteItem(Pkt, a_Item);
 }
 
@@ -421,11 +427,11 @@ void cProtocol180::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum
 
 
 
-void cProtocol180::SendEntityHeadLook(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendEntityHeadLook(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x19);  // Entity Head Look packet
+	cPacketizer Pkt(*this, 0x34);  // Entity Head Look packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetHeadYaw());
 }
@@ -434,11 +440,11 @@ void cProtocol180::SendEntityHeadLook(const cEntity & a_Entity)
 
 
 
-void cProtocol180::SendEntityLook(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendEntityLook(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x16);  // Entity Look packet
+	cPacketizer Pkt(*this, 0x27);  // Entity Look packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
@@ -449,25 +455,25 @@ void cProtocol180::SendEntityLook(const cEntity & a_Entity)
 
 
 
-void cProtocol180::SendEntityMetadata(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendEntityMetadata(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
+	cPacketizer Pkt(*this, 0x39);  // Entity Metadata packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	WriteEntityMetadata(Pkt, a_Entity);
-	Pkt.WriteBEUInt8(0x7f);  // The termination byte
+	Pkt.WriteBEUInt8(0xff);  // The termination byte
 }
 
 
 
 
 
-void cProtocol180::SendEntityProperties(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendEntityProperties(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x20);  // Entity Properties packet
+	cPacketizer Pkt(*this, 0x4b);  // Entity Properties packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	WriteEntityProperties(Pkt, a_Entity);
 }
@@ -476,15 +482,16 @@ void cProtocol180::SendEntityProperties(const cEntity & a_Entity)
 
 
 
-void cProtocol180::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
+void cProtocol_1_9_0::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x15);  // Entity Relative Move packet
+	cPacketizer Pkt(*this, 0x25);  // Entity Relative Move packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEInt8(a_RelX);
-	Pkt.WriteBEInt8(a_RelY);
-	Pkt.WriteBEInt8(a_RelZ);
+	// TODO: 1.9 changed these from chars to shorts, meaning that there can be more percision and data.  Other code needs to be updated for that.
+	Pkt.WriteBEInt16(a_RelX * 128);
+	Pkt.WriteBEInt16(a_RelY * 128);
+	Pkt.WriteBEInt16(a_RelZ * 128);
 	Pkt.WriteBool(a_Entity.IsOnGround());
 }
 
@@ -492,15 +499,16 @@ void cProtocol180::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char
 
 
 
-void cProtocol180::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
+void cProtocol_1_9_0::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, char a_RelY, char a_RelZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x17);  // Entity Look And Relative Move packet
+	cPacketizer Pkt(*this, 0x26);  // Entity Look And Relative Move packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEInt8(a_RelX);
-	Pkt.WriteBEInt8(a_RelY);
-	Pkt.WriteBEInt8(a_RelZ);
+	// TODO: 1.9 changed these from chars to shorts, meaning that there can be more percision and data.  Other code needs to be updated for that.
+	Pkt.WriteBEInt16(a_RelX * 128);
+	Pkt.WriteBEInt16(a_RelY * 128);
+	Pkt.WriteBEInt16(a_RelZ * 128);
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteBool(a_Entity.IsOnGround());
@@ -510,11 +518,11 @@ void cProtocol180::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, 
 
 
 
-void cProtocol180::SendEntityStatus(const cEntity & a_Entity, char a_Status)
+void cProtocol_1_9_0::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1a);  // Entity Status packet
+	cPacketizer Pkt(*this, 0x1b);  // Entity Status packet
 	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEInt8(a_Status);
 }
@@ -523,11 +531,11 @@ void cProtocol180::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 
 
 
-void cProtocol180::SendEntityVelocity(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendEntityVelocity(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x12);  // Entity Velocity packet
+	cPacketizer Pkt(*this, 0x3b);  // Entity Velocity packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	// 400 = 8000 / 20 ... Conversion from our speed in m / s to 8000 m / tick
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
@@ -539,11 +547,11 @@ void cProtocol180::SendEntityVelocity(const cEntity & a_Entity)
 
 
 
-void cProtocol180::SendExplosion(double a_BlockX, double a_BlockY, double a_BlockZ, float a_Radius, const cVector3iArray & a_BlocksAffected, const Vector3d & a_PlayerMotion)
+void cProtocol_1_9_0::SendExplosion(double a_BlockX, double a_BlockY, double a_BlockZ, float a_Radius, const cVector3iArray & a_BlocksAffected, const Vector3d & a_PlayerMotion)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x27);  // Explosion packet
+	cPacketizer Pkt(*this, 0x1c);  // Explosion packet
 	Pkt.WriteBEFloat(static_cast<float>(a_BlockX));
 	Pkt.WriteBEFloat(static_cast<float>(a_BlockY));
 	Pkt.WriteBEFloat(static_cast<float>(a_BlockZ));
@@ -564,11 +572,11 @@ void cProtocol180::SendExplosion(double a_BlockX, double a_BlockY, double a_Bloc
 
 
 
-void cProtocol180::SendGameMode(eGameMode a_GameMode)
+void cProtocol_1_9_0::SendGameMode(eGameMode a_GameMode)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
+	cPacketizer Pkt(*this, 0x1e);  // Change Game State packet
 	Pkt.WriteBEUInt8(3);  // Reason: Change game mode
 	Pkt.WriteBEFloat(static_cast<float>(a_GameMode));  // The protocol really represents the value with a float!
 }
@@ -577,11 +585,11 @@ void cProtocol180::SendGameMode(eGameMode a_GameMode)
 
 
 
-void cProtocol180::SendHealth(void)
+void cProtocol_1_9_0::SendHealth(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x06);  // Update Health packet
+	cPacketizer Pkt(*this, 0x3e);  // Update Health packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEFloat(static_cast<float>(Player->GetHealth()));
 	Pkt.WriteVarInt32(static_cast<UInt32>(Player->GetFoodLevel()));
@@ -592,7 +600,7 @@ void cProtocol180::SendHealth(void)
 
 
 
-void cProtocol180::SendHideTitle(void)
+void cProtocol_1_9_0::SendHideTitle(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -604,11 +612,11 @@ void cProtocol180::SendHideTitle(void)
 
 
 
-void cProtocol180::SendInventorySlot(char a_WindowID, short a_SlotNum, const cItem & a_Item)
+void cProtocol_1_9_0::SendInventorySlot(char a_WindowID, short a_SlotNum, const cItem & a_Item)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2f);  // Set Slot packet
+	cPacketizer Pkt(*this, 0x16);  // Set Slot packet
 	Pkt.WriteBEInt8(a_WindowID);
 	Pkt.WriteBEInt16(a_SlotNum);
 	WriteItem(Pkt, a_Item);
@@ -618,7 +626,7 @@ void cProtocol180::SendInventorySlot(char a_WindowID, short a_SlotNum, const cIt
 
 
 
-void cProtocol180::SendKeepAlive(UInt32 a_PingID)
+void cProtocol_1_9_0::SendKeepAlive(UInt32 a_PingID)
 {
 	// Drop the packet if the protocol is not in the Game state yet (caused a client crash):
 	if (m_State != 3)
@@ -627,7 +635,7 @@ void cProtocol180::SendKeepAlive(UInt32 a_PingID)
 		return;
 	}
 
-	cPacketizer Pkt(*this, 0x00);  // Keep Alive packet
+	cPacketizer Pkt(*this, 0x1f);  // Keep Alive packet
 	Pkt.WriteVarInt32(a_PingID);
 }
 
@@ -635,12 +643,12 @@ void cProtocol180::SendKeepAlive(UInt32 a_PingID)
 
 
 
-void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
+void cProtocol_1_9_0::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 {
 	// Send the Join Game packet:
 	{
 		cServer * Server = cRoot::Get()->GetServer();
-		cPacketizer Pkt(*this, 0x01);  // Join Game packet
+		cPacketizer Pkt(*this, 0x23);  // Join Game packet
 		Pkt.WriteBEUInt32(a_Player.GetUniqueID());
 		Pkt.WriteBEUInt8(static_cast<UInt8>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
 		Pkt.WriteBEInt8(static_cast<Int8>(a_World.GetDimension()));
@@ -652,13 +660,13 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 
 	// Send the spawn position:
 	{
-		cPacketizer Pkt(*this, 0x05);  // Spawn Position packet
+		cPacketizer Pkt(*this, 0x43);  // Spawn Position packet
 		Pkt.WritePosition64(FloorC(a_World.GetSpawnX()), FloorC(a_World.GetSpawnY()), FloorC(a_World.GetSpawnZ()));
 	}
 
 	// Send the server difficulty:
 	{
-		cPacketizer Pkt(*this, 0x41);
+		cPacketizer Pkt(*this, 0x0d);  // Server difficulty packet
 		Pkt.WriteBEInt8(1);
 	}
 
@@ -669,7 +677,7 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 
 
 
-void cProtocol180::SendLoginSuccess(void)
+void cProtocol_1_9_0::SendLoginSuccess(void)
 {
 	ASSERT(m_State == 2);  // State: login?
 
@@ -692,15 +700,18 @@ void cProtocol180::SendLoginSuccess(void)
 
 
 
-void cProtocol180::SendPaintingSpawn(const cPainting & a_Painting)
+void cProtocol_1_9_0::SendPaintingSpawn(const cPainting & a_Painting)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	double PosX = a_Painting.GetPosX();
 	double PosY = a_Painting.GetPosY();
 	double PosZ = a_Painting.GetPosZ();
 
-	cPacketizer Pkt(*this, 0x10);  // Spawn Painting packet
+	cPacketizer Pkt(*this, 0x04);  // Spawn Painting packet
 	Pkt.WriteVarInt32(a_Painting.GetUniqueID());
+	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
+	Pkt.WriteBEUInt64(0);
+	Pkt.WriteBEUInt64(a_Painting.GetUniqueID());
 	Pkt.WriteString(a_Painting.GetName().c_str());
 	Pkt.WritePosition64(static_cast<Int32>(PosX), static_cast<Int32>(PosY), static_cast<Int32>(PosZ));
 	Pkt.WriteBEInt8(static_cast<Int8>(a_Painting.GetProtocolFacing()));
@@ -710,14 +721,15 @@ void cProtocol180::SendPaintingSpawn(const cPainting & a_Painting)
 
 
 
-void cProtocol180::SendMapData(const cMap & a_Map, int a_DataStartX, int a_DataStartY)
+void cProtocol_1_9_0::SendMapData(const cMap & a_Map, int a_DataStartX, int a_DataStartY)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x34);
+	cPacketizer Pkt(*this, 0x24);  // Map packet
 	Pkt.WriteVarInt32(a_Map.GetID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Map.GetScale()));
 
+	Pkt.WriteBool(true);
 	Pkt.WriteVarInt32(static_cast<UInt32>(a_Map.GetDecorators().size()));
 	for (const auto & Decorator : a_Map.GetDecorators())
 	{
@@ -741,40 +753,40 @@ void cProtocol180::SendMapData(const cMap & a_Map, int a_DataStartX, int a_DataS
 
 
 
-void cProtocol180::SendPickupSpawn(const cPickup & a_Pickup)
+void cProtocol_1_9_0::SendPickupSpawn(const cPickup & a_Pickup)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	{
-		cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
+	{  // TODO Use SendSpawnObject
+		cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
 		Pkt.WriteVarInt32(a_Pickup.GetUniqueID());
+		// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
+		Pkt.WriteBEUInt64(0);
+		Pkt.WriteBEUInt64(a_Pickup.GetUniqueID());
 		Pkt.WriteBEUInt8(2);  // Type = Pickup
-		Pkt.WriteFPInt(a_Pickup.GetPosX());
-		Pkt.WriteFPInt(a_Pickup.GetPosY());
-		Pkt.WriteFPInt(a_Pickup.GetPosZ());
+		Pkt.WriteBEDouble(a_Pickup.GetPosX());
+		Pkt.WriteBEDouble(a_Pickup.GetPosY());
+		Pkt.WriteBEDouble(a_Pickup.GetPosZ());
 		Pkt.WriteByteAngle(a_Pickup.GetYaw());
 		Pkt.WriteByteAngle(a_Pickup.GetPitch());
 		Pkt.WriteBEInt32(0);  // No object data
+		Pkt.WriteBEInt16(0);  // No velocity
+		Pkt.WriteBEInt16(0);
+		Pkt.WriteBEInt16(0);
 	}
 
-	{
-		cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
-		Pkt.WriteVarInt32(a_Pickup.GetUniqueID());
-		Pkt.WriteBEUInt8((0x05 << 5) | 10);  // Slot type + index 10
-		WriteItem(Pkt, a_Pickup.GetItem());
-		Pkt.WriteBEUInt8(0x7f);  // End of metadata
-	}
+	SendEntityMetadata(a_Pickup);
 }
 
 
 
 
 
-void cProtocol180::SendPlayerAbilities(void)
+void cProtocol_1_9_0::SendPlayerAbilities(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x39);  // Player Abilities packet
+	cPacketizer Pkt(*this, 0x2b);  // Player Abilities packet
 	Byte Flags = 0;
 	cPlayer * Player = m_Client->GetPlayer();
 	if (Player->IsGameModeCreative())
@@ -799,11 +811,11 @@ void cProtocol180::SendPlayerAbilities(void)
 
 
 
-void cProtocol180::SendEntityAnimation(const cEntity & a_Entity, char a_Animation)
+void cProtocol_1_9_0::SendEntityAnimation(const cEntity & a_Entity, char a_Animation)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0b);  // Animation packet
+	cPacketizer Pkt(*this, 0x06);  // Animation packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEInt8(a_Animation);
 }
@@ -812,12 +824,12 @@ void cProtocol180::SendEntityAnimation(const cEntity & a_Entity, char a_Animatio
 
 
 
-void cProtocol180::SendParticleEffect(const AString & a_ParticleName, float a_SrcX, float a_SrcY, float a_SrcZ, float a_OffsetX, float a_OffsetY, float a_OffsetZ, float a_ParticleData, int a_ParticleAmount)
+void cProtocol_1_9_0::SendParticleEffect(const AString & a_ParticleName, float a_SrcX, float a_SrcY, float a_SrcZ, float a_OffsetX, float a_OffsetY, float a_OffsetZ, float a_ParticleData, int a_ParticleAmount)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	int ParticleID = GetParticleID(a_ParticleName);
 
-	cPacketizer Pkt(*this, 0x2A);
+	cPacketizer Pkt(*this, 0x22);  // Particle effect packet
 	Pkt.WriteBEInt32(ParticleID);
 	Pkt.WriteBool(false);
 	Pkt.WriteBEFloat(a_SrcX);
@@ -834,12 +846,12 @@ void cProtocol180::SendParticleEffect(const AString & a_ParticleName, float a_Sr
 
 
 
-void cProtocol180::SendParticleEffect(const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, std::array<int, 2> a_Data)
+void cProtocol_1_9_0::SendParticleEffect(const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, std::array<int, 2> a_Data)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	int ParticleID = GetParticleID(a_ParticleName);
 
-	cPacketizer Pkt(*this, 0x2A);
+	cPacketizer Pkt(*this, 0x22);  // Particle effect packet
 	Pkt.WriteBEInt32(ParticleID);
 	Pkt.WriteBool(false);
 	Pkt.WriteBEFloat(a_Src.x);
@@ -878,11 +890,11 @@ void cProtocol180::SendParticleEffect(const AString & a_ParticleName, Vector3f a
 
 
 
-void cProtocol180::SendPlayerListAddPlayer(const cPlayer & a_Player)
+void cProtocol_1_9_0::SendPlayerListAddPlayer(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
 	Pkt.WriteVarInt32(0);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -915,11 +927,11 @@ void cProtocol180::SendPlayerListAddPlayer(const cPlayer & a_Player)
 
 
 
-void cProtocol180::SendPlayerListRemovePlayer(const cPlayer & a_Player)
+void cProtocol_1_9_0::SendPlayerListRemovePlayer(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
 	Pkt.WriteVarInt32(4);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -929,11 +941,11 @@ void cProtocol180::SendPlayerListRemovePlayer(const cPlayer & a_Player)
 
 
 
-void cProtocol180::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
+void cProtocol_1_9_0::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -944,14 +956,14 @@ void cProtocol180::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
 
 
 
-void cProtocol180::SendPlayerListUpdatePing(const cPlayer & a_Player)
+void cProtocol_1_9_0::SendPlayerListUpdatePing(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	auto ClientHandle = a_Player.GetClientHandlePtr();
 	if (ClientHandle != nullptr)
 	{
-		cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
+		cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
 		Pkt.WriteVarInt32(2);
 		Pkt.WriteVarInt32(1);
 		Pkt.WriteUUID(a_Player.GetUUID());
@@ -963,11 +975,11 @@ void cProtocol180::SendPlayerListUpdatePing(const cPlayer & a_Player)
 
 
 
-void cProtocol180::SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName)
+void cProtocol_1_9_0::SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
+	cPacketizer Pkt(*this, 0x2d);  // Playerlist Item packet
 	Pkt.WriteVarInt32(3);
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
@@ -987,11 +999,11 @@ void cProtocol180::SendPlayerListUpdateDisplayName(const cPlayer & a_Player, con
 
 
 
-void cProtocol180::SendPlayerMaxSpeed(void)
+void cProtocol_1_9_0::SendPlayerMaxSpeed(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x20);  // Entity Properties
+	cPacketizer Pkt(*this, 0x4b);  // Entity Properties
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteVarInt32(Player->GetUniqueID());
 	Pkt.WriteBEInt32(1);  // Count
@@ -1016,11 +1028,11 @@ void cProtocol180::SendPlayerMaxSpeed(void)
 
 
 
-void cProtocol180::SendPlayerMoveLook(void)
+void cProtocol_1_9_0::SendPlayerMoveLook(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x08);  // Player Position And Look packet
+	cPacketizer Pkt(*this, 0x2e);  // Player Position And Look packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEDouble(Player->GetPosX());
 	Pkt.WriteBEDouble(Player->GetPosY());
@@ -1028,13 +1040,14 @@ void cProtocol180::SendPlayerMoveLook(void)
 	Pkt.WriteBEFloat(static_cast<float>(Player->GetYaw()));
 	Pkt.WriteBEFloat(static_cast<float>(Player->GetPitch()));
 	Pkt.WriteBEUInt8(0);
+	Pkt.WriteVarInt32(0);  // Teleport ID - not implemented here
 }
 
 
 
 
 
-void cProtocol180::SendPlayerPosition(void)
+void cProtocol_1_9_0::SendPlayerPosition(void)
 {
 	// There is no dedicated packet for this, send the whole thing:
 	SendPlayerMoveLook();
@@ -1044,35 +1057,30 @@ void cProtocol180::SendPlayerPosition(void)
 
 
 
-void cProtocol180::SendPlayerSpawn(const cPlayer & a_Player)
+void cProtocol_1_9_0::SendPlayerSpawn(const cPlayer & a_Player)
 {
 	// Called to spawn another player for the client
-	cPacketizer Pkt(*this, 0x0c);  // Spawn Player packet
+	cPacketizer Pkt(*this, 0x05);  // Spawn Player packet
 	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 	Pkt.WriteUUID(cMojangAPI::MakeUUIDShort(a_Player.GetUUID()));
-	Pkt.WriteFPInt(a_Player.GetPosX());
-	Pkt.WriteFPInt(a_Player.GetPosY() + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
-	Pkt.WriteFPInt(a_Player.GetPosZ());
+	Pkt.WriteBEDouble(a_Player.GetPosX());
+	Pkt.WriteBEDouble(a_Player.GetPosY() + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
+	Pkt.WriteBEDouble(a_Player.GetPosZ());
 	Pkt.WriteByteAngle(a_Player.GetYaw());
 	Pkt.WriteByteAngle(a_Player.GetPitch());
-	short ItemType = a_Player.GetEquippedItem().IsEmpty() ? 0 : a_Player.GetEquippedItem().m_ItemType;
-	Pkt.WriteBEInt16(ItemType);
-	Pkt.WriteBEUInt8((3 << 5) | 6);  // Metadata: float + index 6
-	Pkt.WriteBEFloat(static_cast<float>(a_Player.GetHealth()));
-	Pkt.WriteBEUInt8((4 << 5 | (2 & 0x1F)) & 0xFF);
-	Pkt.WriteString(a_Player.GetName());
-	Pkt.WriteBEUInt8(0x7f);  // Metadata: end
+	WriteEntityMetadata(Pkt, a_Player);
+	Pkt.WriteBEUInt8(0xff);  // Metadata: end
 }
 
 
 
 
 
-void cProtocol180::SendPluginMessage(const AString & a_Channel, const AString & a_Message)
+void cProtocol_1_9_0::SendPluginMessage(const AString & a_Channel, const AString & a_Message)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3f);
+	cPacketizer Pkt(*this, 0x18);  // Plugin message packet
 	Pkt.WriteString(a_Channel);
 	Pkt.WriteBuf(a_Message.data(), a_Message.size());
 }
@@ -1081,11 +1089,11 @@ void cProtocol180::SendPluginMessage(const AString & a_Channel, const AString & 
 
 
 
-void cProtocol180::SendRemoveEntityEffect(const cEntity & a_Entity, int a_EffectID)
+void cProtocol_1_9_0::SendRemoveEntityEffect(const cEntity & a_Entity, int a_EffectID)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1e);
+	cPacketizer Pkt(*this, 0x31);  // Remove entity effect packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_EffectID));
 }
@@ -1094,7 +1102,7 @@ void cProtocol180::SendRemoveEntityEffect(const cEntity & a_Entity, int a_Effect
 
 
 
-void cProtocol180::SendResetTitle(void)
+void cProtocol_1_9_0::SendResetTitle(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1106,10 +1114,9 @@ void cProtocol180::SendResetTitle(void)
 
 
 
-void cProtocol180::SendRespawn(eDimension a_Dimension)
+void cProtocol_1_9_0::SendRespawn(eDimension a_Dimension)
 {
-
-	cPacketizer Pkt(*this, 0x07);  // Respawn packet
+	cPacketizer Pkt(*this, 0x33);  // Respawn packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Dimension));
 	Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
@@ -1121,11 +1128,11 @@ void cProtocol180::SendRespawn(eDimension a_Dimension)
 
 
 
-void cProtocol180::SendExperience(void)
+void cProtocol_1_9_0::SendExperience(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x1f);  // Experience Packet
+	cPacketizer Pkt(*this, 0x3d);  // Experience Packet
 	cPlayer * Player = m_Client->GetPlayer();
 	Pkt.WriteBEFloat(Player->GetXpPercentage());
 	Pkt.WriteVarInt32(static_cast<UInt32>(Player->GetXpLevel()));
@@ -1136,15 +1143,15 @@ void cProtocol180::SendExperience(void)
 
 
 
-void cProtocol180::SendExperienceOrb(const cExpOrb & a_ExpOrb)
+void cProtocol_1_9_0::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x11);
+	cPacketizer Pkt(*this, 0x01);  // Spawn experience orb packet
 	Pkt.WriteVarInt32(a_ExpOrb.GetUniqueID());
-	Pkt.WriteFPInt(a_ExpOrb.GetPosX());
-	Pkt.WriteFPInt(a_ExpOrb.GetPosY());
-	Pkt.WriteFPInt(a_ExpOrb.GetPosZ());
+	Pkt.WriteBEDouble(a_ExpOrb.GetPosX());
+	Pkt.WriteBEDouble(a_ExpOrb.GetPosY());
+	Pkt.WriteBEDouble(a_ExpOrb.GetPosZ());
 	Pkt.WriteBEInt16(static_cast<Int16>(a_ExpOrb.GetReward()));
 }
 
@@ -1152,11 +1159,11 @@ void cProtocol180::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 
 
 
-void cProtocol180::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
+void cProtocol_1_9_0::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3b);
+	cPacketizer Pkt(*this, 0x3f);  // Scoreboard objective packet
 	Pkt.WriteString(a_Name);
 	Pkt.WriteBEUInt8(a_Mode);
 	if ((a_Mode == 0) || (a_Mode == 2))
@@ -1170,11 +1177,11 @@ void cProtocol180::SendScoreboardObjective(const AString & a_Name, const AString
 
 
 
-void cProtocol180::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
+void cProtocol_1_9_0::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3c);
+	cPacketizer Pkt(*this, 0x42);  // Update score packet
 	Pkt.WriteString(a_Player);
 	Pkt.WriteBEUInt8(a_Mode);
 	Pkt.WriteString(a_Objective);
@@ -1189,11 +1196,11 @@ void cProtocol180::SendScoreUpdate(const AString & a_Objective, const AString & 
 
 
 
-void cProtocol180::SendDisplayObjective(const AString & a_Objective, cScoreboard::eDisplaySlot a_Display)
+void cProtocol_1_9_0::SendDisplayObjective(const AString & a_Objective, cScoreboard::eDisplaySlot a_Display)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3d);
+	cPacketizer Pkt(*this, 0x38);  // Display scoreboard packet
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Display));
 	Pkt.WriteString(a_Objective);
 }
@@ -1202,7 +1209,7 @@ void cProtocol180::SendDisplayObjective(const AString & a_Objective, cScoreboard
 
 
 
-void cProtocol180::SendSetSubTitle(const cCompositeChat & a_SubTitle)
+void cProtocol_1_9_0::SendSetSubTitle(const cCompositeChat & a_SubTitle)
 {
 	SendSetRawSubTitle(a_SubTitle.CreateJsonString(false));
 }
@@ -1211,7 +1218,7 @@ void cProtocol180::SendSetSubTitle(const cCompositeChat & a_SubTitle)
 
 
 
-void cProtocol180::SendSetRawSubTitle(const AString & a_SubTitle)
+void cProtocol_1_9_0::SendSetRawSubTitle(const AString & a_SubTitle)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1225,7 +1232,7 @@ void cProtocol180::SendSetRawSubTitle(const AString & a_SubTitle)
 
 
 
-void cProtocol180::SendSetTitle(const cCompositeChat & a_Title)
+void cProtocol_1_9_0::SendSetTitle(const cCompositeChat & a_Title)
 {
 	SendSetRawTitle(a_Title.CreateJsonString(false));
 }
@@ -1234,7 +1241,7 @@ void cProtocol180::SendSetTitle(const cCompositeChat & a_Title)
 
 
 
-void cProtocol180::SendSetRawTitle(const AString & a_Title)
+void cProtocol_1_9_0::SendSetRawTitle(const AString & a_Title)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1248,12 +1255,13 @@ void cProtocol180::SendSetRawTitle(const AString & a_Title)
 
 
 
-void cProtocol180::SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch)
+void cProtocol_1_9_0::SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x29);  // Sound Effect packet
+	cPacketizer Pkt(*this, 0x19);  // Named sound effect packet
 	Pkt.WriteString(a_SoundName);
+	Pkt.WriteVarInt32(0);  // Master sound category (may want to be changed to a parameter later)
 	Pkt.WriteBEInt32(static_cast<Int32>(a_X * 8.0));
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Y * 8.0));
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Z * 8.0));
@@ -1265,11 +1273,11 @@ void cProtocol180::SendSoundEffect(const AString & a_SoundName, double a_X, doub
 
 
 
-void cProtocol180::SendSoundParticleEffect(const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data)
+void cProtocol_1_9_0::SendSoundParticleEffect(const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x28);  // Effect packet
+	cPacketizer Pkt(*this, 0x21);  // Effect packet
 	Pkt.WriteBEInt32(static_cast<int>(a_EffectID));
 	Pkt.WritePosition64(a_SrcX, a_SrcY, a_SrcZ);
 	Pkt.WriteBEInt32(a_Data);
@@ -1280,16 +1288,19 @@ void cProtocol180::SendSoundParticleEffect(const EffectID a_EffectID, int a_SrcX
 
 
 
-void cProtocol180::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
+void cProtocol_1_9_0::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
+	cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
 	Pkt.WriteVarInt32(a_FallingBlock.GetUniqueID());
+	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
+	Pkt.WriteBEUInt64(0);
+	Pkt.WriteBEUInt64(a_FallingBlock.GetUniqueID());
 	Pkt.WriteBEUInt8(70);  // Falling block
-	Pkt.WriteFPInt(a_FallingBlock.GetPosX());
-	Pkt.WriteFPInt(a_FallingBlock.GetPosY());
-	Pkt.WriteFPInt(a_FallingBlock.GetPosZ());
+	Pkt.WriteBEDouble(a_FallingBlock.GetPosX());
+	Pkt.WriteBEDouble(a_FallingBlock.GetPosY());
+	Pkt.WriteBEDouble(a_FallingBlock.GetPosZ());
 	Pkt.WriteByteAngle(a_FallingBlock.GetYaw());
 	Pkt.WriteByteAngle(a_FallingBlock.GetPitch());
 	Pkt.WriteBEInt32(static_cast<Int32>(a_FallingBlock.GetBlockType()) | (static_cast<Int32>(a_FallingBlock.GetBlockMeta()) << 12));
@@ -1302,16 +1313,19 @@ void cProtocol180::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
 
 
 
-void cProtocol180::SendSpawnMob(const cMonster & a_Mob)
+void cProtocol_1_9_0::SendSpawnMob(const cMonster & a_Mob)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0f);  // Spawn Mob packet
+	cPacketizer Pkt(*this, 0x03);  // Spawn Mob packet
 	Pkt.WriteVarInt32(a_Mob.GetUniqueID());
+	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
+	Pkt.WriteBEUInt64(0);
+	Pkt.WriteBEUInt64(a_Mob.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<Byte>(a_Mob.GetMobType()));
-	Pkt.WriteFPInt(a_Mob.GetPosX());
-	Pkt.WriteFPInt(a_Mob.GetPosY());
-	Pkt.WriteFPInt(a_Mob.GetPosZ());
+	Pkt.WriteBEDouble(a_Mob.GetPosX());
+	Pkt.WriteBEDouble(a_Mob.GetPosY());
+	Pkt.WriteBEDouble(a_Mob.GetPosZ());
 	Pkt.WriteByteAngle(a_Mob.GetPitch());
 	Pkt.WriteByteAngle(a_Mob.GetHeadYaw());
 	Pkt.WriteByteAngle(a_Mob.GetYaw());
@@ -1319,14 +1333,14 @@ void cProtocol180::SendSpawnMob(const cMonster & a_Mob)
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Mob.GetSpeedY() * 400));
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Mob.GetSpeedZ() * 400));
 	WriteEntityMetadata(Pkt, a_Mob);
-	Pkt.WriteBEUInt8(0x7f);  // Metadata terminator
+	Pkt.WriteBEUInt8(0xff);  // Metadata terminator
 }
 
 
 
 
 
-void cProtocol180::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, int a_ObjectData, Byte a_Yaw, Byte a_Pitch)
+void cProtocol_1_9_0::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, int a_ObjectData, Byte a_Yaw, Byte a_Pitch)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	double PosX = a_Entity.GetPosX();
@@ -1337,57 +1351,57 @@ void cProtocol180::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, 
 		FixItemFramePositions(a_ObjectData, PosX, PosZ, Yaw);
 	}
 
-	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
+	cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
+	Pkt.WriteBEUInt64(0);
+	Pkt.WriteBEUInt64(a_Entity.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_ObjectType));
-	Pkt.WriteFPInt(PosX);
-	Pkt.WriteFPInt(a_Entity.GetPosY());
-	Pkt.WriteFPInt(PosZ);
+	Pkt.WriteBEDouble(PosX);
+	Pkt.WriteBEDouble(a_Entity.GetPosY());
+	Pkt.WriteBEDouble(PosZ);
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteByteAngle(Yaw);
 	Pkt.WriteBEInt32(a_ObjectData);
-	if (a_ObjectData != 0)
-	{
-		Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
-		Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedY() * 400));
-		Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedZ() * 400));
-	}
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedY() * 400));
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedZ() * 400));
 }
 
 
 
 
 
-void cProtocol180::SendSpawnVehicle(const cEntity & a_Vehicle, char a_VehicleType, char a_VehicleSubType)
+void cProtocol_1_9_0::SendSpawnVehicle(const cEntity & a_Vehicle, char a_VehicleType, char a_VehicleSubType)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
+	cPacketizer Pkt(*this, 0x00);  // Spawn Object packet
 	Pkt.WriteVarInt32(a_Vehicle.GetUniqueID());
+	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
+	Pkt.WriteBEUInt64(0);
+	Pkt.WriteBEUInt64(a_Vehicle.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_VehicleType));
-	Pkt.WriteFPInt(a_Vehicle.GetPosX());
-	Pkt.WriteFPInt(a_Vehicle.GetPosY());
-	Pkt.WriteFPInt(a_Vehicle.GetPosZ());
+	Pkt.WriteBEDouble(a_Vehicle.GetPosX());
+	Pkt.WriteBEDouble(a_Vehicle.GetPosY());
+	Pkt.WriteBEDouble(a_Vehicle.GetPosZ());
 	Pkt.WriteByteAngle(a_Vehicle.GetPitch());
 	Pkt.WriteByteAngle(a_Vehicle.GetYaw());
 	Pkt.WriteBEInt32(a_VehicleSubType);
-	if (a_VehicleSubType != 0)
-	{
-		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedX() * 400));
-		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedY() * 400));
-		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedZ() * 400));
-	}
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedX() * 400));
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedY() * 400));
+	Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedZ() * 400));
 }
 
 
 
 
 
-void cProtocol180::SendStatistics(const cStatManager & a_Manager)
+void cProtocol_1_9_0::SendStatistics(const cStatManager & a_Manager)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x37);
+	cPacketizer Pkt(*this, 0x07);  // Statistics packet
 	Pkt.WriteVarInt32(statCount);  // TODO 2014-05-11 xdot: Optimization: Send "dirty" statistics only
 
 	size_t Count = static_cast<size_t>(statCount);
@@ -1405,11 +1419,11 @@ void cProtocol180::SendStatistics(const cStatManager & a_Manager)
 
 
 
-void cProtocol180::SendTabCompletionResults(const AStringVector & a_Results)
+void cProtocol_1_9_0::SendTabCompletionResults(const AStringVector & a_Results)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x3a);  // Tab-Complete packet
+	cPacketizer Pkt(*this, 0x0e);  // Tab-Complete packet
 	Pkt.WriteVarInt32(static_cast<UInt32>(a_Results.size()));
 
 	for (AStringVector::const_iterator itr = a_Results.begin(), end = a_Results.end(); itr != end; ++itr)
@@ -1422,15 +1436,15 @@ void cProtocol180::SendTabCompletionResults(const AStringVector & a_Results)
 
 
 
-void cProtocol180::SendTeleportEntity(const cEntity & a_Entity)
+void cProtocol_1_9_0::SendTeleportEntity(const cEntity & a_Entity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x18);
+	cPacketizer Pkt(*this, 0x4a);  // Entity teleport packet
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteFPInt(a_Entity.GetPosX());
-	Pkt.WriteFPInt(a_Entity.GetPosY());
-	Pkt.WriteFPInt(a_Entity.GetPosZ());
+	Pkt.WriteBEDouble(a_Entity.GetPosX());
+	Pkt.WriteBEDouble(a_Entity.GetPosY());
+	Pkt.WriteBEDouble(a_Entity.GetPosZ());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteBool(a_Entity.IsOnGround());
@@ -1440,23 +1454,23 @@ void cProtocol180::SendTeleportEntity(const cEntity & a_Entity)
 
 
 
-void cProtocol180::SendThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ)
+void cProtocol_1_9_0::SendThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2c);  // Spawn Global Entity packet
+	cPacketizer Pkt(*this, 0x02);  // Spawn Global Entity packet
 	Pkt.WriteVarInt32(0);  // EntityID = 0, always
 	Pkt.WriteBEUInt8(1);  // Type = Thunderbolt
-	Pkt.WriteFPInt(a_BlockX);
-	Pkt.WriteFPInt(a_BlockY);
-	Pkt.WriteFPInt(a_BlockZ);
+	Pkt.WriteBEDouble(a_BlockX);
+	Pkt.WriteBEDouble(a_BlockY);
+	Pkt.WriteBEDouble(a_BlockZ);
 }
 
 
 
 
 
-void cProtocol180::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks)
+void cProtocol_1_9_0::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1472,7 +1486,7 @@ void cProtocol180::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_F
 
 
 
-void cProtocol180::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_DoDaylightCycle)
+void cProtocol_1_9_0::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_DoDaylightCycle)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	if (!a_DoDaylightCycle)
@@ -1481,7 +1495,7 @@ void cProtocol180::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_Do
 		a_TimeOfDay = std::min(-a_TimeOfDay, -1LL);
 	}
 
-	cPacketizer Pkt(*this, 0x03);
+	cPacketizer Pkt(*this, 0x44);  // Time update packet
 	Pkt.WriteBEInt64(a_WorldAge);
 	Pkt.WriteBEInt64(a_TimeOfDay);
 }
@@ -1490,26 +1504,23 @@ void cProtocol180::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_Do
 
 
 
-void cProtocol180::SendUnloadChunk(int a_ChunkX, int a_ChunkZ)
+void cProtocol_1_9_0::SendUnloadChunk(int a_ChunkX, int a_ChunkZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x21);  // Chunk Data packet
+	cPacketizer Pkt(*this, 0x1d);  // Unload chunk packet
 	Pkt.WriteBEInt32(a_ChunkX);
 	Pkt.WriteBEInt32(a_ChunkZ);
-	Pkt.WriteBool(true);
-	Pkt.WriteBEInt16(0);  // Primary bitmap
-	Pkt.WriteVarInt32(0);  // Data size
 }
 
 
 
 
-void cProtocol180::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
+void cProtocol_1_9_0::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x35);  // Update tile entity packet
+	cPacketizer Pkt(*this, 0x09);  // Update tile entity packet
 	Pkt.WritePosition64(a_BlockEntity.GetPosX(), a_BlockEntity.GetPosY(), a_BlockEntity.GetPosZ());
 
 	Byte Action = 0;
@@ -1531,11 +1542,11 @@ void cProtocol180::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 
 
 
-void cProtocol180::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
+void cProtocol_1_9_0::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x33);
+	cPacketizer Pkt(*this, 0x46);  // Update sign packet
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 
 	Json::StyledWriter JsonWriter;
@@ -1552,11 +1563,11 @@ void cProtocol180::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 
 
 
-void cProtocol180::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
+void cProtocol_1_9_0::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x0a);
+	cPacketizer Pkt(*this, 0x2f);  // Use bed
 	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 }
@@ -1565,12 +1576,12 @@ void cProtocol180::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_Bloc
 
 
 
-void cProtocol180::SendWeather(eWeather a_Weather)
+void cProtocol_1_9_0::SendWeather(eWeather a_Weather)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	{
-		cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
+		cPacketizer Pkt(*this, 0x1e);  // Change Game State packet
 		Pkt.WriteBEUInt8((a_Weather == wSunny) ? 1 : 2);  // End rain / begin rain
 		Pkt.WriteBEFloat(0);  // Unused for weather
 	}
@@ -1582,11 +1593,11 @@ void cProtocol180::SendWeather(eWeather a_Weather)
 
 
 
-void cProtocol180::SendWholeInventory(const cWindow & a_Window)
+void cProtocol_1_9_0::SendWholeInventory(const cWindow & a_Window)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x30);  // Window Items packet
+	cPacketizer Pkt(*this, 0x14);  // Window Items packet
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Window.GetNumSlots()));
 	cItems Slots;
@@ -1601,11 +1612,11 @@ void cProtocol180::SendWholeInventory(const cWindow & a_Window)
 
 
 
-void cProtocol180::SendWindowClose(const cWindow & a_Window)
+void cProtocol_1_9_0::SendWindowClose(const cWindow & a_Window)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x2e);
+	cPacketizer Pkt(*this, 0x12);  // Close window packet
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 }
 
@@ -1613,7 +1624,7 @@ void cProtocol180::SendWindowClose(const cWindow & a_Window)
 
 
 
-void cProtocol180::SendWindowOpen(const cWindow & a_Window)
+void cProtocol_1_9_0::SendWindowOpen(const cWindow & a_Window)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
@@ -1623,7 +1634,7 @@ void cProtocol180::SendWindowOpen(const cWindow & a_Window)
 		return;
 	}
 
-	cPacketizer Pkt(*this, 0x2d);
+	cPacketizer Pkt(*this, 0x13);  // Open window packet
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 	Pkt.WriteString(a_Window.GetWindowTypeName());
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", a_Window.GetWindowTitle().c_str()));
@@ -1654,11 +1665,11 @@ void cProtocol180::SendWindowOpen(const cWindow & a_Window)
 
 
 
-void cProtocol180::SendWindowProperty(const cWindow & a_Window, short a_Property, short a_Value)
+void cProtocol_1_9_0::SendWindowProperty(const cWindow & a_Window, short a_Property, short a_Value)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	cPacketizer Pkt(*this, 0x31);  // Window Property packet
+	cPacketizer Pkt(*this, 0x15);  // Window Property packet
 	Pkt.WriteBEInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(a_Property);
 	Pkt.WriteBEInt16(a_Value);
@@ -1668,7 +1679,7 @@ void cProtocol180::SendWindowProperty(const cWindow & a_Window, short a_Property
 
 
 
-bool cProtocol180::CompressPacket(const AString & a_Packet, AString & a_CompressedData)
+bool cProtocol_1_9_0::CompressPacket(const AString & a_Packet, AString & a_CompressedData)
 {
 	// Compress the data:
 	char CompressedData[MAX_COMPRESSED_PACKET_LEN];
@@ -1711,7 +1722,7 @@ bool cProtocol180::CompressPacket(const AString & a_Packet, AString & a_Compress
 
 
 
-int cProtocol180::GetParticleID(const AString & a_ParticleName)
+int cProtocol_1_9_0::GetParticleID(const AString & a_ParticleName)
 {
 	static bool IsInitialized = false;
 	static std::map<AString, int> ParticleMap;
@@ -1777,7 +1788,7 @@ int cProtocol180::GetParticleID(const AString & a_ParticleName)
 
 
 
-void cProtocol180::FixItemFramePositions(int a_ObjectData, double & a_PosX, double & a_PosZ, double & a_Yaw)
+void cProtocol_1_9_0::FixItemFramePositions(int a_ObjectData, double & a_PosX, double & a_PosZ, double & a_Yaw)
 {
 	switch (a_ObjectData)
 	{
@@ -1812,7 +1823,7 @@ void cProtocol180::FixItemFramePositions(int a_ObjectData, double & a_PosX, doub
 
 
 
-void cProtocol180::AddReceivedData(const char * a_Data, size_t a_Size)
+void cProtocol_1_9_0::AddReceivedData(const char * a_Data, size_t a_Size)
 {
 	// Write the incoming data into the comm log file:
 	if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
@@ -1942,7 +1953,7 @@ void cProtocol180::AddReceivedData(const char * a_Data, size_t a_Size)
 		if (!HandlePacket(bb, PacketType))
 		{
 			// Unknown packet, already been reported, but without the length. Log the length here:
-			LOGWARNING("Unhandled packet: type 0x%x, state %d, length %u", PacketType, m_State, PacketLen);
+			LOGWARNING("Protocol 1.9: Unhandled packet: type 0x%x, state %d, length %u", PacketType, m_State, PacketLen);
 
 			#ifdef _DEBUG
 				// Dump the packet contents into the log:
@@ -1968,7 +1979,7 @@ void cProtocol180::AddReceivedData(const char * a_Data, size_t a_Size)
 		if (bb.GetReadableSpace() != 1)
 		{
 			// Read more or less than packet length, report as error
-			LOGWARNING("Protocol 1.8: Wrong number of bytes read for packet 0x%x, state %d. Read " SIZE_T_FMT " bytes, packet contained %u bytes",
+			LOGWARNING("Protocol 1.9: Wrong number of bytes read for packet 0x%x, state %d. Read " SIZE_T_FMT " bytes, packet contained %u bytes",
 				PacketType, m_State, bb.GetUsedSpace() - bb.GetReadableSpace(), PacketLen
 			);
 
@@ -1997,7 +2008,7 @@ void cProtocol180::AddReceivedData(const char * a_Data, size_t a_Size)
 		ASSERT(m_ReceivedData.GetReadableSpace() == OldReadableSpace);
 		AString Hex;
 		CreateHexDump(Hex, AllData.data(), AllData.size(), 16);
-		m_CommLogFile.Printf("There are " SIZE_T_FMT " (0x" SIZE_T_FMT_HEX ") bytes of non-parse-able data left in the buffer:\n%s",
+		m_CommLogFile.Printf("Protocol 1.9: There are " SIZE_T_FMT " (0x" SIZE_T_FMT_HEX ") bytes of non-parse-able data left in the buffer:\n%s",
 			m_ReceivedData.GetReadableSpace(), m_ReceivedData.GetReadableSpace(), Hex.c_str()
 		);
 		m_CommLogFile.Flush();
@@ -2007,7 +2018,7 @@ void cProtocol180::AddReceivedData(const char * a_Data, size_t a_Size)
 
 
 
-bool cProtocol180::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
+bool cProtocol_1_9_0::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
 {
 	switch (m_State)
 	{
@@ -2038,31 +2049,36 @@ bool cProtocol180::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
 			// Game
 			switch (a_PacketType)
 			{
-				case 0x00: HandlePacketKeepAlive              (a_ByteBuffer); return true;
-				case 0x01: HandlePacketChatMessage            (a_ByteBuffer); return true;
-				case 0x02: HandlePacketUseEntity              (a_ByteBuffer); return true;
-				case 0x03: HandlePacketPlayer                 (a_ByteBuffer); return true;
-				case 0x04: HandlePacketPlayerPos              (a_ByteBuffer); return true;
-				case 0x05: HandlePacketPlayerLook             (a_ByteBuffer); return true;
-				case 0x06: HandlePacketPlayerPosLook          (a_ByteBuffer); return true;
-				case 0x07: HandlePacketBlockDig               (a_ByteBuffer); return true;
-				case 0x08: HandlePacketBlockPlace             (a_ByteBuffer); return true;
-				case 0x09: HandlePacketSlotSelect             (a_ByteBuffer); return true;
-				case 0x0a: HandlePacketAnimation              (a_ByteBuffer); return true;
-				case 0x0b: HandlePacketEntityAction           (a_ByteBuffer); return true;
-				case 0x0c: HandlePacketSteerVehicle           (a_ByteBuffer); return true;
-				case 0x0d: HandlePacketWindowClose            (a_ByteBuffer); return true;
-				case 0x0e: HandlePacketWindowClick            (a_ByteBuffer); return true;
-				case 0x0f:  // Confirm transaction - not used in MCS
-				case 0x10: HandlePacketCreativeInventoryAction(a_ByteBuffer); return true;
-				case 0x11: HandlePacketEnchantItem            (a_ByteBuffer); return true;
-				case 0x12: HandlePacketUpdateSign             (a_ByteBuffer); return true;
-				case 0x13: HandlePacketPlayerAbilities        (a_ByteBuffer); return true;
-				case 0x14: HandlePacketTabComplete            (a_ByteBuffer); return true;
-				case 0x15: HandlePacketClientSettings         (a_ByteBuffer); return true;
-				case 0x16: HandlePacketClientStatus           (a_ByteBuffer); return true;
-				case 0x17: HandlePacketPluginMessage          (a_ByteBuffer); return true;
-				case 0x18: HandlePacketSpectate               (a_ByteBuffer); return true;
+				case 0x00: HandleConfirmTeleport              (a_ByteBuffer); return true;
+				case 0x01: HandlePacketTabComplete            (a_ByteBuffer); return true;
+				case 0x02: HandlePacketChatMessage            (a_ByteBuffer); return true;
+				case 0x03: HandlePacketClientStatus           (a_ByteBuffer); return true;
+				case 0x04: HandlePacketClientSettings         (a_ByteBuffer); return true;
+				case 0x05: break;  // Confirm transaction - not used in MCS
+				case 0x06: HandlePacketEnchantItem            (a_ByteBuffer); return true;
+				case 0x07: HandlePacketWindowClick            (a_ByteBuffer); return true;
+				case 0x08: HandlePacketWindowClose            (a_ByteBuffer); return true;
+				case 0x09: HandlePacketPluginMessage          (a_ByteBuffer); return true;
+				case 0x0a: HandlePacketUseEntity              (a_ByteBuffer); return true;
+				case 0x0b: HandlePacketKeepAlive              (a_ByteBuffer); return true;
+				case 0x0c: HandlePacketPlayerPos              (a_ByteBuffer); return true;
+				case 0x0d: HandlePacketPlayerPosLook          (a_ByteBuffer); return true;
+				case 0x0e: HandlePacketPlayerLook             (a_ByteBuffer); return true;
+				case 0x0f: HandlePacketPlayer                 (a_ByteBuffer); return true;
+				case 0x10: HandlePacketVehicleMove            (a_ByteBuffer); return true;
+				case 0x11: HandlePacketBoatSteer              (a_ByteBuffer); return true;
+				case 0x12: HandlePacketPlayerAbilities        (a_ByteBuffer); return true;
+				case 0x13: HandlePacketBlockDig               (a_ByteBuffer); return true;
+				case 0x14: HandlePacketEntityAction           (a_ByteBuffer); return true;
+				case 0x15: HandlePacketSteerVehicle           (a_ByteBuffer); return true;
+				case 0x16: break;  // Resource pack status - not yet implemented
+				case 0x17: HandlePacketSlotSelect             (a_ByteBuffer); return true;
+				case 0x18: HandlePacketCreativeInventoryAction(a_ByteBuffer); return true;
+				case 0x19: HandlePacketUpdateSign             (a_ByteBuffer); return true;
+				case 0x1a: HandlePacketAnimation              (a_ByteBuffer); return true;
+				case 0x1b: HandlePacketSpectate               (a_ByteBuffer); return true;
+				case 0x1c: HandlePacketBlockPlace             (a_ByteBuffer); return true;
+				case 0x1d: HandlePacketUseItem                (a_ByteBuffer); return true;
 			}
 			break;
 		}
@@ -2094,7 +2110,7 @@ bool cProtocol180::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
 
 
 
-void cProtocol180::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt64, Int64, Timestamp);
 
@@ -2106,7 +2122,7 @@ void cProtocol180::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 {
 	cServer * Server = cRoot::Get()->GetServer();
 	AString ServerDescription = Server->GetDescription();
@@ -2117,8 +2133,8 @@ void cProtocol180::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 	// Version:
 	Json::Value Version;
-	Version["name"] = "Cuberite 1.8";
-	Version["protocol"] = 47;
+	Version["name"] = "Cuberite 1.9";
+	Version["protocol"] = 107;
 
 	// Players:
 	Json::Value Players;
@@ -2151,7 +2167,7 @@ void cProtocol180::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffer)
 {
 	UInt32 EncKeyLength, EncNonceLength;
 	if (!a_ByteBuffer.ReadVarInt(EncKeyLength))
@@ -2214,7 +2230,7 @@ void cProtocol180::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffe
 
 
 
-void cProtocol180::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 {
 	AString Username;
 	if (!a_ByteBuffer.ReadVarUTF8String(Username))
@@ -2251,8 +2267,10 @@ void cProtocol180::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 {
+	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Hand);
+
 	m_Client->HandleAnimation(0);  // Packet exists solely for arm-swing notification
 }
 
@@ -2260,7 +2278,7 @@ void cProtocol180::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Status);
 
@@ -2270,7 +2288,7 @@ void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 		return;
 	}
 
-	HANDLE_READ(a_ByteBuffer, ReadBEInt8, Int8, Face);
+	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Face);
 	m_Client->HandleLeftClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), Status);
 }
 
@@ -2278,7 +2296,7 @@ void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 {
 	int BlockX, BlockY, BlockZ;
 	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
@@ -2286,11 +2304,8 @@ void cProtocol180::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 		return;
 	}
 
-	HANDLE_READ(a_ByteBuffer, ReadBEInt8, Int8, Face);
-
-	cItem Item;
-	ReadItem(a_ByteBuffer, Item, 3);
-
+	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Face);
+	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Hand);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorX);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorY);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorZ);
@@ -2301,7 +2316,30 @@ void cProtocol180::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketBoatSteer(cByteBuffer & a_ByteBuffer)
+{
+	HANDLE_READ(a_ByteBuffer, ReadBool, bool, RightPaddle);
+	HANDLE_READ(a_ByteBuffer, ReadBool, bool, LeftPaddle);
+
+	// Get the players vehicle
+	cPlayer * Player = m_Client->GetPlayer();
+	cEntity * Vehicle = Player->GetAttached();
+
+	if (Vehicle)
+	{
+		if (Vehicle->GetEntityType() == cEntity::etBoat)
+		{
+			auto * Boat = reinterpret_cast<cBoat *>(Vehicle);
+			Boat->UpdatePaddles(RightPaddle, LeftPaddle);
+		}
+	}
+}
+
+
+
+
+
+void cProtocol_1_9_0::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Message);
 	m_Client->HandleChat(Message);
@@ -2311,13 +2349,14 @@ void cProtocol180::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Locale);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   ViewDistance);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   ChatFlags);
 	HANDLE_READ(a_ByteBuffer, ReadBool,          bool,    ChatColors);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   SkinFlags);
+	HANDLE_READ(a_ByteBuffer, ReadVarInt,        UInt32,   MainHand);
 
 	m_Client->SetLocale(Locale);
 	m_Client->SetViewDistance(ViewDistance);
@@ -2328,7 +2367,7 @@ void cProtocol180::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, ActionID);
 	switch (ActionID)
@@ -2360,7 +2399,17 @@ void cProtocol180::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandleConfirmTeleport(cByteBuffer & a_ByteBuffer)
+{
+	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, TeleportID);
+	// We don't actually validate that this packet is sent or anything yet, but it still needs to be read.
+}
+
+
+
+
+
+void cProtocol_1_9_0::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
 	cItem Item;
@@ -2375,7 +2424,7 @@ void cProtocol180::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffe
 
 
 
-void cProtocol180::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt,  UInt32, PlayerID);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8,  Action);
@@ -2395,7 +2444,7 @@ void cProtocol180::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, KeepAliveID);
 	m_Client->HandleKeepAlive(KeepAliveID);
@@ -2405,7 +2454,7 @@ void cProtocol180::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketPlayer(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketPlayer(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBool, bool, IsOnGround);
 	// TODO: m_Client->HandlePlayerOnGround(IsOnGround);
@@ -2415,7 +2464,7 @@ void cProtocol180::HandlePacketPlayer(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Flags);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, FlyingSpeed);
@@ -2439,7 +2488,7 @@ void cProtocol180::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Yaw);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Pitch);
@@ -2451,7 +2500,7 @@ void cProtocol180::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosX);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
@@ -2464,7 +2513,7 @@ void cProtocol180::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosX);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
@@ -2479,7 +2528,7 @@ void cProtocol180::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Channel);
 
@@ -2510,7 +2559,7 @@ void cProtocol180::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
 	m_Client->HandleSlotSelected(SlotNum);
@@ -2520,7 +2569,7 @@ void cProtocol180::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketSpectate(cByteBuffer &a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketSpectate(cByteBuffer & a_ByteBuffer)
 {
 	AString playerUUID;
 	if (!a_ByteBuffer.ReadUUID(playerUUID))
@@ -2535,7 +2584,7 @@ void cProtocol180::HandlePacketSpectate(cByteBuffer &a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Sideways);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Forward);
@@ -2547,7 +2596,7 @@ void cProtocol180::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 	}
 	else if ((Flags & 0x1) != 0)
 	{
-		// jump
+		// TODO: Handle vehicle jump (for animals)
 	}
 	else
 	{
@@ -2559,9 +2608,10 @@ void cProtocol180::HandlePacketSteerVehicle(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Text);
+	HANDLE_READ(a_ByteBuffer, ReadBool,          bool,    AssumeCommand);
 	HANDLE_READ(a_ByteBuffer, ReadBool,          bool,    HasPosition);
 
 	if (HasPosition)
@@ -2576,7 +2626,7 @@ void cProtocol180::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 {
 	int BlockX, BlockY, BlockZ;
 	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
@@ -2585,15 +2635,10 @@ void cProtocol180::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 	}
 
 	AString Lines[4];
-	Json::Value root;
-	Json::Reader reader;
 	for (int i = 0; i < 4; i++)
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Line);
-		if (reader.parse(Line, root, false))
-		{
-			Lines[i] = root.asString();
-		}
+		Lines[i] = Line;
 	}
 
 	m_Client->HandleUpdateSign(BlockX, BlockY, BlockZ, Lines[0], Lines[1], Lines[2], Lines[3]);
@@ -2603,7 +2648,7 @@ void cProtocol180::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, EntityID);
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Type);
@@ -2612,6 +2657,7 @@ void cProtocol180::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 	{
 		case 0:
 		{
+			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand)
 			m_Client->HandleUseEntity(EntityID, false);
 			break;
 		}
@@ -2625,6 +2671,7 @@ void cProtocol180::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 			HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, TargetX);
 			HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, TargetY);
 			HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, TargetZ);
+			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand);
 
 			// TODO: Do anything
 			break;
@@ -2641,7 +2688,19 @@ void cProtocol180::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketEnchantItem(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketUseItem(cByteBuffer & a_ByteBuffer)
+{
+	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt64, Hand);
+
+	// Didn't click a block - emulate old values used with place block of -1, -1, -1 (and BLOCK_FACE_NONE).
+	m_Client->HandleRightClick(-1, 255, -1, BLOCK_FACE_NONE, 0, 0, 0, m_Client->GetPlayer()->GetEquippedItem());
+}
+
+
+
+
+
+void cProtocol_1_9_0::HandlePacketEnchantItem(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, WindowID);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Enchantment);
@@ -2653,13 +2712,39 @@ void cProtocol180::HandlePacketEnchantItem(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketVehicleMove(cByteBuffer & a_ByteBuffer)
+{
+	// This handles updating the vehicles location server side
+	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, xPos);
+	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, yPos);
+	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, zPos);
+	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  yaw);
+	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  pitch);
+
+	// Get the players vehicle
+	cEntity * Vehicle = m_Client->GetPlayer()->GetAttached();
+
+	if (Vehicle)
+	{
+		Vehicle->SetPosX(xPos);
+		Vehicle->SetPosY(yPos);
+		Vehicle->SetPosZ(zPos);
+		Vehicle->SetYaw(yaw);
+		Vehicle->SetPitch(pitch);
+	}
+}
+
+
+
+
+
+void cProtocol_1_9_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  WindowID);
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16,  Int16,  SlotNum);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  Button);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt16, UInt16, TransactionID);
-	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  Mode);
+	HANDLE_READ(a_ByteBuffer, ReadVarInt32,  UInt32,  Mode);
 	cItem Item;
 	ReadItem(a_ByteBuffer, Item);
 
@@ -2705,7 +2790,7 @@ void cProtocol180::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
+void cProtocol_1_9_0::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, WindowID);
 	m_Client->HandleWindowClose(WindowID);
@@ -2715,7 +2800,7 @@ void cProtocol180::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol180::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel)
+void cProtocol_1_9_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel)
 {
 	if (a_Channel == "MC|AdvCdm")
 	{
@@ -2780,7 +2865,7 @@ void cProtocol180::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const 
 
 
 
-void cProtocol180::SendData(const char * a_Data, size_t a_Size)
+void cProtocol_1_9_0::SendData(const char * a_Data, size_t a_Size)
 {
 	if (m_IsEncrypted)
 	{
@@ -2804,7 +2889,7 @@ void cProtocol180::SendData(const char * a_Data, size_t a_Size)
 
 
 
-bool cProtocol180::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes)
+bool cProtocol_1_9_0::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes)
 {
 	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt16, Int16, ItemType);
 	if (ItemType == -1)
@@ -2839,7 +2924,7 @@ bool cProtocol180::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a
 
 
 
-void cProtocol180::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
+void cProtocol_1_9_0::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 {
 	// Parse into NBT:
 	cParsedNBT NBT(a_Metadata.data(), a_Metadata.size());
@@ -2896,6 +2981,18 @@ void cProtocol180::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 				{
 					cFireworkItem::ParseFromNBT(a_Item.m_FireworkItem, NBT, tag, static_cast<ENUM_ITEM_ID>(a_Item.m_ItemType));
 				}
+				else if (TagName == "EntityTag")
+				{
+					for (int entitytag = NBT.GetFirstChild(tag); entitytag >= 0; entitytag = NBT.GetNextSibling(entitytag))
+					{
+						if ((NBT.GetType(entitytag) == TAG_String) && (NBT.GetName(entitytag) == "id"))
+						{
+							eMonsterType MonsterType = cMonster::StringToMobType(NBT.GetString(entitytag));
+							// No special method here to convert to the numeric damage value; just cast to the given ID
+							a_Item.m_ItemDamage = static_cast<short>(MonsterType);
+						}
+					}
+				}
 				break;
 			}
 			case TAG_Int:
@@ -2904,6 +3001,122 @@ void cProtocol180::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 				{
 					a_Item.m_RepairCost = NBT.GetInt(tag);
 				}
+				break;
+			}
+			case TAG_String:
+			{
+				if (TagName == "Potion")
+				{
+					AString PotionEffect = NBT.GetString(tag);
+					if (PotionEffect.find("minecraft:") == AString::npos)
+					{
+						LOGD("Unknown or missing domain on potion effect name %s!", PotionEffect.c_str());
+						continue;
+					}
+
+					if (PotionEffect.find("water") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 0;
+						// Water bottles shouldn't have other bits set on them; exit early.
+						continue;
+					}
+					if (PotionEffect.find("empty") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 0;
+					}
+					else if (PotionEffect.find("mundane") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 0;
+					}
+					else if (PotionEffect.find("thick") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 20;
+					}
+					else if (PotionEffect.find("awkward") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 10;
+					}
+					else if (PotionEffect.find("regeneration") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 1;
+					}
+					else if (PotionEffect.find("swiftness") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 2;
+					}
+					else if (PotionEffect.find("fire_resistance") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 3;
+					}
+					else if (PotionEffect.find("poison") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 4;
+					}
+					else if (PotionEffect.find("healing") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 5;
+					}
+					else if (PotionEffect.find("night_vision") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 6;
+					}
+					else if (PotionEffect.find("weakness") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 8;
+					}
+					else if (PotionEffect.find("strength") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 9;
+					}
+					else if (PotionEffect.find("slowness") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 10;
+					}
+					else if (PotionEffect.find("leaping") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 11;
+					}
+					else if (PotionEffect.find("harming") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 12;
+					}
+					else if (PotionEffect.find("water_breathing") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 13;
+					}
+					else if (PotionEffect.find("invisibility") != AString::npos)
+					{
+						a_Item.m_ItemDamage = 14;
+					}
+					else
+					{
+						// Note: luck potions are not handled and will reach this location
+						LOGD("Unknown potion type for effect name %s!", PotionEffect.c_str());
+						continue;
+					}
+
+					if (PotionEffect.find("strong") != AString::npos)
+					{
+						a_Item.m_ItemDamage |= 0x20;
+					}
+					if (PotionEffect.find("long") != AString::npos)
+					{
+						a_Item.m_ItemDamage |= 0x40;
+					}
+
+					// Ugly special case with the changed splash potion ID in 1.9
+					if ((a_Item.m_ItemType == 438) || (a_Item.m_ItemType == 441))
+					{
+						// Splash or lingering potions - change the ID to the normal one and mark as splash potions
+						a_Item.m_ItemType = E_ITEM_POTION;
+						a_Item.m_ItemDamage |= 0x4000;  // Is splash potion
+					}
+					else
+					{
+						a_Item.m_ItemDamage |= 0x2000;  // Is drinkable
+					}
+				}
+				break;
 			}
 			default: LOGD("Unimplemented NBT data when parsing!"); break;
 		}
@@ -2914,7 +3127,7 @@ void cProtocol180::ParseItemMetadata(cItem & a_Item, const AString & a_Metadata)
 
 
 
-void cProtocol180::StartEncryption(const Byte * a_Key)
+void cProtocol_1_9_0::StartEncryption(const Byte * a_Key)
 {
 	m_Encryptor.Init(a_Key, a_Key);
 	m_Decryptor.Init(a_Key, a_Key);
@@ -2936,7 +3149,7 @@ void cProtocol180::StartEncryption(const Byte * a_Key)
 
 
 
-eBlockFace cProtocol180::FaceIntToBlockFace(Int8 a_BlockFace)
+eBlockFace cProtocol_1_9_0::FaceIntToBlockFace(Int32 a_BlockFace)
 {
 	// Normalize the blockface values returned from the protocol
 	// Anything known gets mapped 1:1, everything else returns BLOCK_FACE_NONE
@@ -2957,9 +3170,9 @@ eBlockFace cProtocol180::FaceIntToBlockFace(Int8 a_BlockFace)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// cProtocol180::cPacketizer:
+// cProtocol_1_9_0::cPacketizer:
 
-void cProtocol180::SendPacket(cPacketizer & a_Pkt)
+void cProtocol_1_9_0::SendPacket(cPacketizer & a_Pkt)
 {
 	UInt32 PacketLen = static_cast<UInt32>(m_OutPacketBuffer.GetUsedSpace());
 	AString PacketData, CompressedPacket;
@@ -2969,7 +3182,7 @@ void cProtocol180::SendPacket(cPacketizer & a_Pkt)
 	if ((m_State == 3) && (PacketLen >= 256))
 	{
 		// Compress the packet payload:
-		if (!cProtocol180::CompressPacket(PacketData, CompressedPacket))
+		if (!cProtocol_1_9_0::CompressPacket(PacketData, CompressedPacket))
 		{
 			return;
 		}
@@ -3019,7 +3232,7 @@ void cProtocol180::SendPacket(cPacketizer & a_Pkt)
 
 
 
-void cProtocol180::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
+void cProtocol_1_9_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 {
 	short ItemType = a_Item.m_ItemType;
 	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime
@@ -3035,11 +3248,28 @@ void cProtocol180::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 		return;
 	}
 
-	a_Pkt.WriteBEInt16(ItemType);
+	if ((ItemType == E_ITEM_POTION) && ((a_Item.m_ItemDamage & 0x4000) != 0))
+	{
+		// Ugly special case for splash potion ids which changed in 1.9; this can be removed when the new 1.9 ids are implemented
+		a_Pkt.WriteBEInt16(438);  // minecraft:splash_potion
+	}
+	else
+	{
+		// Normal item
+		a_Pkt.WriteBEInt16(ItemType);
+	}
 	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
-	a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
+	if ((ItemType == E_ITEM_POTION) || (ItemType == E_ITEM_SPAWN_EGG))
+	{
+		// These items lost their metadata; if it is sent they don't render correctly.
+		a_Pkt.WriteBEInt16(0);
+	}
+	else
+	{
+		a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
+	}
 
-	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) && (a_Item.m_ItemType != E_ITEM_FIREWORK_STAR) && !a_Item.m_ItemColor.IsValid())
+	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (ItemType != E_ITEM_FIREWORK_ROCKET) && (ItemType != E_ITEM_FIREWORK_STAR) && !a_Item.m_ItemColor.IsValid() && (ItemType != E_ITEM_POTION) && (ItemType != E_ITEM_SPAWN_EGG))
 	{
 		a_Pkt.WriteBEInt8(0);
 		return;
@@ -3092,6 +3322,76 @@ void cProtocol180::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 	{
 		cFireworkItem::WriteToNBTCompound(a_Item.m_FireworkItem, Writer, static_cast<ENUM_ITEM_ID>(a_Item.m_ItemType));
 	}
+	if (a_Item.m_ItemType == E_ITEM_POTION)
+	{
+		// 1.9 potions use a different format.  In the future (when only 1.9+ is supported) this should be its own class
+		AString PotionID = "empty";  // Fallback of "Uncraftable potion" for unhandled cases
+
+		cEntityEffect::eType Type = cEntityEffect::GetPotionEffectType(a_Item.m_ItemDamage);
+		if (Type != cEntityEffect::effNoEffect)
+		{
+			switch (Type)
+			{
+				case cEntityEffect::effRegeneration: PotionID = "regeneration"; break;
+				case cEntityEffect::effSpeed: PotionID = "swiftness"; break;
+				case cEntityEffect::effFireResistance: PotionID = "fire_resistance"; break;
+				case cEntityEffect::effPoison: PotionID = "poison"; break;
+				case cEntityEffect::effInstantHealth: PotionID = "healing"; break;
+				case cEntityEffect::effNightVision: PotionID = "night_vision"; break;
+				case cEntityEffect::effWeakness: PotionID = "weakness"; break;
+				case cEntityEffect::effStrength: PotionID = "strength"; break;
+				case cEntityEffect::effSlowness: PotionID = "slowness"; break;
+				case cEntityEffect::effJumpBoost: PotionID = "leaping"; break;
+				case cEntityEffect::effInstantDamage: PotionID = "harming"; break;
+				case cEntityEffect::effWaterBreathing: PotionID = "water_breathing"; break;
+				case cEntityEffect::effInvisibility: PotionID = "invisibility"; break;
+			}
+			if (cEntityEffect::GetPotionEffectIntensity(a_Item.m_ItemDamage) == 1)
+			{
+				PotionID = "strong_" + PotionID;
+			}
+			else if (a_Item.m_ItemDamage & 0x40)
+			{
+				// Extended potion bit
+				PotionID = "long_" + PotionID;
+			}
+		}
+		else
+		{
+			// Empty potions: Water bottles and other base ones
+			if (a_Item.m_ItemDamage == 0)
+			{
+				// No other bits set; thus it's a water bottle
+				PotionID = "water";
+			}
+			else
+			{
+				switch (a_Item.m_ItemDamage & 0x3f)
+				{
+					case 0x00: PotionID = "mundane"; break;
+					case 0x10: PotionID = "awkward"; break;
+					case 0x20: PotionID = "thick"; break;
+				}
+				// Default cases will use "empty" from before.
+			}
+		}
+
+		PotionID = "minecraft:" + PotionID;
+
+		Writer.AddString("Potion", PotionID.c_str());
+	}
+	if (a_Item.m_ItemType == E_ITEM_SPAWN_EGG)
+	{
+		// Convert entity ID to the name.
+		eMonsterType MonsterType = cItemSpawnEggHandler::ItemDamageToMonsterType(a_Item.m_ItemDamage);
+		if (MonsterType != eMonsterType::mtInvalidType)
+		{
+			Writer.BeginCompound("EntityTag");
+			Writer.AddString("id", cMonster::MobTypeToVanillaName(MonsterType));
+			Writer.EndCompound();
+		}
+	}
+
 	Writer.Finish();
 
 	AString Result = Writer.GetResult();
@@ -3107,7 +3407,7 @@ void cProtocol180::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 
 
 
-void cProtocol180::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity)
+void cProtocol_1_9_0::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity)
 {
 	cFastNBTWriter Writer;
 
@@ -3211,10 +3511,10 @@ void cProtocol180::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_
 
 
 
-void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_9_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
 {
 	// Common metadata:
-	Byte Flags = 0;
+	Int8 Flags = 0;
 	if (a_Entity.IsOnFire())
 	{
 		Flags |= 0x01;
@@ -3235,35 +3535,53 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 	{
 		Flags |= 0x20;
 	}
-	a_Pkt.WriteBEUInt8(0);  // Byte(0) + index 0
-	a_Pkt.WriteBEUInt8(Flags);
+	a_Pkt.WriteBEUInt8(0);  // Index 0
+	a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);  // Type
+	a_Pkt.WriteBEInt8(Flags);
 
 	switch (a_Entity.GetEntityType())
 	{
-		case cEntity::etPlayer: break;  // TODO?
+		case cEntity::etPlayer:
+		{
+			auto & Player = reinterpret_cast<const cPlayer &>(a_Entity);
+
+			// TODO Set player custom name to their name.
+			// Then it's possible to move the custom name of mobs to the entities
+			// and to remove the "special" player custom name.
+			a_Pkt.WriteBEUInt8(2);  // Index 2: Custom name
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_STRING);
+			a_Pkt.WriteString(Player.GetName());
+
+			a_Pkt.WriteBEUInt8(6);  // Start metadata - Index 6: Health
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
+			a_Pkt.WriteBEFloat(static_cast<float>(Player.GetHealth()));
+			break;
+		}
 		case cEntity::etPickup:
 		{
-			a_Pkt.WriteBEUInt8((5 << 5) | 10);  // Slot(5) + index 10
+			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
 			WriteItem(a_Pkt, reinterpret_cast<const cPickup &>(a_Entity).GetItem());
 			break;
 		}
 		case cEntity::etMinecart:
 		{
-			a_Pkt.WriteBEUInt8(0x51);
+			a_Pkt.WriteBEUInt8(5);  // Index 5: Shaking power
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
 
 			// The following expression makes Minecarts shake more with less health or higher damage taken
-			// It gets half the maximum health, and takes it away from the current health minus the half health:
-			/*
-			Health: 5 | 3 - (5 - 3) = 1 (shake power)
-			Health: 3 | 3 - (3 - 3) = 3
-			Health: 1 | 3 - (1 - 3) = 5
-			*/
 			auto & Minecart = reinterpret_cast<const cMinecart &>(a_Entity);
-			a_Pkt.WriteBEInt32((((a_Entity.GetMaxHealth() / 2) - (a_Entity.GetHealth() - (a_Entity.GetMaxHealth() / 2))) * Minecart.LastDamage()) * 4);
-			a_Pkt.WriteBEUInt8(0x52);
-			a_Pkt.WriteBEInt32(1);  // Shaking direction, doesn't seem to affect anything
-			a_Pkt.WriteBEUInt8(0x73);
-			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));  // Damage taken / shake effect multiplyer
+			auto maxHealth = a_Entity.GetMaxHealth();
+			auto curHealth = a_Entity.GetHealth();
+			a_Pkt.WriteVarInt32(static_cast<UInt32>((maxHealth - curHealth) * Minecart.LastDamage() * 4));
+
+			a_Pkt.WriteBEUInt8(6);  // Index 6: Shaking direction (doesn't seem to effect anything)
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(1);
+
+			a_Pkt.WriteBEUInt8(7);  // Index 7: Shake multiplier / damage taken
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
+			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));
 
 			if (Minecart.GetPayload() == cMinecart::mpNone)
 			{
@@ -3271,20 +3589,26 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 				const cItem & MinecartContent = RideableMinecart.GetContent();
 				if (!MinecartContent.IsEmpty())
 				{
-					a_Pkt.WriteBEUInt8(0x54);
+					a_Pkt.WriteBEUInt8(8);  // Index 8: Block ID and damage
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
 					int Content = MinecartContent.m_ItemType;
 					Content |= MinecartContent.m_ItemDamage << 8;
-					a_Pkt.WriteBEInt32(Content);
-					a_Pkt.WriteBEUInt8(0x55);
-					a_Pkt.WriteBEInt32(RideableMinecart.GetBlockHeight());
-					a_Pkt.WriteBEUInt8(0x56);
-					a_Pkt.WriteBEUInt8(1);
+					a_Pkt.WriteVarInt32(static_cast<UInt32>(Content));
+
+					a_Pkt.WriteBEUInt8(9);  // Index 9: Block ID and damage
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+					a_Pkt.WriteVarInt32(static_cast<UInt32>(RideableMinecart.GetBlockHeight()));
+
+					a_Pkt.WriteBEUInt8(10);  // Index 10: Show block
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+					a_Pkt.WriteBool(true);
 				}
 			}
 			else if (Minecart.GetPayload() == cMinecart::mpFurnace)
 			{
-				a_Pkt.WriteBEUInt8(0x10);
-				a_Pkt.WriteBEUInt8(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled() ? 1 : 0);
+				a_Pkt.WriteBEUInt8(11);  // Index 11: Is powered
+				a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+				a_Pkt.WriteBool(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled());
 			}
 			break;
 		}  // case etMinecart
@@ -3296,15 +3620,23 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			{
 				case cProjectileEntity::pkArrow:
 				{
-					a_Pkt.WriteBEUInt8(0x10);
-					a_Pkt.WriteBEUInt8(reinterpret_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
+					a_Pkt.WriteBEUInt8(5);  // Index 5: Is critical
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+					a_Pkt.WriteBEInt8(reinterpret_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
 					break;
 				}
 				case cProjectileEntity::pkFirework:
 				{
-					a_Pkt.WriteBEUInt8(0xa8);
+					a_Pkt.WriteBEUInt8(5);  // Index 5: Firework item used for this firework
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
 					WriteItem(a_Pkt, reinterpret_cast<const cFireworkEntity &>(Projectile).GetItem());
 					break;
+				}
+				case cProjectileEntity::pkSplashPotion:
+				{
+					a_Pkt.WriteBEUInt8(5);  // Index 5: Potion item which was thrown
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+					WriteItem(a_Pkt, reinterpret_cast<const cSplashPotionEntity &>(Projectile).GetItem());
 				}
 				default:
 				{
@@ -3320,13 +3652,46 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			break;
 		}
 
+		case cEntity::etBoat:
+		{
+			auto & Boat = reinterpret_cast<const cBoat &>(a_Entity);
+
+			a_Pkt.WriteBEInt8(5);  // Index 6: Time since last hit
+			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteBEInt32(Boat.GetLastDamage());
+
+			a_Pkt.WriteBEInt8(6);  // Index 7: Forward direction
+			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteBEInt32(Boat.GetForwardDirection());
+
+			a_Pkt.WriteBEInt8(7);  // Index 8: Damage taken
+			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
+			a_Pkt.WriteBEFloat(Boat.GetDamageTaken());
+
+			a_Pkt.WriteBEInt8(8);  // Index 9: Type
+			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteBEInt32(Boat.GetType());
+
+			a_Pkt.WriteBEInt8(9);  // Index 10: Right paddle turning
+			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Boat.IsRightPaddleUsed());
+
+			a_Pkt.WriteBEInt8(10);  // Index 11: Left paddle turning
+			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Boat.IsLeftPaddleUsed());
+
+			break;
+		}  // case etBoat
+
 		case cEntity::etItemFrame:
 		{
 			auto & Frame = reinterpret_cast<const cItemFrame &>(a_Entity);
-			a_Pkt.WriteBEUInt8(0xa8);
+			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
 			WriteItem(a_Pkt, Frame.GetItem());
-			a_Pkt.WriteBEUInt8(0x09);
-			a_Pkt.WriteBEUInt8(Frame.GetItemRotation());
+			a_Pkt.WriteBEUInt8(6);  // Index 6: Rotation
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(Frame.GetItemRotation());
 			break;
 		}  // case etItemFrame
 
@@ -3341,19 +3706,23 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 
 
 
-void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_9_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 {
 	// Living Enitiy Metadata
 	if (a_Mob.HasCustomName())
 	{
-		a_Pkt.WriteBEUInt8(0x82);
+		// TODO: As of 1.9 _all_ entities can have custom names; should this be moved up?
+		a_Pkt.WriteBEUInt8(2);  // Index 2: Custom name
+		a_Pkt.WriteBEUInt8(METADATA_TYPE_STRING);
 		a_Pkt.WriteString(a_Mob.GetCustomName());
 
-		a_Pkt.WriteBEUInt8(0x03);
+		a_Pkt.WriteBEUInt8(3);  // Index 3: Custom name always visible
+		a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
 		a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());
 	}
 
-	a_Pkt.WriteBEUInt8(0x66);
+	a_Pkt.WriteBEUInt8(6);  // Index 6: Health
+	a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
 	a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
 
 	switch (a_Mob.GetMobType())
@@ -3361,45 +3730,58 @@ void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 		case mtBat:
 		{
 			auto & Bat = reinterpret_cast<const cBat &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x10);
-			a_Pkt.WriteBEUInt8(Bat.IsHanging() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Bat flags - currently only hanging
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+			a_Pkt.WriteBEInt8(Bat.IsHanging() ? 1 : 0);
 			break;
 		}  // case mtBat
 
 		case mtCreeper:
 		{
 			auto & Creeper = reinterpret_cast<const cCreeper &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x10);
-			a_Pkt.WriteBEUInt8(Creeper.IsBlowing() ? 1 : 255);
-			a_Pkt.WriteBEUInt8(0x11);
-			a_Pkt.WriteBEUInt8(Creeper.IsCharged() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: State (idle or "blowing")
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(Creeper.IsBlowing() ? 1 : 0xffffffff);
+
+			a_Pkt.WriteBEUInt8(12);  // Index 12: Is charged
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Creeper.IsCharged());
+
+			a_Pkt.WriteBEUInt8(13);  // Index 13: Is ignited
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Creeper.IsBurnedWithFlintAndSteel());
 			break;
 		}  // case mtCreeper
 
 		case mtEnderman:
 		{
 			auto & Enderman = reinterpret_cast<const cEnderman &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x30);
-			a_Pkt.WriteBEInt16(static_cast<Byte>(Enderman.GetCarriedBlock()));
-			a_Pkt.WriteBEUInt8(0x11);
-			a_Pkt.WriteBEUInt8(static_cast<Byte>(Enderman.GetCarriedMeta()));
-			a_Pkt.WriteBEUInt8(0x12);
-			a_Pkt.WriteBEUInt8(Enderman.IsScreaming() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Carried block
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BLOCKID);
+			UInt32 Carried = 0;
+			Carried |= static_cast<UInt32>(Enderman.GetCarriedBlock() << 4);
+			Carried |= Enderman.GetCarriedMeta();
+			a_Pkt.WriteVarInt32(Carried);
+
+			a_Pkt.WriteBEUInt8(12);  // Index 12: Is screaming
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Enderman.IsScreaming());
 			break;
 		}  // case mtEnderman
 
 		case mtGhast:
 		{
 			auto & Ghast = reinterpret_cast<const cGhast &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x10);
-			a_Pkt.WriteBEUInt8(Ghast.IsCharging());
+			a_Pkt.WriteBEUInt8(11);  // Is attacking
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Ghast.IsCharging());
 			break;
 		}  // case mtGhast
 
 		case mtHorse:
 		{
 			auto & Horse = reinterpret_cast<const cHorse &>(a_Mob);
-			int Flags = 0;
+			Int8 Flags = 0;
 			if (Horse.IsTame())
 			{
 				Flags |= 0x02;
@@ -3424,139 +3806,177 @@ void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				Flags |= 0x80;
 			}
-			a_Pkt.WriteBEUInt8(0x50);  // Int at index 16
-			a_Pkt.WriteBEInt32(Flags);
-			a_Pkt.WriteBEUInt8(0x13);  // Byte at index 19
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Horse.GetHorseType()));
-			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
+			a_Pkt.WriteBEUInt8(12);  // Index 12: flags
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+			a_Pkt.WriteBEInt8(Flags);
+
+			a_Pkt.WriteBEUInt8(13);  // Index 13: Variant / type
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Horse.GetHorseType()));
+
+			a_Pkt.WriteBEUInt8(14);  // Index 14: Color / style
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
 			int Appearance = 0;
 			Appearance = Horse.GetHorseColor();
 			Appearance |= Horse.GetHorseStyle() << 8;
-			a_Pkt.WriteBEInt32(Appearance);
-			a_Pkt.WriteBEUInt8(0x56);  // Int at index 22
-			a_Pkt.WriteBEInt32(Horse.GetHorseArmour());
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Horse.IsBaby() ? -1 : (Horse.IsInLoveCooldown() ? 1 : 0));
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Appearance));
+
+			a_Pkt.WriteBEUInt8(16);  // Index 16: Armor
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Horse.GetHorseArmour()));
+
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Horse.IsBaby());
 			break;
 		}  // case mtHorse
 
 		case mtMagmaCube:
 		{
 			auto & MagmaCube = reinterpret_cast<const cMagmaCube &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x10);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(MagmaCube.GetSize()));
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Size
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(MagmaCube.GetSize()));
 			break;
 		}  // case mtMagmaCube
 
 		case mtOcelot:
 		{
 			auto & Ocelot = reinterpret_cast<const cOcelot &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Ocelot.IsBaby() ? -1 : (Ocelot.IsInLoveCooldown() ? 1 : 0));
+
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Ocelot.IsBaby());
 			break;
 		}  // case mtOcelot
 
 		case mtCow:
 		{
 			auto & Cow = reinterpret_cast<const cCow &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Cow.IsBaby() ? -1 : (Cow.IsInLoveCooldown() ? 1 : 0));
+
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Cow.IsBaby());
 			break;
 		}  // case mtCow
 
 		case mtChicken:
 		{
 			auto & Chicken = reinterpret_cast<const cChicken &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Chicken.IsBaby() ? -1 : (Chicken.IsInLoveCooldown() ? 1 : 0));
+
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Chicken.IsBaby());
 			break;
 		}  // case mtChicken
 
 		case mtPig:
 		{
 			auto & Pig = reinterpret_cast<const cPig &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Pig.IsBaby() ? -1 : (Pig.IsInLoveCooldown() ? 1 : 0));
-			a_Pkt.WriteBEUInt8(0x10);
-			a_Pkt.WriteBEUInt8(Pig.IsSaddled() ? 1 : 0);
+
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Pig.IsBaby());
+
+			a_Pkt.WriteBEUInt8(12);  // Index 12: Is saddled
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Pig.IsSaddled());
+
 			break;
 		}  // case mtPig
 
 		case mtSheep:
 		{
 			auto & Sheep = reinterpret_cast<const cSheep &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Sheep.IsBaby() ? -1 : (Sheep.IsInLoveCooldown() ? 1 : 0));
 
-			a_Pkt.WriteBEUInt8(0x10);
-			Byte SheepMetadata = 0;
-			SheepMetadata = static_cast<Byte>(Sheep.GetFurColor());
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Sheep.IsBaby());
+
+			a_Pkt.WriteBEUInt8(12);  // Index 12: sheared, color
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+			Int8 SheepMetadata = 0;
+			SheepMetadata = static_cast<Int8>(Sheep.GetFurColor());
 			if (Sheep.IsSheared())
 			{
 				SheepMetadata |= 0x10;
 			}
-			a_Pkt.WriteBEUInt8(SheepMetadata);
+			a_Pkt.WriteBEInt8(SheepMetadata);
 			break;
 		}  // case mtSheep
 
 		case mtRabbit:
 		{
 			auto & Rabbit = reinterpret_cast<const cRabbit &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x12);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Rabbit.GetRabbitType()));
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Rabbit.IsBaby() ? -1 : (Rabbit.IsInLoveCooldown() ? 1 : 0));
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Rabbit.IsBaby());
+
+			a_Pkt.WriteBEUInt8(12);  // Index 12: Type
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Rabbit.GetRabbitType()));
 			break;
 		}  // case mtRabbit
 
 		case mtSkeleton:
 		{
 			auto & Skeleton = reinterpret_cast<const cSkeleton &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0d);
-			a_Pkt.WriteBEUInt8(Skeleton.IsWither() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Type
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(Skeleton.IsWither() ? 1 : 0);
 			break;
 		}  // case mtSkeleton
 
 		case mtSlime:
 		{
 			auto & Slime = reinterpret_cast<const cSlime &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x10);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Slime.GetSize()));
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Size
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Slime.GetSize()));
 			break;
 		}  // case mtSlime
 
 		case mtVillager:
 		{
 			auto & Villager = reinterpret_cast<const cVillager &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x50);
-			a_Pkt.WriteBEInt32(Villager.GetVilType());
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Villager.IsBaby() ? -1 : 0);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Villager.IsBaby());
+
+			a_Pkt.WriteBEUInt8(12);  // Index 12: Type
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Villager.GetVilType()));
 			break;
 		}  // case mtVillager
 
 		case mtWitch:
 		{
 			auto & Witch = reinterpret_cast<const cWitch &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x15);
-			a_Pkt.WriteBEUInt8(Witch.IsAngry() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is angry
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Witch.IsAngry());
 			break;
 		}  // case mtWitch
 
 		case mtWither:
 		{
 			auto & Wither = reinterpret_cast<const cWither &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
-			a_Pkt.WriteBEInt32(static_cast<Int32>(Wither.GetWitherInvulnerableTicks()));
-			a_Pkt.WriteBEUInt8(0x66);  // Float at index 6
-			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
+			a_Pkt.WriteBEUInt8(14);  // Index 14: Invulnerable ticks
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(Wither.GetWitherInvulnerableTicks());
+
+			// TODO: Use boss bar packet for health
 			break;
 		}  // case mtWither
 
 		case mtWolf:
 		{
 			auto & Wolf = reinterpret_cast<const cWolf &>(a_Mob);
-			Byte WolfStatus = 0;
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Wolf.IsBaby());
+
+			Int8 WolfStatus = 0;
 			if (Wolf.IsSitting())
 			{
 				WolfStatus |= 0x1;
@@ -3569,37 +3989,47 @@ void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				WolfStatus |= 0x4;
 			}
-			a_Pkt.WriteBEUInt8(0x10);
-			a_Pkt.WriteBEUInt8(WolfStatus);
+			a_Pkt.WriteBEUInt8(12);  // Index 12: status
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+			a_Pkt.WriteBEInt8(WolfStatus);
 
-			a_Pkt.WriteBEUInt8(0x72);
+			a_Pkt.WriteBEUInt8(14);  // Index 14: Health
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
 			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
-			a_Pkt.WriteBEUInt8(0x13);
-			a_Pkt.WriteBEUInt8(Wolf.IsBegging() ? 1 : 0);
-			a_Pkt.WriteBEUInt8(0x14);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Wolf.GetCollarColor()));
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Wolf.IsBaby() ? -1 : 0);
+
+			a_Pkt.WriteBEUInt8(15);  // Index 15: Is begging
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Wolf.IsBegging());
+
+			a_Pkt.WriteBEUInt8(16);  // Index 16: Collar color
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Wolf.GetCollarColor()));
 			break;
 		}  // case mtWolf
 
 		case mtZombie:
 		{
 			auto & Zombie = reinterpret_cast<const cZombie &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(Zombie.IsBaby() ? 1 : -1);
-			a_Pkt.WriteBEUInt8(0x0d);
-			a_Pkt.WriteBEUInt8(Zombie.IsVillagerZombie() ? 1 : 0);
-			a_Pkt.WriteBEUInt8(0x0e);
-			a_Pkt.WriteBEUInt8(Zombie.IsConverting() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Zombie.IsBaby());
+
+			a_Pkt.WriteBEUInt8(12);  // Index 12: Is a villager
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(Zombie.IsVillagerZombie() ? 1 : 0);  // TODO: This actually encodes the zombie villager profession, but that isn't implemented yet.
+
+			a_Pkt.WriteBEUInt8(13);  // Index 13: Is converting
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Zombie.IsConverting());
 			break;
 		}  // case mtZombie
 
 		case mtZombiePigman:
 		{
 			auto & ZombiePigman = reinterpret_cast<const cZombiePigman &>(a_Mob);
-			a_Pkt.WriteBEUInt8(0x0c);
-			a_Pkt.WriteBEInt8(ZombiePigman.IsBaby() ? 1 : -1);
+			a_Pkt.WriteBEUInt8(11);  // Index 11: Is baby
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(ZombiePigman.IsBaby());
 			break;
 		}  // case mtZombiePigman
 	}  // switch (a_Mob.GetType())
@@ -3609,7 +4039,7 @@ void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 
 
 
-void cProtocol180::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_9_0::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity)
 {
 	if (!a_Entity.IsMob())
 	{
@@ -3627,3 +4057,350 @@ void cProtocol180::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_
 
 
 
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cProtocol_1_9_1:
+
+cProtocol_1_9_1::cProtocol_1_9_1(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
+	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
+{
+}
+
+
+
+
+
+void cProtocol_1_9_1::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
+{
+	// Send the Join Game packet:
+	{
+		cServer * Server = cRoot::Get()->GetServer();
+		cPacketizer Pkt(*this, 0x23);  // Join Game packet
+		Pkt.WriteBEUInt32(a_Player.GetUniqueID());
+		Pkt.WriteBEUInt8(static_cast<UInt8>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
+		Pkt.WriteBEInt32(static_cast<Int32>(a_World.GetDimension()));
+		Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
+		Pkt.WriteBEUInt8(static_cast<UInt8>(Clamp<int>(Server->GetMaxPlayers(), 0, 255)));
+		Pkt.WriteString("default");  // Level type - wtf?
+		Pkt.WriteBool(false);  // Reduced Debug Info - wtf?
+	}
+
+	// Send the spawn position:
+	{
+		cPacketizer Pkt(*this, 0x43);  // Spawn Position packet
+		Pkt.WritePosition64(FloorC(a_World.GetSpawnX()), FloorC(a_World.GetSpawnY()), FloorC(a_World.GetSpawnZ()));
+	}
+
+	// Send the server difficulty:
+	{
+		cPacketizer Pkt(*this, 0x0d);  // Server difficulty packet
+		Pkt.WriteBEInt8(1);
+	}
+
+	// Send player abilities:
+	SendPlayerAbilities();
+}
+
+
+
+
+
+void cProtocol_1_9_1::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
+{
+	cServer * Server = cRoot::Get()->GetServer();
+	AString ServerDescription = Server->GetDescription();
+	int NumPlayers = Server->GetNumPlayers();
+	int MaxPlayers = Server->GetMaxPlayers();
+	AString Favicon = Server->GetFaviconData();
+	cRoot::Get()->GetPluginManager()->CallHookServerPing(*m_Client, ServerDescription, NumPlayers, MaxPlayers, Favicon);
+
+	// Version:
+	Json::Value Version;
+	Version["name"] = "Cuberite 1.9.1";
+	Version["protocol"] = 108;
+
+	// Players:
+	Json::Value Players;
+	Players["online"] = NumPlayers;
+	Players["max"] = MaxPlayers;
+	// TODO: Add "sample"
+
+	// Description:
+	Json::Value Description;
+	Description["text"] = ServerDescription.c_str();
+
+	// Create the response:
+	Json::Value ResponseValue;
+	ResponseValue["version"] = Version;
+	ResponseValue["players"] = Players;
+	ResponseValue["description"] = Description;
+	if (!Favicon.empty())
+	{
+		ResponseValue["favicon"] = Printf("data:image/png;base64,%s", Favicon.c_str());
+	}
+
+	Json::StyledWriter Writer;
+	AString Response = Writer.write(ResponseValue);
+
+	cPacketizer Pkt(*this, 0x00);  // Response packet
+	Pkt.WriteString(Response);
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cProtocol_1_9_2:
+
+cProtocol_1_9_2::cProtocol_1_9_2(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
+	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
+{
+}
+
+
+
+
+
+void cProtocol_1_9_2::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
+{
+	cServer * Server = cRoot::Get()->GetServer();
+	AString ServerDescription = Server->GetDescription();
+	int NumPlayers = Server->GetNumPlayers();
+	int MaxPlayers = Server->GetMaxPlayers();
+	AString Favicon = Server->GetFaviconData();
+	cRoot::Get()->GetPluginManager()->CallHookServerPing(*m_Client, ServerDescription, NumPlayers, MaxPlayers, Favicon);
+
+	// Version:
+	Json::Value Version;
+	Version["name"] = "Cuberite 1.9.2";
+	Version["protocol"] = 109;
+
+	// Players:
+	Json::Value Players;
+	Players["online"] = NumPlayers;
+	Players["max"] = MaxPlayers;
+	// TODO: Add "sample"
+
+	// Description:
+	Json::Value Description;
+	Description["text"] = ServerDescription.c_str();
+
+	// Create the response:
+	Json::Value ResponseValue;
+	ResponseValue["version"] = Version;
+	ResponseValue["players"] = Players;
+	ResponseValue["description"] = Description;
+	if (!Favicon.empty())
+	{
+		ResponseValue["favicon"] = Printf("data:image/png;base64,%s", Favicon.c_str());
+	}
+
+	Json::StyledWriter Writer;
+	AString Response = Writer.write(ResponseValue);
+
+	cPacketizer Pkt(*this, 0x00);  // Response packet
+	Pkt.WriteString(Response);
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cProtocol_1_9_4:
+
+cProtocol_1_9_4::cProtocol_1_9_4(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State) :
+	super(a_Client, a_ServerAddress, a_ServerPort, a_State)
+{
+}
+
+
+
+
+
+void cProtocol_1_9_4::HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer)
+{
+	cServer * Server = cRoot::Get()->GetServer();
+	AString ServerDescription = Server->GetDescription();
+	int NumPlayers = Server->GetNumPlayers();
+	int MaxPlayers = Server->GetMaxPlayers();
+	AString Favicon = Server->GetFaviconData();
+	cRoot::Get()->GetPluginManager()->CallHookServerPing(*m_Client, ServerDescription, NumPlayers, MaxPlayers, Favicon);
+
+	// Version:
+	Json::Value Version;
+	Version["name"] = "Cuberite 1.9.4";
+	Version["protocol"] = 110;
+
+	// Players:
+	Json::Value Players;
+	Players["online"] = NumPlayers;
+	Players["max"] = MaxPlayers;
+	// TODO: Add "sample"
+
+	// Description:
+	Json::Value Description;
+	Description["text"] = ServerDescription.c_str();
+
+	// Create the response:
+	Json::Value ResponseValue;
+	ResponseValue["version"] = Version;
+	ResponseValue["players"] = Players;
+	ResponseValue["description"] = Description;
+	if (!Favicon.empty())
+	{
+		ResponseValue["favicon"] = Printf("data:image/png;base64,%s", Favicon.c_str());
+	}
+
+	Json::StyledWriter Writer;
+	AString Response = Writer.write(ResponseValue);
+
+	cPacketizer Pkt(*this, 0x00);  // Response packet
+	Pkt.WriteString(Response);
+}
+
+
+
+
+
+void cProtocol_1_9_4::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count)
+{
+	UNUSED(a_Count);
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x48);  // Collect Item packet
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Player.GetUniqueID());
+}
+
+
+
+
+
+void cProtocol_1_9_4::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	// Serialize first, before creating the Packetizer (the packetizer locks a CS)
+	// This contains the flags and bitmasks, too
+	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_4, a_ChunkX, a_ChunkZ);
+
+	cCSLock Lock(m_CSPacket);
+	SendData(ChunkData.data(), ChunkData.size());
+}
+
+
+
+
+
+void cProtocol_1_9_4::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x4b);  // Entity Effect packet
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_EffectID));
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Amplifier));
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_Duration));
+	Pkt.WriteBool(false);  // Hide particles
+}
+
+
+
+
+
+void cProtocol_1_9_4::SendEntityProperties(const cEntity & a_Entity)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+
+	cPacketizer Pkt(*this, 0x4a);  // Entity Properties packet
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	WriteEntityProperties(Pkt, a_Entity);
+}
+
+
+
+
+
+void cProtocol_1_9_4::SendPlayerMaxSpeed(void)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x4a);  // Entity Properties
+	cPlayer * Player = m_Client->GetPlayer();
+	Pkt.WriteVarInt32(Player->GetUniqueID());
+	Pkt.WriteBEInt32(1);  // Count
+	Pkt.WriteString("generic.movementSpeed");
+	// The default game speed is 0.1, multiply that value by the relative speed:
+	Pkt.WriteBEDouble(0.1 * Player->GetNormalMaxSpeed());
+	if (Player->IsSprinting())
+	{
+		Pkt.WriteVarInt32(1);  // Modifier count
+		Pkt.WriteBEUInt64(0x662a6b8dda3e4c1c);
+		Pkt.WriteBEUInt64(0x881396ea6097278d);  // UUID of the modifier
+		Pkt.WriteBEDouble(Player->GetSprintingMaxSpeed() - Player->GetNormalMaxSpeed());
+		Pkt.WriteBEUInt8(2);
+	}
+	else
+	{
+		Pkt.WriteVarInt32(0);  // Modifier count
+	}
+}
+
+
+
+
+
+void cProtocol_1_9_4::SendTeleportEntity(const cEntity & a_Entity)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, 0x49);  // Entity teleport packet
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEDouble(a_Entity.GetPosX());
+	Pkt.WriteBEDouble(a_Entity.GetPosY());
+	Pkt.WriteBEDouble(a_Entity.GetPosZ());
+	Pkt.WriteByteAngle(a_Entity.GetYaw());
+	Pkt.WriteByteAngle(a_Entity.GetPitch());
+	Pkt.WriteBool(a_Entity.IsOnGround());
+}
+
+
+
+
+
+void cProtocol_1_9_4::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
+{
+	ASSERT(m_State == 3);  // In game mode?
+
+	// 1.9.4 removed the update sign packet and now uses Update Block Entity
+	cPacketizer Pkt(*this, 0x09);  // Update tile entity packet
+	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
+	Pkt.WriteBEUInt8(9);  // Action 9 - update sign
+
+	cFastNBTWriter Writer;
+	Writer.AddInt("x",        a_BlockX);
+	Writer.AddInt("y",        a_BlockY);
+	Writer.AddInt("z",        a_BlockZ);
+	Writer.AddString("id", "Sign");
+
+	Json::StyledWriter JsonWriter;
+	Json::Value Line1;
+	Line1["text"] = a_Line1;
+	Writer.AddString("Text1", JsonWriter.write(Line1));
+	Json::Value Line2;
+	Line2["text"] = a_Line2;
+	Writer.AddString("Text2", JsonWriter.write(Line2));
+	Json::Value Line3;
+	Line3["text"] = a_Line3;
+	Writer.AddString("Text3", JsonWriter.write(Line3));
+	Json::Value Line4;
+	Line4["text"] = a_Line4;
+	Writer.AddString("Text4", JsonWriter.write(Line4));
+
+	Writer.Finish();
+	Pkt.WriteBuf(Writer.GetResult().data(), Writer.GetResult().size());
+}

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -1,11 +1,16 @@
 
-// Protocol18x.h
+// Protocol_1_9.h
 
 /*
-Declares the 1.8.x protocol classes:
-	- cProtocol180
-		- release 1.8.0 protocol (#47)
-(others may be added later in the future for the 1.8 release series)
+Declares the 1.9 protocol classes:
+	- cProtocol_1_9_0
+		- release 1.9 protocol (#107)
+	- cProtocol_1_9_1
+		- release 1.9.1 protocol (#108)
+	- cProtocol_1_9_2
+		- release 1.9.2 protocol (#109)
+	- cProtocol_1_9_4
+		- release 1.9.4 protocol (#110)
 */
 
 
@@ -47,14 +52,14 @@ namespace Json
 
 
 
-class cProtocol180 :
+class cProtocol_1_9_0 :
 	public cProtocol
 {
 	typedef cProtocol super;
 
 public:
 
-	cProtocol180(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
+	cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
 	/** Called when client sends some data: */
 	virtual void DataReceived(const char * a_Data, size_t a_Size) override;
@@ -70,7 +75,7 @@ public:
 	virtual void SendChat                       (const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes) override;
 	virtual void SendChatRaw                    (const AString & a_MessageRaw, eChatType a_Type) override;
 	virtual void SendChunkData                  (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer) override;
-	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player) override;
+	virtual void SendCollectEntity              (const cEntity & a_Entity, const cPlayer & a_Player, int a_Count) override;
 	virtual void SendDestroyEntity              (const cEntity & a_Entity) override;
 	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
 	virtual void SendDisconnect                 (const AString & a_Reason) override;
@@ -183,47 +188,50 @@ protected:
 	void AddReceivedData(const char * a_Data, size_t a_Size);
 
 	/** Reads and handles the packet. The packet length and type have already been read.
-	Returns true if the packet was understood, false if it was an unknown packet
-	*/
-	bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType);
+	Returns true if the packet was understood, false if it was an unknown packet. */
+	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType);
 
 	// Packet handlers while in the Status state (m_State == 1):
-	void HandlePacketStatusPing(cByteBuffer & a_ByteBuffer);
-	void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketStatusPing(cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer);
 
 	// Packet handlers while in the Login state (m_State == 2):
-	void HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffer);
-	void HandlePacketLoginStart(cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketLoginStart(cByteBuffer & a_ByteBuffer);
 
 	// Packet handlers while in the Game state (m_State == 3):
-	void HandlePacketAnimation              (cByteBuffer & a_ByteBuffer);
-	void HandlePacketBlockDig               (cByteBuffer & a_ByteBuffer);
-	void HandlePacketBlockPlace             (cByteBuffer & a_ByteBuffer);
-	void HandlePacketChatMessage            (cByteBuffer & a_ByteBuffer);
-	void HandlePacketClientSettings         (cByteBuffer & a_ByteBuffer);
-	void HandlePacketClientStatus           (cByteBuffer & a_ByteBuffer);
-	void HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer);
-	void HandlePacketEntityAction           (cByteBuffer & a_ByteBuffer);
-	void HandlePacketKeepAlive              (cByteBuffer & a_ByteBuffer);
-	void HandlePacketPlayer                 (cByteBuffer & a_ByteBuffer);
-	void HandlePacketPlayerAbilities        (cByteBuffer & a_ByteBuffer);
-	void HandlePacketPlayerLook             (cByteBuffer & a_ByteBuffer);
-	void HandlePacketPlayerPos              (cByteBuffer & a_ByteBuffer);
-	void HandlePacketPlayerPosLook          (cByteBuffer & a_ByteBuffer);
-	void HandlePacketPluginMessage          (cByteBuffer & a_ByteBuffer);
-	void HandlePacketSlotSelect             (cByteBuffer & a_ByteBuffer);
-	void HandlePacketSpectate               (cByteBuffer & a_ByteBuffer);
-	void HandlePacketSteerVehicle           (cByteBuffer & a_ByteBuffer);
-	void HandlePacketTabComplete            (cByteBuffer & a_ByteBuffer);
-	void HandlePacketUpdateSign             (cByteBuffer & a_ByteBuffer);
-	void HandlePacketUseEntity              (cByteBuffer & a_ByteBuffer);
-	void HandlePacketEnchantItem            (cByteBuffer & a_ByteBuffer);
-	void HandlePacketWindowClick            (cByteBuffer & a_ByteBuffer);
-	void HandlePacketWindowClose            (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketAnimation              (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketBlockDig               (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketBlockPlace             (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketBoatSteer              (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketChatMessage            (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketClientSettings         (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketClientStatus           (cByteBuffer & a_ByteBuffer);
+	virtual void HandleConfirmTeleport              (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketEntityAction           (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketKeepAlive              (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketPlayer                 (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketPlayerAbilities        (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketPlayerLook             (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketPlayerPos              (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketPlayerPosLook          (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketPluginMessage          (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketSlotSelect             (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketSteerVehicle           (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketSpectate               (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketTabComplete            (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketUpdateSign             (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketUseEntity              (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketUseItem                (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketEnchantItem            (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketVehicleMove            (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketWindowClick            (cByteBuffer & a_ByteBuffer);
+	virtual void HandlePacketWindowClose            (cByteBuffer & a_ByteBuffer);
 
 	/** Parses Vanilla plugin messages into specific ClientHandle calls.
 	The message payload is still in the bytebuffer, the handler reads it specifically for each handled channel */
-	void HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel);
+	virtual void HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel);
 
 
 	/** Sends the data to the client, encrypting them if needed. */
@@ -246,23 +254,105 @@ protected:
 
 	/** Converts the BlockFace received by the protocol into eBlockFace constants.
 	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
-	eBlockFace FaceIntToBlockFace(Int8 a_FaceInt);
+	eBlockFace FaceIntToBlockFace(Int32 a_FaceInt);
 
 	/** Writes the item data into a packet. */
 	void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item);
 
-	/** Writes the metadata for the specified entity, not including the terminating 0x7f. */
-	void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity);
+	/** Writes the metadata for the specified entity, not including the terminating 0xff. */
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity);
 
 	/** Writes the mob-specific metadata for the specified mob */
-	void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob);
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob);
 
 	/** Writes the entity properties for the specified entity, including the Count field. */
 	void WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity);
 
 	/** Writes the block entity data for the specified block entity into the packet. */
 	void WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity);
+
+	/** Types used within metadata */
+	enum eMetadataType
+	{
+		METADATA_TYPE_BYTE              = 0,
+		METADATA_TYPE_VARINT            = 1,
+		METADATA_TYPE_FLOAT             = 2,
+		METADATA_TYPE_STRING            = 3,
+		METADATA_TYPE_CHAT              = 4,
+		METADATA_TYPE_ITEM              = 5,
+		METADATA_TYPE_BOOL              = 6,
+		METADATA_TYPE_ROTATION          = 7,
+		METADATA_TYPE_POSITION          = 8,
+		METADATA_TYPE_OPTIONAL_POSITION = 9,
+		METADATA_TYPE_DIRECTION         = 10,
+		METADATA_TYPE_OPTIONAL_UUID     = 11,
+		METADATA_TYPE_BLOCKID           = 12
+	} ;
 } ;
+
+
+
+
+
+/** The version 108 protocol, used by 1.9.1.  Uses an int rather than a byte for dimension in join game. */
+class cProtocol_1_9_1 :
+	public cProtocol_1_9_0
+{
+	typedef cProtocol_1_9_0 super;
+
+public:
+	cProtocol_1_9_1(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
+
+	// cProtocol_1_9_0 overrides:
+	virtual void SendLogin(const cPlayer & a_Player, const cWorld & a_World) override;
+	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
+
+} ;
+
+
+
+
+
+/** The version 109 protocol, used by 1.9.2.  Same as 1.9.1, except the server list ping version number changed with the protocol number. */
+class cProtocol_1_9_2 :
+	public cProtocol_1_9_1
+{
+	typedef cProtocol_1_9_1 super;
+
+public:
+	cProtocol_1_9_2(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
+
+	// cProtocol_1_9_1 overrides:
+	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
+
+} ;
+
+
+
+
+
+/** The version 110 protocol, used by 1.9.3 and 1.9.4. */
+class cProtocol_1_9_4 :
+	public cProtocol_1_9_2
+{
+	typedef cProtocol_1_9_2 super;
+
+public:
+	cProtocol_1_9_4(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
+
+	// cProtocol_1_9_2 overrides:
+	virtual void SendCollectEntity   (const cEntity & a_Entity, const cPlayer & a_Player, int a_Count) override;
+	virtual void SendChunkData       (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer) override;
+	virtual void SendEntityEffect    (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration) override;
+	virtual void SendEntityProperties(const cEntity & a_Entity) override;
+	virtual void SendPlayerMaxSpeed  (void) override;
+	virtual void SendTeleportEntity  (const cEntity & a_Entity) override;
+	virtual void SendUpdateSign      (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) override;
+
+	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
+
+} ;
+
 
 
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2446,9 +2446,9 @@ void cWorld::BroadcastChat(const cCompositeChat & a_Message, const cClientHandle
 
 
 
-void cWorld::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude)
+void cWorld::BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count, const cClientHandle * a_Exclude)
 {
-	m_ChunkMap->BroadcastCollectEntity(a_Entity, a_Player, a_Exclude);
+	m_ChunkMap->BroadcastCollectEntity(a_Entity, a_Player, a_Count, a_Exclude);
 }
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -192,7 +192,7 @@ public:
 	void BroadcastChat       (const cCompositeChat & a_Message, const cClientHandle * a_Exclude = nullptr);
 	// tolua_end
 
-	void BroadcastCollectEntity              (const cEntity & a_Pickup, const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
+	void BroadcastCollectEntity              (const cEntity & a_Pickup, const cPlayer & a_Player, int a_Count, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastDestroyEntity              (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);
 	void BroadcastEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration, const cClientHandle * a_Exclude = nullptr);


### PR DESCRIPTION
Basic support for the 1.11 protocol. Doesn't support mobs yet (any mob will D/C clients immediately)

Also changed the protocol classes' names for better legibility, and slightly refactored to allow simple overrides for handling incoming packets.

Ref.: #3479 