### PR TITLE
Fixed memory leak in cClientHandle.

### DIFF
--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -405,7 +405,7 @@ private:
 	std::unordered_set<cChunkCoords, cChunkCoordsHash> m_ChunksToSend;  // Chunks that need to be sent to the player (queued because they weren't generated yet or there's not enough time to send them)
 	cChunkCoordsList                                   m_SentChunks;    // Chunks that are currently sent to the client
 
-	cProtocol * m_Protocol;
+	std::unique_ptr<cProtocol> m_Protocol;
 
 	/** Protects m_IncomingData against multithreaded access. */
 	cCriticalSection m_CSIncomingData;


### PR DESCRIPTION
This fixes a memory leak in `cClientHandle` - the "ping" connections didn't reset their `m_Self`, causing a circular dependent `shared_ptr` and memory leaks in the end.

Additionally, this changes `cClientHandle::m_Protocol` to `unique_ptr`.