### PR TITLE
Debuggers: PluginStats are now output only on request.

### DIFF
--- a/Server/Plugins/Debuggers/Info.lua
+++ b/Server/Plugins/Debuggers/Info.lua
@@ -290,6 +290,12 @@ g_PluginInfo =
 			HelpString = "Loads the specified chunk into memory",
 		},
 
+		["pluginstats"] =
+		{
+			Handler = HandleConsolePluginStats,
+			HelpString = "Shows the stats for each plugin",
+		},
+
 		["preparechunk"] =
 		{
 			Handler = HandleConsolePrepareChunk,


### PR DESCRIPTION
The stats are no longer output on plugin startup. There is a new console command, `pluginstats`, that outputs the stats.