### PR TITLE
Detach player from entity / object if he is dead

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1042,6 +1042,10 @@ void cPlayer::KilledBy(TakeDamageInfo & a_TDI)
 
 	m_bVisible = false;  // So new clients don't see the player
 
+	// Detach player from object / entity. If the player dies, the server still says
+	// that the player is attached to the entity / object
+	Detach();
+
 	// Puke out all the items
 	cItems Pickups;
 	m_Inventory.CopyToItems(Pickups);


### PR DESCRIPTION
Detach player from entity / object on death. If player respawns the server still says the player is still attached to a object / entity, but the client says no -> The player became a ghost :)
* Walking around is possible
* A block that is placed will disappear
* A block that is  destroyed will reappear
* Attacking mobs is possible :)

Steps to reproduce:
1) Place minecart
2) Enter it
3) Run command `/kill`
4) Respawn

* If you attack a wolf in the near of your death point, it will run to the minecart and attack you there :)
* Relogin will place you at the minecart and your life as ghost ends :)
* Walk far away and you will reappear at the minecart