### PR TITLE
Stricter API checks in cNetwork

### DIFF
--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -1775,7 +1775,33 @@ bool cLuaState::CheckParamSelf(const char * a_SelfClassName)
 	VERIFY(lua_getstack(m_LuaState, 0,   &entry));
 	VERIFY(lua_getinfo (m_LuaState, "n", &entry));
 	AString ErrMsg = Printf(
-		"Error in function '%s'. The 'self' parameter is not of the expected type, \"instance of %s\". Make sure you're using the correct calling convention (obj:fn() instead of obj.fn()).",
+		"Error in function '%s'. The 'self' parameter is not of the expected type, \"instance of %s\". " \
+		"Make sure you're using the correct calling convention (obj:fn() instead of obj.fn()).",
+		(entry.name != nullptr) ? entry.name : "<unknown>", a_SelfClassName
+	);
+	tolua_error(m_LuaState, ErrMsg.c_str(), &tolua_err);
+	return false;
+}
+
+
+
+
+
+bool cLuaState::CheckParamStaticSelf(const char * a_SelfClassName)
+{
+	tolua_Error tolua_err;
+	if (tolua_isusertable(m_LuaState, 1, a_SelfClassName, 0, &tolua_err) && !lua_isnil(m_LuaState, 1))
+	{
+		return true;
+	}
+
+	// Not the correct parameter
+	lua_Debug entry;
+	VERIFY(lua_getstack(m_LuaState, 0,   &entry));
+	VERIFY(lua_getinfo (m_LuaState, "n", &entry));
+	AString ErrMsg = Printf(
+		"Error in function '%s'. The 'self' parameter is not of the expected type, \"class %s\". " \
+		"Make sure you're using the correct calling convention (cClassName:fn() instead of cClassName.fn() or obj:fn()).",
 		(entry.name != nullptr) ? entry.name : "<unknown>", a_SelfClassName
 	);
 	tolua_error(m_LuaState, ErrMsg.c_str(), &tolua_err);
@@ -1857,6 +1883,46 @@ void cLuaState::LogStackTrace(lua_State * a_LuaState, int a_StartingDepth)
 		depth++;
 	}
 	LOGWARNING("Stack trace end");
+}
+
+
+
+
+
+int cLuaState::ApiParamError(const char * a_MsgFormat, ...)
+{
+	// Retrieve current function name
+	lua_Debug entry;
+	VERIFY(lua_getstack(m_LuaState, 0, &entry));
+	VERIFY(lua_getinfo(m_LuaState, "n", &entry));
+
+	// Compose the error message:
+	va_list argp;
+	va_start(argp, a_MsgFormat);
+	AString msg;
+
+	#ifdef __clang__
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wformat-nonliteral"
+	#endif
+
+	AppendVPrintf(msg, a_MsgFormat, argp);
+
+	#ifdef __clang__
+		#pragma clang diagnostic pop
+	#endif
+
+	va_end(argp);
+	AString errorMsg = Printf("%s: %s", (entry.name != nullptr) ? entry.name : "<unknown function>", msg.c_str());
+
+	// Log everything into the console:
+	LOGWARNING("%s", errorMsg.c_str());
+	// cLuaState::LogStackTrace(a_LuaState);  // Do NOT log stack trace, it is already output as part of the Lua error handling
+	LogStackValues(m_LuaState, "Parameters on the stack");
+
+	// Raise Lua error:
+	lua_pushstring(m_LuaState, errorMsg.c_str());
+	return lua_error(m_LuaState);
 }
 
 

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -792,6 +792,10 @@ public:
 	Returns false and logs a special warning ("wrong calling convention") if not. */
 	bool CheckParamSelf(const char * a_SelfClassName);
 
+	/** Returns true if the first parameter is the expected class (static).
+	Returns false and logs a special warning ("wrong calling convention") if not. */
+	bool CheckParamStaticSelf(const char * a_SelfClassName);
+
 	bool IsParamUserType(int a_Param, AString a_UserType);
 
 	bool IsParamNumber(int a_Param);
@@ -807,6 +811,11 @@ public:
 
 	/** Logs all items in the current stack trace to the server console */
 	static void LogStackTrace(lua_State * a_LuaState, int a_StartingDepth = 0);
+
+	/** Formats and prints the message, prefixed with the current function name, then logs the stack contents and raises a Lua error.
+	To be used for bindings when they detect bad parameters.
+	Doesn't return, but a dummy return type is provided so that Lua API functions may do "return ApiParamError(...)". */
+	int ApiParamError(const char * a_MsgFormat, ...);
 
 	/** Returns the type of the item on the specified position in the stack */
 	AString GetTypeText(int a_StackPos);

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -132,46 +132,6 @@ int cManualBindings::lua_do_error(lua_State * L, const char * a_pFormat, ...)
 
 
 
-int cManualBindings::ApiParamError(lua_State * a_LuaState, const char * a_MsgFormat, ...)
-{
-	// Retrieve current function name
-	lua_Debug entry;
-	VERIFY(lua_getstack(a_LuaState, 0, &entry));
-	VERIFY(lua_getinfo(a_LuaState, "n", &entry));
-
-	// Compose the error message:
-	va_list argp;
-	va_start(argp, a_MsgFormat);
-	AString msg;
-
-	#ifdef __clang__
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored "-Wformat-nonliteral"
-	#endif
-
-	AppendVPrintf(msg, a_MsgFormat, argp);
-
-	#ifdef __clang__
-		#pragma clang diagnostic pop
-	#endif
-
-	va_end(argp);
-	AString errorMsg = Printf("%s: %s", (entry.name != nullptr) ? entry.name : "<unknown function>", msg.c_str());
-
-	// Log everything into the console:
-	LOGWARNING("%s", errorMsg.c_str());
-	// cLuaState::LogStackTrace(a_LuaState);  // Do NOT log stack trace, it is already output as part of the Lua error handling
-	cLuaState::LogStackValues(a_LuaState, "Parameters on the stack");
-
-	// Raise Lua error:
-	lua_pushstring(a_LuaState, errorMsg.c_str());
-	return lua_error(a_LuaState);
-}
-
-
-
-
-
 // Lua bound functions with special return types
 static int tolua_Clamp(lua_State * tolua_S)
 {

--- a/src/Bindings/ManualBindings.h
+++ b/src/Bindings/ManualBindings.h
@@ -52,11 +52,6 @@ public:
 	static int tolua_do_error(lua_State * L, const char * a_pMsg, tolua_Error * a_pToLuaError);
 	static int lua_do_error(lua_State * L, const char * a_pFormat, ...);
 
-	/** Formats and prints the message, prefixed with the current function name, then logs the stack contents and raises a Lua error.
-	To be used for bindings when they detect bad parameters.
-	Doesn't return, but a dummy return type is provided so that Lua API functions may do "return ApiParamError(...)". */
-	static int ApiParamError(lua_State * a_LuaState, const char * a_MsgFormat, ...);
-
 
 	/** Binds the DoWith(ItemName) functions of regular classes. */
 	template <

--- a/src/Bindings/ManualBindings_BlockArea.cpp
+++ b/src/Bindings/ManualBindings_BlockArea.cpp
@@ -31,7 +31,7 @@ static int readCuboidOverloadParams(cLuaState & a_LuaState, int a_StartParam, cC
 		// Assume the 6-number version:
 		if (!a_LuaState.GetStackValues(a_StartParam, a_Cuboid.p1.x, a_Cuboid.p2.x, a_Cuboid.p1.y, a_Cuboid.p2.y, a_Cuboid.p1.z, a_Cuboid.p2.z))
 		{
-			return cManualBindings::ApiParamError(a_LuaState, "Cannot read the bounds parameters, expected 6 numbers.");
+			return a_LuaState.ApiParamError("Cannot read the bounds parameters, expected 6 numbers.");
 		}
 		return a_StartParam + 6;
 	}
@@ -41,7 +41,7 @@ static int readCuboidOverloadParams(cLuaState & a_LuaState, int a_StartParam, cC
 		cCuboid * c;
 		if (!a_LuaState.GetStackValues(a_StartParam, c))
 		{
-			return cManualBindings::ApiParamError(a_LuaState, "Cannot read the bounds parameter, expected a cCuboid instance.");
+			return a_LuaState.ApiParamError("Cannot read the bounds parameter, expected a cCuboid instance.");
 		}
 		a_Cuboid = *c;
 		return a_StartParam + 1;
@@ -53,7 +53,7 @@ static int readCuboidOverloadParams(cLuaState & a_LuaState, int a_StartParam, cC
 		Vector3i * p2;
 		if (!a_LuaState.GetStackValues(a_StartParam, p1, p2))
 		{
-			return cManualBindings::ApiParamError(a_LuaState, "Cannot read the bounds parameter, expected two Vector3i instances.");
+			return a_LuaState.ApiParamError("Cannot read the bounds parameter, expected two Vector3i instances.");
 		}
 		a_Cuboid.p1 = *p1;
 		a_Cuboid.p2 = *p2;
@@ -79,7 +79,7 @@ static int readVector3iOverloadParams(cLuaState & a_LuaState, int a_StartParam, 
 		// Assume the 3-number version:
 		if (!a_LuaState.GetStackValues(a_StartParam, a_Coords.x, a_Coords.y, a_Coords.z))
 		{
-			return cManualBindings::ApiParamError(a_LuaState, "Cannot read the %s, expected 3 numbers.", a_ParamName);
+			return a_LuaState.ApiParamError("Cannot read the %s, expected 3 numbers.", a_ParamName);
 		}
 		return a_StartParam + 3;
 	}
@@ -89,7 +89,7 @@ static int readVector3iOverloadParams(cLuaState & a_LuaState, int a_StartParam, 
 		Vector3i * c;
 		if (!a_LuaState.GetStackValues(a_StartParam, c))
 		{
-			return cManualBindings::ApiParamError(a_LuaState, "Cannot read the %s, expected a Vector3i instance.", a_ParamName);
+			return a_LuaState.ApiParamError("Cannot read the %s, expected a Vector3i instance.", a_ParamName);
 		}
 		a_Coords = *c;
 		return a_StartParam + 1;
@@ -111,11 +111,11 @@ static int tolua_cBlockArea_Create(lua_State * a_LuaState)
 	cBlockArea * self = nullptr;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read self.");
+		return L.ApiParamError("Cannot read self.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	int dataTypes = cBlockArea::baTypes | cBlockArea::baMetas | cBlockArea::baBlockEntities;
@@ -124,13 +124,13 @@ static int tolua_cBlockArea_Create(lua_State * a_LuaState)
 	L.GetStackValue(dataTypesIdx, dataTypes);
 	if (!cBlockArea::IsValidDataTypeCombination(dataTypes))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid combination of baDataTypes specified (%d).", dataTypes);
+		return L.ApiParamError("Invalid combination of baDataTypes specified (%d).", dataTypes);
 	}
 
 	// Create the area:
 	if ((size.x <= 0) || (size.y <= 0) || (size.z <= 0))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid sizes, must be greater than zero, got {%d, %d, %d}", size.x, size.y, size.z);
+		return L.ApiParamError("Invalid sizes, must be greater than zero, got {%d, %d, %d}", size.x, size.y, size.z);
 	}
 	ASSERT(self != nullptr);
 	self->Create(size, dataTypes);
@@ -155,11 +155,11 @@ static int tolua_cBlockArea_FillRelCuboid(lua_State * a_LuaState)
 	cBlockArea * self = nullptr;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read self.");
+		return L.ApiParamError("Cannot read self.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	// Check and get the overloaded params:
@@ -170,12 +170,12 @@ static int tolua_cBlockArea_FillRelCuboid(lua_State * a_LuaState)
 	NIBBLETYPE blockMeta = 0, blockLight = 0, blockSkyLight = 0x0f;
 	if (!L.GetStackValues(nextIdx, dataTypes, blockType))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the datatypes or block type params");
+		return L.ApiParamError("Cannot read the datatypes or block type params");
 	}
 	L.GetStackValues(nextIdx + 2, blockMeta, blockLight, blockSkyLight);  // These values are optional
 	if (!cBlockArea::IsValidDataTypeCombination(dataTypes))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid baDataTypes combination (%d).", dataTypes);
+		return L.ApiParamError("Invalid baDataTypes combination (%d).", dataTypes);
 	}
 
 	// Check the coords, shift if needed:
@@ -206,18 +206,18 @@ static int tolua_cBlockArea_GetBlockTypeMeta(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read 'self'");
+		return L.ApiParamError("Cannot read 'self'");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	Vector3i coords;
 	readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Coords ({%d, %d, %d}) out of range ({%d, %d, %d} - {%d, %d, %d}).",
+		return L.ApiParamError("Coords ({%d, %d, %d}) out of range ({%d, %d, %d} - {%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetOriginX(), self->GetOriginY(), self->GetOriginZ(),
 			self->GetOriginX() + self->GetSizeX() - 1, self->GetOriginY() + self->GetSizeY() - 1, self->GetOriginZ() + self->GetSizeZ() - 1
@@ -250,11 +250,11 @@ static int tolua_cBlockArea_GetCoordRange(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' parameter.");
+		return L.ApiParamError("Cannot read the 'self' parameter.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	L.Push(self->GetSizeX() - 1, self->GetSizeY() - 1, self->GetSizeZ() - 1);
@@ -280,15 +280,15 @@ static int tolua_cBlockArea_GetNonAirCropRelCoords(lua_State * a_LuaState)
 	BLOCKTYPE ignoreBlockType = E_BLOCK_AIR;
 	if (!L.GetStackValues(1, self, ignoreBlockType))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read params");
+		return L.ApiParamError("Cannot read params");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil");
+		return L.ApiParamError("Invalid 'self', must not be nil");
 	}
 	if (!self->HasBlockTypes())
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain baTypes datatype");
+		return L.ApiParamError("The area doesn't contain baTypes datatype");
 	}
 
 	// Calculate the crop coords:
@@ -320,11 +320,11 @@ static int tolua_cBlockArea_GetOrigin(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' parameter.");
+		return L.ApiParamError("Cannot read the 'self' parameter.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	// Push the three origin coords:
@@ -350,26 +350,26 @@ static int tolua_cBlockArea_GetRelBlockTypeMeta(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' parameter.");
+		return L.ApiParamError("Cannot read the 'self' parameter.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 	if (!self->HasBlockTypes())
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain baTypes datatype");
+		return L.ApiParamError("The area doesn't contain baTypes datatype");
 	}
 	if (!self->HasBlockMetas())
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain baMetas datatype");
+		return L.ApiParamError("The area doesn't contain baMetas datatype");
 	}
 
 	Vector3i coords;
 	readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidRelCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The coords ({%d, %d, %d}) are out of range (max {%d, %d, %d}).",
+		return L.ApiParamError("The coords ({%d, %d, %d}) are out of range (max {%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetSizeX() - 1, self->GetSizeY() - 1, self->GetSizeZ() - 1
 		);
@@ -401,11 +401,11 @@ static int tolua_cBlockArea_GetSize(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' parameter.");
+		return L.ApiParamError("Cannot read the 'self' parameter.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	L.Push(self->GetSizeX(), self->GetSizeY(), self->GetSizeZ());
@@ -433,11 +433,11 @@ static int tolua_cBlockArea_LoadFromSchematicFile(lua_State * a_LuaState)
 	AString fileName;
 	if (!L.GetStackValues(1, self, fileName))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the parameters.");
+		return L.ApiParamError("Cannot read the parameters.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	L.Push(cSchematicFileSerializer::LoadFromSchematicFile(*self, fileName));
@@ -465,11 +465,11 @@ static int tolua_cBlockArea_LoadFromSchematicString(lua_State * a_LuaState)
 	AString data;
 	if (!L.GetStackValues(1, self, data))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the parameters.");
+		return L.ApiParamError("Cannot read the parameters.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	L.Push(cSchematicFileSerializer::LoadFromSchematicString(*self, data));
@@ -498,11 +498,11 @@ static int tolua_cBlockArea_Read(lua_State * a_LuaState)
 	cWorld * world = nullptr;
 	if (!L.GetStackValues(1, self, world))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read self or world.");
+		return L.ApiParamError("Cannot read self or world.");
 	}
 	if (world == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid world instance. The world must be not nil.");
+		return L.ApiParamError("Invalid world instance. The world must be not nil.");
 	}
 
 	// Check and get the overloaded params:
@@ -512,7 +512,7 @@ static int tolua_cBlockArea_Read(lua_State * a_LuaState)
 	L.GetStackValues(dataTypesIdx, dataTypes);
 	if (!cBlockArea::IsValidDataTypeCombination(dataTypes))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid baDataTypes combination (%d).", dataTypes);
+		return L.ApiParamError("Invalid baDataTypes combination (%d).", dataTypes);
 	}
 
 	// Check the coords, shift if needed:
@@ -574,7 +574,7 @@ static int tolua_cBlockArea_RelLine(lua_State * a_LuaState)
 	cBlockArea * self = nullptr;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read self.");
+		return L.ApiParamError("Cannot read self.");
 	}
 
 	// Check and get the overloaded params:
@@ -588,11 +588,11 @@ static int tolua_cBlockArea_RelLine(lua_State * a_LuaState)
 	L.GetStackValues(idx, dataTypes, blockType, blockMeta, blockLight, blockSkyLight);
 	if (!cBlockArea::IsValidDataTypeCombination(dataTypes))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid baDataTypes combination (%d).", dataTypes);
+		return L.ApiParamError("Invalid baDataTypes combination (%d).", dataTypes);
 	}
 	if ((self->GetDataTypes() & dataTypes) != dataTypes)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Requested datatypes not present in the cBlockArea. Got only 0x%02x, requested 0x%02x",
+		return L.ApiParamError("Requested datatypes not present in the cBlockArea. Got only 0x%02x, requested 0x%02x",
 			self->GetDataTypes(), dataTypes
 		);
 	}
@@ -623,11 +623,11 @@ static int tolua_cBlockArea_SaveToSchematicFile(lua_State * a_LuaState)
 	AString fileName;
 	if (!L.GetStackValues(1, self, fileName))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the parameters.");
+		return L.ApiParamError("Cannot read the parameters.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	L.Push(cSchematicFileSerializer::SaveToSchematicFile(*self, fileName));
@@ -653,11 +653,11 @@ static int tolua_cBlockArea_SaveToSchematicString(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' parameter.");
+		return L.ApiParamError("Cannot read the 'self' parameter.");
 	}
 	if (self == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid 'self', must not be nil.");
+		return L.ApiParamError("Invalid 'self', must not be nil.");
 	}
 
 	AString data;
@@ -691,11 +691,11 @@ static int tolua_cBlockArea_Write(lua_State * a_LuaState)
 	cWorld * world = nullptr;
 	if (!L.GetStackValues(1, self, world))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read self or world.");
+		return L.ApiParamError("Cannot read self or world.");
 	}
 	if (world == nullptr)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid world instance. The world must be not nil.");
+		return L.ApiParamError("Invalid world instance. The world must be not nil.");
 	}
 
 	// Check and get the overloaded params:
@@ -707,11 +707,11 @@ static int tolua_cBlockArea_Write(lua_State * a_LuaState)
 	// Check the dataType parameter validity:
 	if (!cBlockArea::IsValidDataTypeCombination(dataTypes))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Invalid datatype combination (%d).", dataTypes);
+		return L.ApiParamError("Invalid datatype combination (%d).", dataTypes);
 	}
 	if ((self->GetDataTypes() & dataTypes) != dataTypes)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Requesting datatypes not present in the cBlockArea. Got only 0x%02x, requested 0x%02x",
+		return L.ApiParamError("Requesting datatypes not present in the cBlockArea. Got only 0x%02x, requested 0x%02x",
 			self->GetDataTypes(), dataTypes
 		);
 	}
@@ -766,13 +766,13 @@ static int GetBlock(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' param.");
+		return L.ApiParamError("Cannot read the 'self' param.");
 	}
 
 	// Check the datatype's presence:
 	if ((self->GetDataTypes() & DataTypeFlag) == 0)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain the datatype (%d).", DataTypeFlag);
+		return L.ApiParamError("The area doesn't contain the datatype (%d).", DataTypeFlag);
 	}
 
 	// Read the overloaded params:
@@ -780,7 +780,7 @@ static int GetBlock(lua_State * a_LuaState)
 	readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The coords ({%d, %d, %d}) are out of range ({%d, %d, %d} - {%d, %d, %d}).",
+		return L.ApiParamError("The coords ({%d, %d, %d}) are out of range ({%d, %d, %d} - {%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetOriginX(), self->GetOriginY(), self->GetOriginZ(),
 			self->GetOriginX() + self->GetSizeX() - 1, self->GetOriginY() + self->GetSizeY() - 1, self->GetOriginZ() + self->GetSizeZ() - 1
@@ -819,13 +819,13 @@ static int GetRelBlock(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' param.");
+		return L.ApiParamError("Cannot read the 'self' param.");
 	}
 
 	// Check the datatype's presence:
 	if ((self->GetDataTypes() & DataTypeFlag) == 0)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain the datatype (%d).", DataTypeFlag);
+		return L.ApiParamError("The area doesn't contain the datatype (%d).", DataTypeFlag);
 	}
 
 	// Read the overloaded params:
@@ -833,7 +833,7 @@ static int GetRelBlock(lua_State * a_LuaState)
 	readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidRelCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The coords ({%d, %d, %d}) are out of range ({%d, %d, %d}).",
+		return L.ApiParamError("The coords ({%d, %d, %d}) are out of range ({%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetSizeX(), self->GetSizeY(), self->GetSizeZ()
 		);
@@ -871,13 +871,13 @@ static int SetBlock(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' param.");
+		return L.ApiParamError("Cannot read the 'self' param.");
 	}
 
 	// Check the datatype's presence:
 	if ((self->GetDataTypes() & DataTypeFlag) == 0)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain the datatype (%d).", DataTypeFlag);
+		return L.ApiParamError("The area doesn't contain the datatype (%d).", DataTypeFlag);
 	}
 
 	// Read the overloaded params:
@@ -885,7 +885,7 @@ static int SetBlock(lua_State * a_LuaState)
 	auto idx = readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The coords ({%d, %d, %d}) are out of range ({%d, %d, %d} - {%d, %d, %d}).",
+		return L.ApiParamError("The coords ({%d, %d, %d}) are out of range ({%d, %d, %d} - {%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetOriginX(), self->GetOriginY(), self->GetOriginZ(),
 			self->GetOriginX() + self->GetSizeX() - 1, self->GetOriginY() + self->GetSizeY() - 1, self->GetOriginZ() + self->GetSizeZ() - 1
@@ -926,13 +926,13 @@ static int SetRelBlock(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' param.");
+		return L.ApiParamError("Cannot read the 'self' param.");
 	}
 
 	// Check the datatype's presence:
 	if ((self->GetDataTypes() & DataTypeFlag) == 0)
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain the datatype (%d).", DataTypeFlag);
+		return L.ApiParamError("The area doesn't contain the datatype (%d).", DataTypeFlag);
 	}
 
 	// Read the overloaded params:
@@ -940,7 +940,7 @@ static int SetRelBlock(lua_State * a_LuaState)
 	auto idx = readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidRelCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The coords ({%d, %d, %d}) are out of range ({%d, %d, %d}).",
+		return L.ApiParamError("The coords ({%d, %d, %d}) are out of range ({%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetSizeX(), self->GetSizeY(), self->GetSizeZ()
 		);
@@ -970,13 +970,13 @@ static int tolua_cBlockArea_SetBlockTypeMeta(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' param.");
+		return L.ApiParamError("Cannot read the 'self' param.");
 	}
 
 	// Check if block types and metas are present:
 	if (!self->HasBlockTypes() || !self->HasBlockMetas())
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain the datatypes baTypes and baMetas.");
+		return L.ApiParamError("The area doesn't contain the datatypes baTypes and baMetas.");
 	}
 
 	// Read the overloaded params:
@@ -984,7 +984,7 @@ static int tolua_cBlockArea_SetBlockTypeMeta(lua_State * a_LuaState)
 	auto idx = readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The coords ({%d, %d, %d}) are out of range ({%d, %d, %d} - {%d, %d, %d}).",
+		return L.ApiParamError("The coords ({%d, %d, %d}) are out of range ({%d, %d, %d} - {%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetOriginX(), self->GetOriginY(), self->GetOriginZ(),
 			self->GetOriginX() + self->GetSizeX() - 1, self->GetOriginY() + self->GetSizeY() - 1, self->GetOriginZ() + self->GetSizeZ() - 1
@@ -995,7 +995,7 @@ static int tolua_cBlockArea_SetBlockTypeMeta(lua_State * a_LuaState)
 	NIBBLETYPE meta;
 	if (!L.GetStackValues(idx, block, meta))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Bad number for block type or meta type.");
+		return L.ApiParamError("Bad number for block type or meta type.");
 	}
 
 	// Set block type and meta:
@@ -1020,13 +1020,13 @@ static int tolua_cBlockArea_SetRelBlockTypeMeta(lua_State * a_LuaState)
 	cBlockArea * self;
 	if (!L.GetStackValues(1, self))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Cannot read the 'self' param.");
+		return L.ApiParamError("Cannot read the 'self' param.");
 	}
 
 	// Check if block types and metas are present:
 	if (!self->HasBlockTypes() || !self->HasBlockMetas())
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The area doesn't contain the datatypes baTypes and baMetas.");
+		return L.ApiParamError("The area doesn't contain the baTypes or baMetas datatypes (0x%02x).", self->GetDataTypes());
 	}
 
 	// Read the overloaded params:
@@ -1034,7 +1034,7 @@ static int tolua_cBlockArea_SetRelBlockTypeMeta(lua_State * a_LuaState)
 	auto idx = readVector3iOverloadParams(L, 2, coords, "coords");
 	if (!self->IsValidRelCoords(coords))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "The coords ({%d, %d, %d}) are out of range ({%d, %d, %d}).",
+		return L.ApiParamError("The coords ({%d, %d, %d}) are out of range ({%d, %d, %d}).",
 			coords.x, coords.y, coords.z,
 			self->GetSizeX(), self->GetSizeY(), self->GetSizeZ()
 		);
@@ -1044,7 +1044,7 @@ static int tolua_cBlockArea_SetRelBlockTypeMeta(lua_State * a_LuaState)
 	NIBBLETYPE meta;
 	if (!L.GetStackValues(idx, block, meta))
 	{
-		return cManualBindings::ApiParamError(a_LuaState, "Bad number for block type or meta type.");
+		return L.ApiParamError("Bad number for block type or meta type.");
 	}
 
 	// Set block type and meta:

--- a/src/Bindings/ManualBindings_Network.cpp
+++ b/src/Bindings/ManualBindings_Network.cpp
@@ -30,7 +30,7 @@ static int tolua_cNetwork_Connect(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserTable(1, "cNetwork") ||
+		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamString(2) ||
 		!S.CheckParamNumber(3) ||
 		!S.CheckParamTable(4) ||
@@ -46,20 +46,13 @@ static int tolua_cNetwork_Connect(lua_State * L)
 	cLuaState::cTableRefPtr callbacks;
 	if (!S.GetStackValues(2, host, port, callbacks))
 	{
-		LOGWARNING("cNetwork::Connect() cannot read its parameters, failing the request.");
-		S.LogStackTrace();
-		S.LogStackValues("Values on the stack");
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Cannot read parameters.");
 	}
 
 	// Check validity:
 	if ((port < 0) || (port > 65535))
 	{
-		LOGWARNING("cNetwork:Connect() called with invalid port (%d), failing the request.", port);
-		S.LogStackTrace();
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Port number out of range (%d, range 0 - 65535)", port);
 	}
 	ASSERT(callbacks != nullptr);  // Invalid callbacks would have resulted in GetStackValues() returning false
 
@@ -85,7 +78,7 @@ static int tolua_cNetwork_CreateUDPEndpoint(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserTable(1, "cNetwork") ||
+		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamNumber(2) ||
 		!S.CheckParamTable(3) ||
 		!S.CheckParamEnd(4)
@@ -95,30 +88,23 @@ static int tolua_cNetwork_CreateUDPEndpoint(lua_State * L)
 	}
 
 	// Read the params:
-	UInt16 port;
+	int port;
 	cLuaState::cTableRefPtr callbacks;
 	if (!S.GetStackValues(2, port, callbacks))
 	{
-		LOGWARNING("cNetwork:CreateUDPEndpoint() cannot read its parameters, failing the request.");
-		S.LogStackTrace();
-		S.LogStackValues("Values on the stack");
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Cannot read parameters");
 	}
 
 	// Check validity:
 	if ((port < 0) || (port > 65535))
 	{
-		LOGWARNING("cNetwork:CreateUDPEndpoint() called with invalid port (%d), failing the request.", port);
-		S.LogStackTrace();
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Port number out of range (%d, range 0 - 65535)", port);
 	}
 	ASSERT(callbacks != nullptr);  // Invalid callbacks would have resulted in GetStackValues() returning false
 
 	// Create the LuaUDPEndpoint glue class:
 	auto endpoint = std::make_shared<cLuaUDPEndpoint>(std::move(callbacks));
-	endpoint->Open(port, endpoint);
+	endpoint->Open(static_cast<UInt16>(port), endpoint);
 
 	// Register the endpoint to be garbage-collected by Lua:
 	tolua_pushusertype(L, endpoint.get(), "cUDPEndpoint");
@@ -141,7 +127,7 @@ static int tolua_cNetwork_EnumLocalIPAddresses(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserTable(1, "cNetwork") ||
+		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -165,7 +151,7 @@ static int tolua_cNetwork_HostnameToIP(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserTable(1, "cNetwork") ||
+		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamString(2) ||
 		!S.CheckParamTable(3) ||
 		!S.CheckParamEnd(4)
@@ -179,18 +165,13 @@ static int tolua_cNetwork_HostnameToIP(lua_State * L)
 	cLuaState::cTableRefPtr callbacks;
 	if (!S.GetStackValues(2, host, callbacks))
 	{
-		LOGWARNING("cNetwork::HostnameToIP() cannot read its parameters, failing the request.");
-		S.LogStackTrace();
-		S.LogStackValues("Values on the stack");
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Cannot read parameters.");
 	}
 	ASSERT(callbacks != nullptr);  // Invalid callbacks would have resulted in GetStackValues() returning false
 
 	// Try to look up:
 	bool res = cNetwork::HostnameToIP(host, std::make_shared<cLuaNameLookup>(host, std::move(callbacks)));
 	S.Push(res);
-
 	return 1;
 }
 
@@ -206,7 +187,7 @@ static int tolua_cNetwork_IPToHostname(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserTable(1, "cNetwork") ||
+		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamString(2) ||
 		!S.CheckParamTable(3) ||
 		!S.CheckParamEnd(4)
@@ -220,18 +201,13 @@ static int tolua_cNetwork_IPToHostname(lua_State * L)
 	cLuaState::cTableRefPtr callbacks;
 	if (!S.GetStackValues(2, ip, callbacks))
 	{
-		LOGWARNING("cNetwork::IPToHostname() cannot read its parameters, failing the request.");
-		S.LogStackTrace();
-		S.LogStackValues("Values on the stack");
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Cannot read parameters.");
 	}
 	ASSERT(callbacks != nullptr);  // Invalid callbacks would have resulted in GetStackValues() returning false
 
 	// Try to look up:
 	bool res = cNetwork::IPToHostName(ip, std::make_shared<cLuaNameLookup>(ip, std::move(callbacks)));
 	S.Push(res);
-
 	return 1;
 }
 
@@ -247,7 +223,7 @@ static int tolua_cNetwork_Listen(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserTable(1, "cNetwork") ||
+		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamNumber(2) ||
 		!S.CheckParamTable(3) ||
 		!S.CheckParamEnd(4)
@@ -261,20 +237,13 @@ static int tolua_cNetwork_Listen(lua_State * L)
 	cLuaState::cTableRefPtr callbacks;
 	if (!S.GetStackValues(2, port, callbacks))
 	{
-		LOGWARNING("cNetwork::Listen() cannot read its parameters, failing the request.");
-		S.LogStackTrace();
-		S.LogStackValues("Values on the stack");
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Cannot read parameters");
 	}
 
 	// Check the validity:
 	if ((port < 0) || (port > 65535))
 	{
-		LOGWARNING("cNetwork:Listen() called with invalid port (%d), failing the request.", port);
-		S.LogStackTrace();
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Port number out of range (%d, range 0 - 65535)", port);
 	}
 	auto port16 = static_cast<UInt16>(port);
 
@@ -304,7 +273,8 @@ static int tolua_cNetwork_Listen(lua_State * L)
 Close the server and let it deallocate on its own (it's in a SharedPtr). */
 static int tolua_collect_cServerHandle(lua_State * L)
 {
-	cLuaServerHandle * Srv = static_cast<cLuaServerHandle *>(tolua_tousertype(L, 1, nullptr));
+	auto Srv = static_cast<cLuaServerHandle *>(tolua_tousertype(L, 1, nullptr));
+	ASSERT(Srv != nullptr);
 	Srv->Release();
 	return 0;
 }
@@ -321,7 +291,7 @@ static int tolua_cServerHandle_Close(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cServerHandle") ||
+		!S.CheckParamSelf("cServerHandle") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -329,14 +299,8 @@ static int tolua_cServerHandle_Close(lua_State * L)
 	}
 
 	// Get the server handle:
-	cLuaServerHandle * Srv;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cServerHandle:Close(): invalid server handle object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(L, 1));
+	auto Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(L, 1));
+	ASSERT(Srv != nullptr);  // Checked by CheckParamSelf()
 
 	// Close it:
 	Srv->Close();
@@ -355,7 +319,7 @@ static int tolua_cServerHandle_IsListening(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cServerHandle") ||
+		!S.CheckParamSelf("cServerHandle") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -363,16 +327,10 @@ static int tolua_cServerHandle_IsListening(lua_State * L)
 	}
 
 	// Get the server handle:
-	cLuaServerHandle * Srv;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cServerHandle:IsListening(): invalid server handle object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(L, 1));
+	auto Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(L, 1));
+	ASSERT(Srv != nullptr);  // Checked by CheckParamSelf()
 
-	// Close it:
+	// Query it:
 	S.Push(Srv->IsListening());
 	return 1;
 }
@@ -392,7 +350,7 @@ static int tolua_cTCPLink_Close(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -400,16 +358,10 @@ static int tolua_cTCPLink_Close(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:Close(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
-	// CLose the link:
+	// Close the link:
 	Link->Close();
 	return 0;
 }
@@ -426,7 +378,7 @@ static int tolua_cTCPLink_GetLocalIP(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -434,14 +386,8 @@ static int tolua_cTCPLink_GetLocalIP(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:GetLocalIP(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the IP:
 	S.Push(Link->GetLocalIP());
@@ -460,7 +406,7 @@ static int tolua_cTCPLink_GetLocalPort(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -468,14 +414,8 @@ static int tolua_cTCPLink_GetLocalPort(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:GetLocalPort(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the Port:
 	S.Push(Link->GetLocalPort());
@@ -494,7 +434,7 @@ static int tolua_cTCPLink_GetRemoteIP(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -502,14 +442,8 @@ static int tolua_cTCPLink_GetRemoteIP(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:GetRemoteIP(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the IP:
 	S.Push(Link->GetRemoteIP());
@@ -528,7 +462,7 @@ static int tolua_cTCPLink_GetRemotePort(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -536,14 +470,8 @@ static int tolua_cTCPLink_GetRemotePort(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:GetRemotePort(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the Port:
 	S.Push(Link->GetRemotePort());
@@ -562,7 +490,7 @@ static int tolua_cTCPLink_Send(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamString(2) ||
 		!S.CheckParamEnd(3)
 	)
@@ -571,14 +499,8 @@ static int tolua_cTCPLink_Send(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:Send(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the data to send:
 	AString Data;
@@ -601,7 +523,7 @@ static int tolua_cTCPLink_Shutdown(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -609,14 +531,8 @@ static int tolua_cTCPLink_Shutdown(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:Shutdown(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Shutdown the link:
 	Link->Shutdown();
@@ -635,15 +551,14 @@ static int tolua_cTCPLink_StartTLSClient(lua_State * L)
 
 	// Get the link:
 	cLuaState S(L);
-	if (lua_isnil(L, 1))
+	if (!S.CheckParamSelf("cTCPLink"))
 	{
-		LOGWARNING("cTCPLink:StartTLSClient(): invalid link object. Stack trace:");
-		S.LogStackTrace();
 		return 0;
 	}
 	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
-	// Read the params:
+	// Read the (optional) params:
 	AString OwnCert, OwnPrivKey, OwnPrivKeyPassword;
 	S.GetStackValues(2, OwnCert, OwnPrivKey, OwnPrivKeyPassword);
 
@@ -669,7 +584,7 @@ static int tolua_cTCPLink_StartTLSServer(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cTCPLink") ||
+		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamString(2, 4) ||
 		// Param 5 is optional, don't check
 		!S.CheckParamEnd(6)
@@ -679,14 +594,8 @@ static int tolua_cTCPLink_StartTLSServer(lua_State * L)
 	}
 
 	// Get the link:
-	cLuaTCPLink * Link;
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cTCPLink:StartTLSServer(): invalid link object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Read the params:
 	AString OwnCert, OwnPrivKey, OwnPrivKeyPassword, StartTLSData;
@@ -714,9 +623,9 @@ static int tolua_cTCPLink_StartTLSServer(lua_State * L)
 Close the endpoint and let it deallocate on its own (it's in a SharedPtr). */
 static int tolua_collect_cUDPEndpoint(lua_State * L)
 {
-	LOGD("Lua: Collecting cUDPEndpoint");
-	cLuaUDPEndpoint * Endpoint = static_cast<cLuaUDPEndpoint *>(tolua_tousertype(L, 1, nullptr));
-	Endpoint->Release();
+	auto endpoint = static_cast<cLuaUDPEndpoint *>(tolua_tousertype(L, 1, nullptr));
+	ASSERT(endpoint != nullptr);
+	endpoint->Release();
 	return 0;
 }
 
@@ -732,7 +641,7 @@ static int tolua_cUDPEndpoint_Close(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cUDPEndpoint") ||
+		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -740,16 +649,11 @@ static int tolua_cUDPEndpoint_Close(lua_State * L)
 	}
 
 	// Get the endpoint:
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cUDPEndpoint:Close(): invalid endpoint object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	auto Endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	ASSERT(endpoint != nullptr);
 
 	// Close it:
-	Endpoint->Close();
+	endpoint->Close();
 	return 0;
 }
 
@@ -765,7 +669,7 @@ static int tolua_cUDPEndpoint_EnableBroadcasts(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cUDPEndpoint") ||
+		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -773,16 +677,11 @@ static int tolua_cUDPEndpoint_EnableBroadcasts(lua_State * L)
 	}
 
 	// Get the endpoint:
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cUDPEndpoint:EnableBroadcasts(): invalid endpoint object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	auto Endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	ASSERT(endpoint != nullptr);
 
 	// Enable the broadcasts:
-	Endpoint->EnableBroadcasts();
+	endpoint->EnableBroadcasts();
 	return 0;
 }
 
@@ -798,7 +697,7 @@ static int tolua_cUDPEndpoint_GetPort(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cUDPEndpoint") ||
+		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -806,16 +705,11 @@ static int tolua_cUDPEndpoint_GetPort(lua_State * L)
 	}
 
 	// Get the endpoint:
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cUDPEndpoint:GetPort(): invalid endpoint object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	auto Endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	ASSERT(endpoint != nullptr);
 
 	// Get the Port:
-	S.Push(Endpoint->GetPort());
+	S.Push(endpoint->GetPort());
 	return 1;
 }
 
@@ -831,7 +725,7 @@ static int tolua_cUDPEndpoint_IsOpen(lua_State * L)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cUDPEndpoint") ||
+		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
 	)
 	{
@@ -839,16 +733,11 @@ static int tolua_cUDPEndpoint_IsOpen(lua_State * L)
 	}
 
 	// Get the endpoint:
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cUDPEndpoint:IsListening(): invalid server handle object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	auto Endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	ASSERT(endpoint != nullptr);
 
 	// Close it:
-	S.Push(Endpoint->IsOpen());
+	S.Push(endpoint->IsOpen());
 	return 1;
 }
 
@@ -860,11 +749,11 @@ static int tolua_cUDPEndpoint_IsOpen(lua_State * L)
 static int tolua_cUDPEndpoint_Send(lua_State * L)
 {
 	// Function signature:
-	// LinkInstance:Send(DataString)
+	// Endpoint:Send(DataString)
 
 	cLuaState S(L);
 	if (
-		!S.CheckParamUserType(1, "cUDPEndpoint") ||
+		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamString(2, 3) ||
 		!S.CheckParamNumber(4) ||
 		!S.CheckParamEnd(5)
@@ -874,30 +763,22 @@ static int tolua_cUDPEndpoint_Send(lua_State * L)
 	}
 
 	// Get the link:
-	if (lua_isnil(L, 1))
-	{
-		LOGWARNING("cUDPEndpoint:Send(): invalid endpoint object. Stack trace:");
-		S.LogStackTrace();
-		return 0;
-	}
-	auto Endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	ASSERT(endpoint != nullptr);
 
 	// Get the data to send:
-	AString Data, RemotePeer;
-	int RemotePort = 0;
-	S.GetStackValues(2, Data, RemotePeer, RemotePort);
+	AString data, remotePeer;
+	int remotePort = 0;
+	S.GetStackValues(2, data, remotePeer, remotePort);
 
 	// Check the port:
-	if ((RemotePort < 0) || (RemotePort > USHRT_MAX))
+	if ((remotePort < 0) || (remotePort > USHRT_MAX))
 	{
-		LOGWARNING("cUDPEndpoint:Send() called with invalid port (%d), failing.", RemotePort);
-		S.LogStackTrace();
-		S.Push(false);
-		return 1;
+		return S.ApiParamError("Port number out of range (%d, range 0 - 65535)", remotePort);
 	}
 
 	// Send the data:
-	S.Push(Endpoint->Send(Data, RemotePeer, static_cast<UInt16>(RemotePort)));
+	S.Push(endpoint->Send(data, remotePeer, static_cast<UInt16>(remotePort)));
 	return 1;
 }
 
@@ -1078,20 +959,14 @@ static int tolua_cUrlClient_Request_Common(lua_State * a_LuaState, const AString
 	cLuaState::cCallbackPtr onCompleteBodyCallback;
 	if (!L.GetStackValues(a_UrlStackIdx, url))
 	{
-		L.LogApiCallParamFailure("cUrlClient:Request()", Printf("URL (%d)", a_UrlStackIdx).c_str());
-		L.Push(false);
-		L.Push("Invalid params");
-		return 2;
+		return L.ApiParamError("Cannot read URL parameter at idx %d", a_UrlStackIdx);
 	}
 	cUrlClient::cCallbacksPtr urlClientCallbacks;
 	if (lua_istable(L, a_UrlStackIdx + 1))
 	{
 		if (!L.GetStackValue(a_UrlStackIdx + 1, callbacks))
 		{
-			L.LogApiCallParamFailure("cUrlClient:Request()", Printf("CallbacksTable (%d)", a_UrlStackIdx + 1).c_str());
-			L.Push(false);
-			L.Push("Invalid Callbacks param");
-			return 2;
+			return L.ApiParamError("Cannot read the CallbacksTable parameter at idx %d", a_UrlStackIdx + 1);
 		}
 		urlClientCallbacks = cpp14::make_unique<cFullUrlClientCallbacks>(std::move(callbacks));
 	}
@@ -1099,26 +974,17 @@ static int tolua_cUrlClient_Request_Common(lua_State * a_LuaState, const AString
 	{
 		if (!L.GetStackValue(a_UrlStackIdx + 1, onCompleteBodyCallback))
 		{
-			L.LogApiCallParamFailure("cUrlClient:Request()", Printf("CallbacksFn (%d)", a_UrlStackIdx + 1).c_str());
-			L.Push(false);
-			L.Push("Invalid OnCompleteBodyCallback param");
-			return 2;
+			return L.ApiParamError("Cannot read the CallbackFn parameter at idx %d", a_UrlStackIdx + 1);
 		}
 		urlClientCallbacks = cpp14::make_unique<cSimpleUrlClientCallbacks>(std::move(onCompleteBodyCallback));
 	}
 	else
 	{
-		L.LogApiCallParamFailure("cUrlClient:Request()", Printf("Callbacks (%d)", a_UrlStackIdx + 1).c_str());
-		L.Push(false);
-		L.Push("Invalid OnCompleteBodyCallback param");
-		return 2;
+		L.ApiParamError("Invalid Callbacks parameter at %d, expected a table or function, got %s", a_UrlStackIdx + 1, L.GetTypeText(a_UrlStackIdx + 1).c_str());
 	}
 	if (!L.GetStackValues(a_UrlStackIdx + 2, cLuaState::cOptionalParam<AStringMap>(headers), cLuaState::cOptionalParam<AString>(requestBody), cLuaState::cOptionalParam<AStringMap>(options)))
 	{
-		L.LogApiCallParamFailure("cUrlClient:Request()", Printf("Header, Body or Options (%d, %d, %d)", a_UrlStackIdx + 2, a_UrlStackIdx + 3, a_UrlStackIdx + 4).c_str());
-		L.Push(false);
-		L.Push("Invalid params");
-		return 2;
+		L.ApiParamError("Cannot read the Header, Body or Options parameter at idx %d, %d, %d.", a_UrlStackIdx + 2, a_UrlStackIdx + 3, a_UrlStackIdx + 4);
 	}
 
 	// Make the request:
@@ -1207,7 +1073,9 @@ static int tolua_cUrlClient_Request(lua_State * a_LuaState)
 
 	// Check that the Method param is a string:
 	cLuaState L(a_LuaState);
-	if (!L.CheckParamString(2))
+	if (
+		!L.CheckParamStaticSelf("cUrlClient") ||
+		!L.CheckParamString(2))
 	{
 		return 0;
 	}
@@ -1216,10 +1084,7 @@ static int tolua_cUrlClient_Request(lua_State * a_LuaState)
 	AString method;
 	if (!L.GetStackValue(2, method))
 	{
-		L.LogApiCallParamFailure("cUrlClient:Request", "Method (2)");
-		L.Push(cLuaState::Nil);
-		L.Push("Invalid params");
-		return 2;
+		L.ApiParamError("Cannot read the Method parameter");
 	}
 	return tolua_cUrlClient_Request_Common(a_LuaState, method, 3);
 }


### PR DESCRIPTION
This is a part of #3805 and #3800, but the changes are relevant to code that is currently hot, so I want to merge them early.

Calling the `cNetwork` API functions with invalid parameters (such as port out of range) will now raise a Lua error, rather than returning with a console warning only.