### PR TITLE
Remove reference to EAI_NODATA

### DIFF
--- a/src/OSSupport/HostnameLookup.cpp
+++ b/src/OSSupport/HostnameLookup.cpp
@@ -106,7 +106,7 @@ void cHostnameLookup::Callback(int a_ErrCode, addrinfo * a_Addr)
 	// If only unsupported families were reported, call the Error handler:
 	if (!HasResolved)
 	{
-		m_Callbacks->OnError(EAI_NODATA, ErrorString(EAI_NODATA));
+		m_Callbacks->OnError(EAI_NONAME, ErrorString(EAI_NONAME));
 	}
 	else
 	{


### PR DESCRIPTION
The [BSD build](https://cuberite.org/status/) is now failing with ```error: use of undeclared identifier 'EAI_NODATA'```
According to [this](https://sourceware.org/glibc/wiki/NameResolver#Return_value), `EAI_NODATA` is non-standard and isn't defined on FreeBSD.  Moreover, on windows it's just an alias for `EAI_NONAME` so I've changed it to that.

I'm not sure if this is the right solution though.  Having an `#ifndef` and aliasing it like on windows might be a better option.