### PR TITLE
If player is dead, set wolf's target nullptr.

### DIFF
--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -101,9 +101,17 @@ bool cWolf::Attack(std::chrono::milliseconds a_Dt)
 
 	if ((GetTarget() != nullptr) && (GetTarget()->IsPlayer()))
 	{
-		if (static_cast<cPlayer *>(GetTarget())->GetUUID() == m_OwnerUUID)
+		cPlayer * Player = static_cast<cPlayer *>(GetTarget());
+		if (Player->GetUUID() == m_OwnerUUID)
 		{
 			SetTarget(nullptr);
+			return false;
+		}
+		else if (Player->GetHealth() == 0)
+		{
+			SetTarget(nullptr);
+			SetIsAngry(false);
+			m_World->BroadcastEntityMetadata(*this);  // Broadcast health and possibly angry face
 			return false;
 		}
 	}


### PR DESCRIPTION
If the player dies and respawns, the wolf/wolves still have him as target and will attack him again. In vanilla minercaft that's no the case.