### PR TITLE
Double chest fixes

### DIFF
--- a/src/BlockEntities/ChestEntity.cpp
+++ b/src/BlockEntities/ChestEntity.cpp
@@ -127,21 +127,28 @@ void cChestEntity::ScanNeighbours()
 	{
 	public:
 		cChestEntity * m_Neighbour;
+		BLOCKTYPE      m_ChestType;
 
-		cFindNeighbour() :
-			m_Neighbour(nullptr)
+		cFindNeighbour(BLOCKTYPE a_ChestType) :
+			m_Neighbour(nullptr),
+			m_ChestType(a_ChestType)
 		{
 		}
 
 		virtual bool Item(cChestEntity * a_Chest) override
 		{
+			if (a_Chest->GetBlockType() != m_ChestType)
+			{
+				// Don't neighbour with the wrong type of chest
+				return true;
+			}
 			m_Neighbour = a_Chest;
 			return false;
 		}
 	};
 
-	// Scan horizontally adjacent blocks for any neighbouring chest:
-	cFindNeighbour FindNeighbour;
+	// Scan horizontally adjacent blocks for any neighbouring chest of the same type:
+	cFindNeighbour FindNeighbour(m_BlockType);
 	if (
 		m_World->DoWithChestAt(m_PosX - 1, m_PosY, m_PosZ,     FindNeighbour) ||
 		m_World->DoWithChestAt(m_PosX + 1, m_PosY, m_PosZ,     FindNeighbour) ||

--- a/src/BlockEntities/ChestEntity.cpp
+++ b/src/BlockEntities/ChestEntity.cpp
@@ -139,7 +139,7 @@ void cChestEntity::ScanNeighbours()
 		{
 			if (a_Chest->GetBlockType() != m_ChestType)
 			{
-				// Don't neighbour with the wrong type of chest
+				// Neighboring block is not the same type of chest
 				return true;
 			}
 			m_Neighbour = a_Chest;

--- a/src/BlockEntities/ChestEntity.h
+++ b/src/BlockEntities/ChestEntity.h
@@ -39,7 +39,7 @@ public:
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 
-	/** Search horizontally adjacent blocks for neighbouring chests and links them together. */
+	/** Search horizontally adjacent blocks for neighbouring chests of the same type and links them together. */
 	void ScanNeighbours();
 
 	/** Opens a new chest window where this is the primary chest and any neighbour is the secondary. */
@@ -72,9 +72,19 @@ private:
 		ASSERT(a_Grid == &m_Contents);
 		if (m_World != nullptr)
 		{
-			if (GetWindow() != nullptr)
+			cWindow * Window = GetWindow();
+			if (
+				(Window == nullptr) &&
+				(m_Neighbour != nullptr)
+			)
 			{
-				GetWindow()->BroadcastWholeWindow();
+				// Neighbour might own the window
+				Window = m_Neighbour->GetWindow();
+			}
+
+			if (Window != nullptr)
+			{
+				Window->BroadcastWholeWindow();
 			}
 
 			m_World->MarkChunkDirty(GetChunkX(), GetChunkZ());

--- a/src/Items/ItemChest.h
+++ b/src/Items/ItemChest.h
@@ -154,7 +154,7 @@ public:
 		}
 
 		// Adjust the existing chest, if any:
-		if (NeighborIdx > 0)
+		if (NeighborIdx != -1)
 		{
 			a_World.FastSetBlock(a_BlockX + CrossCoords[NeighborIdx].x, a_BlockY, a_BlockZ + CrossCoords[NeighborIdx].z, ChestBlockType, Meta);
 		}


### PR DESCRIPTION
This fixes 3 issues I noticed with double chests:

- Normal and trapped chests next to each other would open a double chest window
- Slot changes in the secondary chest were not being broadcast
- Placing a chest in +x of another did not update the original chest's metadata