### PR TITLE
Don't destroy monster when last target type is a player

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -101,6 +101,7 @@ cMonster::cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const A
 	, m_Age(1)
 	, m_AgingTimer(20 * 60 * 20)  // about 20 minutes
 	, m_Target(nullptr)
+	, m_WasLastTargetAPlayer(false)
 {
 	if (!a_ConfigName.empty())
 	{

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -100,8 +100,8 @@ cMonster::cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const A
 	, m_RelativeWalkSpeed(1)
 	, m_Age(1)
 	, m_AgingTimer(20 * 60 * 20)  // about 20 minutes
-	, m_Target(nullptr)
 	, m_WasLastTargetAPlayer(false)
+	, m_Target(nullptr)
 {
 	if (!a_ConfigName.empty())
 	{

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -945,6 +945,7 @@ void cMonster::SetTarget (cPawn * a_NewTarget)
 		ASSERT(a_NewTarget->IsTicking());
 		// Notify the new target that we are now targeting it.
 		m_Target->TargetingMe(this);
+		m_LastTargetWasAPlayer = m_Target->IsPlayer();
 	}
 
 }

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -945,7 +945,7 @@ void cMonster::SetTarget (cPawn * a_NewTarget)
 		ASSERT(a_NewTarget->IsTicking());
 		// Notify the new target that we are now targeting it.
 		m_Target->TargetingMe(this);
-		m_LastTargetWasAPlayer = m_Target->IsPlayer();
+		m_WasLastTargetAPlayer = m_Target->IsPlayer();
 	}
 
 }

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -177,7 +177,7 @@ public:
 	static cMonster * NewMonsterFromType(eMonsterType a_MobType);
 
 	/** Returns if this mob last target was a player to avoid destruction on player quit */
-	const bool IsLastTargetWasAPlayer() const { return m_LastTargetWasAPlayer; }
+	const bool WasLastTargetAPlayer() const { return m_WasLastTargetAPlayer; }
 
 protected:
 
@@ -254,7 +254,7 @@ protected:
 	int m_Age;
 	int m_AgingTimer;
 
-	bool m_LastTargetWasAPlayer;
+	bool m_WasLastTargetAPlayer;
 
 	/** Adds a random number of a_Item between a_Min and a_Max to itemdrops a_Drops */
 	void AddRandomDropItem(cItems & a_Drops, unsigned int a_Min, unsigned int a_Max, short a_Item, short a_ItemHealth = 0);

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -176,6 +176,9 @@ public:
 	*/
 	static cMonster * NewMonsterFromType(eMonsterType a_MobType);
 
+	/** Returns if this mob last target was a player to avoid destruction on player quit */
+	const bool IsLastTargetWasAPlayer() const { return m_LastTargetWasAPlayer; }
+
 protected:
 
 	/** The pathfinder instance handles pathfinding for this monster. */
@@ -250,6 +253,8 @@ protected:
 
 	int m_Age;
 	int m_AgingTimer;
+
+	bool m_LastTargetWasAPlayer;
 
 	/** Adds a random number of a_Item between a_Min and a_Max to itemdrops a_Drops */
 	void AddRandomDropItem(cItems & a_Drops, unsigned int a_Min, unsigned int a_Max, short a_Item, short a_ItemHealth = 0);

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -177,7 +177,7 @@ public:
 	static cMonster * NewMonsterFromType(eMonsterType a_MobType);
 
 	/** Returns if this mob last target was a player to avoid destruction on player quit */
-	const bool WasLastTargetAPlayer() const { return m_WasLastTargetAPlayer; }
+	bool WasLastTargetAPlayer() const { return m_WasLastTargetAPlayer; }
 
 protected:
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1149,8 +1149,8 @@ void cWorld::TickMobs(std::chrono::milliseconds a_Dt)
 			{
 				Monster->Tick(m_Dt, *(a_Entity->GetParentChunk()));
 			}
-			// Destroy far hostile mobs
-			else if ((Monster->GetMobFamily() == cMonster::eFamily::mfHostile))
+			// Destroy far hostile mobs except if last target was a player
+			else if ((Monster->GetMobFamily() == cMonster::eFamily::mfHostile) && !Monster->IsLastTargetWasAPlayer() )
 			{
 				if (Monster->GetMobType() != eMonsterType::mtWolf)
 				{

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1150,7 +1150,7 @@ void cWorld::TickMobs(std::chrono::milliseconds a_Dt)
 				Monster->Tick(m_Dt, *(a_Entity->GetParentChunk()));
 			}
 			// Destroy far hostile mobs except if last target was a player
-			else if ((Monster->GetMobFamily() == cMonster::eFamily::mfHostile) && !Monster->IsLastTargetWasAPlayer() )
+			else if ((Monster->GetMobFamily() == cMonster::eFamily::mfHostile) && !Monster->IsLastTargetWasAPlayer())
 			{
 				if (Monster->GetMobType() != eMonsterType::mtWolf)
 				{

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1150,7 +1150,7 @@ void cWorld::TickMobs(std::chrono::milliseconds a_Dt)
 				Monster->Tick(m_Dt, *(a_Entity->GetParentChunk()));
 			}
 			// Destroy far hostile mobs except if last target was a player
-			else if ((Monster->GetMobFamily() == cMonster::eFamily::mfHostile) && !Monster->IsLastTargetWasAPlayer())
+			else if ((Monster->GetMobFamily() == cMonster::eFamily::mfHostile) && !Monster->WasLastTargetAPlayer())
 			{
 				if (Monster->GetMobType() != eMonsterType::mtWolf)
 				{


### PR DESCRIPTION
In current Cuberite version if you are pursued by monsters you just have to disconnect and connect again to get rid of them. If no other player is in your chunk monsters will get destroyed. These changes avoid that.
I considered the situation of several players moving from one place to another at night, making monsters to target them. In this case those mobs will never get destroyed until someone kills them or the Sun burns them or whatever. I think this is not really a problem in terms of gameplay, but I ignore if is there any problem in terms of performance.