### PR TITLE
Prevent infinite loop when logging fails

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -119,6 +119,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 	auto fileLogListenerRet = MakeFileListener();
 	if (!fileLogListenerRet.first)
 	{
+		this->m_TerminateEventRaised = true;
 		LOGERROR("Failed to open log file, aborting");
 		return;
 	}

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -119,7 +119,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 	auto fileLogListenerRet = MakeFileListener();
 	if (!fileLogListenerRet.first)
 	{
-		this->m_TerminateEventRaised = true;
+		m_TerminateEventRaised = true;
 		LOGERROR("Failed to open log file, aborting");
 		return;
 	}


### PR DESCRIPTION
If logging fails because of file permissions or whatever, the program goes into a hard loop. Fixed.