### PR TITLE
Fixed race conditions and forgotten clear in Lua ref tracking.

### DIFF
--- a/src/Generating/PrefabPiecePool.cpp
+++ b/src/Generating/PrefabPiecePool.cpp
@@ -204,6 +204,7 @@ bool cPrefabPiecePool::LoadFromCubeset(const AString & a_Contents, const AString
 	// Load the file in the Lua interpreter:
 	cLuaState Lua(Printf("LoadablePiecePool %s", a_FileName.c_str()));
 	Lua.Create();
+	cLuaState::cLock lock(Lua);
 	if (!Lua.LoadString(a_Contents, a_FileName, a_LogWarnings))
 	{
 		// Reason for failure has already been logged in LoadFile()


### PR DESCRIPTION
This fixes occasional crashes on plugin reload.

With this fix I finally get stable networking API and no crashes on plugin reload.