### PR TITLE
Fix VS2017 throw warnings

### DIFF
--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -77,7 +77,7 @@ public:
 				}
 			}
 
-			~cStackBalanceCheck()
+			~cStackBalanceCheck() NO_THROW
 			{
 				auto currStackPos = lua_gettop(m_LuaState);
 				if (currStackPos != m_StackPos)
@@ -117,7 +117,7 @@ public:
 		{
 		}
 
-		~cStackBalancePopper()
+		~cStackBalancePopper() NO_THROW
 		{
 			auto curTop = lua_gettop(m_LuaState);
 			if (curTop > m_Count)
@@ -476,7 +476,7 @@ public:
 			std::swap(m_StackLen, a_Src.m_StackLen);
 		}
 
-		~cStackValue()
+		~cStackValue() NO_THROW
 		{
 			if (m_LuaState != nullptr)
 			{

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -49,7 +49,13 @@
 	#define SIZE_T_FMT_PRECISION(x) "%" #x "Iu"
 	#define SIZE_T_FMT_HEX "%Ix"
 
-	#define NORETURN      __declspec(noreturn)
+	#define NORETURN __declspec(noreturn)
+	#if (_MSC_VER < 1910)
+		// MSVC 2013 (and possibly 2015?) have no idea about "noexcept(false)"
+		#define NO_THROW throw(...)
+	#else
+		#define NO_THROW noexcept(false)
+	#endif
 
 	// Use non-standard defines in <cmath>
 	#define _USE_MATH_DEFINES
@@ -93,7 +99,8 @@
 		#define SIZE_T_FMT_HEX "%zx"
 	#endif
 
-	#define NORETURN      __attribute((__noreturn__))
+	#define NORETURN __attribute((__noreturn__))
+	#define NO_THROW noexcept(false)
 
 #else
 


### PR DESCRIPTION
VS2017 complains about these functions throwing (the asserts in Tests), although they shouldn't.

VS2013 (and possibly 2015) don't recognize `noexcept(false)`, clang doesn't like `throw(...)`, so a compromise macro has to be used.