### PR TITLE
Made cBlockArea:cChunkReader AreaBounds inclusive on both sides.

### DIFF
--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -2787,7 +2787,7 @@ void cBlockArea::RemoveNonMatchingBlockEntities(void)
 
 cBlockArea::cChunkReader::cChunkReader(cBlockArea & a_Area) :
 	m_Area(a_Area),
-	m_AreaBounds(cCuboid(a_Area.GetOrigin(), a_Area.GetOrigin() + a_Area.GetSize())),
+	m_AreaBounds(cCuboid(a_Area.GetOrigin(), a_Area.GetOrigin() + a_Area.GetSize() - Vector3i(1, 1, 1))),
 	m_Origin(a_Area.m_Origin.x, a_Area.m_Origin.y, a_Area.m_Origin.z),
 	m_CurrentChunkX(0),
 	m_CurrentChunkZ(0)


### PR DESCRIPTION
In cBlockArea, m_Size is such that the upper bound is inclusive (https://github.com/cuberite/cuberite/blob/master/src/BlockArea.cpp#L513). This is fine, except that then GetOrigin() + GetSize() is not the index of the highest included block (for each axis), but rather the index of the lowest non-included coordinate.

For example: A block area ranging from X=5 to X=10 would have m_Size.x == (10+1-5) == 6 and m_Origin.x == 5. Thus, m_Size.x + m_Origin.x == 11.

This is fine, except that cBlockArea::cChunkReader::cChunkReader creates a cCuboid (which has both bounds being inclusive) by adding m_Size and m_Origin.

This fixes that by subtracting 1 from each axis when creating the cuboid.
