### PR TITLE
Fixed bindings for cBlockArea:Read and Write.

### DIFF
--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -434,7 +434,7 @@ void cBlockArea::SetOrigin(const Vector3i & a_Origin)
 
 
 
-bool cBlockArea::Read(cForEachChunkProvider * a_ForEachChunkProvider, int a_MinBlockX, int a_MaxBlockX, int a_MinBlockY, int a_MaxBlockY, int a_MinBlockZ, int a_MaxBlockZ, int a_DataTypes)
+bool cBlockArea::Read(cForEachChunkProvider & a_ForEachChunkProvider, int a_MinBlockX, int a_MaxBlockX, int a_MinBlockY, int a_MaxBlockY, int a_MinBlockZ, int a_MaxBlockZ, int a_DataTypes)
 {
 	// Normalize the coords:
 	if (a_MinBlockX > a_MaxBlockX)
@@ -501,7 +501,7 @@ bool cBlockArea::Read(cForEachChunkProvider * a_ForEachChunkProvider, int a_MinB
 	cChunkDef::AbsoluteToRelative(a_MaxBlockX, a_MaxBlockY, a_MaxBlockZ, MaxChunkX, MaxChunkZ);
 
 	// Query block data:
-	if (!a_ForEachChunkProvider->ForEachChunkInRect(MinChunkX, MaxChunkX, MinChunkZ, MaxChunkZ, Reader))
+	if (!a_ForEachChunkProvider.ForEachChunkInRect(MinChunkX, MaxChunkX, MinChunkZ, MaxChunkZ, Reader))
 	{
 		Clear();
 		return false;
@@ -514,7 +514,7 @@ bool cBlockArea::Read(cForEachChunkProvider * a_ForEachChunkProvider, int a_MinB
 
 
 
-bool cBlockArea::Read(cForEachChunkProvider * a_ForEachChunkProvider, const cCuboid & a_Bounds, int a_DataTypes)
+bool cBlockArea::Read(cForEachChunkProvider & a_ForEachChunkProvider, const cCuboid & a_Bounds, int a_DataTypes)
 {
 	return Read(
 		a_ForEachChunkProvider,
@@ -529,7 +529,7 @@ bool cBlockArea::Read(cForEachChunkProvider * a_ForEachChunkProvider, const cCub
 
 
 
-bool cBlockArea::Read(cForEachChunkProvider * a_ForEachChunkProvider, const Vector3i & a_Point1, const Vector3i & a_Point2, int a_DataTypes)
+bool cBlockArea::Read(cForEachChunkProvider & a_ForEachChunkProvider, const Vector3i & a_Point1, const Vector3i & a_Point2, int a_DataTypes)
 {
 	return Read(
 		a_ForEachChunkProvider,
@@ -544,7 +544,7 @@ bool cBlockArea::Read(cForEachChunkProvider * a_ForEachChunkProvider, const Vect
 
 
 
-bool cBlockArea::Write(cForEachChunkProvider * a_ForEachChunkProvider, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes)
+bool cBlockArea::Write(cForEachChunkProvider & a_ForEachChunkProvider, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes)
 {
 	ASSERT((a_DataTypes & GetDataTypes()) == a_DataTypes);  // Are you requesting only the data that I have?
 	a_DataTypes = a_DataTypes & GetDataTypes();  // For release builds, silently cut off the datatypes that I don't have
@@ -561,14 +561,14 @@ bool cBlockArea::Write(cForEachChunkProvider * a_ForEachChunkProvider, int a_Min
 		a_MinBlockY = std::max(cChunkDef::Height - m_Size.y, 0);
 	}
 
-	return a_ForEachChunkProvider->WriteBlockArea(*this, a_MinBlockX, a_MinBlockY, a_MinBlockZ, a_DataTypes);
+	return a_ForEachChunkProvider.WriteBlockArea(*this, a_MinBlockX, a_MinBlockY, a_MinBlockZ, a_DataTypes);
 }
 
 
 
 
 
-bool cBlockArea::Write(cForEachChunkProvider * a_ForEachChunkProvider, const Vector3i & a_MinCoords, int a_DataTypes)
+bool cBlockArea::Write(cForEachChunkProvider & a_ForEachChunkProvider, const Vector3i & a_MinCoords, int a_DataTypes)
 {
 	return Write(
 		a_ForEachChunkProvider,

--- a/src/BlockArea.h
+++ b/src/BlockArea.h
@@ -83,22 +83,22 @@ public:
 	void SetOrigin(const Vector3i & a_Origin);
 
 	/** Reads an area of blocks specified. Returns true if successful. All coords are inclusive. */
-	bool Read(cForEachChunkProvider * a_ForEachChunkProvider, int a_MinBlockX, int a_MaxBlockX, int a_MinBlockY, int a_MaxBlockY, int a_MinBlockZ, int a_MaxBlockZ, int a_DataTypes = baTypes | baMetas);
+	bool Read(cForEachChunkProvider & a_ForEachChunkProvider, int a_MinBlockX, int a_MaxBlockX, int a_MinBlockY, int a_MaxBlockY, int a_MinBlockZ, int a_MaxBlockZ, int a_DataTypes = baTypes | baMetas);
 
 	/** Reads an area of blocks specified. Returns true if successful. The bounds are included in the read area. */
-	bool Read(cForEachChunkProvider * a_ForEachChunkProvider, const cCuboid & a_Bounds, int a_DataTypes = baTypes | baMetas);
+	bool Read(cForEachChunkProvider & a_ForEachChunkProvider, const cCuboid & a_Bounds, int a_DataTypes = baTypes | baMetas);
 
 	/** Reads an area of blocks specified. Returns true if successful. The bounds are included in the read area. */
-	bool Read(cForEachChunkProvider * a_ForEachChunkProvider, const Vector3i & a_Point1, const Vector3i & a_Point2, int a_DataTypes = baTypes | baMetas);
+	bool Read(cForEachChunkProvider & a_ForEachChunkProvider, const Vector3i & a_Point1, const Vector3i & a_Point2, int a_DataTypes = baTypes | baMetas);
 
 	// TODO: Write() is not too good an interface: if it fails, there's no way to repeat only for the parts that didn't write
 	// A better way may be to return a list of cBlockAreas for each part that didn't succeed writing, so that the caller may try again
 
 	/** Writes the area back into cWorld at the coords specified. Returns true if successful in all chunks, false if only partially / not at all */
-	bool Write(cForEachChunkProvider * a_ForEachChunkProvider, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes = baTypes | baMetas);
+	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes = baTypes | baMetas);
 
 	/** Writes the area back into cWorld at the coords specified. Returns true if successful in all chunks, false if only partially / not at all */
-	bool Write(cForEachChunkProvider * a_ForEachChunkProvider, const Vector3i & a_MinCoords, int a_DataTypes = baTypes | baMetas);
+	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, const Vector3i & a_MinCoords, int a_DataTypes = baTypes | baMetas);
 
 	/** Copies this object's contents into the specified BlockArea. */
 	void CopyTo(cBlockArea & a_Into) const;

--- a/src/BlockEntities/BeaconEntity.cpp
+++ b/src/BlockEntities/BeaconEntity.cpp
@@ -32,7 +32,7 @@ char cBeaconEntity::CalculatePyramidLevel(void)
 	int MaxY = std::max(GetPosY() - 1, 0);
 
 	Area.Read(
-		m_World,
+		*m_World,
 		GetPosX() - 4, GetPosX() + 4,
 		MinY, MaxY,
 		GetPosZ() - 4, GetPosZ() + 4,

--- a/src/Blocks/BlockChest.h
+++ b/src/Blocks/BlockChest.h
@@ -37,7 +37,7 @@ public:
 
 		// Check if this forms a doublechest, if so, need to adjust the meta:
 		cBlockArea Area;
-		if (!Area.Read(&a_ChunkInterface, a_BlockX - 1, a_BlockX + 1, a_BlockY, a_BlockY, a_BlockZ - 1, a_BlockZ + 1))
+		if (!Area.Read(a_ChunkInterface, a_BlockX - 1, a_BlockX + 1, a_BlockY, a_BlockY, a_BlockZ - 1, a_BlockZ + 1))
 		{
 			return false;
 		}
@@ -75,7 +75,7 @@ public:
 	virtual bool CanBeAt(cChunkInterface & a_ChunkInterface, int a_BlockX, int a_BlockY, int a_BlockZ)
 	{
 		cBlockArea Area;
-		if (!Area.Read(&a_ChunkInterface, a_BlockX - 2, a_BlockX + 2, a_BlockY, a_BlockY, a_BlockZ - 2, a_BlockZ + 2))
+		if (!Area.Read(a_ChunkInterface, a_BlockX - 2, a_BlockX + 2, a_BlockY, a_BlockY, a_BlockZ - 2, a_BlockZ + 2))
 		{
 			// Cannot read the surroundings, probably at the edge of loaded chunks. Disallow.
 			return false;

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -109,7 +109,7 @@ public:
 		cBlockArea Area;
 		int BlockX = a_RelX + a_Chunk.GetPosX() * cChunkDef::Width;
 		int BlockZ = a_RelZ + a_Chunk.GetPosZ() * cChunkDef::Width;
-		if (!Area.Read(a_Chunk.GetWorld(), BlockX - 4, BlockX + 4, a_RelY, a_RelY + 1, BlockZ - 4, BlockZ + 4))
+		if (!Area.Read(*a_Chunk.GetWorld(), BlockX - 4, BlockX + 4, a_RelY, a_RelY + 1, BlockZ - 4, BlockZ + 4))
 		{
 			// Too close to the world edge, cannot check surroundings
 			return false;

--- a/src/Blocks/BlockLeaves.h
+++ b/src/Blocks/BlockLeaves.h
@@ -104,7 +104,7 @@ public:
 		int BlockZ = a_RelZ + a_Chunk.GetPosZ() * cChunkDef::Width;
 		cBlockArea Area;
 		if (!Area.Read(
-			a_Chunk.GetWorld(),
+			*a_Chunk.GetWorld(),
 			BlockX - LEAVES_CHECK_DISTANCE, BlockX + LEAVES_CHECK_DISTANCE,
 			a_RelY - LEAVES_CHECK_DISTANCE, a_RelY + LEAVES_CHECK_DISTANCE,
 			BlockZ - LEAVES_CHECK_DISTANCE, BlockZ + LEAVES_CHECK_DISTANCE,

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1707,7 +1707,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 	{
 		cBlockArea area;
 		a_BlocksAffected.reserve(8 * static_cast<size_t>(ExplosionSizeInt * ExplosionSizeInt * ExplosionSizeInt));
-		if (!area.Read(m_World, bx - ExplosionSizeInt, static_cast<int>(ceil(a_BlockX + ExplosionSizeInt)), MinY, MaxY, bz - ExplosionSizeInt, static_cast<int>(ceil(a_BlockZ + ExplosionSizeInt))))
+		if (!area.Read(*m_World, bx - ExplosionSizeInt, static_cast<int>(ceil(a_BlockX + ExplosionSizeInt)), MinY, MaxY, bz - ExplosionSizeInt, static_cast<int>(ceil(a_BlockZ + ExplosionSizeInt))))
 		{
 			return;
 		}
@@ -1803,7 +1803,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 				}  // for z
 			}  // for y
 		}  // for x
-		area.Write(m_World, bx - ExplosionSizeInt, MinY, bz - ExplosionSizeInt);
+		area.Write(*m_World, bx - ExplosionSizeInt, MinY, bz - ExplosionSizeInt);
 	}
 
 	class cTNTDamageCallback :

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -121,7 +121,7 @@ void cVillager::HandleFarmerPrepareFarmCrops()
 
 	// Read a 11x7x11 area:
 	Surrounding.Read(
-		m_World,
+		*m_World,
 		FloorC(GetPosX()) - 5,
 		FloorC(GetPosX()) + 6,
 		FloorC(GetPosY()) - 3,

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1576,7 +1576,7 @@ void cSlotAreaEnchanting::UpdateResult(cPlayer & a_Player)
 
 	if (cItem::IsEnchantable(Item.m_ItemType) && Item.m_Enchantments.IsEmpty())
 	{
-		int Bookshelves = std::min(GetBookshelvesCount(a_Player.GetWorld()), 15);
+		int Bookshelves = std::min(GetBookshelvesCount(*a_Player.GetWorld()), 15);
 
 		cFastRandom Random;
 		int Base = (Random.GenerateRandomInteger(1, 8) + static_cast<int>(floor(static_cast<float>(Bookshelves / 2)) + Random.GenerateRandomInteger(0, Bookshelves)));
@@ -1600,7 +1600,7 @@ void cSlotAreaEnchanting::UpdateResult(cPlayer & a_Player)
 
 
 
-int cSlotAreaEnchanting::GetBookshelvesCount(cWorld * a_World)
+int cSlotAreaEnchanting::GetBookshelvesCount(cWorld & a_World)
 {
 	int Bookshelves = 0;
 	cBlockArea Area;

--- a/src/UI/SlotArea.h
+++ b/src/UI/SlotArea.h
@@ -362,7 +362,7 @@ public:
 	virtual void OnPlayerRemoved(cPlayer & a_Player) override;
 
 	/* Get the count of bookshelves who stand in the near of the enchanting table */
-	int GetBookshelvesCount(cWorld * a_World);
+	int GetBookshelvesCount(cWorld & a_World);
 
 protected:
 	/** Handles a click in the item slot. */


### PR DESCRIPTION
The original bindings accepted `nil` as the `World` param, causing a crash.

Now the bindings check that the param is `nil`, and refuse to call the function if so.