### PR TITLE
Increment fire block iterator

### DIFF
--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -145,6 +145,7 @@ void cFireSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX,
 			a_Chunk->SetMeta(x, y, z, BlockMeta + 1);
 		}
 		itr->Data = GetBurnStepTime(a_Chunk, itr->x, itr->y, itr->z);  // TODO: Add some randomness into this
+		++itr;
 	}  // for itr - Data[]
 }
 


### PR DESCRIPTION
* Resolves potential deadlock

I'm not entirely sure if I'm fixing anything or if this was intentional. However, it seems to me that if the server is particularly slow and NumMSecs large (> GetBurnStepTime(Netherrack)), and the block below burns forever (i.e. Netherrack), itr->Data can be always negative and so `itr` is never incremented.

Also, for unfuelled fires on slow servers (NumMSecs > GetBurnStepTime(Fuel)) it seems that they can extinguish and spread too quickly.

Is this right or am I missing something?