### PR TITLE
If entity is a player, send relmove packets.

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1920,7 +1920,7 @@ void cEntity::BroadcastMovementUpdate(const cClientHandle * a_Exclude)
 		}
 
 		// Only send movement if speed is not 0 and 'no speed' was sent to client
-		if (!m_bHasSentNoSpeed)
+		if (!m_bHasSentNoSpeed || IsPlayer())
 		{
 			// TODO: Pickups move disgracefully if relative move packets are sent as opposed to just velocity. Have a system to send relmove only when SetPosXXX() is called with a large difference in position
 			int DiffX = FloorC(GetPosX() * 32.0) - FloorC(m_LastSentPosition.x * 32.0);


### PR DESCRIPTION
I don't know whether this is the correct fix, but this appears to fix #3790 without reverting #3739.

My understanding is that, for players, m_Speed is not set as the player moves around, thus causing BroadcastMovementUpdate to not send the relmove packets for players.

This PR forces BroadcastMovementUpdate to send relmove packets if the entity is a player.

Another possibility would be to just set m_Speed correctly on the player entity, but the client doesn't seem to send us that info, so I don't know whether that's right (we'd have to estimate it, and then when we set it we wouldn't want to send it back to the client and overwrite their speed).
