### PR TITLE
MSVC Debug builds: Added operator new redirection to provide more info.

### DIFF
--- a/src/AllocationPool.h
+++ b/src/AllocationPool.h
@@ -81,7 +81,19 @@ public:
 			void * space = malloc(sizeof(T));
 			if (space != nullptr)
 			{
+				#if defined(_MSC_VER) && defined(_DEBUG)
+					// The debugging-new that is set up using macros in Globals.h doesn't support the placement-new syntax used here.
+					// Temporarily disable the macro
+					#pragma push_macro("new")
+					#undef new
+				#endif
+
 				return new(space) T;
+
+				#if defined(_MSC_VER) && defined(_DEBUG)
+					// Re-enable the debugging-new macro
+					#pragma pop_macro("new")
+				#endif
 			}
 			else if (m_FreeList.size() == NumElementsInReserve)
 			{
@@ -95,7 +107,21 @@ public:
 			}
 		}
 		// placement new, used to initalize the object
+
+		#if defined(_MSC_VER) && defined(_DEBUG)
+			// The debugging-new that is set up using macros in Globals.h doesn't support the placement-new syntax used here.
+			// Temporarily disable the macro
+			#pragma push_macro("new")
+			#undef new
+		#endif
+
 		T * ret = new (m_FreeList.front()) T;
+
+		#if defined(_MSC_VER) && defined(_DEBUG)
+			// Re-enable the debugging-new macro
+			#pragma pop_macro("new")
+		#endif
+
 		m_FreeList.pop_front();
 		return ret;
 	}

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -54,6 +54,24 @@
 	// Use non-standard defines in <cmath>
 	#define _USE_MATH_DEFINES
 
+	#ifdef _DEBUG
+		// Override the "new" operator to include file and line specification for debugging memory leaks
+		// Ref.: https://social.msdn.microsoft.com/Forums/en-US/ebc7dd7a-f3c6-49f1-8a60-e381052f21b6/debugging-memory-leaks?forum=vcgeneral#53f0cc89-62fe-45e8-bbf0-56b89f2a1901
+		// This causes MSVC Debug runs to produce a report upon program exit, that contains memory-leaks
+		// together with the file:line information about where the memory was allocated.
+		// Note that this doesn't work with placement-new, which needs to temporarily #undef the macro
+		// (See AllocationPool.h for an example).
+		#ifdef _DEBUG
+			#define _CRTDBG_MAP_ALLOC
+			#include <stdlib.h>
+			#include <crtdbg.h>
+			#define DEBUG_CLIENTBLOCK   new(_CLIENT_BLOCK, __FILE__, __LINE__)
+			#define new DEBUG_CLIENTBLOCK
+			// For some reason this works magically - each "new X" gets replaced as "new(_CLIENT_BLOCK, "file", line) X"
+			// The CRT has a definition for this operator new that stores the debugging info for leak-finding later.
+		#endif
+	#endif
+
 #elif defined(__GNUC__)
 
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?


### PR DESCRIPTION
This causes debug builds to provide more information about leaked memory when terminating the server.
Upon termination, all leaked memory blocks are listed and each block allocated via `new` reports the file and line number of the allocation.

Unfortunately this causes some problems with placement-new, which needs to be specially shielded from the redirection; fortunately we only use it in two places in `cAllocationPool`, so I fixed it there.