### PR TITLE
Fixes double right click on entities till off-hand actions gets implemented

### DIFF
--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -2666,7 +2666,7 @@ void cProtocol_1_9_0::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 		case 0:
 		{
 			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand);
-			if (Hand == 0)  // TODO: implement handle off-hand (1) actions
+			if (Hand == hMain)  // TODO: implement handling of off-hand actions; ignore them for now to avoid processing actions twice
 			{
 				m_Client->HandleUseEntity(EntityID, false);
 			}

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -2665,8 +2665,11 @@ void cProtocol_1_9_0::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 	{
 		case 0:
 		{
-			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand)
-			m_Client->HandleUseEntity(EntityID, false);
+			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand);
+			if (Hand == 0)  // TODO: implement handle off-hand (1) actions
+			{
+				m_Client->HandleUseEntity(EntityID, false);
+			}
 			break;
 		}
 		case 1:

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -63,6 +63,9 @@ Implements the 1.9 protocol classes:
 /** The slot number that the client uses to indicate "outside the window". */
 static const Int16 SLOT_NUM_OUTSIDE = -999;
 
+/** Value for main hand in Hand parameter for Protocol 1.9. */
+static const UInt32 MAIN_HAND = 0;
+
 
 
 
@@ -2666,7 +2669,7 @@ void cProtocol_1_9_0::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 		case 0:
 		{
 			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand);
-			if (Hand == hMain)  // TODO: implement handling of off-hand actions; ignore them for now to avoid processing actions twice
+			if (Hand == MAIN_HAND)  // TODO: implement handling of off-hand actions; ignore them for now to avoid processing actions twice
 			{
 				m_Client->HandleUseEntity(EntityID, false);
 			}


### PR DESCRIPTION
Fixes #3186
When you right click on a aggressive monster (does not happens on passive mobs) this code gets executed twice:

```
void cProtocol_1_9_0::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
{
	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, EntityID);
	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Type);

	switch (Type)
	{
		case 0:
		{
			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand)
			m_Client->HandleUseEntity(EntityID, false);
			break;
		}
```

The "Hand" variable first time is 0 and second time is 1. According to the protocol doc (http://wiki.vg/Protocol#Use_Entity) that means main hand (0) or off-hand (1). The reason is that client sends an action with main hand and an action with the off-hand. 

This results on double actions. Affects mob leashing (in development) and right clicking a tamed wolf issue (#3186), maybe others.

Maybe we should check which hand holds the item we want to use with the entity, but we need to change the code a bit in order to let this parameter arrive to every place. 

This fix ignores calls for the off-hand. This way we can get rid of those double action related issues till a complete solution is done.