### PR TITLE
Added missing checks for Initialize function and updated APIDoc

### DIFF
--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -2910,7 +2910,7 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 						Type = "number",
 					},
 				},
-				Notes = "Spawns a boat at the specific coordinates. Returns the entity ID of the new boat, or {{cEntity#NO_ID|cEntity.NO_ID}} if no boat was created.",
+				Notes = "Spawns a boat at the specific coordinates. Returns the EntityID of the new boat, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no boat was created.",
 			},
 			SpawnExperienceOrb =
 			{
@@ -2940,7 +2940,7 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 						Type = "number",
 					},
 				},
-				Notes = "Spawns an {{cExpOrb|experience orb}} at the specified coords, with the given reward",
+				Notes = "Spawns an {{cExpOrb|experience orb}} at the specified coords, with the given reward. Returns the EntityID of the new experience orb, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no experience orb was created.",
 			},
 			SpawnFallingBlock =
 			{
@@ -2974,7 +2974,7 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 						Type = "number",
 					},
 				},
-				Notes = "Spawns a {{cFallingBlock|Falling Block}} entity at the specified coords with the given block type/meta",
+				Notes = "Spawns a {{cFallingBlock|Falling Block}} entity at the specified coords with the given block type/meta. Returns the EntityID of the new falling block, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no falling block was created.",
 			},
 			SpawnItemPickups =
 			{
@@ -3088,7 +3088,7 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 						Type = "number",
 					},
 				},
-				Notes = "Spawns a minecart at the specific coordinates. MinecartType is the item type of the minecart. If the minecart is an empty minecart then the given Item (default: empty) is the block to be displayed inside the minecart, and BlockHeight (default: 1) is the relative distance of the block from the minecart. Returns the entity ID of the new minecart, or {{cEntity#NO_ID|cEntity.NO_ID}} if no minecart was created.",
+				Notes = "Spawns a minecart at the specific coordinates. MinecartType is the item type of the minecart. If the minecart is an empty minecart then the given Item (default: empty) is the block to be displayed inside the minecart, and BlockHeight (default: 1) is the relative distance of the block from the minecart. Returns the EntityID of the new minecart, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no minecart was created.",
 			},
 			SpawnMob =
 			{
@@ -3123,7 +3123,7 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 						Type = "number",
 					},
 				},
-				Notes = "Spawns the specified type of mob at the specified coords. If the Baby parameter is true, the mob will be a baby. Returns the EntityID of the creates entity, or -1 on failure. ",
+				Notes = "Spawns the specified type of mob at the specified coords. If the Baby parameter is true, the mob will be a baby. Returns the EntityID of the created entity, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} on failure.",
 			},
 			SpawnPrimedTNT =
 			{
@@ -3157,7 +3157,7 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 						Type = "number",
 					},
 				},
-				Notes = "Spawns a {{cTNTEntity|primed TNT entity}} at the specified coords, with the given fuse ticks. The entity gets a random speed multiplied by the InitialVelocityCoeff, 1 being the default value.",
+				Notes = "Spawns a {{cTNTEntity|primed TNT entity}} at the specified coords, with the given fuse ticks. The entity gets a random speed multiplied by the InitialVelocityCoeff, 1 being the default value. Returns the EntityID of the new spawned primed tnt, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no primed tnt was created.",
 			},
 			TryGetHeight =
 			{

--- a/src/Items/ItemBoat.h
+++ b/src/Items/ItemBoat.h
@@ -96,7 +96,12 @@ public:
 
 		// Spawn block at water level
 		cBoat * Boat = new cBoat(x + 0.5, y + 0.5, z + 0.5);
-		Boat->Initialize(*a_World);
+		if (!Boat->Initialize(*a_World))
+		{
+			delete Boat;
+			Boat = nullptr;
+			return false;
+		}
 
 		// Remove boat from players hand
 		if (!a_Player->IsGameModeCreative())

--- a/src/Items/ItemFishingRod.h
+++ b/src/Items/ItemFishingRod.h
@@ -251,7 +251,12 @@ public:
 		else
 		{
 			cFloater * Floater = new cFloater(a_Player->GetPosX(), a_Player->GetStance(), a_Player->GetPosZ(), a_Player->GetLookVector() * 15, a_Player->GetUniqueID(), static_cast<int>(100 + static_cast<unsigned int>(a_World->GetTickRandomNumber(800)) - (a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100)));
-			Floater->Initialize(*a_World);
+			if (!Floater->Initialize(*a_World))
+			{
+				delete Floater;
+				Floater = nullptr;
+				return false;
+			}
 			a_Player->SetIsFishing(true, Floater->GetUniqueID());
 		}
 		return true;

--- a/src/Items/ItemMinecart.h
+++ b/src/Items/ItemMinecart.h
@@ -73,7 +73,12 @@ public:
 				return false;
 			}
 		}  // switch (m_ItemType)
-		Minecart->Initialize(*a_World);
+		if (!Minecart->Initialize(*a_World))
+		{
+			delete Minecart;
+			Minecart = nullptr;
+			return false;
+		}
 
 		if (!a_Player->IsGameModeCreative())
 		{

--- a/src/Items/ItemPainting.h
+++ b/src/Items/ItemPainting.h
@@ -71,7 +71,12 @@ public:
 			};
 
 			cPainting * Painting = new cPainting(gPaintingTitlesList[a_World->GetTickRandomNumber(ARRAYCOUNT(gPaintingTitlesList) - 1)].Title, a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
-			Painting->Initialize(*a_World);
+			if (!Painting->Initialize(*a_World))
+			{
+				delete Painting;
+				Painting = nullptr;
+				return false;
+			}
 
 			if (!a_Player->IsGameModeCreative())
 			{

--- a/src/Simulator/SandSimulator.cpp
+++ b/src/Simulator/SandSimulator.cpp
@@ -62,7 +62,12 @@ void cSandSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX,
 			);
 			*/
 			cFallingBlock * FallingBlock = new cFallingBlock(Pos, BlockType, a_Chunk->GetMeta(itr->x, itr->y, itr->z));
-			FallingBlock->Initialize(m_World);
+			if (!FallingBlock->Initialize(m_World))
+			{
+				delete FallingBlock;
+				FallingBlock = nullptr;
+				continue;
+			}
 			a_Chunk->SetBlock(itr->x, itr->y, itr->z, E_BLOCK_AIR, 0);
 		}
 	}

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2183,7 +2183,11 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 			a_BlockX, a_BlockY, a_BlockZ,
 			*itr, IsPlayerCreated, SpeedX, SpeedY, SpeedZ
 		);
-		Pickup->Initialize(*this);
+		if (!Pickup->Initialize(*this))
+		{
+			delete Pickup;
+			Pickup = nullptr;
+		}
 	}
 }
 
@@ -2204,7 +2208,11 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 			a_BlockX, a_BlockY, a_BlockZ,
 			*itr, IsPlayerCreated, static_cast<float>(a_SpeedX), static_cast<float>(a_SpeedY), static_cast<float>(a_SpeedZ)
 		);
-		Pickup->Initialize(*this);
+		if (!Pickup->Initialize(*this))
+		{
+			delete Pickup;
+			Pickup = nullptr;
+		}
 	}
 }
 
@@ -2215,7 +2223,12 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 UInt32 cWorld::SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta)
 {
 	cFallingBlock * FallingBlock = new cFallingBlock(Vector3i(a_X, a_Y, a_Z), BlockType, BlockMeta);
-	FallingBlock->Initialize(*this);
+	if (!FallingBlock->Initialize(*this))
+	{
+		delete FallingBlock;
+		FallingBlock = nullptr;
+		return cEntity::INVALID_ID;
+	}
 	return FallingBlock->GetUniqueID();
 }
 
@@ -2232,7 +2245,12 @@ UInt32 cWorld::SpawnExperienceOrb(double a_X, double a_Y, double a_Z, int a_Rewa
 	}
 
 	cExpOrb * ExpOrb = new cExpOrb(a_X, a_Y, a_Z, a_Reward);
-	ExpOrb->Initialize(*this);
+	if (!ExpOrb->Initialize(*this))
+	{
+		delete ExpOrb;
+		ExpOrb = nullptr;
+		return cEntity::INVALID_ID;
+	}
 	return ExpOrb->GetUniqueID();
 }
 
@@ -2255,7 +2273,12 @@ UInt32 cWorld::SpawnMinecart(double a_X, double a_Y, double a_Z, int a_MinecartT
 			return cEntity::INVALID_ID;
 		}
 	}  // switch (a_MinecartType)
-	Minecart->Initialize(*this);
+	if (!Minecart->Initialize(*this))
+	{
+		delete Minecart;
+		Minecart = nullptr;
+		return cEntity::INVALID_ID;
+	}
 	return Minecart->GetUniqueID();
 }
 
@@ -2273,6 +2296,7 @@ UInt32 cWorld::SpawnBoat(double a_X, double a_Y, double a_Z)
 	if (!Boat->Initialize(*this))
 	{
 		delete Boat;
+		Boat = nullptr;
 		return cEntity::INVALID_ID;
 	}
 	return Boat->GetUniqueID();
@@ -2284,7 +2308,12 @@ UInt32 cWorld::SpawnBoat(double a_X, double a_Y, double a_Z)
 UInt32 cWorld::SpawnPrimedTNT(double a_X, double a_Y, double a_Z, int a_FuseTicks, double a_InitialVelocityCoeff)
 {
 	cTNTEntity * TNT = new cTNTEntity(a_X, a_Y, a_Z, a_FuseTicks);
-	TNT->Initialize(*this);
+	if (!TNT->Initialize(*this))
+	{
+		delete TNT;
+		TNT = nullptr;
+		return cEntity::INVALID_ID;
+	}
 	TNT->SetSpeed(
 		a_InitialVelocityCoeff * (GetTickRandomNumber(2) - 1), /** -1, 0, 1 */
 		a_InitialVelocityCoeff * 2,
@@ -2878,7 +2907,11 @@ void cWorld::SetChunkData(cSetChunkData & a_SetChunkData)
 	std::swap(a_SetChunkData.GetEntities(), Entities);
 	for (cEntityList::iterator itr = Entities.begin(), end = Entities.end(); itr != end; ++itr)
 	{
-		(*itr)->Initialize(*this);
+		if (!(*itr)->Initialize(*this))
+		{
+			delete *itr;
+			*itr = nullptr;
+		}
 	}
 
 	// If a client is requesting this chunk, send it to them:


### PR DESCRIPTION
This adds missing checks for the `Initialize`-function to all functions that wants to spawn a entity. Also added `cEntity#INVALID_ID` to all the functions in the APIDoc, if the spawning failed.