### PR TITLE
WebAdmin: Renamed two neighboring locks for better clarity / style.

### DIFF
--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -340,8 +340,8 @@ void cWebAdmin::HandleWebadminRequest(cHTTPServerConnection & a_Connection, cHTT
 	// Try to get the template from the Lua template script
 	if (ShouldWrapInTemplate)
 	{
-		cCSLock Lock(m_CS);
-		cLuaState::cLock lock(m_TemplateScript);
+		cCSLock LockSelf(m_CS);
+		cLuaState::cLock LockTemplate(m_TemplateScript);
 		if (m_TemplateScript.Call("ShowPage", this, &TemplateRequest, cLuaState::Return, Template))
 		{
 			cHTTPOutgoingResponse Resp;


### PR DESCRIPTION
Fixed a naming issue introduced in #3548 