### PR TITLE
Remove smart pointer and other macros from Globals.h

### DIFF
--- a/src/Bindings/LuaServerHandle.h
+++ b/src/Bindings/LuaServerHandle.h
@@ -18,10 +18,10 @@
 
 // fwd:
 class cLuaTCPLink;
-typedef SharedPtr<cLuaTCPLink> cLuaTCPLinkPtr;
+typedef std::shared_ptr<cLuaTCPLink> cLuaTCPLinkPtr;
 typedef std::vector<cLuaTCPLinkPtr> cLuaTCPLinkPtrs;
 class cLuaServerHandle;
-typedef SharedPtr<cLuaServerHandle> cLuaServerHandlePtr;
+typedef std::shared_ptr<cLuaServerHandle> cLuaServerHandlePtr;
 
 
 

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -270,8 +270,8 @@ public:
 		Use a smart pointer for a copyable object. */
 		cTrackedRef(cTrackedRef &&) = delete;
 	};
-	typedef UniquePtr<cTrackedRef> cTrackedRefPtr;
-	typedef SharedPtr<cTrackedRef> cTrackedRefSharedPtr;
+	typedef std::unique_ptr<cTrackedRef> cTrackedRefPtr;
+	typedef std::shared_ptr<cTrackedRef> cTrackedRefSharedPtr;
 
 
 	/** Represents a stored callback to Lua that C++ code can call.
@@ -324,8 +324,8 @@ public:
 		Use cCallbackPtr for a copyable object. */
 		cCallback(cCallback &&) = delete;
 	};
-	typedef UniquePtr<cCallback> cCallbackPtr;
-	typedef SharedPtr<cCallback> cCallbackSharedPtr;
+	typedef std::unique_ptr<cCallback> cCallbackPtr;
+	typedef std::shared_ptr<cCallback> cCallbackSharedPtr;
 
 
 	/** Same thing as cCallback, but GetStackValue() won't fail if the callback value is nil.
@@ -354,7 +354,7 @@ public:
 		Use cCallbackPtr for a copyable object. */
 		cOptionalCallback(cOptionalCallback &&) = delete;
 	};
-	typedef UniquePtr<cOptionalCallback> cOptionalCallbackPtr;
+	typedef std::unique_ptr<cOptionalCallback> cOptionalCallbackPtr;
 
 
 	/** Represents a stored Lua table with callback functions that C++ code can call.
@@ -416,7 +416,7 @@ public:
 		Returns true on success, false on failure (not a table at the specified stack pos). */
 		bool RefStack(cLuaState & a_LuaState, int a_StackPos);
 	};
-	typedef UniquePtr<cTableRef> cTableRefPtr;
+	typedef std::unique_ptr<cTableRef> cTableRefPtr;
 
 
 	/** Represents a parameter that is optional - calling a GetStackValue() with this object will not fail if the value on the Lua stack is nil.
@@ -539,7 +539,7 @@ public:
 		/** The stack index where the table resides in the Lua state. */
 		int m_StackPos;
 	};
-	typedef UniquePtr<cStackTable> cStackTablePtr;
+	typedef std::unique_ptr<cStackTable> cStackTablePtr;
 
 
 	/** Creates a new instance. The LuaState is not initialized.

--- a/src/Bindings/LuaTCPLink.h
+++ b/src/Bindings/LuaTCPLink.h
@@ -18,7 +18,7 @@
 
 // fwd:
 class cLuaServerHandle;
-typedef WeakPtr<cLuaServerHandle> cLuaServerHandleWPtr;
+typedef std::weak_ptr<cLuaServerHandle> cLuaServerHandleWPtr;
 
 
 

--- a/src/Bindings/LuaUDPEndpoint.h
+++ b/src/Bindings/LuaUDPEndpoint.h
@@ -18,7 +18,7 @@
 
 // fwd:
 class cLuaUDPEndpoint;
-typedef SharedPtr<cLuaUDPEndpoint> cLuaUDPEndpointPtr;
+typedef std::shared_ptr<cLuaUDPEndpoint> cLuaUDPEndpointPtr;
 
 
 

--- a/src/Bindings/PluginManager.h
+++ b/src/Bindings/PluginManager.h
@@ -29,7 +29,7 @@ class cSettingsRepositoryInterface;
 class cDeadlockDetect;
 struct TakeDamageInfo;
 
-typedef SharedPtr<cPlugin> cPluginPtr;
+typedef std::shared_ptr<cPlugin> cPluginPtr;
 typedef std::vector<cPluginPtr> cPluginPtrs;
 
 
@@ -187,7 +187,7 @@ public:
 		) = 0;
 	};
 
-	typedef SharedPtr<cCommandHandler> cCommandHandlerPtr;
+	typedef std::shared_ptr<cCommandHandler> cCommandHandlerPtr;
 
 
 	/** The interface used for enumerating and extern-calling plugins */

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -44,7 +44,7 @@ class cWorld;
 class cCompositeChat;
 class cStatManager;
 class cClientHandle;
-typedef SharedPtr<cClientHandle> cClientHandlePtr;
+typedef std::shared_ptr<cClientHandle> cClientHandlePtr;
 
 
 

--- a/src/Generating/ComposableGenerator.h
+++ b/src/Generating/ComposableGenerator.h
@@ -30,11 +30,11 @@ class cTerrainShapeGen;
 class cTerrainHeightGen;
 class cTerrainCompositionGen;
 class cFinishGen;
-typedef SharedPtr<cBiomeGen>              cBiomeGenPtr;
-typedef SharedPtr<cTerrainShapeGen>       cTerrainShapeGenPtr;
-typedef SharedPtr<cTerrainHeightGen>      cTerrainHeightGenPtr;
-typedef SharedPtr<cTerrainCompositionGen> cTerrainCompositionGenPtr;
-typedef SharedPtr<cFinishGen>             cFinishGenPtr;
+typedef std::shared_ptr<cBiomeGen>              cBiomeGenPtr;
+typedef std::shared_ptr<cTerrainShapeGen>       cTerrainShapeGenPtr;
+typedef std::shared_ptr<cTerrainHeightGen>      cTerrainHeightGenPtr;
+typedef std::shared_ptr<cTerrainCompositionGen> cTerrainCompositionGenPtr;
+typedef std::shared_ptr<cFinishGen>             cFinishGenPtr;
 
 
 

--- a/src/Generating/GridStructGen.h
+++ b/src/Generating/GridStructGen.h
@@ -74,7 +74,7 @@ public:
 		/** Returns the cost of keeping this structure in the cache */
 		virtual size_t GetCacheCost(void) const { return 1; }
 	} ;
-	typedef SharedPtr<cStructure> cStructurePtr;
+	typedef std::shared_ptr<cStructure> cStructurePtr;
 	typedef std::list<cStructurePtr> cStructurePtrs;
 
 

--- a/src/Generating/HeiGen.cpp
+++ b/src/Generating/HeiGen.cpp
@@ -68,7 +68,7 @@ public:
 protected:
 	int m_Seed;
 
-	SharedPtr<cProtIntGen> m_Gen;
+	std::shared_ptr<cProtIntGen> m_Gen;
 };
 
 

--- a/src/Generating/HeiGen.h
+++ b/src/Generating/HeiGen.h
@@ -79,7 +79,7 @@ public:
 	bool GetHeightAt(int a_ChunkX, int a_ChunkZ, int a_RelX, int a_RelZ, HEIGHTTYPE & a_Height);
 
 protected:
-	typedef SharedPtr<cHeiGenCache> cHeiGenCachePtr;
+	typedef std::shared_ptr<cHeiGenCache> cHeiGenCachePtr;
 	typedef std::vector<cHeiGenCachePtr> cHeiGenCachePtrs;
 
 

--- a/src/Generating/PiecePool.h
+++ b/src/Generating/PiecePool.h
@@ -118,7 +118,7 @@ public:
 		virtual void AssignGens(int a_Seed, cBiomeGenPtr & a_BiomeGen, cTerrainHeightGenPtr & a_TerrainHeightGen, int a_SeaLevel) {}
 	};
 
-	typedef SharedPtr<cVerticalStrategy> cVerticalStrategyPtr;
+	typedef std::shared_ptr<cVerticalStrategy> cVerticalStrategyPtr;
 
 
 	/** Base class (interface) for the vertical limit of piece placement.
@@ -145,7 +145,7 @@ public:
 		virtual void AssignGens(int a_Seed, cBiomeGenPtr & a_BiomeGen, cTerrainHeightGenPtr & a_TerrainHeightGen, int a_SeaLevel) {}
 	};
 
-	typedef SharedPtr<cVerticalLimit> cVerticalLimitPtr;
+	typedef std::shared_ptr<cVerticalLimit> cVerticalLimitPtr;
 
 
 	/** The strategy used for vertical placement of this piece when it is used as a starting piece. */

--- a/src/Generating/PieceStructuresGen.h
+++ b/src/Generating/PieceStructuresGen.h
@@ -44,7 +44,7 @@ protected:
 	Forward-declared so that its implementation changes don't affect the header. */
 	class cGen;
 
-	typedef SharedPtr<cGen> cGenPtr;
+	typedef std::shared_ptr<cGen> cGenPtr;
 	typedef std::vector<cGenPtr> cGenPtrs;
 
 

--- a/src/Generating/PrefabPiecePool.cpp
+++ b/src/Generating/PrefabPiecePool.cpp
@@ -372,7 +372,7 @@ bool cPrefabPiecePool::LoadCubesetPieceVer1(const AString & a_FileName, cLuaStat
 
 
 
-UniquePtr<cPrefab> cPrefabPiecePool::LoadPrefabFromCubesetVer1(
+std::unique_ptr<cPrefab> cPrefabPiecePool::LoadPrefabFromCubesetVer1(
 	const AString & a_FileName,
 	cLuaState & a_LuaState,
 	const AString & a_PieceName,

--- a/src/Generating/PrefabPiecePool.h
+++ b/src/Generating/PrefabPiecePool.h
@@ -190,7 +190,7 @@ protected:
 	Returns the prefab on success, nullptr on failure.
 	a_PieceName is the identification of the piece, used for logging only.
 	If a_LogWarnings is true, logs a warning to console when loading fails. */
-	UniquePtr<cPrefab> LoadPrefabFromCubesetVer1(
+	std::unique_ptr<cPrefab> LoadPrefabFromCubesetVer1(
 		const AString & a_FileName,
 		cLuaState & a_LuaState,
 		const AString & a_PieceName,

--- a/src/Generating/ShapeGen.cpp
+++ b/src/Generating/ShapeGen.cpp
@@ -66,7 +66,7 @@ protected:
 	cTerrainHeightGenPtr m_HeightGen;
 };
 
-typedef SharedPtr<cTerrainHeightToShapeGen> cTerrainHeightToShapeGenPtr;
+typedef std::shared_ptr<cTerrainHeightToShapeGen> cTerrainHeightToShapeGenPtr;
 
 
 

--- a/src/Generating/VillageGen.cpp
+++ b/src/Generating/VillageGen.cpp
@@ -381,7 +381,7 @@ cGridStructGen::cStructurePtr cVillageGen::CreateStructure(int a_GridX, int a_Gr
 	{
 		auto biome = Biomes[i];
 		availablePools.erase(std::remove_if(availablePools.begin(), availablePools.end(),
-			[biome](SharedPtr<cPrefabPiecePool> a_Pool)
+			[biome](std::shared_ptr<cVillagePiecePool> & a_Pool)
 			{
 				return !a_Pool->IsBiomeAllowed(biome);
 			}),

--- a/src/Generating/VillageGen.h
+++ b/src/Generating/VillageGen.h
@@ -44,7 +44,7 @@ public:
 
 protected:
 	class cVillage;  // fwd: VillageGen.cpp
-	typedef std::vector<SharedPtr<cVillagePiecePool> > cVillagePiecePools;
+	typedef std::vector<std::shared_ptr<cVillagePiecePool>> cVillagePiecePools;
 
 	/** The noise used for generating random numbers */
 	cNoise m_RandNoise;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -38,10 +38,6 @@
 
 	#define OBSOLETE __declspec(deprecated)
 
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
-
 	#define FORMATSTRING(formatIndex, va_argsIndex)
 
 	// MSVC has its own custom version of zu format
@@ -89,9 +85,6 @@
 	#endif
 
 	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
 
 	// Some portability macros :)
 	#define stricmp strcasecmp

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -87,8 +87,6 @@
 	#define OBSOLETE __attribute__((deprecated))
 
 	// Some portability macros :)
-	#define stricmp strcasecmp
-
 	#define FORMATSTRING(formatIndex, va_argsIndex) __attribute__((format (printf, formatIndex, va_argsIndex)))
 
 	#if defined(_WIN32)

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -86,7 +86,6 @@
 
 	#define OBSOLETE __attribute__((deprecated))
 
-	// Some portability macros :)
 	#define FORMATSTRING(formatIndex, va_argsIndex) __attribute__((format (printf, formatIndex, va_argsIndex)))
 
 	#if defined(_WIN32)

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -145,14 +145,10 @@ typedef unsigned char Byte;
 typedef Byte ColourID;
 
 
-// If you get an error about specialization check the size of integral types
-template <typename T, size_t Size, bool x = sizeof(T) == Size>
-class SizeChecker;
-
 template <typename T, size_t Size>
-class SizeChecker<T, Size, true>
+class SizeChecker
 {
-	T v;
+	static_assert(sizeof(T) == Size, "Check the size of integral types");
 };
 
 template class SizeChecker<Int64, 8>;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -421,11 +421,6 @@ template class SizeChecker<UInt8,  1>;
 	#define assert_test(x) ( !!(x) || (assert(!#x), exit(1), 0))
 #endif
 
-// Unified ptr types from before C++11. Also no silly undercores.
-#define SharedPtr std::shared_ptr
-#define WeakPtr std::weak_ptr
-#define UniquePtr std::unique_ptr
-
 
 
 

--- a/src/HTTP/HTTPMessage.h
+++ b/src/HTTP/HTTPMessage.h
@@ -96,7 +96,7 @@ public:
 		// Force a virtual destructor in descendants:
 		virtual ~cUserData() {}
 	};
-	typedef SharedPtr<cUserData> cUserDataPtr;
+	typedef std::shared_ptr<cUserData> cUserDataPtr;
 
 
 	/** Creates a new instance of the class, containing the method and URL provided by the client. */

--- a/src/HTTP/TransferEncodingParser.h
+++ b/src/HTTP/TransferEncodingParser.h
@@ -11,7 +11,7 @@
 
 // fwd:
 class cTransferEncodingParser;
-typedef SharedPtr<cTransferEncodingParser> cTransferEncodingParserPtr;
+typedef std::shared_ptr<cTransferEncodingParser> cTransferEncodingParserPtr;
 
 
 

--- a/src/HTTP/UrlClient.cpp
+++ b/src/HTTP/UrlClient.cpp
@@ -16,7 +16,7 @@
 
 // fwd:
 class cSchemeHandler;
-typedef SharedPtr<cSchemeHandler> cSchemeHandlerPtr;
+typedef std::shared_ptr<cSchemeHandler> cSchemeHandlerPtr;
 
 
 
@@ -40,7 +40,7 @@ public:
 	{
 		// Create a new instance of cUrlClientRequest, wrapped in a SharedPtr, so that it has a controlled lifetime.
 		// Cannot use std::make_shared, because the constructor is not public
-		SharedPtr<cUrlClientRequest> ptr (new cUrlClientRequest(
+		std::shared_ptr<cUrlClientRequest> ptr (new cUrlClientRequest(
 			a_Method, a_URL, std::move(a_Callbacks), std::move(a_Headers), a_Body, std::move(a_Options)
 		));
 		return ptr->DoRequest(ptr);
@@ -128,10 +128,10 @@ protected:
 
 	/** SharedPtr to self, so that this object can keep itself alive for as long as it needs,
 	and pass self as callbacks to cNetwork functions. */
-	SharedPtr<cUrlClientRequest> m_Self;
+	std::shared_ptr<cUrlClientRequest> m_Self;
 
 	/** The handler that "talks" the protocol specified in m_UrlScheme, handles all the sending and receiving. */
-	SharedPtr<cSchemeHandler> m_SchemeHandler;
+	std::shared_ptr<cSchemeHandler> m_SchemeHandler;
 
 	/** The link handling the request. */
 	cTCPLinkPtr m_Link;
@@ -161,7 +161,7 @@ protected:
 	}
 
 
-	std::pair<bool, AString> DoRequest(SharedPtr<cUrlClientRequest> a_Self);
+	std::pair<bool, AString> DoRequest(std::shared_ptr<cUrlClientRequest> a_Self);
 
 
 	// cNetwork::cConnectCallbacks override: TCP link connected:
@@ -569,7 +569,7 @@ void cUrlClientRequest::OnRemoteClosed()
 
 
 
-std::pair<bool, AString> cUrlClientRequest::DoRequest(SharedPtr<cUrlClientRequest> a_Self)
+std::pair<bool, AString> cUrlClientRequest::DoRequest(std::shared_ptr<cUrlClientRequest> a_Self)
 {
 	// We need a shared pointer to self, care must be taken not to pass any other ptr:
 	ASSERT(a_Self.get() == this);

--- a/src/HTTP/UrlClient.h
+++ b/src/HTTP/UrlClient.h
@@ -86,7 +86,7 @@ public:
 		for such a response; instead, the redirect is silently attempted. */
 		virtual void OnRedirecting(const AString & a_NewLocation) {}
 	};
-	typedef UniquePtr<cCallbacks> cCallbacksPtr;
+	typedef std::unique_ptr<cCallbacks> cCallbacksPtr;
 
 
 	/** Used for HTTP status codes. */

--- a/src/OSSupport/CriticalSection.h
+++ b/src/OSSupport/CriticalSection.h
@@ -45,7 +45,7 @@ private:
 	std::thread::id m_OwningThreadID;
 
 	std::recursive_mutex m_Mutex;
-} ALIGN_8;
+};
 
 
 

--- a/src/OSSupport/HostnameLookup.h
+++ b/src/OSSupport/HostnameLookup.h
@@ -37,7 +37,7 @@ protected:
 
 	void Callback(int a_ErrCode, struct addrinfo * a_Addr);
 };
-typedef SharedPtr<cHostnameLookup> cHostnameLookupPtr;
+typedef std::shared_ptr<cHostnameLookup> cHostnameLookupPtr;
 typedef std::vector<cHostnameLookupPtr> cHostnameLookupPtrs;
 
 

--- a/src/OSSupport/IPLookup.h
+++ b/src/OSSupport/IPLookup.h
@@ -39,7 +39,7 @@ protected:
 	/** Callback that is called by LibEvent when there's an event for the request. */
 	void Callback(int a_Result, const char * a_Address);
 };
-typedef SharedPtr<cIPLookup> cIPLookupPtr;
+typedef std::shared_ptr<cIPLookup> cIPLookupPtr;
 typedef std::vector<cIPLookupPtr> cIPLookupPtrs;
 
 

--- a/src/OSSupport/Network.h
+++ b/src/OSSupport/Network.h
@@ -15,15 +15,15 @@
 
 // fwd:
 class cTCPLink;
-typedef SharedPtr<cTCPLink> cTCPLinkPtr;
+typedef std::shared_ptr<cTCPLink> cTCPLinkPtr;
 typedef std::vector<cTCPLinkPtr> cTCPLinkPtrs;
 class cServerHandle;
-typedef SharedPtr<cServerHandle> cServerHandlePtr;
+typedef std::shared_ptr<cServerHandle> cServerHandlePtr;
 typedef std::vector<cServerHandlePtr> cServerHandlePtrs;
 class cCryptoKey;
-typedef SharedPtr<cCryptoKey> cCryptoKeyPtr;
+typedef std::shared_ptr<cCryptoKey> cCryptoKeyPtr;
 class cX509Cert;
-typedef SharedPtr<cX509Cert> cX509CertPtr;
+typedef std::shared_ptr<cX509Cert> cX509CertPtr;
 
 
 
@@ -61,7 +61,7 @@ public:
 		/** Called when an error is detected on the connection. */
 		virtual void OnError(int a_ErrorCode, const AString & a_ErrorMsg) = 0;
 	};
-	typedef SharedPtr<cCallbacks> cCallbacksPtr;
+	typedef std::shared_ptr<cCallbacks> cCallbacksPtr;
 
 
 	// Force a virtual destructor for all descendants:
@@ -215,7 +215,7 @@ protected:
 	}
 };
 
-typedef SharedPtr<cUDPEndpoint> cUDPEndpointPtr;
+typedef std::shared_ptr<cUDPEndpoint> cUDPEndpointPtr;
 
 
 
@@ -238,7 +238,7 @@ public:
 		/** Called when the Connect call fails. */
 		virtual void OnError(int a_ErrorCode, const AString & a_ErrorMsg) = 0;
 	};
-	typedef SharedPtr<cConnectCallbacks> cConnectCallbacksPtr;
+	typedef std::shared_ptr<cConnectCallbacks> cConnectCallbacksPtr;
 
 
 	/** Callbacks used when listening for incoming connections as a server. */
@@ -262,7 +262,7 @@ public:
 		/** Called when the socket fails to listen on the specified port. */
 		virtual void OnError(int a_ErrorCode, const AString & a_ErrorMsg) = 0;
 	};
-	typedef SharedPtr<cListenCallbacks> cListenCallbacksPtr;
+	typedef std::shared_ptr<cListenCallbacks> cListenCallbacksPtr;
 
 
 	/** Callbacks used when resolving names to IPs. */
@@ -298,7 +298,7 @@ public:
 		Only called if there was no error reported. */
 		virtual void OnFinished(void) = 0;
 	};
-	typedef SharedPtr<cResolveNameCallbacks> cResolveNameCallbacksPtr;
+	typedef std::shared_ptr<cResolveNameCallbacks> cResolveNameCallbacksPtr;
 
 
 	/** Queues a TCP connection to be made to the specified host.

--- a/src/OSSupport/NetworkSingleton.h
+++ b/src/OSSupport/NetworkSingleton.h
@@ -27,10 +27,10 @@
 // fwd:
 struct event_base;
 class cTCPLinkImpl;
-typedef SharedPtr<cTCPLinkImpl> cTCPLinkImplPtr;
+typedef std::shared_ptr<cTCPLinkImpl> cTCPLinkImplPtr;
 typedef std::vector<cTCPLinkImplPtr> cTCPLinkImplPtrs;
 class cServerHandleImpl;
-typedef SharedPtr<cServerHandleImpl> cServerHandleImplPtr;
+typedef std::shared_ptr<cServerHandleImpl> cServerHandleImplPtr;
 typedef std::vector<cServerHandleImplPtr> cServerHandleImplPtrs;
 
 

--- a/src/OSSupport/ServerHandleImpl.h
+++ b/src/OSSupport/ServerHandleImpl.h
@@ -21,10 +21,10 @@
 
 // fwd:
 class cTCPLinkImpl;
-typedef SharedPtr<cTCPLinkImpl> cTCPLinkImplPtr;
+typedef std::shared_ptr<cTCPLinkImpl> cTCPLinkImplPtr;
 typedef std::vector<cTCPLinkImplPtr> cTCPLinkImplPtrs;
 class cServerHandleImpl;
-typedef SharedPtr<cServerHandleImpl> cServerHandleImplPtr;
+typedef std::shared_ptr<cServerHandleImpl> cServerHandleImplPtr;
 typedef std::vector<cServerHandleImplPtr> cServerHandleImplPtrs;
 
 

--- a/src/OSSupport/TCPLinkImpl.h
+++ b/src/OSSupport/TCPLinkImpl.h
@@ -22,9 +22,9 @@
 
 // fwd:
 class cServerHandleImpl;
-typedef SharedPtr<cServerHandleImpl> cServerHandleImplPtr;
+typedef std::shared_ptr<cServerHandleImpl> cServerHandleImplPtr;
 class cTCPLinkImpl;
-typedef SharedPtr<cTCPLinkImpl> cTCPLinkImplPtr;
+typedef std::shared_ptr<cTCPLinkImpl> cTCPLinkImplPtr;
 typedef std::vector<cTCPLinkImplPtr> cTCPLinkImplPtrs;
 
 
@@ -79,8 +79,8 @@ protected:
 
 	// fwd:
 	class cLinkTlsContext;
-	typedef SharedPtr<cLinkTlsContext> cLinkTlsContextPtr;
-	typedef WeakPtr<cLinkTlsContext> cLinkTlsContextWPtr;
+	typedef std::shared_ptr<cLinkTlsContext> cLinkTlsContextPtr;
+	typedef std::weak_ptr<cLinkTlsContext> cLinkTlsContextWPtr;
 
 	/** Wrapper around cSslContext that is used when this link is being encrypted by SSL. */
 	class cLinkTlsContext :

--- a/src/OSSupport/UDPEndpointImpl.h
+++ b/src/OSSupport/UDPEndpointImpl.h
@@ -18,7 +18,7 @@
 
 // fwd:
 class cUDPEndpointImpl;
-typedef SharedPtr<cUDPEndpointImpl> cUDPEndpointImplPtr;
+typedef std::shared_ptr<cUDPEndpointImpl> cUDPEndpointImplPtr;
 
 
 

--- a/src/PolarSSL++/CryptoKey.h
+++ b/src/PolarSSL++/CryptoKey.h
@@ -69,7 +69,7 @@ protected:
 	pk_context * GetInternal(void) { return &m_Pk; }
 } ;
 
-typedef SharedPtr<cCryptoKey> cCryptoKeyPtr;
+typedef std::shared_ptr<cCryptoKey> cCryptoKeyPtr;
 
 
 

--- a/src/PolarSSL++/CtrDrbgContext.cpp
+++ b/src/PolarSSL++/CtrDrbgContext.cpp
@@ -21,7 +21,7 @@ cCtrDrbgContext::cCtrDrbgContext(void) :
 
 
 
-cCtrDrbgContext::cCtrDrbgContext(const SharedPtr<cEntropyContext> & a_EntropyContext) :
+cCtrDrbgContext::cCtrDrbgContext(const std::shared_ptr<cEntropyContext> & a_EntropyContext) :
 	m_EntropyContext(a_EntropyContext),
 	m_IsValid(false)
 {

--- a/src/PolarSSL++/CtrDrbgContext.h
+++ b/src/PolarSSL++/CtrDrbgContext.h
@@ -33,7 +33,7 @@ public:
 	cCtrDrbgContext(void);
 
 	/** Constructs the context with the specified entropy context. */
-	cCtrDrbgContext(const SharedPtr<cEntropyContext> & a_EntropyContext);
+	cCtrDrbgContext(const std::shared_ptr<cEntropyContext> & a_EntropyContext);
 
 	/** Initializes the context.
 	a_Custom is optional additional data to use for entropy, nullptr is accepted.
@@ -45,7 +45,7 @@ public:
 
 protected:
 	/** The entropy source used for generating the random */
-	SharedPtr<cEntropyContext> m_EntropyContext;
+	std::shared_ptr<cEntropyContext> m_EntropyContext;
 
 	/** The random generator context */
 	ctr_drbg_context m_CtrDrbg;

--- a/src/PolarSSL++/RsaPrivateKey.h
+++ b/src/PolarSSL++/RsaPrivateKey.h
@@ -59,7 +59,7 @@ protected:
 	rsa_context * GetInternal(void) { return &m_Rsa; }
 } ;
 
-typedef SharedPtr<cRsaPrivateKey> cRsaPrivateKeyPtr;
+typedef std::shared_ptr<cRsaPrivateKey> cRsaPrivateKeyPtr;
 
 
 

--- a/src/PolarSSL++/SslContext.cpp
+++ b/src/PolarSSL++/SslContext.cpp
@@ -36,7 +36,7 @@ cSslContext::~cSslContext()
 
 
 
-int cSslContext::Initialize(bool a_IsClient, const SharedPtr<cCtrDrbgContext> & a_CtrDrbg)
+int cSslContext::Initialize(bool a_IsClient, const std::shared_ptr<cCtrDrbgContext> & a_CtrDrbg)
 {
 	// Check double-initialization:
 	if (m_IsValid)

--- a/src/PolarSSL++/SslContext.h
+++ b/src/PolarSSL++/SslContext.h
@@ -44,7 +44,7 @@ public:
 
 	/** Initializes the context for use as a server or client.
 	Returns 0 on success, PolarSSL error on failure. */
-	int Initialize(bool a_IsClient, const SharedPtr<cCtrDrbgContext> & a_CtrDrbg = SharedPtr<cCtrDrbgContext>());
+	int Initialize(bool a_IsClient, const std::shared_ptr<cCtrDrbgContext> & a_CtrDrbg = {});
 
 	/** Returns true if the object has been initialized properly. */
 	bool IsValid(void) const { return m_IsValid; }
@@ -98,7 +98,7 @@ protected:
 	bool m_IsValid;
 
 	/** The random generator to use */
-	SharedPtr<cCtrDrbgContext> m_CtrDrbg;
+	std::shared_ptr<cCtrDrbgContext> m_CtrDrbg;
 
 	/** The SSL context that PolarSSL uses. */
 	ssl_context m_Ssl;

--- a/src/PolarSSL++/X509Cert.h
+++ b/src/PolarSSL++/X509Cert.h
@@ -34,7 +34,7 @@ protected:
 	x509_crt * GetInternal(void) { return &m_Cert; }
 } ;
 
-typedef SharedPtr<cX509Cert> cX509CertPtr;
+typedef std::shared_ptr<cX509Cert> cX509CertPtr;
 
 
 

--- a/src/Protocol/MojangAPI.h
+++ b/src/Protocol/MojangAPI.h
@@ -183,7 +183,7 @@ protected:
 	cCriticalSection m_CSRankMgr;
 
 	/** The thread that periodically updates the stale data in the DB from the Mojang servers. */
-	SharedPtr<cUpdateThread> m_UpdateThread;
+	std::shared_ptr<cUpdateThread> m_UpdateThread;
 
 
 	/** Loads the caches from a disk storage. */

--- a/src/Server.h
+++ b/src/Server.h
@@ -35,7 +35,7 @@
 // fwd:
 class cPlayer;
 class cClientHandle;
-typedef SharedPtr<cClientHandle> cClientHandlePtr;
+typedef std::shared_ptr<cClientHandle> cClientHandlePtr;
 typedef std::list<cClientHandlePtr> cClientHandlePtrs;
 typedef std::list<cClientHandle *> cClientHandles;
 class cCommandOutputCallback;

--- a/src/SetChunkData.h
+++ b/src/SetChunkData.h
@@ -116,7 +116,7 @@ protected:
 	bool m_ShouldMarkDirty;
 };
 
-typedef SharedPtr<cSetChunkData> cSetChunkDataPtr;  // TODO: Change to unique_ptr once we go C++11
+typedef std::unique_ptr<cSetChunkData> cSetChunkDataPtr;
 typedef std::vector<cSetChunkDataPtr> cSetChunkDataPtrs;
 
 

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -329,11 +329,9 @@ AString StrToUpper(const AString & s)
 int NoCaseCompare(const AString & s1, const AString & s2)
 {
 	#ifdef _MSC_VER
-		// MSVC has stricmp that compares case-insensitive:
 		return _stricmp(s1.c_str(), s2.c_str());
 	#else
-		// Do it the hard way - convert both strings to lowercase:
-		return StrToLower(s1).compare(StrToLower(s2));
+		return strcasecmp(s1.c_str(), s2.c_str());
 	#endif  // else _MSC_VER
 }
 

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -540,7 +540,7 @@ void cWebAdmin::AddWebTab(
 	const AString & a_Title,
 	const AString & a_UrlPath,
 	const AString & a_PluginName,
-	SharedPtr<cWebAdmin::cWebTabCallback> a_Callback
+	std::shared_ptr<cWebAdmin::cWebTabCallback> a_Callback
 )
 {
 	cCSLock lock(m_CS);

--- a/src/WebAdmin.h
+++ b/src/WebAdmin.h
@@ -142,9 +142,9 @@ public:
 		AString m_Title;
 		AString m_UrlPath;
 		AString m_PluginName;
-		SharedPtr<cWebTabCallback> m_Callback;
+		std::shared_ptr<cWebTabCallback> m_Callback;
 
-		cWebTab(const AString & a_Title, const AString & a_UrlPath, const AString & a_PluginName, SharedPtr<cWebTabCallback> a_Callback):
+		cWebTab(const AString & a_Title, const AString & a_UrlPath, const AString & a_PluginName, std::shared_ptr<cWebTabCallback> a_Callback):
 			m_Title(a_Title),
 			m_UrlPath(a_UrlPath),
 			m_PluginName(a_PluginName),
@@ -152,7 +152,7 @@ public:
 		{
 		}
 	};
-	typedef SharedPtr<cWebTab> cWebTabPtr;
+	typedef std::shared_ptr<cWebTab> cWebTabPtr;
 	typedef std::vector<cWebTabPtr> cWebTabPtrs;
 
 
@@ -214,7 +214,7 @@ public:
 		const AString & a_Title,
 		const AString & a_UrlPath,
 		const AString & a_PluginName,
-		SharedPtr<cWebTabCallback> a_Callback
+		std::shared_ptr<cWebTabCallback> a_Callback
 	);
 
 	/** Removes the WebTab with the specified URL path.

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2889,7 +2889,7 @@ void cWorld::MarkChunkSaved (int a_ChunkX, int a_ChunkZ)
 
 
 
-void cWorld::QueueSetChunkData(const cSetChunkDataPtr & a_SetChunkData)
+void cWorld::QueueSetChunkData(cSetChunkDataPtr a_SetChunkData)
 {
 	// Validate biomes, if needed:
 	if (!a_SetChunkData->AreBiomesValid())
@@ -2908,7 +2908,7 @@ void cWorld::QueueSetChunkData(const cSetChunkDataPtr & a_SetChunkData)
 	// Store a copy of the data in the queue:
 	// TODO: If the queue is too large, wait for it to get processed. Not likely, though.
 	cCSLock Lock(m_CSSetChunkDataQueue);
-	m_SetChunkDataQueue.push_back(a_SetChunkData);
+	m_SetChunkDataQueue.push_back(std::move(a_SetChunkData));
 }
 
 
@@ -4092,7 +4092,7 @@ void cWorld::cChunkGeneratorCallbacks::OnChunkGenerated(cChunkDesc & a_ChunkDesc
 		true
 	));
 	SetChunkData->RemoveInvalidBlockEntities();
-	m_World->QueueSetChunkData(SetChunkData);
+	m_World->QueueSetChunkData(std::move(SetChunkData));
 }
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -39,7 +39,7 @@ class cRedstoneSimulator;
 class cItem;
 class cPlayer;
 class cClientHandle;
-typedef SharedPtr<cClientHandle> cClientHandlePtr;
+typedef std::shared_ptr<cClientHandle> cClientHandlePtr;
 typedef std::list<cClientHandlePtr> cClientHandlePtrs;
 typedef std::list<cClientHandle *> cClientHandles;
 class cEntity;
@@ -63,7 +63,7 @@ class cDeadlockDetect;
 typedef std::list< cPlayer * > cPlayerList;
 typedef std::list< std::pair< cPlayer *, cWorld * > > cAwaitingPlayerList;
 
-typedef SharedPtr<cSetChunkData> cSetChunkDataPtr;  // TODO: Change to unique_ptr once we go C++11
+typedef std::unique_ptr<cSetChunkData> cSetChunkDataPtr;
 typedef std::vector<cSetChunkDataPtr> cSetChunkDataPtrs;
 
 typedef cItemCallback<cPlayer>             cPlayerListCallback;
@@ -237,7 +237,7 @@ public:
 
 	/** Puts the chunk data into a queue to be set into the chunkmap in the tick thread.
 	If the chunk data doesn't contain valid biomes, the biomes are calculated before adding the data into the queue. */
-	void QueueSetChunkData(const cSetChunkDataPtr & a_SetChunkData);
+	void QueueSetChunkData(cSetChunkDataPtr a_SetChunkData);
 
 	void ChunkLighted(
 		int a_ChunkX, int a_ChunkZ,

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -470,7 +470,7 @@ bool cWSSAnvil::LoadChunkFromNBT(const cChunkCoords & a_Chunk, const cParsedNBT 
 		std::move(Entities), std::move(BlockEntities),
 		false
 	));
-	m_World->QueueSetChunkData(SetChunkData);
+	m_World->QueueSetChunkData(std::move(SetChunkData));
 	return true;
 }
 


### PR DESCRIPTION
Gets rid of mixed usage of the `std::{smart}_ptr` and `{Smart}Ptr` as well as a few other macros which weren't really used anywhere.