### PR TITLE
Fix crash after calling OnTick on removed effect

### DIFF
--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -57,9 +57,6 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		cEntityEffect::eType EffectType = iter->first;
 		cEntityEffect * Effect = iter->second;
 
-		// Call OnTick later to make sure the iterator won't be invalid
-		EffectsToTick.push_back(Effect);
-
 		// Iterates (must be called before any possible erasure)
 		++iter;
 
@@ -67,6 +64,11 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		if (Effect->GetDuration() - Effect->GetTicks() <= 0)
 		{
 			RemoveEntityEffect(EffectType);
+		}
+		// Call OnTick later to make sure the iterator won't be invalid
+		else
+		{
+			EffectsToTick.push_back(Effect);
 		}
 
 		// TODO: Check for discrepancies between client and server effect values


### PR DESCRIPTION
This fixes a crash introduced in #3497 where the `OnTick` function of a removed effect would be called, resulting in a segfault.