### PR TITLE
APIDump: Add missing 'My' to generated function hook example.

### DIFF
--- a/Server/Plugins/APIDump/main_APIDump.lua
+++ b/Server/Plugins/APIDump/main_APIDump.lua
@@ -298,7 +298,7 @@ local function WriteHtmlHook(a_Hook, a_HookNav)
 	f:write(LinkifyString(a_Hook.Desc, HookName));
 	f:write("</p>\n<hr /><h1>Callback function</h1>\n<p>The default name for the callback function is ");
 	f:write(a_Hook.DefaultFnName, ". It has the following signature:\n");
-	f:write("<pre class=\"prettyprint lang-lua\">function ", HookName, "(");
+	f:write("<pre class=\"prettyprint lang-lua\">function My", HookName, "(");
 	if (a_Hook.Params == nil) then
 		a_Hook.Params = {};
 	end


### PR DESCRIPTION
Fixes #3698.

Adds the missing 'My' to the example function for the hook that is generated by APIDump.