### PR TITLE
Use unique_ptr for array ownership

### DIFF
--- a/src/BlockArea.h
+++ b/src/BlockArea.h
@@ -32,10 +32,6 @@ class cCuboid;
 // tolua_begin
 class cBlockArea
 {
-	// tolua_end
-	DISALLOW_COPY_AND_ASSIGN(cBlockArea);
-	// tolua_begin
-
 public:
 
 	/** What data is to be queried (bit-mask) */
@@ -62,9 +58,6 @@ public:
 		msSimpleCompare,
 		msMask,
 	} ;
-
-	cBlockArea(void);
-	~cBlockArea();
 
 	/** Returns true if the datatype combination is valid.
 	Invalid combinations include BlockEntities without BlockTypes. */
@@ -363,10 +356,10 @@ public:
 
 	// Clients can use these for faster access to all blocktypes. Be careful though!
 	/** Returns the internal pointer to the block types */
-	BLOCKTYPE *  GetBlockTypes   (void) const { return m_BlockTypes; }
-	NIBBLETYPE * GetBlockMetas   (void) const { return m_BlockMetas; }     // NOTE: one byte per block!
-	NIBBLETYPE * GetBlockLight   (void) const { return m_BlockLight; }     // NOTE: one byte per block!
-	NIBBLETYPE * GetBlockSkyLight(void) const { return m_BlockSkyLight; }  // NOTE: one byte per block!
+	BLOCKTYPE *  GetBlockTypes   (void) const { return m_BlockTypes.get();    }
+	NIBBLETYPE * GetBlockMetas   (void) const { return m_BlockMetas.get();    }  // NOTE: one byte per block!
+	NIBBLETYPE * GetBlockLight   (void) const { return m_BlockLight.get();    }  // NOTE: one byte per block!
+	NIBBLETYPE * GetBlockSkyLight(void) const { return m_BlockSkyLight.get(); }  // NOTE: one byte per block!
 	size_t       GetBlockCount(void) const { return static_cast<size_t>(m_Size.x * m_Size.y * m_Size.z); }
 	int MakeIndex(int a_RelX, int a_RelY, int a_RelZ) const;
 
@@ -416,7 +409,8 @@ protected:
 		virtual void BlockEntity(cBlockEntity * a_BlockEntity) override;
 	} ;
 
-	typedef NIBBLETYPE * NIBBLEARRAY;
+	using NIBBLEARRAY = std::unique_ptr<NIBBLETYPE[]>;
+	using BLOCKARRAY = std::unique_ptr<BLOCKTYPE[]>;
 
 
 	Vector3i m_Origin;
@@ -426,15 +420,23 @@ protected:
 	cBlockArea doesn't use this value in any way. */
 	Vector3i m_WEOffset;
 
-	BLOCKTYPE *  m_BlockTypes;
-	NIBBLETYPE * m_BlockMetas;     // Each meta is stored as a separate byte for faster access
-	NIBBLETYPE * m_BlockLight;     // Each light value is stored as a separate byte for faster access
-	NIBBLETYPE * m_BlockSkyLight;  // Each light value is stored as a separate byte for faster access
+	BLOCKARRAY  m_BlockTypes;
+	NIBBLEARRAY m_BlockMetas;     // Each meta is stored as a separate byte for faster access
+	NIBBLEARRAY m_BlockLight;     // Each light value is stored as a separate byte for faster access
+	NIBBLEARRAY m_BlockSkyLight;  // Each light value is stored as a separate byte for faster access
+
+	/** Deleter to clear the block entities before deleting the container. */
+	struct sBlockEntitiesDeleter
+	{
+		void operator () (cBlockEntities * a_BlockEntities);
+	};
+
+	using cBlockEntitiesPtr = std::unique_ptr<cBlockEntities, sBlockEntitiesDeleter>;
 
 	/** The block entities contained within the area.
 	Only valid if the area was created / read with the baBlockEntities flag.
 	The block entities are owned by this object. */
-	std::unique_ptr<cBlockEntities> m_BlockEntities;
+	cBlockEntitiesPtr m_BlockEntities;
 
 	/** Clears the data stored and prepares a fresh new block area with the specified dimensions */
 	bool SetSize(int a_SizeX, int a_SizeY, int a_SizeZ, int a_DataTypes);

--- a/src/ByteBuffer.cpp
+++ b/src/ByteBuffer.cpp
@@ -109,8 +109,6 @@ cByteBuffer::cByteBuffer(size_t a_BufferSize) :
 cByteBuffer::~cByteBuffer()
 {
 	CheckValid();
-	delete[] m_Buffer;
-	m_Buffer = nullptr;
 }
 
 
@@ -141,7 +139,7 @@ bool cByteBuffer::Write(const void * a_Bytes, size_t a_Count)
 		// Need to wrap around the ringbuffer end
 		if (TillEnd > 0)
 		{
-			memcpy(m_Buffer + m_WritePos, Bytes, TillEnd);
+			memcpy(m_Buffer.get() + m_WritePos, Bytes, TillEnd);
 			Bytes += TillEnd;
 			a_Count -= TillEnd;
 			WrittenBytes = TillEnd;
@@ -152,7 +150,7 @@ bool cByteBuffer::Write(const void * a_Bytes, size_t a_Count)
 	// We're guaranteed that we'll fit in a single write op
 	if (a_Count > 0)
 	{
-		memcpy(m_Buffer + m_WritePos, Bytes, a_Count);
+		memcpy(m_Buffer.get() + m_WritePos, Bytes, a_Count);
 		m_WritePos += a_Count;
 		WrittenBytes += a_Count;
 	}
@@ -761,7 +759,7 @@ bool cByteBuffer::ReadBuf(void * a_Buffer, size_t a_Count)
 		// Reading across the ringbuffer end, read the first part and adjust parameters:
 		if (BytesToEndOfBuffer > 0)
 		{
-			memcpy(Dst, m_Buffer + m_ReadPos, BytesToEndOfBuffer);
+			memcpy(Dst, m_Buffer.get() + m_ReadPos, BytesToEndOfBuffer);
 			Dst += BytesToEndOfBuffer;
 			a_Count -= BytesToEndOfBuffer;
 		}
@@ -771,7 +769,7 @@ bool cByteBuffer::ReadBuf(void * a_Buffer, size_t a_Count)
 	// Read the rest of the bytes in a single read (guaranteed to fit):
 	if (a_Count > 0)
 	{
-		memcpy(Dst, m_Buffer + m_ReadPos, a_Count);
+		memcpy(Dst, m_Buffer.get() + m_ReadPos, a_Count);
 		m_ReadPos += a_Count;
 	}
 	return true;
@@ -792,7 +790,7 @@ bool cByteBuffer::WriteBuf(const void * a_Buffer, size_t a_Count)
 	if (BytesToEndOfBuffer <= a_Count)
 	{
 		// Reading across the ringbuffer end, read the first part and adjust parameters:
-		memcpy(m_Buffer + m_WritePos, Src, BytesToEndOfBuffer);
+		memcpy(m_Buffer.get() + m_WritePos, Src, BytesToEndOfBuffer);
 		Src += BytesToEndOfBuffer;
 		a_Count -= BytesToEndOfBuffer;
 		m_WritePos = 0;
@@ -801,7 +799,7 @@ bool cByteBuffer::WriteBuf(const void * a_Buffer, size_t a_Count)
 	// Read the rest of the bytes in a single read (guaranteed to fit):
 	if (a_Count > 0)
 	{
-		memcpy(m_Buffer + m_WritePos, Src, a_Count);
+		memcpy(m_Buffer.get() + m_WritePos, Src, a_Count);
 		m_WritePos += a_Count;
 	}
 	return true;
@@ -825,7 +823,7 @@ bool cByteBuffer::ReadString(AString & a_String, size_t a_Count)
 		// Reading across the ringbuffer end, read the first part and adjust parameters:
 		if (BytesToEndOfBuffer > 0)
 		{
-			a_String.assign(m_Buffer + m_ReadPos, BytesToEndOfBuffer);
+			a_String.assign(m_Buffer.get() + m_ReadPos, BytesToEndOfBuffer);
 			ASSERT(a_Count >= BytesToEndOfBuffer);
 			a_Count -= BytesToEndOfBuffer;
 		}
@@ -835,7 +833,7 @@ bool cByteBuffer::ReadString(AString & a_String, size_t a_Count)
 	// Read the rest of the bytes in a single read (guaranteed to fit):
 	if (a_Count > 0)
 	{
-		a_String.append(m_Buffer + m_ReadPos, a_Count);
+		a_String.append(m_Buffer.get() + m_ReadPos, a_Count);
 		m_ReadPos += a_Count;
 	}
 	return true;
@@ -930,11 +928,11 @@ void cByteBuffer::ReadAgain(AString & a_Out)
 	{
 		// Across the ringbuffer end, read the first part and adjust next part's start:
 		ASSERT(m_BufferSize >= m_DataStart);
-		a_Out.append(m_Buffer + m_DataStart, m_BufferSize - m_DataStart);
+		a_Out.append(m_Buffer.get() + m_DataStart, m_BufferSize - m_DataStart);
 		DataStart = 0;
 	}
 	ASSERT(m_ReadPos >= DataStart);
-	a_Out.append(m_Buffer + DataStart, m_ReadPos - DataStart);
+	a_Out.append(m_Buffer.get() + DataStart, m_ReadPos - DataStart);
 }
 
 

--- a/src/ByteBuffer.h
+++ b/src/ByteBuffer.h
@@ -134,7 +134,7 @@ public:
 	static size_t GetVarIntSize(UInt32 a_Value);
 
 protected:
-	char * m_Buffer;
+	std::unique_ptr<char[]> m_Buffer;
 	size_t m_BufferSize;  // Total size of the ringbuffer
 
 	size_t m_DataStart;  // Where the data starts in the ringbuffer

--- a/src/CraftingRecipes.cpp
+++ b/src/CraftingRecipes.cpp
@@ -56,16 +56,6 @@ cCraftingGrid::cCraftingGrid(const cCraftingGrid & a_Original) :
 
 
 
-cCraftingGrid::~cCraftingGrid()
-{
-	delete[] m_Items;
-	m_Items = nullptr;
-}
-
-
-
-
-
 cItem & cCraftingGrid::GetItem(int x, int y) const
 {
 	// Accessible through scripting, must verify parameters:

--- a/src/CraftingRecipes.h
+++ b/src/CraftingRecipes.h
@@ -27,7 +27,6 @@ public:
 	cCraftingGrid(const cCraftingGrid & a_Original);
 	cCraftingGrid(int a_Width, int a_Height);  // tolua_export
 	cCraftingGrid(const cItem * a_Items, int a_Width, int a_Height);
-	~cCraftingGrid();
 
 	// tolua_begin
 	int     GetWidth (void) const {return m_Width; }
@@ -45,16 +44,16 @@ public:
 
 	// tolua_end
 
-	cItem * GetItems(void) const {return m_Items; }
+	cItem * GetItems(void) const {return m_Items.get(); }
 
 	/** Copies internal contents into the item array specified. Assumes that the array has the same dimensions as self */
 	void  CopyToItems(cItem * a_Items) const;
 
 protected:
 
-	int     m_Width;
-	int     m_Height;
-	cItem * m_Items;
+	int                      m_Width;
+	int                      m_Height;
+	std::unique_ptr<cItem[]> m_Items;
 } ;  // tolua_export
 
 

--- a/src/Generating/BioGen.cpp
+++ b/src/Generating/BioGen.cpp
@@ -70,18 +70,6 @@ cBioGenCache::cBioGenCache(cBiomeGenPtr a_BioGenToCache, size_t a_CacheSize) :
 
 
 
-cBioGenCache::~cBioGenCache()
-{
-	delete[] m_CacheData;
-	m_CacheData = nullptr;
-	delete[] m_CacheOrder;
-	m_CacheOrder = nullptr;
-}
-
-
-
-
-
 void cBioGenCache::GenBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap)
 {
 	if (((m_NumHits + m_NumMisses) % 1024) == 10)

--- a/src/Generating/BioGen.h
+++ b/src/Generating/BioGen.h
@@ -49,7 +49,7 @@ class cBioGenCache :
 
 public:
 	cBioGenCache(cBiomeGenPtr a_BioGenToCache, size_t a_CacheSize);
-	virtual ~cBioGenCache() override;
+	virtual ~cBioGenCache() override = default;
 
 protected:
 
@@ -63,9 +63,9 @@ protected:
 	} ;
 
 	// To avoid moving large amounts of data for the MRU behavior, we MRU-ize indices to an array of the actual data
-	size_t          m_CacheSize;
-	size_t *        m_CacheOrder;  // MRU-ized order, indices into m_CacheData array
-	sCacheData * m_CacheData;   // m_CacheData[m_CacheOrder[0]] is the most recently used
+	size_t                        m_CacheSize;
+	std::unique_ptr<size_t[]>     m_CacheOrder;  // MRU-ized order, indices into m_CacheData array
+	std::unique_ptr<sCacheData[]> m_CacheData;   // m_CacheData[m_CacheOrder[0]] is the most recently used
 
 	// Cache statistics
 	size_t m_NumHits;

--- a/src/Generating/CompoGen.cpp
+++ b/src/Generating/CompoGen.cpp
@@ -359,18 +359,6 @@ cCompoGenCache::cCompoGenCache(cTerrainCompositionGenPtr a_Underlying, int a_Cac
 
 
 
-cCompoGenCache::~cCompoGenCache()
-{
-	delete[] m_CacheData;
-	m_CacheData = nullptr;
-	delete[] m_CacheOrder;
-	m_CacheOrder = nullptr;
-}
-
-
-
-
-
 void cCompoGenCache::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc::Shape & a_Shape)
 {
 	#ifdef _DEBUG

--- a/src/Generating/CompoGen.h
+++ b/src/Generating/CompoGen.h
@@ -116,7 +116,7 @@ class cCompoGenCache :
 {
 public:
 	cCompoGenCache(cTerrainCompositionGenPtr a_Underlying, int a_CacheSize);  // Doesn't take ownership of a_Underlying
-	virtual ~cCompoGenCache() override;
+	virtual ~cCompoGenCache() override = default;
 
 	// cTerrainCompositionGen override:
 	virtual void ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc::Shape & a_Shape) override;
@@ -136,9 +136,9 @@ protected:
 	} ;
 
 	// To avoid moving large amounts of data for the MRU behavior, we MRU-ize indices to an array of the actual data
-	int          m_CacheSize;
-	int *        m_CacheOrder;  // MRU-ized order, indices into m_CacheData array
-	sCacheData * m_CacheData;   // m_CacheData[m_CacheOrder[0]] is the most recently used
+	int                           m_CacheSize;
+	std::unique_ptr<int[]>        m_CacheOrder;  // MRU-ized order, indices into m_CacheData array
+	std::unique_ptr<sCacheData[]> m_CacheData;   // m_CacheData[m_CacheOrder[0]] is the most recently used
 
 	// Cache statistics
 	int m_NumHits;

--- a/src/Generating/HeiGen.cpp
+++ b/src/Generating/HeiGen.cpp
@@ -123,18 +123,6 @@ cHeiGenCache::cHeiGenCache(cTerrainHeightGenPtr a_HeiGenToCache, size_t a_CacheS
 
 
 
-cHeiGenCache::~cHeiGenCache()
-{
-	delete[] m_CacheData;
-	m_CacheData = nullptr;
-	delete[] m_CacheOrder;
-	m_CacheOrder = nullptr;
-}
-
-
-
-
-
 void cHeiGenCache::GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::HeightMap & a_HeightMap)
 {
 	/*

--- a/src/Generating/HeiGen.h
+++ b/src/Generating/HeiGen.h
@@ -29,7 +29,7 @@ class cHeiGenCache :
 {
 public:
 	cHeiGenCache(cTerrainHeightGenPtr a_HeiGenToCache, size_t a_CacheSize);
-	virtual ~cHeiGenCache() override;
+	virtual ~cHeiGenCache() override = default;
 
 	// cTerrainHeightGen overrides:
 	virtual void GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::HeightMap & a_HeightMap) override;
@@ -50,9 +50,9 @@ protected:
 	cTerrainHeightGenPtr m_HeiGenToCache;
 
 	// To avoid moving large amounts of data for the MRU behavior, we MRU-ize indices to an array of the actual data
-	size_t       m_CacheSize;
-	size_t *     m_CacheOrder;  // MRU-ized order, indices into m_CacheData array
-	sCacheData * m_CacheData;   // m_CacheData[m_CacheOrder[0]] is the most recently used
+	size_t                        m_CacheSize;
+	std::unique_ptr<size_t[]>     m_CacheOrder;  // MRU-ized order, indices into m_CacheData array
+	std::unique_ptr<sCacheData[]> m_CacheData;   // m_CacheData[m_CacheOrder[0]] is the most recently used
 
 	// Cache statistics
 	size_t m_NumHits;

--- a/src/ItemGrid.cpp
+++ b/src/ItemGrid.cpp
@@ -25,16 +25,6 @@ cItemGrid::cItemGrid(int a_Width, int a_Height) :
 
 
 
-cItemGrid::~cItemGrid()
-{
-	delete[] m_Slots;
-	m_Slots = nullptr;
-}
-
-
-
-
-
 int cItemGrid::GetSlotNum(int a_X, int a_Y) const
 {
 	if (

--- a/src/ItemGrid.h
+++ b/src/ItemGrid.h
@@ -33,8 +33,6 @@ public:
 
 	cItemGrid(int a_Width, int a_Height);
 
-	~cItemGrid();
-
 	// tolua_begin
 	int GetWidth   (void) const { return m_Width; }
 	int GetHeight  (void) const { return m_Height; }
@@ -177,10 +175,10 @@ public:
 	// tolua_begin
 
 protected:
-	int     m_Width;
-	int     m_Height;
-	int     m_NumSlots;  // m_Width * m_Height, for easier validity checking in the access functions
-	cItem * m_Slots;     // x + m_Width * y
+	int                      m_Width;
+	int                      m_Height;
+	int                      m_NumSlots;  // m_Width * m_Height, for easier validity checking in the access functions
+	std::unique_ptr<cItem[]> m_Slots;     // x + m_Width * y
 
 	cListeners       m_Listeners;    ///< Listeners which should be notified on slot changes; the pointers are not owned by this object
 	cCriticalSection m_CSListeners;  ///< CS that guards the m_Listeners against multi-thread access

--- a/src/Simulator/DelayedFluidSimulator.cpp
+++ b/src/Simulator/DelayedFluidSimulator.cpp
@@ -52,16 +52,6 @@ cDelayedFluidSimulatorChunkData::cDelayedFluidSimulatorChunkData(int a_TickDelay
 
 
 
-cDelayedFluidSimulatorChunkData::~cDelayedFluidSimulatorChunkData()
-{
-	delete[] m_Slots;
-	m_Slots = nullptr;
-}
-
-
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // cDelayedFluidSimulator:
 

--- a/src/Simulator/DelayedFluidSimulator.h
+++ b/src/Simulator/DelayedFluidSimulator.h
@@ -35,10 +35,10 @@ public:
 	} ;
 
 	cDelayedFluidSimulatorChunkData(int a_TickDelay);
-	virtual ~cDelayedFluidSimulatorChunkData();
+	virtual ~cDelayedFluidSimulatorChunkData() override = default;
 
 	/** Slots, one for each delay tick, each containing the blocks to simulate */
-	cSlot * m_Slots;
+	std::unique_ptr<cSlot[]> m_Slots;
 } ;
 
 

--- a/src/WorldStorage/SchematicFileSerializer.cpp
+++ b/src/WorldStorage/SchematicFileSerializer.cpp
@@ -210,7 +210,7 @@ bool cSchematicFileSerializer::LoadFromSchematicNBT(cBlockArea & a_BlockArea, cP
 		);
 		NumTypeBytes = a_NBT.GetDataLength(TBlockTypes);
 	}
-	memcpy(a_BlockArea.m_BlockTypes, a_NBT.GetData(TBlockTypes), NumTypeBytes);
+	memcpy(a_BlockArea.GetBlockTypes(), a_NBT.GetData(TBlockTypes), NumTypeBytes);
 
 	if (AreMetasPresent)
 	{
@@ -222,7 +222,7 @@ bool cSchematicFileSerializer::LoadFromSchematicNBT(cBlockArea & a_BlockArea, cP
 			);
 			NumMetaBytes = a_NBT.GetDataLength(TBlockMetas);
 		}
-		memcpy(a_BlockArea.m_BlockMetas, a_NBT.GetData(TBlockMetas), NumMetaBytes);
+		memcpy(a_BlockArea.GetBlockMetas(), a_NBT.GetData(TBlockMetas), NumMetaBytes);
 	}
 
 	return true;
@@ -241,7 +241,7 @@ AString cSchematicFileSerializer::SaveToSchematicNBT(const cBlockArea & a_BlockA
 	Writer.AddString("Materials", "Alpha");
 	if (a_BlockArea.HasBlockTypes())
 	{
-		Writer.AddByteArray("Blocks", reinterpret_cast<const char *>(a_BlockArea.m_BlockTypes), a_BlockArea.GetBlockCount());
+		Writer.AddByteArray("Blocks", reinterpret_cast<const char *>(a_BlockArea.GetBlockTypes()), a_BlockArea.GetBlockCount());
 	}
 	else
 	{
@@ -250,7 +250,7 @@ AString cSchematicFileSerializer::SaveToSchematicNBT(const cBlockArea & a_BlockA
 	}
 	if (a_BlockArea.HasBlockMetas())
 	{
-		Writer.AddByteArray("Data", reinterpret_cast<const char *>(a_BlockArea.m_BlockMetas), a_BlockArea.GetBlockCount());
+		Writer.AddByteArray("Data", reinterpret_cast<const char *>(a_BlockArea.GetBlockMetas()), a_BlockArea.GetBlockCount());
 	}
 	else
 	{


### PR DESCRIPTION
Replaces all the cases I could find of raw pointers owning arrays with `unique_ptr`. 