### PR TITLE
Warning fix, remove dead code

### DIFF
--- a/src/Bindings/ManualBindings_Network.cpp
+++ b/src/Bindings/ManualBindings_Network.cpp
@@ -106,14 +106,6 @@ static int tolua_cNetwork_CreateUDPEndpoint(lua_State * L)
 		return 1;
 	}
 
-	// Check validity:
-	if ((port < 0) || (port > 65535))
-	{
-		LOGWARNING("cNetwork:CreateUDPEndpoint() called with invalid port (%d), failing the request.", port);
-		S.LogStackTrace();
-		S.Push(false);
-		return 1;
-	}
 	ASSERT(callbacks != nullptr);  // Invalid callbacks would have resulted in GetStackValues() returning false
 
 	// Create the LuaUDPEndpoint glue class:

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -587,9 +587,11 @@ bool cFinishGenVines::IsJungleVariant(EMCSBiome a_Biome)
 		{
 			return true;
 		}
+		default:
+		{
+			return false;
+		}
 	}
-
-	return false;
 }
 
 

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -72,7 +72,7 @@ void cStructGenTrees::GenFinish(cChunkDesc & a_ChunkDesc)
 	{
 		for (int z = 0; z < cChunkDef::Width; z++)
 		{
-			for (HEIGHTTYPE y = cChunkDef::Height - 1; y >= 0; y--)
+			for (HEIGHTTYPE y = cChunkDef::Height - 1; ; y--)
 			{
 				if (a_ChunkDesc.GetBlockType(x, y, z) != E_BLOCK_AIR)
 				{

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -270,6 +270,7 @@ int cStructGenTrees::GetNumTrees(
 			case biMesaBryce:            Add =   4; break;
 			case biMesaPlateauFM:        Add =  12; break;
 			case biMesaPlateauM:         Add =  12; break;
+			default: break;
 		}
 		NumTrees += Add;
 	}

--- a/src/Protocol/Protocol_1_10.cpp
+++ b/src/Protocol/Protocol_1_10.cpp
@@ -887,5 +887,10 @@ void cProtocol_1_10_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_
 			a_Pkt.WriteBool(ZombiePigman.IsBaby());
 			break;
 		}  // case mtZombiePigman
+
+		default:
+		{
+			break;
+		}
 	}  // switch (a_Mob.GetType())
 }

--- a/src/Protocol/Protocol_1_11.cpp
+++ b/src/Protocol/Protocol_1_11.cpp
@@ -1019,6 +1019,11 @@ void cProtocol_1_11_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_
 			a_Pkt.WriteBool(ZombiePigman.IsBaby());
 			break;
 		}  // case mtZombiePigman
+
+		default:
+		{
+			break;
+		}
 	}  // switch (a_Mob.GetType())
 }
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -3616,6 +3616,11 @@ void cProtocol_1_8_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_M
 			a_Pkt.WriteBEInt8(ZombiePigman.IsBaby() ? 1 : -1);
 			break;
 		}  // case mtZombiePigman
+
+		default:
+		{
+			break;
+		}
 	}  // switch (a_Mob.GetType())
 }
 

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -3353,6 +3353,7 @@ void cProtocol_1_9_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 				case cEntityEffect::effInstantDamage: PotionID = "harming"; break;
 				case cEntityEffect::effWaterBreathing: PotionID = "water_breathing"; break;
 				case cEntityEffect::effInvisibility: PotionID = "invisibility"; break;
+				default: break;
 			}
 			if (cEntityEffect::GetPotionEffectIntensity(a_Item.m_ItemDamage) == 1)
 			{
@@ -4048,6 +4049,11 @@ void cProtocol_1_9_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_M
 			a_Pkt.WriteBool(ZombiePigman.IsBaby());
 			break;
 		}  // case mtZombiePigman
+
+		default:
+		{
+			break;
+		}
 	}  // switch (a_Mob.GetType())
 }
 


### PR DESCRIPTION
In GCC there is about 100 warnings due to unhandled enums in switch statements. To fix it, I added default statements in all switch.
Also there is unreachable code due to if condition always return true/false.