### PR TITLE
Renamed OSX to macOS and use curl to get EasyInstall script

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -4,7 +4,7 @@ COMPILING
 To compile Cuberite from source, you need the following set of software:
 
  * CMake
- * Platform-specific make tool \(windows would be MSVC, linux/macos GNU make, etc.\)
+ * Platform-specific make tool \(Windows would be MSVC, Linux/macOS GNU make, etc.\)
  * C compiler
  * modern C++ compiler and linker
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -4,7 +4,7 @@ COMPILING
 To compile Cuberite from source, you need the following set of software:
 
  * CMake
- * Platform-specific make tool \(windows would be MSVC, linux/osx GNU make, etc.\)
+ * Platform-specific make tool \(windows would be MSVC, linux/macos GNU make, etc.\)
  * C compiler
  * modern C++ compiler and linker
 
@@ -47,7 +47,7 @@ To make Visual Studio produce the version with the best performance, you will ne
 
 In order to tinker with the code, you'll more than likely need to use the debugging features of your IDE. To make them the easiest to use, you should switch to the Debug configuration - this provides the highest level of information while debugging, for the price of the executable being 2 - 10 times slower. Go to menu Build -> Configuration Manager, and in the opened dialog, change the top left combo box (Active solution configuration) to Debug. Close the dialog and build the solution. The resulting executable is called `Cuberite_debug.exe` in the `Server` folder.
 
-OSX
+macOS
 ---
 
 Install git from its [website](https://git-scm.com/) or homebrew: `brew install git`.

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -32,7 +32,7 @@ Setting up a Dev Environment
 Requirements
 ------------
 
-**Linux/BSD/Solaris/OSX:**
+**Linux/BSD/Solaris/macOS:**
 
 You'll need the basic C++ build tools:
 
@@ -82,7 +82,7 @@ Note that there is a script file, $/src/CheckBasicStyle.lua, that can check some
 How to Build
 ------------------
 
-**Linux/BSD/Solaris/OSX:**
+**Linux/BSD/Solaris/macOS:**
 
 Follow the instructions in [COMPILING.md](https://github.com/cuberite/cuberite/blob/master/COMPILING.md). You probably want to build in debug mode (when you're developing) for console alerts and debugging capability, even though it's much slower for everyday use.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are several ways to obtain Cuberite.
 ##### The EasyInstall script
 This script will download the correct binary from the project site.
 
-    sh -c "$(wget -O - https://download.cuberite.org)"
+    curl -sSfL https://download.cuberite.org | sh
 
 #### Compiling
  - You can compile automatically for Linux / *nix with the `compile.sh` script. The script is described below.


### PR DESCRIPTION
Use curl to get the EasyInstall script because the script itself uses curl.

I didn't change the cmd to get the compile.sh script because it didn't work in my testing.