### PR TITLE
Disabled anticheat temporarily

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -155,7 +155,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 
 	LOG("Starting server...");
 
-	cClientHandle::FASTBREAK_PERCENTAGE = settingsRepo->GetValueSetI("AntiCheat", "FastBreakPercentage", 97) / 100.0f;
+	cClientHandle::FASTBREAK_PERCENTAGE = 0
 
 	m_MojangAPI = new cMojangAPI;
 	bool ShouldAuthenticate = settingsRepo->GetValueSetB("Authentication", "Authenticate", true);


### PR DESCRIPTION
This PR disables the fastbreak anticheat temporarily until #3506 is solved.