### PR TITLE
Removed binary ToLua++ from build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ endif()
 add_subdirectory(lib/jsoncpp/)
 add_subdirectory(lib/zlib/)
 add_subdirectory(lib/lua/)
-add_subdirectory(lib/tolua++/)
+add_subdirectory(lib/tolua++/ EXCLUDE_FROM_ALL)
 add_subdirectory(lib/sqlite/)
 add_subdirectory(lib/SQLiteCpp/)
 add_subdirectory(lib/expat/)
@@ -305,7 +305,7 @@ if (MSVC)
 	)
 	set_target_properties(
 		luaproxy
-		tolua
+		luaexe
 		PROPERTIES FOLDER Support
 	)
 

--- a/Server/.gitignore
+++ b/Server/.gitignore
@@ -5,6 +5,7 @@
 *.ini
 Cuberite
 Cuberite_debug
+luaexe
 CommLogs/
 GalExports/
 GalExportWeb/

--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -147,9 +147,9 @@ if (NOT MSVC)
 	else()
 		ADD_CUSTOM_COMMAND(
 			OUTPUT ${BINDING_OUTPUTS}
-			COMMAND tolua -L BindingsProcessor.lua -o Bindings.cpp -H Bindings.h AllToLua.pkg
+			COMMAND luaexe BindingsProcessor.lua
 			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-			DEPENDS ${BINDING_DEPENDENCIES} tolua
+			DEPENDS ${BINDING_DEPENDENCIES} luaexe
 		)
 	endif()
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -310,13 +310,10 @@ if (MSVC)
 		ADD_CUSTOM_COMMAND(
 			OUTPUT ${BINDING_OUTPUTS}
 
-			# Copy the Lua DLL into the Bindings folder, so that tolua can run from there:
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/Server/lua51.dll ./lua51.dll
-
 			# Regenerate bindings:
-			COMMAND tolua -L BindingsProcessor.lua -o Bindings.cpp -H Bindings.h AllToLua.pkg
+			COMMAND luaexe BindingsProcessor.lua
 			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Bindings/
-			DEPENDS ${BINDINGS_DEPENDENCIES} tolua
+			DEPENDS ${BINDINGS_DEPENDENCIES} luaexe
 		)
 	endif()
 endif()


### PR DESCRIPTION
A local Lua executable is used instead.

Note that this depends on changes in the "lua" submodule as well, defining the new `luaexe` target.

Tested on Win+MSVC+noSysLua, Ubuntu+clang+SysLua and Ubuntu+gcc+noSysLua.

Fixes #3689.