### PR TITLE
FastRandom: Remove discrepancy between arg and return value type.

### DIFF
--- a/src/FastRandom.h
+++ b/src/FastRandom.h
@@ -97,8 +97,8 @@ public:
 
 
 	/** Return a random IntType in the range [0, a_Max]. */
-	template <class IntType = int, class ArgType>
-	IntType RandInt(ArgType a_Max)
+	template <class IntType = int>
+	IntType RandInt(IntType a_Max)
 	{
 		ASSERT((a_Max >= 0) && (a_Max <= std::numeric_limits<IntType>::max()));
 		Detail::cUniform<IntType> dist(IntType(0), static_cast<IntType>(a_Max));

--- a/src/FastRandom.h
+++ b/src/FastRandom.h
@@ -77,8 +77,8 @@ public:
 
 
 	/** Return a random IntType in the range [a_Min, a_Max]. */
-	template <class IntType = int, class ArgType>
-	IntType RandInt(ArgType a_Min, ArgType a_Max)
+	template <class IntType = int>
+	IntType RandInt(IntType a_Min, IntType a_Max)
 	{
 		ASSERT(
 			(a_Max >= a_Min) &&
@@ -122,8 +122,8 @@ public:
 
 
 	/** Return a random RealType in the range [a_Min, a_Max). */
-	template <class RealType = float, class ArgType>
-	RealType RandReal(ArgType a_Min, ArgType a_Max)
+	template <class RealType = float>
+	RealType RandReal(RealType a_Min, RealType a_Max)
 	{
 		std::uniform_real_distribution<RealType> dist(a_Min, a_Max);
 		return dist(m_Engine);
@@ -134,8 +134,8 @@ public:
 
 
 	/** Return a random RealType in the range [0, a_Max). */
-	template <class RealType = float, class ArgType>
-	RealType RandReal(ArgType a_Max)
+	template <class RealType = float>
+	RealType RandReal(RealType a_Max)
 	{
 		std::uniform_real_distribution<RealType> dist(RealType(0), a_Max);
 		return dist(m_Engine);

--- a/src/MobSpawner.cpp
+++ b/src/MobSpawner.cpp
@@ -107,14 +107,12 @@ eMonsterType cMobSpawner::ChooseMobType(EMCSBiome a_Biome)
 		}
 	}
 
+	// Pick a random mob from the options:
 	size_t allowedMobsSize = allowedMobs.size();
 	if (allowedMobsSize > 0)
 	{
-		std::set<eMonsterType>::iterator itr = allowedMobs.begin();
-
-		using DiffType = decltype(itr)::difference_type;
-		std::advance(itr, GetRandomProvider().RandInt<DiffType>(allowedMobsSize - 1));
-
+		auto itr = allowedMobs.begin();
+		std::advance(itr, GetRandomProvider().RandInt(allowedMobsSize - 1));
 		return *itr;
 	}
 	return mtInvalidType;

--- a/src/MobSpawner.cpp
+++ b/src/MobSpawner.cpp
@@ -45,12 +45,12 @@ bool cMobSpawner::CheckPackCenter(BLOCKTYPE a_BlockType)
 
 
 
-void cMobSpawner::addIfAllowed(eMonsterType toAdd, std::set<eMonsterType>& toAddIn)
+void cMobSpawner::addIfAllowed(eMonsterType toAdd, std::vector<eMonsterType> & toAddIn)
 {
 	std::set<eMonsterType>::iterator itr = m_AllowedTypes.find(toAdd);
 	if (itr != m_AllowedTypes.end())
 	{
-		toAddIn.insert(toAdd);
+		toAddIn.push_back(toAdd);
 	}
 }
 
@@ -60,7 +60,7 @@ void cMobSpawner::addIfAllowed(eMonsterType toAdd, std::set<eMonsterType>& toAdd
 
 eMonsterType cMobSpawner::ChooseMobType(EMCSBiome a_Biome)
 {
-	std::set<eMonsterType> allowedMobs;
+	std::vector<eMonsterType> allowedMobs;
 
 	if ((a_Biome == biMushroomIsland) || (a_Biome == biMushroomShore))
 	{
@@ -111,9 +111,7 @@ eMonsterType cMobSpawner::ChooseMobType(EMCSBiome a_Biome)
 	size_t allowedMobsSize = allowedMobs.size();
 	if (allowedMobsSize > 0)
 	{
-		auto itr = allowedMobs.begin();
-		std::advance(itr, GetRandomProvider().RandInt(allowedMobsSize - 1));
-		return *itr;
+		return allowedMobs[GetRandomProvider().RandInt(allowedMobsSize - 1)];
 	}
 	return mtInvalidType;
 }

--- a/src/MobSpawner.h
+++ b/src/MobSpawner.h
@@ -58,13 +58,13 @@ protected :
 	eMonsterType ChooseMobType(EMCSBiome a_Biome);
 
 	/** Adds toAdd into toAddIn, if toAdd is in m_AllowedTypes */
-	void addIfAllowed(eMonsterType toAdd, std::set<eMonsterType> & toAddIn);
+	void addIfAllowed(eMonsterType toAdd, std::vector<eMonsterType> & toAddIn);
 
 	cMonster::eFamily m_MonsterFamily;
 	std::set<eMonsterType> m_AllowedTypes;
 	bool m_NewPack;
 	eMonsterType m_MobType;
-	std::set<cMonster*> m_Spawned;
+	std::set<cMonster *> m_Spawned;
 } ;
 
 


### PR DESCRIPTION
MSVC would generate a warning due to this. And after all, if you want a random number in certain range, you better make sure all of that range fits the return type.