### PR TITLE
Refactored to put URL Encoding / Decoding in a single place.

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -13534,6 +13534,44 @@ local CompressedString = cStringCompression.CompressStringGZIP("DataToCompress")
 					},
 					Notes = "Parses the Authority part of the URL. Parts that are not explicitly specified in the AuthPart are returned empty, the port is returned zero. If parsing fails, the function returns nil and an error message.",
 				},
+				UrlDecode =
+				{
+					IsStatic = true,
+					Params =
+					{
+						{
+							Name = "Text",
+							Type = "string",
+						},
+					},
+					Returns =
+					{
+						{
+							Name = "Decoded",
+							Type = "string",
+						},
+					},
+					Notes = "Returns the Text, URL-decoded. Returns nil if there is a problem while decoding (invalid input).",
+				},
+				UrlEncode =
+				{
+					IsStatic = true,
+					Params =
+					{
+						{
+							Name = "Text",
+							Type = "string",
+						},
+					},
+					Returns =
+					{
+						{
+							Name = "Encoded",
+							Type = "string",
+						},
+					},
+					Notes = "Returns the Text, URL-encoded.",
+				},
 			},
 			AdditionalInfo =
 			{

--- a/Server/Plugins/APIDump/Classes/WebAdmin.lua
+++ b/Server/Plugins/APIDump/Classes/WebAdmin.lua
@@ -121,6 +121,7 @@ return
 			GetURLEncodedString =
 			{
 				IsStatic = true,
+				ObsoletedBy = "cUrlParser:UrlEncode",
 				Params =
 				{
 					{
@@ -134,7 +135,7 @@ return
 						Type = "string",
 					},
 				},
-				Notes = "Returns the string given to it escaped by URL encoding, which makes the string suitable for transmission in an URL. Invalid characters are turned into \"%xy\" values.",
+				Notes = "<b>OBSOLETE</b> - use {{cUrlParser}}:UrlEncode() instead.<br/>Returns the string given to it escaped by URL encoding, which makes the string suitable for transmission in an URL. Invalid characters are turned into \"%xy\" values.",
 			},
 			Reload =
 			{

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -2112,6 +2112,66 @@ static int tolua_cUrlParser_ParseAuthorityPart(lua_State * a_LuaState)
 
 
 
+static int tolua_cUrlParser_UrlDecode(lua_State * tolua_S)
+{
+	// Check the param types:
+	cLuaState S(tolua_S);
+	if (
+		// Don't care about the first param
+		!S.CheckParamString(2) ||
+		!S.CheckParamEnd(3)
+	)
+	{
+		return 0;
+	}
+
+	// Get the parameters:
+	AString Input;
+	S.GetStackValue(2, Input);
+
+	// Convert and return:
+	auto res = URLDecode(Input);
+	if (res.first)
+	{
+		S.Push(res.second);
+	}
+	else
+	{
+		S.Push(cLuaState::Nil);
+	}
+	return 1;
+}
+
+
+
+
+
+static int tolua_cUrlParser_UrlEncode(lua_State * tolua_S)
+{
+	// Check the param types:
+	cLuaState S(tolua_S);
+	if (
+		// Don't care about the first param
+		!S.CheckParamString(2) ||
+		!S.CheckParamEnd(3)
+	)
+	{
+		return 0;
+	}
+
+	// Get the parameters:
+	AString Input;
+	S.GetStackValue(2, Input);
+
+	// Convert and return:
+	S.Push(URLEncode(Input));
+	return 1;
+}
+
+
+
+
+
 static int tolua_cWebAdmin_AddWebTab(lua_State * tolua_S)
 {
 	// Function signatures:
@@ -2324,28 +2384,15 @@ static int tolua_cWebAdmin_GetPage(lua_State * tolua_S)
 
 
 
-/** Binding for cWebAdmin::GetURLEncodedString.
-Manual code required because ToLua generates an extra return value */
+/** Binding for cWebAdmin::GetURLEncodedString. */
 static int tolua_cWebAdmin_GetURLEncodedString(lua_State * tolua_S)
 {
-	// Check the param types:
+	// Emit the obsoletion warning:
 	cLuaState S(tolua_S);
-	if (
-		// Don't care whether the first param is a cWebAdmin instance or class
-		!S.CheckParamString(2) ||
-		!S.CheckParamEnd(3)
-	)
-	{
-		return 0;
-	}
+	LOGWARNING("cWebAdmin:GetURLEncodedString() is obsolete, use cUrlParser:UrlEncode() instead.");
+	S.LogStackTrace();
 
-	// Get the parameters:
-	AString Input;
-	S.GetStackValue(2, Input);
-
-	// Convert and return:
-	S.Push(cWebAdmin::GetURLEncodedString(Input));
-	return 1;
+	return tolua_cUrlParser_UrlEncode(tolua_S);
 }
 
 
@@ -4042,6 +4089,8 @@ void cManualBindings::Bind(lua_State * tolua_S)
 			tolua_function(tolua_S, "IsKnownScheme",      tolua_cUrlParser_IsKnownScheme);
 			tolua_function(tolua_S, "Parse",              tolua_cUrlParser_Parse);
 			tolua_function(tolua_S, "ParseAuthorityPart", tolua_cUrlParser_ParseAuthorityPart);
+			tolua_function(tolua_S, "UrlDecode",          tolua_cUrlParser_UrlDecode);
+			tolua_function(tolua_S, "UrlEncode",          tolua_cUrlParser_UrlEncode);
 		tolua_endmodule(tolua_S);
 
 		tolua_beginmodule(tolua_S, "cWebAdmin");

--- a/src/HTTP/HTTPFormParser.cpp
+++ b/src/HTTP/HTTPFormParser.cpp
@@ -167,13 +167,22 @@ void cHTTPFormParser::ParseFormUrlEncoded(void)
 			case 1:
 			{
 				// Only name present
-				(*this)[URLDecode(ReplaceAllCharOccurrences(Components[0], '+', ' '))] = "";
+				auto name = URLDecode(ReplaceAllCharOccurrences(Components[0], '+', ' '));
+				if (name.first)
+				{
+					(*this)[name.second] = "";
+				}
 				break;
 			}
 			case 2:
 			{
 				// name=value format:
-				(*this)[URLDecode(ReplaceAllCharOccurrences(Components[0], '+', ' '))] = URLDecode(ReplaceAllCharOccurrences(Components[1], '+', ' '));
+				auto name = URLDecode(Components[0]);
+				auto value = URLDecode(Components[1]);
+				if (name.first && value.first)
+				{
+					(*this)[name.second] = value.second;
+				}
 				break;
 			}
 		}

--- a/src/StringUtils.h
+++ b/src/StringUtils.h
@@ -85,6 +85,9 @@ extern void ReplaceString(AString & iHayStack, const AString & iNeedle, const AS
 /** Converts a stream of BE shorts into UTF-8 string; returns a_UTF8. */
 extern AString & RawBEToUTF8(const char * a_RawData, size_t a_NumShorts, AString & a_UTF8);
 
+/** Converts a unicode character to its UTF8 representation. */
+extern AString UnicodeCharToUtf8(unsigned a_UnicodeChar);
+
 /** Converts a UTF-8 string into a UTF-16 BE string. */
 extern std::u16string UTF8ToRawBEUTF16(const AString & a_String);
 
@@ -98,8 +101,13 @@ extern AString EscapeString(const AString & a_Message);  // tolua_export
 /** Removes all control codes used by MC for colors and styles. */
 extern AString StripColorCodes(const AString & a_Message);  // tolua_export
 
-/** URL-Decodes the given string, replacing all "%HH" into the correct characters. Invalid % sequences are left intact */
-extern AString URLDecode(const AString & a_String);  // Cannot export to Lua automatically - would generated an extra return value
+/** URL-Decodes the given string.
+The first value specifies whether the decoding was successful.
+The second value is the decoded string, if successful. */
+extern std::pair<bool, AString> URLDecode(const AString & a_String);  // Exported to Lua as cUrlParser::UrlDecode()
+
+/** URL-encodes the given string. */
+extern AString URLEncode(const AString & a_Text);
 
 /** Replaces all occurrences of char a_From inside a_String with char a_To. */
 extern AString ReplaceAllCharOccurrences(const AString & a_String, char a_From, char a_To);  // Needn't export to Lua, since Lua doesn't have chars anyway
@@ -112,6 +120,9 @@ extern AString Base64Encode(const AString & a_Input);  // Exported manually due 
 
 /** Reads two bytes from the specified memory location and interprets them as BigEndian short */
 extern short GetBEShort(const char * a_Mem);
+
+/** Reads two bytes from the specified memory location and interprets them as BigEndian unsigned short */
+extern unsigned short GetBEUShort(const char * a_Mem);
 
 /** Reads four bytes from the specified memory location and interprets them as BigEndian int */
 extern int GetBEInt(const char * a_Mem);

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -602,30 +602,7 @@ AString cWebAdmin::GetHTMLEscapedString(const AString & a_Input)
 
 AString cWebAdmin::GetURLEncodedString(const AString & a_Input)
 {
-	// Translation table from nibble to hex:
-	static const char Hex[] = "0123456789abcdef";
-
-	// Preallocate the output to match input:
-	AString dst;
-	size_t len = a_Input.length();
-	dst.reserve(len);
-
-	// Loop over input and substitute whatever is needed:
-	for (size_t i = 0; i < len; i++)
-	{
-		char ch = a_Input[i];
-		if (isalnum(ch) || (ch == '-') || (ch == '_') || (ch == '.') || (ch == '~'))
-		{
-			dst.push_back(ch);
-		}
-		else
-		{
-			dst.push_back('%');
-			dst.push_back(Hex[(ch >> 4) & 0x0f]);
-			dst.push_back(Hex[ch & 0x0f]);
-		}
-	}  // for i - a_Input[]
-	return dst;
+	return URLEncode(a_Input);
 }
 
 


### PR DESCRIPTION
The canon in the Lua API is `cUrlParser:UrlDecode` and `cUrlParser:UrlEncode`. In the C++ code the functions are `URLDecode` and `URLEncode`, both in StringUtils.

The decoding now supports `%u0xxxx` characters and provides proper error checking.

Since this change is rather deep, I'd like someone to verify that nothing major has broken for regular gameplay (I can't test that right now). The refactoring has touched reading strings from the MC protocol.