### PR TITLE
Webadmin: Added a missing CS lock.

### DIFF
--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -341,6 +341,7 @@ void cWebAdmin::HandleWebadminRequest(cHTTPServerConnection & a_Connection, cHTT
 	if (ShouldWrapInTemplate)
 	{
 		cCSLock Lock(m_CS);
+		cLuaState::cLock lock(m_TemplateScript);
 		if (m_TemplateScript.Call("ShowPage", this, &TemplateRequest, cLuaState::Return, Template))
 		{
 			cHTTPOutgoingResponse Resp;


### PR DESCRIPTION
This fixes an assert when accessing the login-page and the plugin-failure pages in the webadmin.

Fixes #3547 