### PR TITLE
Generated tall flowers have flower type meta in both blocks

### DIFF
--- a/src/Blocks/BlockBigFlower.h
+++ b/src/Blocks/BlockBigFlower.h
@@ -49,7 +49,10 @@ public:
 		NIBBLETYPE Meta = a_BlockMeta & 0x7;
 		if (Meta == E_META_BIG_FLOWER_DOUBLE_TALL_GRASS)
 		{
-			a_Pickups.push_back(cItem(E_ITEM_SEEDS));
+			if (GetRandomProvider().RandBool(1.0 / 24.0))
+			{
+				a_Pickups.push_back(cItem(E_ITEM_SEEDS));
+			}
 		}
 		else if (Meta != E_META_BIG_FLOWER_LARGE_FERN)
 		{

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1139,7 +1139,7 @@ bool cChunk::GrowTallGrass(int a_RelX, int a_RelY, int a_RelZ)
 		default:                      return false;
 	}
 	return UnboundedRelFastSetBlock(a_RelX, a_RelY, a_RelZ, E_BLOCK_BIG_FLOWER, LargeFlowerMeta) &&
-		UnboundedRelFastSetBlock(a_RelX, a_RelY + 1, a_RelZ, E_BLOCK_BIG_FLOWER, 8);
+		UnboundedRelFastSetBlock(a_RelX, a_RelY + 1, a_RelZ, E_BLOCK_BIG_FLOWER, 0x8 | LargeFlowerMeta);
 }
 
 

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -260,7 +260,7 @@ void cFinishGenClumpTopBlock::TryPlaceFoliageClump(cChunkDesc & a_ChunkDesc, int
 		a_ChunkDesc.SetBlockTypeMeta(x, Top + 1, z, a_BlockType, a_BlockMeta);
 		if (a_IsDoubleTall)
 		{
-			a_ChunkDesc.SetBlockTypeMeta(x, Top + 2, z, E_BLOCK_BIG_FLOWER, 8);
+			a_ChunkDesc.SetBlockTypeMeta(x, Top + 2, z, E_BLOCK_BIG_FLOWER, 0x8 | a_BlockMeta);
 			a_ChunkDesc.SetHeight(x, z, static_cast<HEIGHTTYPE>(Top + 2));
 		}
 		else
@@ -554,7 +554,7 @@ void cFinishGenTallGrass::GenFinish(cChunkDesc & a_ChunkDesc)
 				{
 					NIBBLETYPE Meta = (m_Noise.IntNoise2DInt(xx * 100, zz * 100) / 7 % 100) > 25 ? 2 : 3;
 					a_ChunkDesc.SetBlockTypeMeta(x, y, z, E_BLOCK_BIG_FLOWER, Meta);
-					a_ChunkDesc.SetBlockTypeMeta(x, y + 1, z, E_BLOCK_BIG_FLOWER, 8);
+					a_ChunkDesc.SetBlockTypeMeta(x, y + 1, z, E_BLOCK_BIG_FLOWER, 0x8 | Meta);
 					a_ChunkDesc.SetHeight(x, z, static_cast<HEIGHTTYPE>(y + 1));
 				}
 			}


### PR DESCRIPTION
This fixes #3778 for all newly generated terrain and from bonemealing normal tall grass.