### PR TITLE
Removed unnecessary check for lower and upper folder

### DIFF
--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -68,7 +68,7 @@ void cPluginManager::RefreshPluginList(void)
 	AStringVector Folders;
 	for (auto & item: Contents)
 	{
-		if ((item == ".") || (item == "..") || (!cFile::IsFolder(PluginsPath + item)))
+		if (!cFile::IsFolder(PluginsPath + item))
 		{
 			// We only want folders, and don't want "." or ".."
 			continue;

--- a/src/OSSupport/File.cpp
+++ b/src/OSSupport/File.cpp
@@ -336,12 +336,6 @@ bool cFile::DeleteFolderContents(const AString & a_FolderName)
 	auto Contents = cFile::GetFolderContents(a_FolderName);
 	for (const auto & item: Contents)
 	{
-		// Skip "." and ".." altogether:
-		if ((item == ".") || (item == ".."))
-		{
-			continue;
-		}
-
 		// Remove the item:
 		auto WholePath = a_FolderName + GetPathSeparator() + item;
 		if (IsFolder(WholePath))


### PR DESCRIPTION
The function `GetFolderContents` from `cFile`, doesn't return the lower and upper folder anymore. Removed unnecessary check in code that uses the function.