### PR TITLE
Remove redundant heighmap code

### DIFF
--- a/src/Generating/Noise3DGenerator.cpp
+++ b/src/Generating/Noise3DGenerator.cpp
@@ -236,7 +236,7 @@ void cNoise3DGenerator::DoGenerate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_Ch
 		}
 	}
 
-	UpdateHeightmap(a_ChunkDesc);
+	a_ChunkDesc.UpdateHeightmap();
 	ComposeTerrain (a_ChunkDesc);
 }
 
@@ -293,28 +293,6 @@ void cNoise3DGenerator::GenerateNoiseArray(int a_ChunkX, int a_ChunkZ, NOISE_DAT
 	);
 
 	// DEBUG: Debug3DNoise(a_OutNoise, 17, 257, 17, Printf("Chunk_%d_%d_lerp", a_ChunkX, a_ChunkZ));
-}
-
-
-
-
-
-void cNoise3DGenerator::UpdateHeightmap(cChunkDesc & a_ChunkDesc)
-{
-	for (int z = 0; z < cChunkDef::Width; z++)
-	{
-		for (int x = 0; x < cChunkDef::Width; x++)
-		{
-			for (HEIGHTTYPE y = cChunkDef::Height - 1; y > 0; y--)
-			{
-				if (a_ChunkDesc.GetBlockType(x, y, z) != E_BLOCK_AIR)
-				{
-					a_ChunkDesc.SetHeight(x, z, y);
-					break;
-				}
-			}  // for y
-		}  // for x
-	}  // for z
 }
 
 

--- a/src/Generating/Noise3DGenerator.h
+++ b/src/Generating/Noise3DGenerator.h
@@ -61,9 +61,6 @@ protected:
 	/** Generates the 3D noise array used for terrain generation; a_Noise is of ChunkData-size */
 	void GenerateNoiseArray(int a_ChunkX, int a_ChunkZ, NOISE_DATATYPE * a_Noise);
 
-	/** Updates heightmap based on the chunk's contents */
-	void UpdateHeightmap(cChunkDesc & a_ChunkDesc);
-
 	/** Composes terrain - adds dirt, grass and sand */
 	void ComposeTerrain(cChunkDesc & a_ChunkDesc);
 } ;

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -67,21 +67,7 @@ void cStructGenTrees::GenFinish(cChunkDesc & a_ChunkDesc)
 		}  // for z
 	}  // for x
 
-	// Update the heightmap:
-	for (int x = 0; x < cChunkDef::Width; x++)
-	{
-		for (int z = 0; z < cChunkDef::Width; z++)
-		{
-			for (HEIGHTTYPE y = cChunkDef::Height - 1; y >= 0; y--)
-			{
-				if (a_ChunkDesc.GetBlockType(x, y, z) != E_BLOCK_AIR)
-				{
-					a_ChunkDesc.SetHeight(x, z, y);
-					break;
-				}
-			}  // for y
-		}  // for z
-	}  // for x
+	a_ChunkDesc.UpdateHeightmap();
 }
 
 


### PR DESCRIPTION
This also fixes this warning from gcc:
```
/home/travis/build/cuberite/cuberite/src/Generating/StructGen.cpp:75:52: 
warning: comparison is always true due to limited range of data type [-Wtype-limits]

    for (HEIGHTTYPE y = cChunkDef::Height - 1; y >= 0; y--)
```