### PR TITLE
Removed asserts about chunk queued.

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -317,7 +317,6 @@ void cChunk::SetAllData(cSetChunkData & a_SetChunkData)
 {
 	ASSERT(a_SetChunkData.IsHeightMapValid());
 	ASSERT(a_SetChunkData.AreBiomesValid());
-	ASSERT(IsQueued());
 
 	memcpy(m_BiomeMap, a_SetChunkData.GetBiomes(), sizeof(m_BiomeMap));
 	memcpy(m_HeightMap, a_SetChunkData.GetHeightMap(), sizeof(m_HeightMap));

--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -288,7 +288,6 @@ void cChunkGenerator::DoGenerate(int a_ChunkX, int a_ChunkZ)
 {
 	ASSERT(m_PluginInterface != nullptr);
 	ASSERT(m_ChunkSink != nullptr);
-	ASSERT(m_ChunkSink->IsChunkQueued(a_ChunkX, a_ChunkZ));
 
 	cChunkDesc ChunkDesc(a_ChunkX, a_ChunkZ);
 	m_PluginInterface->CallHookChunkGenerating(ChunkDesc);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2865,8 +2865,6 @@ void cWorld::MarkChunkSaved (int a_ChunkX, int a_ChunkZ)
 
 void cWorld::QueueSetChunkData(const cSetChunkDataPtr & a_SetChunkData)
 {
-	ASSERT(IsChunkQueued(a_SetChunkData->GetChunkX(), a_SetChunkData->GetChunkZ()));
-
 	// Validate biomes, if needed:
 	if (!a_SetChunkData->AreBiomesValid())
 	{


### PR DESCRIPTION
The assumption is not needed and was invalid under a stress-test.

Fixes #3550 

@Seadragon91 could you please test this change with your stress-tester before merging? Thanks.