### PR TITLE
Fixed BroadcastSoundParticleEffect API function

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -16811,6 +16811,19 @@ end
 						specifically otherwise in the world.ini file.
 					]],
 				},
+				EffectID = 
+				{
+					Include = 
+					{
+						"^SFX_.*",
+						"^PARTICLE_*",
+					},
+					TextBefore = [[
+						These constants are used for effect ids. They are used in the {{cWorld}}:BroadcastSoundParticleEffect()
+						function.
+						
+					]],
+				},
 				eExplosionSource =
 				{
 					Include = "^es.*",
@@ -16996,6 +17009,21 @@ end
 				MetaValues =
 				{
 					Include = "^E_META_.*",
+				},
+				EffectID = 
+				{
+					Include = 
+					{
+						"^SOUTH.*",
+						"^NORTH.*",
+						"EAST",
+						"CENTRE",
+						"WEST",
+					},
+					TextBefore = [[
+						These constants are smoke directions ids. They are used in the {{cWorld}}:BroadcastSoundParticleEffect()
+						function.
+					]],
 				},
 			},
 		},

--- a/src/Bindings/AllToLua.pkg
+++ b/src/Bindings/AllToLua.pkg
@@ -67,6 +67,7 @@ $cfile "../MapManager.h"
 $cfile "../Scoreboard.h"
 $cfile "../Statistics.h"
 $cfile "../Protocol/MojangAPI.h"
+$cfile "../EffectID.h"
 
 // Entities:
 $cfile "../Entities/Entity.h"

--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -91,6 +91,7 @@ set(BINDING_DEPENDENCIES
 	../CraftingRecipes.h
 	../Cuboid.h
 	../Defines.h
+	../EffectID.h
 	../Enchantments.h
 	../Entities/ArrowEntity.h
 	../Entities/Entity.h

--- a/src/EffectID.h
+++ b/src/EffectID.h
@@ -1,6 +1,8 @@
 #pragma once
 
-enum class EffectID : Int32
+// tolua_begin
+
+enum EffectID
 {
 	SFX_RANDOM_CLICK_1 = 1000,
 	SFX_RANDOM_CLICK_2 = 1001,
@@ -35,7 +37,7 @@ enum class EffectID : Int32
 	PARTICLE_FALL_PARTICLES = 2006,
 };
 
-enum class SmokeDirection : Int32
+enum SmokeDirection
 {
 	SOUTH_EAST = 0,
 	SOUTH = 1,
@@ -47,3 +49,5 @@ enum class SmokeDirection : Int32
 	NORTH = 7,
 	NORTH_WEST = 8,
 };
+
+// tolua_end


### PR DESCRIPTION
Changed EffectID and SmokeDirection into normal enums, then added EffectID.h to AllToLua.pkg.
The function can now be used from lua like so:
~~~
world:BroadcastSoundParticleEffect(SFX_MOB_ZOMBIE_METAL,Player:GetPosX(),Player:GetPosY(),Player:GetPosZ(), 0)
~~~
or
~~~
world:BroadcastSoundParticleEffect(1011,Player:GetPosX(),Player:GetPosY(),Player:GetPosZ(), 0)
~~~

Fixes #3505 