### PR TITLE
Revised handling of time increments to ripen for cBlockCropsHandler blocks

### DIFF
--- a/src/Blocks/BlockCrops.h
+++ b/src/Blocks/BlockCrops.h
@@ -29,7 +29,7 @@ public:
 		cFastRandom rand;
 
 		// If not fully grown, drop the "seed" of whatever is growing:
-		if (a_Meta < RipeMeta)
+		if (a_Meta < (RipeMeta - 1))
 		{
 			switch (m_BlockType)
 			{
@@ -97,7 +97,7 @@ public:
 
 		// If there is still room to grow and the plant can grow, then grow.
 		// Otherwise if the plant needs to die, then dig it up
-		if ((Meta < RipeMeta) && (Action == paGrowth))
+		if ((Meta < (RipeMeta - 1)) && (Action == paGrowth))
 		{
 			a_Chunk.FastSetBlock(a_RelX, a_RelY, a_RelZ, m_BlockType, ++Meta);
 		}


### PR DESCRIPTION
I'm fairly new to Cuberite. After installing and running the server, I initiated a survival map, but noticed immediately that many of my crops weren't producing the expected yield. I think the culprit was that the literal being passed into the template class was too high or the test value in cWorld::GrowRipePlant was too low. In either case, the crops in question would never have their meta value incremented to the point where ConvertToPickups would consider it ripe enough to bear fruit.

I also tried to cut down on some of the repeated literals with some additional constants and a function.

This builds on my system and, after some simple testing, seems to solve the problem.