### PR TITLE
Off-hand/shield slot functional, save and load slot, bow + arrow functional (fixes #3714)

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -7978,7 +7978,7 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 							Type = "cItem",
 						},
 					},
-					Notes = "Returns current item in shield slot. Note that the returned item is read-only",
+					Notes = "Returns current item in shield slot.",
 				},				
 				GetInventoryGrid =
 				{
@@ -8192,7 +8192,7 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 					Params =
 					{
 						{
-							Name = "cItem",
+							Name = "Item",
 							Type = "cItem",
 						},
 					},
@@ -8242,7 +8242,7 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 				invHotbarCount =
 				{
 					Notes = "Number of slots in the Hotbar part",
-				},			
+				},
 				invHotbarOffset =
 				{
 					Notes = "Starting slot number of the Hotbar part",

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -7970,6 +7970,16 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 					},
 					Notes = "Returns the specified hotbar slot contents. Note that the returned item is read-only",
 				},
+				GetShieldSlot =
+				{
+					Returns =
+					{
+						{
+							Type = "cItem",
+						},
+					},
+					Notes = "Returns current item in shield slot. Note that the returned item is read-only",
+				},				
 				GetInventoryGrid =
 				{
 					Returns =
@@ -8177,6 +8187,17 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 					},
 					Notes = "Sets the specified hotbar slot contents",
 				},
+				SetShieldSlot =
+				{
+					Params =
+					{
+						{
+							Name = "cItem",
+							Type = "cItem",
+						},
+					},
+					Notes = "Sets the shield slot content",
+				},				
 				SetInventorySlot =
 				{
 					Params =
@@ -8221,7 +8242,7 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 				invHotbarCount =
 				{
 					Notes = "Number of slots in the Hotbar part",
-				},
+				},			
 				invHotbarOffset =
 				{
 					Notes = "Starting slot number of the Hotbar part",
@@ -8233,6 +8254,14 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 				invInventoryOffset =
 				{
 					Notes = "Starting slot number of the main inventory part",
+				},
+				invShieldCount =
+				{
+					Notes = "Number of slots in the Shield part",
+				},
+				invShieldOffset =
+				{
+					Notes = "Starting slot number of the Shield part",
 				},
 				invNumSlots =
 				{

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1530,7 +1530,7 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 		PlgMgr->CallHookPlayerUsedItem(*m_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ);
 	}
 	// Charge bow when it's in slot off-hand / shield
-	if ((a_BlockFace == BLOCK_FACE_NONE && m_Player->GetInventory().GetShieldSlot().m_ItemType == E_ITEM_BOW))
+	if ((a_BlockFace == BLOCK_FACE_NONE) && (m_Player->GetInventory().GetShieldSlot().m_ItemType == E_ITEM_BOW))
 	{
 		m_Player->StartChargingBow();
 	}

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1111,6 +1111,11 @@ void cClientHandle::HandleLeftClick(int a_BlockX, int a_BlockY, int a_BlockZ, eB
 					// A plugin doesn't agree with the action. The plugin itself is responsible for handling the consequences (possible inventory mismatch)
 					return;
 				}
+				// When bow is in off-hand / shield slot
+				if (m_Player->GetInventory().GetShieldSlot().m_ItemType == E_ITEM_BOW)
+				{
+					ItemHandler = cItemHandler::GetItemHandler(m_Player->GetInventory().GetShieldSlot());
+				}
 				ItemHandler->OnItemShoot(m_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace);
 			}
 			return;
@@ -1523,6 +1528,11 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 		cBlockInServerPluginInterface PluginInterface(*World);
 		ItemHandler->OnItemUse(World, m_Player, PluginInterface, Equipped, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace);
 		PlgMgr->CallHookPlayerUsedItem(*m_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ);
+	}
+	// Charge bow when it's in slot off-hand / shield
+	if ((a_BlockFace == BLOCK_FACE_NONE && m_Player->GetInventory().GetShieldSlot().m_ItemType == E_ITEM_BOW))
+	{
+		m_Player->StartChargingBow();
 	}
 }
 

--- a/src/Inventory.h
+++ b/src/Inventory.h
@@ -43,11 +43,13 @@ public:
 		invArmorCount      = 4,
 		invInventoryCount  = 9 * 3,
 		invHotbarCount     = 9,
+		invShieldCount     = 1,
 
 		invArmorOffset     = 0,
 		invInventoryOffset = invArmorOffset     + invArmorCount,
 		invHotbarOffset    = invInventoryOffset + invInventoryCount,
-		invNumSlots        = invHotbarOffset    + invHotbarCount
+		invShieldOffset    = invHotbarOffset    + invHotbarCount,
+		invNumSlots        = invShieldOffset    + invShieldCount
 	} ;
 
 	// tolua_end
@@ -124,11 +126,13 @@ public:
 	const cItem & GetArmorSlot(int a_ArmorSlotNum) const;
 	const cItem & GetInventorySlot(int a_InventorySlotNum) const;
 	const cItem & GetHotbarSlot(int a_HotBarSlotNum) const;
+	const cItem & GetShieldSlot() const;
 	const cItem & GetEquippedItem(void) const;
 	void          SetSlot(int a_SlotNum, const cItem & a_Item);
 	void          SetArmorSlot(int a_ArmorSlotNum, const cItem & a_Item);
 	void          SetInventorySlot(int a_InventorySlotNum, const cItem & a_Item);
 	void          SetHotbarSlot(int a_HotBarSlotNum, const cItem & a_Item);
+	void          SetShieldSlot(const cItem & a_Item);
 
 	void          SetEquippedSlotNum(int a_SlotNum);
 	int           GetEquippedSlotNum(void) { return m_EquippedSlotNum; }
@@ -170,6 +174,7 @@ protected:
 	cItemGrid m_ArmorSlots;
 	cItemGrid m_InventorySlots;
 	cItemGrid m_HotbarSlots;
+	cItemGrid m_ShieldSlots;
 
 	int m_EquippedSlotNum;
 

--- a/src/Inventory.h
+++ b/src/Inventory.h
@@ -140,7 +140,7 @@ public:
 	void          SetArmorSlot(int a_ArmorSlotNum, const cItem & a_Item);
 	/** Puts a_Item item in a_InventorySlotNum slot number in inventory slots */
 	void          SetInventorySlot(int a_InventorySlotNum, const cItem & a_Item);
-	/** Puts a_Item item in a_InventorySlotNum slot number in hotbar slots */
+	/** Puts a_Item item in a_HotBarSlotNum slot number in hotbar slots */
 	void          SetHotbarSlot(int a_HotBarSlotNum, const cItem & a_Item);
 	/** Sets current item in shield slot */
 	void          SetShieldSlot(const cItem & a_Item);

--- a/src/Inventory.h
+++ b/src/Inventory.h
@@ -43,12 +43,12 @@ public:
 		invArmorCount      = 4,
 		invInventoryCount  = 9 * 3,
 		invHotbarCount     = 9,
-		invShieldCount     = 1,
+		invShieldCount     = 1,      // Number of slots in shield slots grid
 
 		invArmorOffset     = 0,
 		invInventoryOffset = invArmorOffset     + invArmorCount,
 		invHotbarOffset    = invInventoryOffset + invInventoryCount,
-		invShieldOffset    = invHotbarOffset    + invHotbarCount,
+		invShieldOffset    = invHotbarOffset    + invHotbarCount,     // Offset where shield slots start
 		invNumSlots        = invShieldOffset    + invShieldCount
 	} ;
 
@@ -122,19 +122,31 @@ public:
 
 	// tolua_begin
 
+	/** Returns current item in a_SlotNum slot */
 	const cItem & GetSlot(int a_SlotNum) const;
+	/** Returns current item in a_ArmorSlotNum in armor slots */
 	const cItem & GetArmorSlot(int a_ArmorSlotNum) const;
+	/** Returns current item in a_ArmorSlotNum in inventory slots */
 	const cItem & GetInventorySlot(int a_InventorySlotNum) const;
+	/** Returns current item in a_ArmorSlotNum in hotbar slots */
 	const cItem & GetHotbarSlot(int a_HotBarSlotNum) const;
+	/** Returns current item in shield slot */
 	const cItem & GetShieldSlot() const;
+	/** Returns current equiped item */
 	const cItem & GetEquippedItem(void) const;
+	/** Puts a_Item item in a_SlotNum slot number */
 	void          SetSlot(int a_SlotNum, const cItem & a_Item);
+	/** Puts a_Item item in a_ArmorSlotNum slot number in armor slots */
 	void          SetArmorSlot(int a_ArmorSlotNum, const cItem & a_Item);
+	/** Puts a_Item item in a_InventorySlotNum slot number in inventory slots */
 	void          SetInventorySlot(int a_InventorySlotNum, const cItem & a_Item);
+	/** Puts a_Item item in a_InventorySlotNum slot number in hotbar slots */
 	void          SetHotbarSlot(int a_HotBarSlotNum, const cItem & a_Item);
+	/** Sets current item in shield slot */
 	void          SetShieldSlot(const cItem & a_Item);
-
+	/** Sets equiped item to the a_SlotNum slot number */
 	void          SetEquippedSlotNum(int a_SlotNum);
+	/** Returns slot number of equiped item */
 	int           GetEquippedSlotNum(void) { return m_EquippedSlotNum; }
 
 	/** Adds (or subtracts, if a_AddToCount is negative) to the count of items in the specified slot.

--- a/src/UI/InventoryWindow.cpp
+++ b/src/UI/InventoryWindow.cpp
@@ -19,6 +19,7 @@ cInventoryWindow::cInventoryWindow(cPlayer & a_Player) :
 	m_SlotAreas.push_back(new cSlotAreaArmor(*this));
 	m_SlotAreas.push_back(new cSlotAreaInventory(*this));
 	m_SlotAreas.push_back(new cSlotAreaHotBar(*this));
+	m_SlotAreas.push_back(new cSlotAreaShield(*this));
 }
 
 

--- a/src/UI/SlotArea.h
+++ b/src/UI/SlotArea.h
@@ -145,6 +145,23 @@ public:
 
 
 
+/** Handles the shield of each player */
+class cSlotAreaShield :
+	public cSlotAreaInventoryBase
+{
+	typedef cSlotAreaInventoryBase super;
+
+public:
+	cSlotAreaShield(cWindow & a_ParentWindow) :
+		cSlotAreaInventoryBase(cInventory::invShieldCount, cInventory::invShieldOffset, a_ParentWindow)
+	{
+	}
+};
+
+
+
+
+
 /** Handles the armor area of the player's inventory */
 class cSlotAreaArmor :
 	public cSlotAreaInventoryBase


### PR DESCRIPTION
This adds these functionalities:
- You can put items in off-hand/shield slot so they don't fall to floor.
- Save / load of inventory slot off-hand/shield.
- Arrow shooting with bow in off-hand slot.

I did several tests. Putting arrows in off-hand slot and hotbar, putting bow in off-hand and arrows in hand, hotbar, and it works. I also tryed with 1.8 protocol, where there is no off-hand/shield slot, no crashes so far.

I didn't test shields, maybe tomorrow!