### PR TITLE
Store cChunk::m_BlockEntities in a map

### DIFF
--- a/src/BlockID.h
+++ b/src/BlockID.h
@@ -1212,12 +1212,15 @@ extern cItem GetIniItemSet(cIniFile & a_IniFile, const char * a_Section, const c
 
 
 
-template <BLOCKTYPE, BLOCKTYPE...> bool IsOneOfImpl(BLOCKTYPE, std::false_type);
-template <class = void> bool IsOneOfImpl(BLOCKTYPE, std::true_type);
+/** Base case for IsOneOf to handle empty template aguments. */
+template <class = void>
+bool IsOneOf(BLOCKTYPE a_BlockType)
+{
+	return false;
+}
 
 
-/** Returns true if the BLOCKTYPE x is equal to any of the variadic template arguments.
-
+/** Returns true if a_BlockType is equal to any of the variadic template arguments.
 Some example usage:
 \code
 	IsOneOf<>(E_BLOCK_AIR)                           == false
@@ -1226,31 +1229,13 @@ Some example usage:
 \endcode
 The implementation is ugly but it is equivalent to this C++17 fold expression:
 \code
-	((x == Types) || ...)
+	((a_BlockType == Types) || ...)
 \endcode
 Just written to be valid without fold expressions or SFINAE. */
-template <BLOCKTYPE ... Types>
-bool IsOneOf(BLOCKTYPE x)
-{
-	return IsOneOfImpl<Types ...>(x,
-		std::integral_constant<bool, sizeof...(Types) == 0>()
-	);
-}
-
-/** The base case of IsOneOf, dealing with the empty parameter pack by always returning false.
-Do not use directly, instead use IsOneOf. */
-template <class>
-bool IsOneOfImpl(BLOCKTYPE x, std::true_type)
-{
-	return false;
-}
-
-/** Recursive IsOneOf case where the variadic Types are not empty.
-Do not use directly, instead use IsOneOf. */
 template <BLOCKTYPE Head, BLOCKTYPE ... Tail>
-bool IsOneOfImpl(BLOCKTYPE x, std::false_type)
+bool IsOneOf(BLOCKTYPE a_BlockType)
 {
-	return ((x == Head) || (IsOneOf<Tail...>(x)));
+	return ((a_BlockType == Head) || (IsOneOf<Tail...>(a_BlockType)));
 }
 
 

--- a/src/BlockID.h
+++ b/src/BlockID.h
@@ -1212,3 +1212,46 @@ extern cItem GetIniItemSet(cIniFile & a_IniFile, const char * a_Section, const c
 
 
 
+template <BLOCKTYPE, BLOCKTYPE...> bool IsOneOfImpl(BLOCKTYPE, std::false_type);
+template <class = void> bool IsOneOfImpl(BLOCKTYPE, std::true_type);
+
+
+/** Returns true if the BLOCKTYPE x is equal to any of the variadic template arguments.
+
+Some example usage:
+\code
+	IsOneOf<>(E_BLOCK_AIR)                           == false
+	IsOneOf<E_BLOCK_AIR>(E_BLOCK_DIRT)               == false
+	IsOneOf<E_BLOCK_AIR, E_BLOCK_DIRT>(E_BLOCK_DIRT) == true
+\endcode
+The implementation is ugly but it is equivalent to this C++17 fold expression:
+\code
+	((x == Types) || ...)
+\endcode
+Just written to be valid without fold expressions or SFINAE. */
+template <BLOCKTYPE ... Types>
+bool IsOneOf(BLOCKTYPE x)
+{
+	return IsOneOfImpl<Types ...>(x,
+		std::integral_constant<bool, sizeof...(Types) == 0>()
+	);
+}
+
+/** The base case of IsOneOf, dealing with the empty parameter pack by always returning false.
+Do not use directly, instead use IsOneOf. */
+template <class>
+bool IsOneOfImpl(BLOCKTYPE x, std::true_type)
+{
+	return false;
+}
+
+/** Recursive IsOneOf case where the variadic Types are not empty.
+Do not use directly, instead use IsOneOf. */
+template <BLOCKTYPE Head, BLOCKTYPE ... Tail>
+bool IsOneOfImpl(BLOCKTYPE x, std::false_type)
+{
+	return ((x == Head) || (IsOneOf<Tail...>(x)));
+}
+
+
+

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -2077,7 +2077,7 @@ bool cChunk::DoWithEntityByID(UInt32 a_EntityID, cLambdaEntityCallback a_Callbac
 // Helper function - there's probably a better place for this
 
 template <BLOCKTYPE, BLOCKTYPE...> bool IsOneOfImpl(BLOCKTYPE, std::false_type);
-template <class> bool IsOneOfImpl(BLOCKTYPE, std::true_type);
+template <class = void> bool IsOneOfImpl(BLOCKTYPE, std::true_type);
 
 template <BLOCKTYPE ... Types>
 bool IsOneOf(BLOCKTYPE x)
@@ -2087,7 +2087,7 @@ bool IsOneOf(BLOCKTYPE x)
 	);
 }
 
-template <class = void>
+template <class>
 bool IsOneOfImpl(BLOCKTYPE x, std::true_type)
 {
 	return false;
@@ -2958,6 +2958,8 @@ void cChunk::BroadcastUseBed(const cEntity & a_Entity, int a_BlockX, int a_Block
 
 void cChunk::SendBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cClientHandle & a_Client)
 {
+	bool t = IsOneOf<>(1);
+	ASSERT(t);
 	cBlockEntity * Entity = GetBlockEntity(a_BlockX, a_BlockY, a_BlockZ);
 	if (Entity == nullptr)
 	{

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -2958,8 +2958,6 @@ void cChunk::BroadcastUseBed(const cEntity & a_Entity, int a_BlockX, int a_Block
 
 void cChunk::SendBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, cClientHandle & a_Client)
 {
-	bool t = IsOneOf<>(1);
-	ASSERT(t);
 	cBlockEntity * Entity = GetBlockEntity(a_BlockX, a_BlockY, a_BlockZ);
 	if (Entity == nullptr)
 	{

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -277,7 +277,7 @@ public:
 	bool DoWithEntityByID(UInt32 a_EntityID, cLambdaEntityCallback a_Callback, bool & a_CallbackResult);  // Lambda version
 
 	/** Calls the callback for each tyEntity; returns true if all block entities processed, false if the callback aborted by returning true
-	tBlocktype is a list of the blocktypes convertible to tyEntity which are to be called. If no block type is given the callback is called for every block entity
+	tBlocktypes are all blocktypes convertible to tyEntity which are to be called. If no block type is given the callback is called for every block entity
 	Accessible only from within Chunk.cpp */
 	template <class tyEntity, BLOCKTYPE... tBlocktype>
 	bool GenericForEachBlockEntity(cItemCallback<tyEntity>& a_Callback);
@@ -536,7 +536,7 @@ private:
 	// A critical section is not needed, because all chunk access is protected by its parent ChunkMap's csLayers
 	std::vector<cClientHandle *> m_LoadedByClient;
 	cEntityList                  m_Entities;
-	std::map<int, cBlockEntity *> m_BlockEntities;
+	cBlockEntities               m_BlockEntities;
 
 	/** Number of times the chunk has been requested to stay (by various cChunkStay objects); if zero, the chunk can be unloaded */
 	int m_StayCount;

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -524,7 +524,7 @@ private:
 	// A critical section is not needed, because all chunk access is protected by its parent ChunkMap's csLayers
 	std::vector<cClientHandle *> m_LoadedByClient;
 	cEntityList                  m_Entities;
-	cBlockEntityList             m_BlockEntities;
+	std::map<int, cBlockEntity *> m_BlockEntities;
 
 	/** Number of times the chunk has been requested to stay (by various cChunkStay objects); if zero, the chunk can be unloaded */
 	int m_StayCount;
@@ -566,7 +566,10 @@ private:
 	void RemoveBlockEntity(cBlockEntity * a_BlockEntity);
 	void AddBlockEntity   (cBlockEntity * a_BlockEntity);
 
-	/** Creates a block entity for each block that needs a block entity and doesn't have one in the list */
+	/** Add a block entity to the chunk without marking the chunk dirty */
+	void AddBlockEntityClean(cBlockEntity * a_BlockEntity);
+
+	/** Creates a block entity for each block that needs a block entity and doesn't have one already */
 	void CreateBlockEntities(void);
 
 	/** Wakes up each simulator for its specific blocks; through all the blocks in the chunk */

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -276,6 +276,12 @@ public:
 	bool DoWithEntityByID(UInt32 a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackResult);  // Lua-accessible
 	bool DoWithEntityByID(UInt32 a_EntityID, cLambdaEntityCallback a_Callback, bool & a_CallbackResult);  // Lambda version
 
+	/** Calls the callback for each tyEntity; returns true if all block entities processed, false if the callback aborted by returning true
+	tBlocktype is a list of the blocktypes convertible to tyEntity which are to be called. If no block type is given the callback is called for every block entity
+	Accessible only from within Chunk.cpp */
+	template <class tyEntity, BLOCKTYPE... tBlocktype>
+	bool GenericForEachBlockEntity(cItemCallback<tyEntity>& a_Callback);
+
 	/** Calls the callback for each block entity; returns true if all block entities processed, false if the callback aborted by returning true */
 	bool ForEachBlockEntity(cBlockEntityCallback & a_Callback);  // Lua-accessible
 

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -303,6 +303,12 @@ public:
 	/** Calls the callback for each furnace; returns true if all furnaces processed, false if the callback aborted by returning true */
 	bool ForEachFurnace(cFurnaceCallback & a_Callback);  // Lua-accessible
 
+	/** Calls the callback for the tyEntity at the specified coords; returns false if there's no such block entity at those coords, true if found
+	tBlocktype is a list of the blocktypes to be called. If no BLOCKTYPE template arguments are given the callback is called for any block entity
+	Accessible only from within Chunk.cpp */
+	template <class tyEntity, BLOCKTYPE... tBlocktype>
+	bool GenericDoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cItemCallback<tyEntity>& a_Callback);
+
 	/** Calls the callback for the block entity at the specified coords; returns false if there's no block entity at those coords, true if found */
 	bool DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBlockEntityCallback & a_Callback);  // Lua-acessible
 

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -31,8 +31,8 @@ class cEntity;
 class cClientHandle;
 class cBlockEntity;
 
-typedef std::list<cEntity *>        cEntityList;
-typedef std::list<cBlockEntity *>   cBlockEntityList;
+typedef std::list<cEntity *>          cEntityList;
+typedef std::map<int, cBlockEntity *> cBlockEntities;
 
 
 

--- a/src/Generating/ChunkDesc.cpp
+++ b/src/Generating/ChunkDesc.cpp
@@ -573,23 +573,27 @@ void cChunkDesc::RandomFillRelCuboid(
 
 cBlockEntity * cChunkDesc::GetBlockEntity(int a_RelX, int a_RelY, int a_RelZ)
 {
+	auto Idx = cChunkDef::MakeIndex(a_RelX, a_RelY, a_RelZ);
+	auto itr = m_BlockEntities.find(Idx);
+
+	if (itr != m_BlockEntities.end())
+	{
+		// Already in the list:
+		cBlockEntity * BlockEntity = itr->second;
+		if (BlockEntity->GetBlockType() == GetBlockType(a_RelX, a_RelY, a_RelZ))
+		{
+			// Correct type, already present. Return it:
+			return BlockEntity;
+		}
+		else
+		{
+			// Wrong type, the block type has been overwritten. Erase and create new:
+			m_BlockEntities.erase(itr);
+		}
+	}
+
 	int AbsX = a_RelX + m_ChunkX * cChunkDef::Width;
 	int AbsZ = a_RelZ + m_ChunkZ * cChunkDef::Width;
-	for (cBlockEntityList::iterator itr = m_BlockEntities.begin(), end = m_BlockEntities.end(); itr != end; ++itr)
-	{
-		if (((*itr)->GetPosX() == AbsX) && ((*itr)->GetPosY() == a_RelY) && ((*itr)->GetPosZ() == AbsZ))
-		{
-			// Already in the list:
-			if ((*itr)->GetBlockType() != GetBlockType(a_RelX, a_RelY, a_RelZ))
-			{
-				// Wrong type, the block type has been overwritten. Erase and create new:
-				m_BlockEntities.erase(itr);
-				break;
-			}
-			// Correct type, already present. Return it:
-			return *itr;
-		}
-	}  // for itr - m_BlockEntities[]
 
 	// The block entity is not created yet, try to create it and add to list:
 	cBlockEntity * be = cBlockEntity::CreateByBlockType(GetBlockType(a_RelX, a_RelY, a_RelZ), GetBlockMeta(a_RelX, a_RelY, a_RelZ), AbsX, a_RelY, AbsZ);
@@ -598,7 +602,7 @@ cBlockEntity * cChunkDesc::GetBlockEntity(int a_RelX, int a_RelY, int a_RelZ)
 		// No block entity for this block type
 		return nullptr;
 	}
-	m_BlockEntities.push_back(be);
+	m_BlockEntities.insert({ Idx, be });
 	return be;
 }
 

--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -215,7 +215,7 @@ public:
 	inline BlockNibbleBytes &        GetBlockMetasUncompressed(void) { return *(reinterpret_cast<BlockNibbleBytes *>(m_BlockArea.GetBlockMetas())); }
 	inline cChunkDef::HeightMap &    GetHeightMap             (void) { return m_HeightMap; }
 	inline cEntityList &             GetEntities              (void) { return m_Entities; }
-	inline cBlockEntityList &        GetBlockEntities         (void) { return m_BlockEntities; }
+	inline cBlockEntities &          GetBlockEntities         (void) { return m_BlockEntities; }
 
 	/** Compresses the metas from the BlockArea format (1 meta per byte) into regular format (2 metas per byte) */
 	void CompressBlockMetas(cChunkDef::BlockNibbles & a_DestMetas);
@@ -233,7 +233,7 @@ private:
 	cBlockArea              m_BlockArea;
 	cChunkDef::HeightMap    m_HeightMap;
 	cEntityList             m_Entities;       // Individual entities are NOT owned by this object!
-	cBlockEntityList        m_BlockEntities;  // Individual block entities are NOT owned by this object!
+	cBlockEntities          m_BlockEntities;  // Individual block entities are NOT owned by this object!
 
 	bool m_bUseDefaultBiomes;
 	bool m_bUseDefaultHeight;

--- a/src/SetChunkData.cpp
+++ b/src/SetChunkData.cpp
@@ -34,7 +34,7 @@ cSetChunkData::cSetChunkData(
 	const cChunkDef::HeightMap * a_HeightMap,
 	const cChunkDef::BiomeMap * a_Biomes,
 	cEntityList && a_Entities,
-	cBlockEntityList && a_BlockEntities,
+	cBlockEntities && a_BlockEntities,
 	bool a_ShouldMarkDirty
 ) :
 	m_ChunkX(a_ChunkX),
@@ -119,23 +119,21 @@ void cSetChunkData::CalculateHeightMap(void)
 
 void cSetChunkData::RemoveInvalidBlockEntities(void)
 {
-	for (cBlockEntityList::iterator itr = m_BlockEntities.begin(); itr != m_BlockEntities.end();)
+	for (cBlockEntities::iterator itr = m_BlockEntities.begin(); itr != m_BlockEntities.end();)
 	{
-		BLOCKTYPE EntityBlockType = (*itr)->GetBlockType();
-		BLOCKTYPE WorldBlockType = cChunkDef::GetBlock(m_BlockTypes, (*itr)->GetRelX(), (*itr)->GetPosY(), (*itr)->GetRelZ());
+		cBlockEntity * BlockEntity = itr->second;
+		BLOCKTYPE EntityBlockType = BlockEntity->GetBlockType();
+		BLOCKTYPE WorldBlockType = cChunkDef::GetBlock(m_BlockTypes, BlockEntity->GetRelX(), BlockEntity->GetPosY(), BlockEntity->GetRelZ());
 		if (EntityBlockType != WorldBlockType)
 		{
 			// Bad blocktype, remove the block entity:
 			LOGD("Block entity blocktype mismatch at {%d, %d, %d}: entity for blocktype %s(%d) in block %s(%d). Deleting the block entity.",
-				(*itr)->GetPosX(), (*itr)->GetPosY(), (*itr)->GetPosZ(),
+				BlockEntity->GetPosX(), BlockEntity->GetPosY(), BlockEntity->GetPosZ(),
 				ItemTypeToString(EntityBlockType).c_str(), EntityBlockType,
 				ItemTypeToString(WorldBlockType).c_str(),  WorldBlockType
 			);
-			cBlockEntityList::iterator itr2 = itr;
-			++itr2;
-			delete *itr;
-			m_BlockEntities.erase(itr);
-			itr = itr2;
+			delete BlockEntity;
+			itr = m_BlockEntities.erase(itr);
 		}
 		else
 		{

--- a/src/SetChunkData.h
+++ b/src/SetChunkData.h
@@ -24,7 +24,7 @@ public:
 
 	/** Constructs a new instance based on data existing elsewhere, will copy all the memory. Prefer to use the
 	other constructor as much as possible.
-	Will move the entity and blockentity lists into the internal storage, and invalidate a_Entities and
+	Will move the entity list and blockentities into the internal storage, and invalidate a_Entities and
 	a_BlockEntities.
 	When passing an lvalue, a_Entities and a_BlockEntities must be explicitly converted to an rvalue beforehand
 	with std::move().
@@ -44,7 +44,7 @@ public:
 		const cChunkDef::HeightMap * a_HeightMap,
 		const cChunkDef::BiomeMap * a_Biomes,
 		cEntityList && a_Entities,
-		cBlockEntityList && a_BlockEntities,
+		cBlockEntities && a_BlockEntities,
 		bool a_ShouldMarkDirty
 	);
 
@@ -73,7 +73,7 @@ public:
 	cEntityList & GetEntities(void) { return m_Entities; }
 
 	/** Returns the internal storage for block entities, read-write. */
-	cBlockEntityList & GetBlockEntities(void) { return m_BlockEntities; }
+	cBlockEntities & GetBlockEntities(void) { return m_BlockEntities; }
 
 	/** Returns whether both light arrays stored in this object are valid. */
 	bool IsLightValid(void) const { return m_IsLightValid; }
@@ -108,7 +108,7 @@ protected:
 	cChunkDef::HeightMap m_HeightMap;
 	cChunkDef::BiomeMap m_Biomes;
 	cEntityList m_Entities;
-	cBlockEntityList m_BlockEntities;
+	cBlockEntities m_BlockEntities;
 
 	bool m_IsLightValid;
 	bool m_IsHeightMapValid;

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -417,7 +417,7 @@ bool cWSSAnvil::LoadChunkFromNBT(const cChunkCoords & a_Chunk, const cParsedNBT 
 
 	// Load the entities from NBT:
 	cEntityList      Entities;
-	cBlockEntityList BlockEntities;
+	cBlockEntities   BlockEntities;
 	LoadEntitiesFromNBT     (Entities,      a_NBT, a_NBT.FindChildByName(Level, "Entities"));
 	LoadBlockEntitiesFromNBT(BlockEntities, a_NBT, a_NBT.FindChildByName(Level, "TileEntities"), BlockTypes, MetaData);
 
@@ -639,7 +639,7 @@ void cWSSAnvil::LoadEntitiesFromNBT(cEntityList & a_Entities, const cParsedNBT &
 
 
 
-void cWSSAnvil::LoadBlockEntitiesFromNBT(cBlockEntityList & a_BlockEntities, const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE * a_BlockTypes, NIBBLETYPE * a_BlockMetas)
+void cWSSAnvil::LoadBlockEntitiesFromNBT(cBlockEntities & a_BlockEntities, const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE * a_BlockTypes, NIBBLETYPE * a_BlockMetas)
 {
 	if ((a_TagIdx < 0) || (a_NBT.GetType(a_TagIdx) != TAG_List))
 	{
@@ -673,7 +673,10 @@ void cWSSAnvil::LoadBlockEntitiesFromNBT(cBlockEntityList & a_BlockEntities, con
 		}
 
 		// Add the BlockEntity to the loaded data:
-		a_BlockEntities.push_back(be.release());
+		auto Idx = cChunkDef::MakeIndex(be->GetRelX(), be->GetPosY(), be->GetRelZ());
+		a_BlockEntities.insert({ Idx, be.get() });
+		// Release after inserting incase it throws.
+		be.release();
 	}  // for Child - tag children
 }
 

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -675,7 +675,7 @@ void cWSSAnvil::LoadBlockEntitiesFromNBT(cBlockEntities & a_BlockEntities, const
 		// Add the BlockEntity to the loaded data:
 		auto Idx = cChunkDef::MakeIndex(be->GetRelX(), be->GetPosY(), be->GetRelZ());
 		a_BlockEntities.insert({ Idx, be.get() });
-		// Release after inserting incase it throws.
+		// Release after inserting in case it throws.
 		be.release();
 	}  // for Child - tag children
 }

--- a/src/WorldStorage/WSSAnvil.h
+++ b/src/WorldStorage/WSSAnvil.h
@@ -131,7 +131,7 @@ protected:
 	void LoadEntitiesFromNBT(cEntityList & a_Entitites, const cParsedNBT & a_NBT, int a_Tag);
 
 	/** Loads the chunk's BlockEntities from NBT data (a_Tag is the Level\\TileEntities list tag; may be -1) */
-	void LoadBlockEntitiesFromNBT(cBlockEntityList & a_BlockEntitites, const cParsedNBT & a_NBT, int a_Tag, BLOCKTYPE * a_BlockTypes, NIBBLETYPE * a_BlockMetas);
+	void LoadBlockEntitiesFromNBT(cBlockEntities & a_BlockEntitites, const cParsedNBT & a_NBT, int a_Tag, BLOCKTYPE * a_BlockTypes, NIBBLETYPE * a_BlockMetas);
 
 	/** Loads the data for a block entity from the specified NBT tag.
 	Returns the loaded block entity, or nullptr upon failure. */


### PR DESCRIPTION
Currently, performance degrades drastically when there are many block entities in a chunk [#1901, #3384].  Switching from a `std::list` to a `std::map` or `std::unordered_map` has greatly improved performance in my tests.

I also cleaned up the `ForEachBlockEntity` and `DoWithBlockEntityAt` functions as there was far too much copy-pasted code.

## Testing method
The server was compiled with MSVC in release mode and run without the debugger.
A new world was generated and used `//sphere hopper 70` from WorldEdit.
After closing the server I backed up the world/region folder.

5 times for each container the region folder was restored from backup and the server started.
The times taken to startup the server was recorded for each.

## Results
![image](https://cloud.githubusercontent.com/assets/13238737/26256204/1a3cd70c-3cb4-11e7-9b91-13eb7e5f4cc9.png)


| Container | Mean startup time (s) |
|---|:---:|
| `std::list` | 59.6(9) |
| `std::map` | 3.6(2) |
| `std::unordered_map` | 2.84(9) |

Clearly there is a huge gain from using an associative container.
There was also a slight improvement from the unordered variety but I'm not sure how well it would translate into normal usage so I've left it as a map.


