### PR TITLE
Updated armor cover calculation.

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3028,7 +3028,7 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 							Type = "number",
 						},
 					},
-					Notes = "Applies durability to the armor, as if the armor blocked the given amount of damage.",
+					Notes = "Lowers armor durability, as if the armor blocked the given amount of damage.",
 				},
 				ArmorCoversAgainst =
 				{

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3019,6 +3019,17 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "Adds the specified amount of speed in the Z axis direction.",
 				},
+				ApplyArmorDamage =
+				{
+					Params =
+					{
+						{
+							Name = "DamageBlocked",
+							Type = "number",
+						},
+					},
+					Notes = "Applies durability to the armor, as if the armor blocked the given amount of damage.",
+				},
 				ArmorCoversAgainst =
 				{
 					Params =
@@ -3123,6 +3134,31 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 						},
 					},
 					Notes = "Returns the entity classname that this class implements. Each descendant overrides this function.",
+				},
+				GetEnchantmentCoverAgainst =
+				{
+					Params =
+					{
+						{
+							Name = "AttackerEntity",
+							Type = "cEntity",
+						},
+						{
+							Name = "DamageType",
+							Type = "eDamageType",
+						},
+						{
+							Name = "RawDamage",
+							Type = "number",
+						},
+					},
+					Returns =
+					{
+						{
+							Type = "number",
+						},
+					},
+					Notes = "Returns the number of hitpoints out of RawDamage that the enchantments on the currently equipped armor would cover. See {{TakeDamageInfo}} for more information on attack damage.",
 				},
 				GetEntityType =
 				{

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -693,7 +693,7 @@ int cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType 
 		}
 	}
 	int CappedEPF = std::min(20, TotalEPF);
-	return a_Damage * CappedEPF / 25.0;
+	return static_cast<int>(a_Damage * CappedEPF / 25.0);
 }
 
 
@@ -751,7 +751,7 @@ int cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_Dama
 	// Ref.: http://minecraft.gamepedia.com/Armor#Mob_armor as of 2012_12_20
 
 	double Reduction = std::max(ArmorValue / 5.0, ArmorValue - a_Damage / (2 + Toughness / 4.0));
-	return a_Damage * std::min(20.0, Reduction) / 25.0;
+	return static_cast<int>(a_Damage * std::min(20.0, Reduction) / 25.0);
 }
 
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -141,12 +141,12 @@ public:
 	static const int BURN_TICKS_PER_DAMAGE = 20;   ///< Ticks to wait between damaging an entity when it is burning
 	static const int BURN_DAMAGE           = 1;    ///< Damage to deal when the entity is burning
 
-	static const int BURN_TICKS            = 200;  ///< Ticks to keep an entity burning after it has stood in lava / fire
+	static const int BURN_TICKS            = 160;  ///< Ticks to keep an entity burning after it has stood in lava / fire
 
 	static const int MAX_AIR_LEVEL         = 300;  ///< Maximum air an entity can have
 	static const int DROWNING_TICKS        = 20;   ///< Number of ticks per heart of damage
 
-	static const int VOID_BOUNDARY         = -46;  ///< Y position to begin applying void damage
+	static const int VOID_BOUNDARY         = -64;  ///< Y position to begin applying void damage
 	static const int FALL_DAMAGE_HEIGHT    = 4;    ///< Y difference after which fall damage is applied
 
 	/** Special ID that is considered an "invalid value", signifying no entity. */
@@ -320,6 +320,9 @@ public:
 	/** Returns the hitpoints out of a_RawDamage that the currently equipped armor would cover */
 	virtual int GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_RawDamage);
 
+	/** Returns the hitpoints that the current enchantments would cover */
+	virtual int GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage);
+
 	/** Returns the knockback amount that the currently equipped items would cause to a_Receiver on a hit */
 	virtual double GetKnockbackAmountAgainst(const cEntity & a_Receiver);
 
@@ -337,6 +340,9 @@ public:
 
 	/** Returns the currently equipped boots; empty item if none */
 	virtual cItem GetEquippedBoots(void) const { return cItem(); }
+
+	/** Applies damage to the armor after the armor blocked the given amount */
+	virtual void ApplyArmorDamage(int DamageBlocked);
 
 	// tolua_end
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -320,7 +320,7 @@ public:
 	/** Returns the hitpoints out of a_RawDamage that the currently equipped armor would cover */
 	virtual int GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_RawDamage);
 
-	/** Returns the hitpoints that the current enchantments would cover */
+	/** Returns the hitpoints that the currently equipped armor's enchantments would cover */
 	virtual int GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage);
 
 	/** Returns the knockback amount that the currently equipped items would cause to a_Receiver on a hit */

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -940,6 +940,22 @@ void cPlayer::SetFlying(bool a_IsFlying)
 
 
 
+void cPlayer::ApplyArmorDamage(int DamageBlocked)
+{
+	short ArmorDamage = static_cast<short>(DamageBlocked / 4);
+	if (ArmorDamage == 0)
+	{
+		ArmorDamage = 1;
+	}
+	m_Inventory.DamageItem(cInventory::invArmorOffset + 0, ArmorDamage);
+	m_Inventory.DamageItem(cInventory::invArmorOffset + 1, ArmorDamage);
+	m_Inventory.DamageItem(cInventory::invArmorOffset + 2, ArmorDamage);
+	m_Inventory.DamageItem(cInventory::invArmorOffset + 3, ArmorDamage);
+}
+
+
+
+
 
 bool cPlayer::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
@@ -975,17 +991,6 @@ bool cPlayer::DoTakeDamage(TakeDamageInfo & a_TDI)
 		// Any kind of damage adds food exhaustion
 		AddFoodExhaustion(0.3f);
 		SendHealth();
-
-		// Damage armor
-		short ArmorDamage = static_cast<short>(a_TDI.RawDamage / 4);
-		if (ArmorDamage == 0)
-		{
-			ArmorDamage = 1;
-		}
-		m_Inventory.DamageItem(cInventory::invArmorOffset + 0, ArmorDamage);
-		m_Inventory.DamageItem(cInventory::invArmorOffset + 1, ArmorDamage);
-		m_Inventory.DamageItem(cInventory::invArmorOffset + 2, ArmorDamage);
-		m_Inventory.DamageItem(cInventory::invArmorOffset + 3, ArmorDamage);
 
 		// Tell the wolves
 		if (a_TDI.Attacker != nullptr)

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -68,6 +68,7 @@ public:
 	/** Returns the currently equipped boots; empty item if none */
 	virtual cItem GetEquippedBoots(void) const override { return m_Inventory.GetEquippedBoots(); }
 
+	virtual void ApplyArmorDamage(int DamageBlocked) override;
 
 	// tolua_begin
 


### PR DESCRIPTION
Fixes #2975.

Updates how armor cover is calculated. Now has a function which calculates the armor cover and a function which calculates the armor cover from enchantments. Armor durability reduction is just from the amount blocked by the armor (not enchantments).

Has been tested with hits from other players (bare handed and with swords) and from zombies (bare handed), with the target player both wearing armor and not wearing armor.
