### PR TITLE
Removed development plugins from settings file

### DIFF
--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -161,9 +161,6 @@ void cPluginManager::ReloadPluginsNow(cSettingsRepositoryInterface & a_Settings)
 void cPluginManager::InsertDefaultPlugins(cSettingsRepositoryInterface & a_Settings)
 {
 	a_Settings.AddKeyName("Plugins");
-	a_Settings.AddKeyComment("Plugins", " Plugin=Debuggers");
-	a_Settings.AddKeyComment("Plugins", " Plugin=HookNotify");
-	a_Settings.AddKeyComment("Plugins", " Plugin=APIDump");
 	a_Settings.AddValue("Plugins", "Plugin", "Core");
 	a_Settings.AddValue("Plugins", "Plugin", "ChatLog");
 }

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -260,6 +260,7 @@ bool cWebAdmin::LoadIniFile(void)
 		m_IniFile.AddHeaderComment(" Password format: Password=*password*; for example:");
 		m_IniFile.AddHeaderComment(" [User:admin]");
 		m_IniFile.AddHeaderComment(" Password=admin");
+		m_IniFile.AddHeaderComment(" Please restart Cuberite to apply changes made in this file!");
 		m_IniFile.SetValue("WebAdmin", "Ports", DEFAULT_WEBADMIN_PORTS);
 		m_IniFile.WriteFile("webadmin.ini");
 	}


### PR DESCRIPTION
We should probably remove (some of) the development plugins from the downloads on the homepage, to prevent cases where new users enable them on production servers. This could probably be done by modifying the build scripts for Linux builds, not sure when it comes to Windows.

- APIDump
- Debuggers
- HookNotify
- NetworkTest
- TestLuaRocks