### PR TITLE
Check for nil in cPlayer:OpenWindow and close windows on reload

### DIFF
--- a/src/Bindings/LuaWindow.h
+++ b/src/Bindings/LuaWindow.h
@@ -15,7 +15,8 @@
 #include "../ItemGrid.h"
 
 
-
+class cPlayer;
+typedef cItemCallback<cPlayer> cPlayerListCallback;
 
 
 /** A window that has been created by a Lua plugin and is handled entirely by that plugin

--- a/src/BlockEntities/BeaconEntity.cpp
+++ b/src/BlockEntities/BeaconEntity.cpp
@@ -297,7 +297,7 @@ bool cBeaconEntity::UsedBy(cPlayer * a_Player)
 		// if (a_Player->GetWindow() != Window)
 		// -> Because mojang doesn't send a 'close window' packet when you click the cancel button in the beacon inventory ...
 		{
-			a_Player->OpenWindow(Window);
+			a_Player->OpenWindow(*Window);
 		}
 	}
 	return true;

--- a/src/BlockEntities/BrewingstandEntity.cpp
+++ b/src/BlockEntities/BrewingstandEntity.cpp
@@ -65,7 +65,7 @@ bool cBrewingstandEntity::UsedBy(cPlayer * a_Player)
 	{
 		if (a_Player->GetWindow() != Window)
 		{
-			a_Player->OpenWindow(Window);
+			a_Player->OpenWindow(*Window);
 		}
 	}
 

--- a/src/BlockEntities/ChestEntity.cpp
+++ b/src/BlockEntities/ChestEntity.cpp
@@ -101,7 +101,7 @@ bool cChestEntity::UsedBy(cPlayer * a_Player)
 	{
 		if (a_Player->GetWindow() != Window)
 		{
-			a_Player->OpenWindow(Window);
+			a_Player->OpenWindow(*Window);
 		}
 	}
 

--- a/src/BlockEntities/DropSpenserEntity.cpp
+++ b/src/BlockEntities/DropSpenserEntity.cpp
@@ -153,7 +153,7 @@ bool cDropSpenserEntity::UsedBy(cPlayer * a_Player)
 	{
 		if (a_Player->GetWindow() != Window)
 		{
-			a_Player->OpenWindow(Window);
+			a_Player->OpenWindow(*Window);
 		}
 	}
 	return true;

--- a/src/BlockEntities/EnderChestEntity.cpp
+++ b/src/BlockEntities/EnderChestEntity.cpp
@@ -66,7 +66,7 @@ bool cEnderChestEntity::UsedBy(cPlayer * a_Player)
 	{
 		if (a_Player->GetWindow() != Window)
 		{
-			a_Player->OpenWindow(Window);
+			a_Player->OpenWindow(*Window);
 		}
 	}
 	return true;

--- a/src/BlockEntities/FurnaceEntity.cpp
+++ b/src/BlockEntities/FurnaceEntity.cpp
@@ -69,7 +69,7 @@ bool cFurnaceEntity::UsedBy(cPlayer * a_Player)
 	{
 		if (a_Player->GetWindow() != Window)
 		{
-			a_Player->OpenWindow(Window);
+			a_Player->OpenWindow(*Window);
 		}
 	}
 

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -95,7 +95,7 @@ bool cHopperEntity::UsedBy(cPlayer * a_Player)
 	{
 		if (a_Player->GetWindow() != Window)
 		{
-			a_Player->OpenWindow(Window);
+			a_Player->OpenWindow(*Window);
 		}
 	}
 

--- a/src/Blocks/BlockAnvil.h
+++ b/src/Blocks/BlockAnvil.h
@@ -27,7 +27,7 @@ public:
 	virtual bool OnUse(cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface, cPlayer * a_Player, int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, int a_CursorX, int a_CursorY, int a_CursorZ) override
 	{
 		cWindow * Window = new cAnvilWindow(a_BlockX, a_BlockY, a_BlockZ);
-		a_Player->OpenWindow(Window);
+		a_Player->OpenWindow(*Window);
 		return true;
 	}
 

--- a/src/Blocks/BlockEnchantmentTable.h
+++ b/src/Blocks/BlockEnchantmentTable.h
@@ -21,7 +21,7 @@ public:
 	virtual bool OnUse(cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface, cPlayer * a_Player, int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, int a_CursorX, int a_CursorY, int a_CursorZ) override
 	{
 		cWindow * Window = new cEnchantingWindow(a_BlockX, a_BlockY, a_BlockZ);
-		a_Player->OpenWindow(Window);
+		a_Player->OpenWindow(*Window);
 		return true;
 	}
 

--- a/src/Blocks/BlockWorkbench.h
+++ b/src/Blocks/BlockWorkbench.h
@@ -21,7 +21,7 @@ public:
 	virtual bool OnUse(cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface, cPlayer * a_Player, int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, int a_CursorX, int a_CursorY, int a_CursorZ) override
 	{
 		cWindow * Window = new cCraftingWindow(a_BlockX, a_BlockY, a_BlockZ);
-		a_Player->OpenWindow(Window);
+		a_Player->OpenWindow(*Window);
 		return true;
 	}
 

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1222,7 +1222,7 @@ void cMinecartWithChest::OnRightClicked(cPlayer & a_Player)
 	{
 		if (a_Player.GetWindow() != Window)
 		{
-			a_Player.OpenWindow(Window);
+			a_Player.OpenWindow(*Window);
 		}
 	}
 }

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1310,15 +1310,15 @@ cTeam * cPlayer::UpdateTeam(void)
 
 
 
-void cPlayer::OpenWindow(cWindow * a_Window)
+void cPlayer::OpenWindow(cWindow & a_Window)
 {
-	if (a_Window != m_CurrentWindow)
+	if (&a_Window != m_CurrentWindow)
 	{
 		CloseWindow(false);
 	}
-	a_Window->OpenedByPlayer(*this);
-	m_CurrentWindow = a_Window;
-	a_Window->SendWholeWindow(*GetClientHandle());
+	a_Window.OpenedByPlayer(*this);
+	m_CurrentWindow = &a_Window;
+	a_Window.SendWholeWindow(*GetClientHandle());
 }
 
 

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -229,7 +229,7 @@ public:
 	// tolua_begin
 
 	/** Opens the specified window; closes the current one first using CloseWindow() */
-	void OpenWindow(cWindow * a_Window);
+	void OpenWindow(cWindow & a_Window);
 
 	/** Closes the current window, resets current window to m_InventoryWindow. A plugin may refuse the closing if a_CanRefuse is true */
 	void CloseWindow(bool a_CanRefuse = true);


### PR DESCRIPTION
Fixes #3727 

Also fixed a crash, if the player has a open window that has been created by a plugin. Fixed by closing window from all players on command reload.
