### PR TITLE
Fixed check to see if block entity is in merge source.

### DIFF
--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -2704,7 +2704,7 @@ void cBlockArea::MergeBlockEntities(int a_RelX, int a_RelY, int a_RelZ, const cB
 		{
 			auto srcIdx = a_Src.MakeIndex(srcX, srcY, srcZ);
 			auto itrSrc = a_Src.m_BlockEntities->find(srcIdx);
-			if (itrSrc == a_Src.m_BlockEntities->end())
+			if (itrSrc != a_Src.m_BlockEntities->end())
 			{
 				m_BlockEntities->insert({idx, itrSrc->second->Clone(x, y, z)});
 				continue;


### PR DESCRIPTION
If you create a nether world using seed "1760462746", then (while generating the nether fortress, I believe) there will be a mob spawner (block type 52) which has no corresponding block entity in a_Src, causing a segfault here.

(to reproduce: Create the above world with a debugger, keep recreating the world until it crashes, 3-5 times should do it, I find it only segfaults sometimes)

This may hint at a bigger issue (mob spawners not having block entities in the source material), but right here the check should not copy the block entity if it does not exist.
