### PR TITLE
Fixed skylight going down through transparent blocks.

### DIFF
--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -368,7 +368,18 @@ void cLightingThread::PrepareSkyLight(void)
 		for (int x = 1; x < cChunkDef::Width * 3 - 1; x++)
 		{
 			int idx = BaseZ + x;
-			int Current   = m_HeightMap[idx] + 1;
+			// Find the lowest block in this column that receives full sunlight (go through transparent blocks):
+			int Current = m_HeightMap[idx];
+			ASSERT(Current < cChunkDef::Height);
+			while (
+				(Current >= 0) &&
+				cBlockInfo::IsTransparent(m_BlockTypes[idx + Current * BlocksPerYLayer])
+			)
+			{
+				Current -= 1;  // Sunlight goes down unchanged through this block
+			}
+			Current += 1;  // Point to the last sunlit block, rather than the first non-transparent one
+			// The other neighbors don't need transparent-block-checking. At worst we'll have a few dud seeds above the ground.
 			int Neighbor1 = m_HeightMap[idx + 1] + 1;  // X + 1
 			int Neighbor2 = m_HeightMap[idx - 1] + 1;  // X - 1
 			int Neighbor3 = m_HeightMap[idx + cChunkDef::Width * 3] + 1;  // Z + 1


### PR DESCRIPTION
Fixes #3746.

Tested by commenting out the loader's light validation, thus enforcing a relight on all loaded chunks, then using a setup similar to #3746 - walls of stone and a ceiling of glass blocks.
Before this fix:
![before](https://user-images.githubusercontent.com/4388386/26939075-6dea5e7a-4c76-11e7-905b-9c325da78137.jpg)

After this fix:
![after](https://user-images.githubusercontent.com/4388386/26939089-760c2598-4c76-11e7-8576-f7832b4b313d.jpg)

Also checked a single-block-wide vertical tunnel filled with torches, also got correct lighting by this fix.