### PR TITLE
Catch crash if any and print backtrace from every thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+    - gdb
 
 script: ./CIbuild.sh
 

--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -17,11 +17,14 @@ echo "Building..."
 make -j 2;
 make -j 2 test ARGS="-V";
 
+# Create .gdbinit in home directory. Switches off the confirmation on quit
+echo -e "define hook-quit\n\tset confirm off\nend\n" > ~/.gdbinit
+
 echo "Testing..."
 cd Server/;
 touch apiCheckFailed.flag
 if [ "$TRAVIS_CUBERITE_BUILD_TYPE" != "COVERAGE" ]; then
-	$CUBERITE_PATH << EOF
+	gdb -return-child-result -ex run -ex "bt" -ex "info threads" -ex "thread apply all bt" -ex "quit" --args $CUBERITE_PATH << EOF
 load APIDump
 apicheck
 restart


### PR DESCRIPTION
This adds the feature to catch crashes in travis:
* Adds gdb to travis
* Starts cuberite under gdb and on exit of Cuberite gdb runs a few commands and then exits with cuberite's exit code.

Example of crash:
[All runs](https://travis-ci.org/Seadragon91/cuberite/builds/212259342)
[clang debug](https://travis-ci.org/Seadragon91/cuberite/jobs/212259346)

Example of no crash:
[All runs](https://travis-ci.org/Seadragon91/cuberite/)
[clang debug](https://travis-ci.org/Seadragon91/cuberite/jobs/212263506)