### PR TITLE
Lua Dragging Item API

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -9503,6 +9503,16 @@ a_Player:OpenWindow(Window);
 					},
 					Notes = "Returns the full color code to be used for this player's messages (based on their rank). Prefix player messages with this code.",
 				},
+				GetDraggingItem =
+				{
+					Returns =
+					{
+						{
+							Type = "cItem",
+						},
+					},
+					Notes = "Returns the item the player is dragging in a UI window."
+				},
 				GetPrefix =
 				{
 					Returns =
@@ -10339,6 +10349,17 @@ a_Player:OpenWindow(Window);
 						},
 					},
 					Notes = "Sets the custom name for this player. If you want to disable the custom name, simply set an empty string. The custom name will be used in the tab-list, in the player nametag and in the tab-completion.",
+				},
+				SetDraggingItem =
+				{
+					Params =
+					{
+						{
+							Name = "Item",
+							Type = "cItem",
+						},
+					},
+					Notes = "Sets the item that the player is dragging in a UI window. If no UI window is open, this function does nothing."
 				},
 				SetFlying =
 				{

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1880,6 +1880,19 @@ AString cPlayer::GetPlayerListName(void) const
 
 
 
+void cPlayer::SetDraggingItem(const cItem & a_Item)
+{
+	if (GetWindow() != nullptr)
+	{
+		m_DraggingItem = a_Item;
+		GetClientHandle()->SendInventorySlot(-1, -1, m_DraggingItem);
+	}
+}
+
+
+
+
+
 void cPlayer::TossEquippedItem(char a_Amount)
 {
 	cItems Drops;

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -404,7 +404,10 @@ public:
 	void SendExperience(void);
 
 	/** In UI windows, get the item that the player is dragging */
-	cItem & GetDraggingItem(void) {return m_DraggingItem; }
+	cItem & GetDraggingItem(void) {return m_DraggingItem; }  // tolua_export
+
+	/** In UI windows, set the item that the player is dragging */
+	void SetDraggingItem(const cItem & a_Item);  // tolua_export
 
 	// In UI windows, when inventory-painting:
 	/** Clears the list of slots that are being inventory-painted. To be used by cWindow only */


### PR DESCRIPTION
Creates a SetDraggingItem method in cPlayer, and exports GetDraggingItem and SetDraggingItem to the Lua API.

Permits this:
```
local Item = Player:GetDraggingItem()
Player:SetDraggingItem(cItem())
```
Useful for e.g. a shop, to clear the player's hand of whatever they just grabbed out of the chest.
