### PR TITLE
Fixed Lua bindings for const objects.

### DIFF
--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -864,44 +864,11 @@ void cLuaState::Push(const AStringVector & a_Vector)
 
 
 
-void cLuaState::Push(const cCraftingGrid * a_Grid)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<cCraftingGrid *>(a_Grid)), "cCraftingGrid");
-}
-
-
-
-
-
-void cLuaState::Push(const cCraftingRecipe * a_Recipe)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<cCraftingRecipe *>(a_Recipe)), "cCraftingRecipe");
-}
-
-
-
-
-
 void cLuaState::Push(const char * a_Value)
 {
 	ASSERT(IsValid());
 
 	tolua_pushstring(m_LuaState, a_Value);
-}
-
-
-
-
-
-void cLuaState::Push(const cItems & a_Items)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<cItems *>(&a_Items)), "cItems");
 }
 
 
@@ -919,17 +886,6 @@ void cLuaState::Push(const cNil & a_Nil)
 
 
 
-void cLuaState::Push(const cPlayer * a_Player)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<cPlayer *>(a_Player)), "cPlayer");
-}
-
-
-
-
-
 void cLuaState::Push(const cLuaState::cRef & a_Ref)
 {
 	ASSERT(IsValid());
@@ -941,44 +897,11 @@ void cLuaState::Push(const cLuaState::cRef & a_Ref)
 
 
 
-void cLuaState::Push(const HTTPRequest * a_Request)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<HTTPRequest *>(a_Request)), "HTTPRequest");
-}
-
-
-
-
-
-void cLuaState::Push(const HTTPTemplateRequest * a_Request)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<HTTPTemplateRequest *>(a_Request)), "HTTPTemplateRequest");
-}
-
-
-
-
-
 void cLuaState::Push(const Vector3d & a_Vector)
 {
 	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<Vector3d *>(&a_Vector)), "Vector3<double>");
-}
-
-
-
-
-
-void cLuaState::Push(const Vector3d * a_Vector)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<Vector3d *>(a_Vector)), "Vector3<double>");
+	auto c = new Vector3d(a_Vector);
+	tolua_pushusertype_and_takeownership(m_LuaState, c, "Vector3<double>");
 }
 
 
@@ -988,19 +911,8 @@ void cLuaState::Push(const Vector3d * a_Vector)
 void cLuaState::Push(const Vector3i & a_Vector)
 {
 	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<Vector3i *>(&a_Vector)), "Vector3<int>");
-}
-
-
-
-
-
-void cLuaState::Push(const Vector3i * a_Vector)
-{
-	ASSERT(IsValid());
-
-	tolua_pushusertype(m_LuaState, reinterpret_cast<void *>(const_cast<Vector3i *>(a_Vector)), "Vector3<int>");
+	auto c = new Vector3i(a_Vector);
+	tolua_pushusertype_and_takeownership(m_LuaState, c, "Vector3<int>");
 }
 
 

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -573,22 +573,16 @@ public:
 	}
 
 	// Push a const value onto the stack (keep alpha-sorted):
+	// Note that these functions will make a copy of the actual value, because Lua doesn't have the concept
+	// of "const", and there would be lifetime management problems if they didn't.
 	void Push(const AString & a_String);
 	void Push(const AStringMap & a_Dictionary);
 	void Push(const AStringVector & a_Vector);
-	void Push(const cCraftingGrid * a_Grid);
-	void Push(const cCraftingRecipe * a_Recipe);
 	void Push(const char * a_Value);
-	void Push(const cItems & a_Items);
 	void Push(const cNil & a_Nil);
-	void Push(const cPlayer * a_Player);
 	void Push(const cRef & a_Ref);
-	void Push(const HTTPRequest * a_Request);
-	void Push(const HTTPTemplateRequest * a_Request);
 	void Push(const Vector3d & a_Vector);
-	void Push(const Vector3d * a_Vector);
 	void Push(const Vector3i & a_Vector);
-	void Push(const Vector3i * a_Vector);
 
 	// Push a simple value onto the stack (keep alpha-sorted):
 	void Push(bool a_Value);

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -1710,7 +1710,7 @@ public:
 	) override
 	{
 		AString content, contentType;
-		return m_Callback.Call(&a_Request, a_UrlPath, cLuaState::Return, a_Content, a_ContentType);
+		return m_Callback.Call(const_cast<HTTPRequest *>(&a_Request), a_UrlPath, cLuaState::Return, a_Content, a_ContentType);
 	}
 };
 

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -605,7 +605,8 @@ bool cPluginLua::OnPlayerFoodLevelChange(cPlayer & a_Player, int a_NewFoodLevel)
 
 bool cPluginLua::OnPlayerFished(cPlayer & a_Player, const cItems & a_Reward)
 {
-	return CallSimpleHooks(cPluginManager::HOOK_PLAYER_FISHED, &a_Player, a_Reward);
+	cItems reward(a_Reward);
+	return CallSimpleHooks(cPluginManager::HOOK_PLAYER_FISHED, &a_Player, &reward);
 }
 
 


### PR DESCRIPTION
Removes the bindings that break const-correctness, and added an explicit note of the copy-making nature of the calls.

Fixes #3701 