### PR TITLE
VarInt metadata written correctly for boats

### DIFF
--- a/src/Protocol/Protocol_1_10.cpp
+++ b/src/Protocol/Protocol_1_10.cpp
@@ -511,11 +511,11 @@ void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_LAST_HIT_TIME);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetLastDamage());
+			a_Pkt.WriteVarInt32(Boat.GetLastDamage());
 
 			a_Pkt.WriteBEInt8(BOAT_FORWARD_DIRECTION);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetForwardDirection());
+			a_Pkt.WriteVarInt32(Boat.GetForwardDirection());
 
 			a_Pkt.WriteBEInt8(BOAT_DAMAGE_TAKEN);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
@@ -523,7 +523,7 @@ void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_TYPE);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetType());
+			a_Pkt.WriteVarInt32(Boat.GetType());
 
 			a_Pkt.WriteBEInt8(BOAT_RIGHT_PADDLE_TURNING);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);

--- a/src/Protocol/Protocol_1_10.cpp
+++ b/src/Protocol/Protocol_1_10.cpp
@@ -511,11 +511,11 @@ void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_LAST_HIT_TIME);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetLastDamage());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetLastDamage()));
 
 			a_Pkt.WriteBEInt8(BOAT_FORWARD_DIRECTION);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetForwardDirection());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetForwardDirection()));
 
 			a_Pkt.WriteBEInt8(BOAT_DAMAGE_TAKEN);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
@@ -523,7 +523,7 @@ void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_TYPE);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetType());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetType()));
 
 			a_Pkt.WriteBEInt8(BOAT_RIGHT_PADDLE_TURNING);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);

--- a/src/Protocol/Protocol_1_11.cpp
+++ b/src/Protocol/Protocol_1_11.cpp
@@ -633,11 +633,11 @@ void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_LAST_HIT_TIME);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetLastDamage());
+			a_Pkt.WriteVarInt32(Boat.GetLastDamage());
 
 			a_Pkt.WriteBEInt8(BOAT_FORWARD_DIRECTION);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetForwardDirection());
+			a_Pkt.WriteVarInt32(Boat.GetForwardDirection());
 
 			a_Pkt.WriteBEInt8(BOAT_DAMAGE_TAKEN);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
@@ -645,7 +645,7 @@ void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_TYPE);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetType());
+			a_Pkt.WriteVarInt32(Boat.GetType());
 
 			a_Pkt.WriteBEInt8(BOAT_RIGHT_PADDLE_TURNING);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);

--- a/src/Protocol/Protocol_1_11.cpp
+++ b/src/Protocol/Protocol_1_11.cpp
@@ -633,11 +633,11 @@ void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_LAST_HIT_TIME);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetLastDamage());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetLastDamage()));
 
 			a_Pkt.WriteBEInt8(BOAT_FORWARD_DIRECTION);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetForwardDirection());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetForwardDirection()));
 
 			a_Pkt.WriteBEInt8(BOAT_DAMAGE_TAKEN);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
@@ -645,7 +645,7 @@ void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEInt8(BOAT_TYPE);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetType());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetType()));
 
 			a_Pkt.WriteBEInt8(BOAT_RIGHT_PADDLE_TURNING);
 			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -3674,11 +3674,11 @@ void cProtocol_1_9_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a
 
 			a_Pkt.WriteBEInt8(5);  // Index 6: Time since last hit
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetLastDamage());
+			a_Pkt.WriteVarInt32(Boat.GetLastDamage());
 
 			a_Pkt.WriteBEInt8(6);  // Index 7: Forward direction
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetForwardDirection());
+			a_Pkt.WriteVarInt32(Boat.GetForwardDirection());
 
 			a_Pkt.WriteBEInt8(7);  // Index 8: Damage taken
 			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
@@ -3686,7 +3686,7 @@ void cProtocol_1_9_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a
 
 			a_Pkt.WriteBEInt8(8);  // Index 9: Type
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteBEInt32(Boat.GetType());
+			a_Pkt.WriteVarInt32(Boat.GetType());
 
 			a_Pkt.WriteBEInt8(9);  // Index 10: Right paddle turning
 			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -3674,11 +3674,11 @@ void cProtocol_1_9_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a
 
 			a_Pkt.WriteBEInt8(5);  // Index 6: Time since last hit
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetLastDamage());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetLastDamage()));
 
 			a_Pkt.WriteBEInt8(6);  // Index 7: Forward direction
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetForwardDirection());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetForwardDirection()));
 
 			a_Pkt.WriteBEInt8(7);  // Index 8: Damage taken
 			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
@@ -3686,7 +3686,7 @@ void cProtocol_1_9_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a
 
 			a_Pkt.WriteBEInt8(8);  // Index 9: Type
 			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Boat.GetType());
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetType()));
 
 			a_Pkt.WriteBEInt8(9);  // Index 10: Right paddle turning
 			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);


### PR DESCRIPTION
Fixes  #3703 

I have tested with the 1.11.2 client and boat types now display correctly.
