### PR TITLE
Fixed placing of double tall flowers and an inconsistency with vanilla

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 Many people have contributed to Cuberite, and this list attempts to broadcast at least some of them.
 
+Altenius
 BasedDoge (Donated AlchemistVillage prefabs)
 bearbin (Alexander Harkness)
 beeduck

--- a/src/Items/ItemBigFlower.h
+++ b/src/Items/ItemBigFlower.h
@@ -40,7 +40,6 @@ public:
 			return false;
 		}
 
-		AddFaceDirection(a_BlockX, a_BlockY, a_BlockZ, a_BlockFace);
 		a_BlocksToSet.emplace_back(a_BlockX, a_BlockY, a_BlockZ, E_BLOCK_BIG_FLOWER, a_EquippedItem.m_ItemDamage & 0x07);
 		if (a_BlockY < cChunkDef::Height - 1)
 		{

--- a/src/Items/ItemBigFlower.h
+++ b/src/Items/ItemBigFlower.h
@@ -35,7 +35,7 @@ public:
 	) override
 	{
 		// Can only be placed on the floor:
-		if (a_BlockFace != BLOCK_FACE_TOP)
+		if ((a_BlockY < 0) || (a_World.GetBlock(a_BlockX, a_BlockY - 1, a_BlockZ) == E_BLOCK_AIR))
 		{
 			return false;
 		}


### PR DESCRIPTION
`AddFaceDirection` is already called at line 357 of Items/ItemHandler.cpp. Calling it again increased a_BlockY causing the later call to cBlockBigFlowerHandler::CanBeAt to return false and destroy the flower.