### PR TITLE
Creepers explode when burned by flint and steel

### DIFF
--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -32,7 +32,7 @@ void cCreeper::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		return;
 	}
 
-	if ((GetTarget() == nullptr) || (!TargetIsInRange() && !m_BurnedWithFlintAndSteel))
+	if (((GetTarget() == nullptr) || !TargetIsInRange()) && !m_BurnedWithFlintAndSteel)
 	{
 		if (m_bIsBlowing)
 		{


### PR DESCRIPTION
Fixed en issue where creepers didn't explode when they were burned with flint and steel