### PR TITLE
Changing pickup lifetime and combining semantics, making these adjustable in the lua api.

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -9260,6 +9260,16 @@ a_Player:OpenWindow(Window);
 			]],
 			Functions =
 			{
+				CanCombine =
+				{
+					Returns =
+					{
+						{
+							Type = "boolean"
+						}
+					},
+					Notes = "Returns whether this pickup is allowed to combine with other similar pickups.",
+				},
 				CollectedBy =
 				{
 					Params =
@@ -9298,6 +9308,16 @@ a_Player:OpenWindow(Window);
 					},
 					Notes = "Returns the item represented by this pickup",
 				},
+				GetLifetime =
+				{
+					Returns =
+					{
+						{
+							Type = "number",
+						},
+					},
+					Notes = "Returns the total length of this pickup's lifespan, in ticks.",
+				},
 				IsCollected =
 				{
 					Returns =
@@ -9328,6 +9348,28 @@ a_Player:OpenWindow(Window);
 						},
 					},
 					Notes = "Sets the pickup's age, in ticks.",
+				},
+				SetCanCombine =
+				{
+					Params =
+					{
+						{
+							Name = "CanCombine",
+							Type = "boolean",
+						},
+					},
+					Notes = "Sets whether this pickup is allowed to combine with other similar pickups.",
+				},
+				SetLifetime =
+				{
+					Params =
+					{
+						{
+							Name = "SetLifetime",
+							Type = "number",
+						},
+					},
+					Notes = "Sets the total lifespan of this pickup before it despawns, in ticks.",
 				},
 			},
 			Inherits = "cEntity",

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -9365,11 +9365,11 @@ a_Player:OpenWindow(Window);
 					Params =
 					{
 						{
-							Name = "SetLifetime",
+							Name = "LifeTimeInTicks",
 							Type = "number",
 						},
 					},
-					Notes = "Sets the total lifespan of this pickup before it despawns, in ticks.",
+					Notes = "Sets the total lifespan of this pickup before it despawns, in ticks. Does not reset the age of the pickup, use SetAge(0). If new lifetime is less than the current age, pickup will despawn.",
 				},
 			},
 			Inherits = "cEntity",

--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -380,6 +380,66 @@ return
 				Notes = "Queues the specified chunks to be loaded or generated and calls the specified callbacks once they are loaded. ChunkCoordTable is an arra-table of chunk coords, each coord being a table of 2 numbers: { {Chunk1x, Chunk1z}, {Chunk2x, Chunk2z}, ...}. When any of those chunks are made available (including being available at the start of this call), the OnChunkAvailable() callback is called. When all the chunks are available, the OnAllChunksAvailable() callback is called. The function signatures are: <pre class=\"prettyprint lang-lua\">function OnChunkAvailable(ChunkX, ChunkZ)\
 function OnAllChunksAvailable()</pre> All return values from the callbacks are ignored.",
 			},
+			CreatePickup =
+			{
+				Params =
+				{
+					{
+						Name = "PosX",
+						Type = "number",
+					},
+					{
+						Name = "PosY",
+						Type = "number",
+					},
+					{
+						Name = "PosZ",
+						Type = "number",
+					},
+					{
+						Name = "Item",
+						Type = "cItem",
+					},
+					{
+						Name = "SpeedX",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Speed along X coordinate to spawn with. Default is 0.",
+					},
+					{
+						Name = "SpeedY",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Speed along Y coordinate to spawn with. Default is 0.",
+					},
+					{
+						Name = "SpeedZ",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Speed along Z coordinate to spawn with. Default is 0.",
+					},
+					{
+						Name = "LifetimeTicks",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Length of the pickups lifetime, in ticks. Default 5 minutes (6000 ticks)",
+					},
+					{
+						Name = "CanCombine",
+						Type = "boolean",
+						IsOptional = true,
+						Notes = "Whether this pickup is allowed to combine with other similar pickups.",
+					},
+				},
+				Returns =
+				{
+					{
+						Name = "EntityID",
+						Type = "number",
+					}
+				},
+				Notes = "Creates a pickup entity of the given item at the given position with the given speed, and returns the entities unique ID."
+			},
 			CreateProjectile =
 			{
 				Params =

--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -380,66 +380,6 @@ return
 				Notes = "Queues the specified chunks to be loaded or generated and calls the specified callbacks once they are loaded. ChunkCoordTable is an arra-table of chunk coords, each coord being a table of 2 numbers: { {Chunk1x, Chunk1z}, {Chunk2x, Chunk2z}, ...}. When any of those chunks are made available (including being available at the start of this call), the OnChunkAvailable() callback is called. When all the chunks are available, the OnAllChunksAvailable() callback is called. The function signatures are: <pre class=\"prettyprint lang-lua\">function OnChunkAvailable(ChunkX, ChunkZ)\
 function OnAllChunksAvailable()</pre> All return values from the callbacks are ignored.",
 			},
-			CreatePickup =
-			{
-				Params =
-				{
-					{
-						Name = "PosX",
-						Type = "number",
-					},
-					{
-						Name = "PosY",
-						Type = "number",
-					},
-					{
-						Name = "PosZ",
-						Type = "number",
-					},
-					{
-						Name = "Item",
-						Type = "cItem",
-					},
-					{
-						Name = "SpeedX",
-						Type = "number",
-						IsOptional = true,
-						Notes = "Speed along X coordinate to spawn with. Default is 0.",
-					},
-					{
-						Name = "SpeedY",
-						Type = "number",
-						IsOptional = true,
-						Notes = "Speed along Y coordinate to spawn with. Default is 0.",
-					},
-					{
-						Name = "SpeedZ",
-						Type = "number",
-						IsOptional = true,
-						Notes = "Speed along Z coordinate to spawn with. Default is 0.",
-					},
-					{
-						Name = "LifetimeTicks",
-						Type = "number",
-						IsOptional = true,
-						Notes = "Length of the pickups lifetime, in ticks. Default 5 minutes (6000 ticks)",
-					},
-					{
-						Name = "CanCombine",
-						Type = "boolean",
-						IsOptional = true,
-						Notes = "Whether this pickup is allowed to combine with other similar pickups.",
-					},
-				},
-				Returns =
-				{
-					{
-						Name = "EntityID",
-						Type = "number",
-					}
-				},
-				Notes = "Creates a pickup entity of the given item at the given position with the given speed, and returns the entities unique ID."
-			},
 			CreateProjectile =
 			{
 				Params =
@@ -3068,6 +3008,66 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 					},
 				},
 				Notes = "Spawns a {{cFallingBlock|Falling Block}} entity at the specified coords with the given block type/meta. Returns the EntityID of the new falling block, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no falling block was created.",
+			},
+			SpawnItemPickup =
+			{
+				Params =
+				{
+					{
+						Name = "PosX",
+						Type = "number",
+					},
+					{
+						Name = "PosY",
+						Type = "number",
+					},
+					{
+						Name = "PosZ",
+						Type = "number",
+					},
+					{
+						Name = "Item",
+						Type = "cItem",
+					},
+					{
+						Name = "SpeedX",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Speed along X coordinate to spawn with. Default is 0.",
+					},
+					{
+						Name = "SpeedY",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Speed along Y coordinate to spawn with. Default is 0.",
+					},
+					{
+						Name = "SpeedZ",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Speed along Z coordinate to spawn with. Default is 0.",
+					},
+					{
+						Name = "LifetimeTicks",
+						Type = "number",
+						IsOptional = true,
+						Notes = "Length of the pickups lifetime, in ticks. Default 5 minutes (6000 ticks)",
+					},
+					{
+						Name = "CanCombine",
+						Type = "boolean",
+						IsOptional = true,
+						Notes = "Whether this pickup is allowed to combine with other similar pickups.",
+					},
+				},
+				Returns =
+				{
+					{
+						Name = "EntityID",
+						Type = "number",
+					}
+				},
+				Notes = "Creates a single pickup entity of the given item at the given position with the given speed, and returns the entities unique ID."
 			},
 			SpawnItemPickups =
 			{

--- a/src/Blocks/WorldInterface.h
+++ b/src/Blocks/WorldInterface.h
@@ -33,6 +33,8 @@ public:
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) = 0;
 
+	virtual UInt32 CreatePickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) = 0;
+
 	/** Spawns a mob of the specified type.
 	Returns the mob's UniqueID if recognized and spawned, or cEntity::INVALID_ID on failure. */
 	virtual UInt32 SpawnMob(double a_PosX, double a_PosY, double a_PosZ, eMonsterType a_MonsterType, bool a_Baby) = 0;

--- a/src/Blocks/WorldInterface.h
+++ b/src/Blocks/WorldInterface.h
@@ -33,7 +33,7 @@ public:
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) = 0;
 
-	virtual UInt32 CreatePickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) = 0;
+	virtual UInt32 SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) = 0;
 
 	/** Spawns a mob of the specified type.
 	Returns the mob's UniqueID if recognized and spawned, or cEntity::INVALID_ID on failure. */

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -40,8 +40,9 @@ public:
 		Vector3d EntityPos = a_Entity->GetPosition();
 		double Distance = (EntityPos - m_Position).Length();
 
-		cItem & Item = static_cast<cPickup *>(a_Entity)->GetItem();
-		if ((Distance < 1.2) && Item.IsEqual(m_Pickup->GetItem()))
+		cPickup * OtherPickup = static_cast<cPickup *>(a_Entity);
+		cItem & Item = OtherPickup->GetItem();
+		if ((Distance < 1.2) && Item.IsEqual(m_Pickup->GetItem()) && OtherPickup->CanCombine())
 		{
 			short CombineCount = Item.m_ItemCount;
 			if ((CombineCount + m_Pickup->GetItem().m_ItemCount) > Item.GetMaxStackSize())
@@ -66,6 +67,9 @@ public:
 				a_Entity->GetWorld()->BroadcastEntityRelMove(*a_Entity, static_cast<char>(DiffX), static_cast<char>(DiffY), static_cast<char>(DiffZ));
 				/* End of experimental animation */
 				a_Entity->Destroy();
+
+				// Reset the timer
+				m_Pickup->SetAge(0);
 			}
 			else
 			{
@@ -92,12 +96,14 @@ protected:
 
 
 
-cPickup::cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX /* = 0.f */, float a_SpeedY /* = 0.f */, float a_SpeedZ /* = 0.f */)
+cPickup::cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX /* = 0.f */, float a_SpeedY /* = 0.f */, float a_SpeedZ /* = 0.f */, int a_LifetimeTicks /* = 6000 = 5 minutes */, bool a_CanCombine /* = true */)
 	: cEntity(etPickup, a_PosX, a_PosY, a_PosZ, 0.2, 0.2)
 	, m_Timer(0)
 	, m_Item(a_Item)
 	, m_bCollected(false)
 	, m_bIsPlayerCreated(IsPlayerCreated)
+	, m_bCanCombine(a_CanCombine)
+	, m_Lifetime(cTickTime(a_LifetimeTicks))
 {
 	SetGravity(-16.0f);
 	SetAirDrag(0.02f);
@@ -165,7 +171,7 @@ void cPickup::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			}
 
 			// Try to combine the pickup with adjacent same-item pickups:
-			if ((m_Item.m_ItemCount < m_Item.GetMaxStackSize()) && IsOnGround())  // Don't combine if already full or not on ground
+			if ((m_Item.m_ItemCount < m_Item.GetMaxStackSize()) && IsOnGround() && CanCombine())  // Don't combine if already full or not on ground
 			{
 				// By using a_Chunk's ForEachEntity() instead of cWorld's, pickups don't combine across chunk boundaries.
 				// That is a small price to pay for not having to traverse the entire world for each entity.
@@ -188,7 +194,7 @@ void cPickup::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		}
 	}
 
-	if (m_Timer > std::chrono::minutes(5))  // 5 minutes
+	if (m_Timer > m_Lifetime)
 	{
 		Destroy(true);
 		return;

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -96,7 +96,7 @@ protected:
 
 
 
-cPickup::cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX /* = 0.f */, float a_SpeedY /* = 0.f */, float a_SpeedZ /* = 0.f */, int a_LifetimeTicks /* = 6000 = 5 minutes */, bool a_CanCombine /* = true */)
+cPickup::cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX, float a_SpeedY, float a_SpeedZ, int a_LifetimeTicks, bool a_CanCombine)
 	: cEntity(etPickup, a_PosX, a_PosY, a_PosZ, 0.2, 0.2)
 	, m_Timer(0)
 	, m_Item(a_Item)

--- a/src/Entities/Pickup.h
+++ b/src/Entities/Pickup.h
@@ -25,7 +25,7 @@ public:
 
 	CLASS_PROTODEF(cPickup)
 
-	cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f);
+	cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true);
 
 	cItem &       GetItem(void)       {return m_Item; }  // tolua_export
 	const cItem & GetItem(void) const {return m_Item; }
@@ -36,11 +36,23 @@ public:
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
+	/** Returns whether this pickup is allowed to combine with other similar pickups */
+	bool CanCombine(void) const { return m_bCanCombine; }  // tolua_export
+
+	/** Sets whether this pickup is allowed to combine with other similar pickups */
+	void SetCanCombine(bool a_CanCombine) { m_bCanCombine = a_CanCombine; }  // tolua_export
+
 	/** Returns the number of ticks that this entity has existed */
 	int GetAge(void) const { return std::chrono::duration_cast<cTickTime>(m_Timer).count(); }     // tolua_export
 
 	/** Set the number of ticks that this entity has existed */
 	void SetAge(int a_Age) { m_Timer = cTickTime(a_Age); }  // tolua_export
+
+	/** Returns the number of ticks that this pickup should live for */
+	int GetLifetime(void) const { return std::chrono::duration_cast<cTickTime>(m_Lifetime).count(); }  // tolua_export
+
+	/** Set the number of ticks that this pickup should live for */
+	void SetLifetime(int a_Lifetime) { m_Lifetime = cTickTime(a_Lifetime); }  // tolua_export
 
 	/** Returns true if the pickup has already been collected */
 	bool IsCollected(void) const { return m_bCollected; }  // tolua_export
@@ -58,4 +70,8 @@ private:
 	bool m_bCollected;
 
 	bool m_bIsPlayerCreated;
+
+	bool m_bCanCombine;
+
+	std::chrono::milliseconds m_Lifetime;
 };  // tolua_export

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2223,6 +2223,22 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 
 
 
+UInt32 cWorld::CreatePickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX, float a_SpeedY, float a_SpeedZ, int a_LifetimeTicks, bool a_CanCombine)
+{
+	cPickup * Pickup = new cPickup(a_PosX, a_PosY, a_PosZ, a_Item, false, a_SpeedX, a_SpeedY, a_SpeedZ, a_LifetimeTicks, a_CanCombine);
+	if (!Pickup->Initialize(*this))
+	{
+		delete Pickup;
+		Pickup = nullptr;
+		return cEntity::INVALID_ID;
+	}
+	return Pickup->GetUniqueID();
+}
+
+
+
+
+
 UInt32 cWorld::SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta)
 {
 	cFallingBlock * FallingBlock = new cFallingBlock(Vector3i(a_X, a_Y, a_Z), BlockType, BlockMeta);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2223,7 +2223,7 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 
 
 
-UInt32 cWorld::CreatePickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX, float a_SpeedY, float a_SpeedZ, int a_LifetimeTicks, bool a_CanCombine)
+UInt32 cWorld::SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX, float a_SpeedY, float a_SpeedZ, int a_LifetimeTicks, bool a_CanCombine)
 {
 	cPickup * Pickup = new cPickup(a_PosX, a_PosY, a_PosZ, a_Item, false, a_SpeedX, a_SpeedY, a_SpeedZ, a_LifetimeTicks, a_CanCombine);
 	if (!Pickup->Initialize(*this))

--- a/src/World.h
+++ b/src/World.h
@@ -443,7 +443,8 @@ public:
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) override;
 
-	virtual UInt32 CreatePickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) override;
+	/** Spawns a single pickup containing the specified item. */
+	virtual UInt32 SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) override;
 
 	/** Spawns an falling block entity at the given position.
 	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */

--- a/src/World.h
+++ b/src/World.h
@@ -443,6 +443,8 @@ public:
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) override;
 
+	virtual UInt32 CreatePickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) override;
+
 	/** Spawns an falling block entity at the given position.
 	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
 	UInt32 SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta);


### PR DESCRIPTION
* Made pickup lifetimes configurable from the lua API.
* Made whether or not a pickup is allowed to be combined with other pickups configurable from the API.
* When a pickup combines with another one, the age is reset to zero ([like in vanilla](http://minecraft.gamepedia.com/Item_(entity))).
* Added cWorld:CreatePickup so that plugins can create a pickup directly, and retrieve the Entity ID for it (for future handling by the plugin).

Useful for e.g. an item generator, so that there is a cap on how many items are uncollected in the generator at one time:
```
local PickupId = World:CreatePickup(generator.x + 0.5, generator.y + 2.0, generator.z + 0.5, cItem(drop.type, 1), 0, 0, 0)
World:DoWithEntityByID(PickupId, function (Pickup)
			      Pickup:SetLifetime(200) -- 10 seconds
			      Pickup:SetCanCombine(false)
			      LOG("Pickup will last for "..Pickup:GetLifetime().." ticks")
end)
```
Or, more concisely:
```
local PickupId = World:CreatePickup(generator.x + 0.5, generator.y + 2.0, generator.z + 0.5, cItem(drop.type, 1), 0, 0, 0, 200, false)
```
(the cap is derived from putting this in a loop, so you run this e.g. every 2 seconds to get a cap of 5.)
