### PR TITLE
Fixed handling Lua errors in nested callbacks

### DIFF
--- a/Server/Plugins/Debuggers/Debuggers.lua
+++ b/Server/Plugins/Debuggers/Debuggers.lua
@@ -2279,6 +2279,18 @@ end
 
 
 
+function HandleConsoleTestErr(a_Split, a_EntireCmd)
+	cRoot:Get():GetDefaultWorld():ForEachEntity(
+		function (a_CBEntity)
+			error("This error should not abort the server")
+		end
+	)
+end
+
+
+
+
+
 function HandleConsoleTestJson(a_Split, a_EntireCmd)
 	LOG("Testing Json parsing...")
 	local t1 = cJson:Parse([[{"a": 1, "b": "2", "c": [3, "4", 5], "d": true }]])

--- a/Server/Plugins/Debuggers/Info.lua
+++ b/Server/Plugins/Debuggers/Info.lua
@@ -350,6 +350,12 @@ g_PluginInfo =
 			HelpString = "Tests inter-plugin calls with various values"
 		},
 
+		["testerr"] =
+		{
+			Handler = HandleConsoleTestErr,
+			HelpString = "Tests the server's ability to recover from errors in callbacks (GH #3733)",
+		},
+
 		["testjson"] =
 		{
 			Handler = HandleConsoleTestJson,

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -1454,8 +1454,12 @@ bool cLuaState::CallFunction(int a_NumResults)
 		LOGWARNING("Error in %s calling function %s()", m_SubsystemName.c_str(), CurrentFunctionName.c_str());
 
 		// Remove the error handler and error message from the stack:
-		ASSERT(lua_gettop(m_LuaState) == 2);
-		lua_pop(m_LuaState, 2);
+		auto top = lua_gettop(m_LuaState);
+		if (top != 2)
+		{
+			LogStackValues(Printf("The Lua stack is in an unexpected state, expected two values there, but got %d", top).c_str());
+		}
+		lua_pop(m_LuaState, top);
 		return false;
 	}
 

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -1455,11 +1455,11 @@ bool cLuaState::CallFunction(int a_NumResults)
 
 		// Remove the error handler and error message from the stack:
 		auto top = lua_gettop(m_LuaState);
-		if (top != 2)
+		if (top < 2)
 		{
-			LogStackValues(Printf("The Lua stack is in an unexpected state, expected two values there, but got %d", top).c_str());
+			LogStackValues(Printf("The Lua stack is in an unexpected state, expected at least two values there, but got %d", top).c_str());
 		}
-		lua_pop(m_LuaState, top);
+		lua_pop(m_LuaState, std::min(2, top));
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #3733.

Such a callback would have extra values on the Lua stack, which the `cLuaState::CallFunction()` didn't expect, it would remove them and then Lua would fail when trying to remove the original function's stack.

Added test code in the Debuggers plugin (`testerr` console command), which crashed the server before the fix and works okay after the fix.

To be squash-merged.