### PR TITLE
Boat spawned, remove it from player's hand

### DIFF
--- a/src/Items/ItemBoat.h
+++ b/src/Items/ItemBoat.h
@@ -98,6 +98,12 @@ public:
 		cBoat * Boat = new cBoat(x + 0.5, y + 0.5, z + 0.5);
 		Boat->Initialize(*a_World);
 
+		// Remove boat from players hand
+		if (!a_Player->IsGameModeCreative())
+		{
+			a_Player->GetInventory().RemoveOneEquippedItem();
+		}
+
 		return true;
 	}
 } ;


### PR DESCRIPTION
This fixes a duplicate bug. Boat successfully placed, but not removed from player's hand.