### PR TITLE
Fixed `cClientHandle:GetProtocolVersion`

### DIFF
--- a/Server/Plugins/Debuggers/Debuggers.lua
+++ b/Server/Plugins/Debuggers/Debuggers.lua
@@ -1567,6 +1567,15 @@ end
 
 
 
+function HandleClientVersionCmd(a_Split, a_Player)
+	a_Player:SendMessage("Your client version number is " .. a_Player:GetClientHandle():GetProtocolVersion() ..".")
+	return true
+end
+
+
+
+
+
 function HandleCompo(a_Split, a_Player)
 	-- Send one composite message to self:
 	local msg = cCompositeChat()

--- a/Server/Plugins/Debuggers/Info.lua
+++ b/Server/Plugins/Debuggers/Info.lua
@@ -28,6 +28,12 @@ g_PluginInfo =
 			Handler = HandleBlkCmd,
 			HelpString = "Gets info about the block you are looking at"
 		},
+		["/clientversion"] =
+		{
+			Permission = "debuggers",
+			Handler = HandleClientVersionCmd,
+			HelpString = "Shows your client's protocol version",
+		},
 		["/compo"] =
 		{
 			Permission = "debuggers",

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -680,7 +680,7 @@ void cClientHandle::HandlePing(void)
 
 
 
-bool cClientHandle::HandleLogin(UInt32 a_ProtocolVersion, const AString & a_Username)
+bool cClientHandle::HandleLogin(const AString & a_Username)
 {
 	{
 		cCSLock lock(m_CSState);
@@ -696,16 +696,10 @@ bool cClientHandle::HandleLogin(UInt32 a_ProtocolVersion, const AString & a_User
 
 		// LOGD("Handling login for client %s @ %s (%p), state = %d", a_Username.c_str(), m_IPString.c_str(), static_cast<void *>(this), m_State.load());
 
-		// If the protocol version hasn't been set yet, set it now:
-		if (m_ProtocolVersion == 0)
-		{
-			m_ProtocolVersion = a_ProtocolVersion;
-		}
-
 		m_Username = a_Username;
 
 		// Let the plugins know about this event, they may refuse the player:
-		if (cRoot::Get()->GetPluginManager()->CallHookLogin(*this, a_ProtocolVersion, a_Username))
+		if (cRoot::Get()->GetPluginManager()->CallHookLogin(*this, m_ProtocolVersion, a_Username))
 		{
 			Destroy();
 			return false;

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -359,7 +359,7 @@ public:  // tolua_export
 	/** Called when the protocol has finished logging the user in.
 	Return true to allow the user in; false to kick them.
 	*/
-	bool HandleLogin(UInt32 a_ProtocolVersion, const AString & a_Username);
+	bool HandleLogin(const AString & a_Username);
 
 	void SendData(const char * a_Data, size_t a_Size);
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -2201,7 +2201,7 @@ void cProtocol_1_8_0::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBu
 	}
 
 	StartEncryption(DecryptedKey);
-	m_Client->HandleLogin(4, m_Client->GetUsername());
+	m_Client->HandleLogin(m_Client->GetUsername());
 }
 
 
@@ -2238,7 +2238,7 @@ void cProtocol_1_8_0::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 		return;
 	}
 
-	m_Client->HandleLogin(4, Username);
+	m_Client->HandleLogin(Username);
 }
 
 

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -2223,7 +2223,7 @@ void cProtocol_1_9_0::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBu
 	}
 
 	StartEncryption(DecryptedKey);
-	m_Client->HandleLogin(4, m_Client->GetUsername());
+	m_Client->HandleLogin(m_Client->GetUsername());
 }
 
 
@@ -2260,7 +2260,7 @@ void cProtocol_1_9_0::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 		return;
 	}
 
-	m_Client->HandleLogin(4, Username);
+	m_Client->HandleLogin(Username);
 }
 
 


### PR DESCRIPTION
There was a remnant of ancient protocols, refactored to report the correct version.
Also added a test command to the Debuggers plugin.

Fixes #3561 