### PR TITLE
Consolidated food effects into EatItem, added all fish type FoodInfos.

### DIFF
--- a/src/Items/ItemFood.h
+++ b/src/Items/ItemFood.h
@@ -39,8 +39,8 @@ public:
 			FoodInfo(5, 6.0),  // Cooked fish
 			FoodInfo(6, 9.6),  // Cooked salmon
 		};
-		static const size_t NumRawFishInfos = sizeof(RawFishInfos) / sizeof(FoodInfo);
-		static const size_t NumCookedFishInfos = sizeof(CookedFishInfos) / sizeof(FoodInfo);
+		static const short NumRawFishInfos = sizeof(RawFishInfos) / sizeof(FoodInfo);
+		static const short NumCookedFishInfos = sizeof(CookedFishInfos) / sizeof(FoodInfo);
 
 		switch (m_ItemType)
 		{

--- a/src/Items/ItemFood.h
+++ b/src/Items/ItemFood.h
@@ -25,8 +25,23 @@ public:
 	}
 
 
-	virtual FoodInfo GetFoodInfo(void) override
+	virtual FoodInfo GetFoodInfo(const cItem * a_Item) override
 	{
+		static const FoodInfo RawFishInfos[] =
+		{
+			FoodInfo(2, 0.4),  // Raw fish
+			FoodInfo(2, 0.2),  // Raw salmon
+			FoodInfo(1, 0.2),  // Clownfish
+			FoodInfo(1, 0.2),  // Pufferfish
+		};
+		static const FoodInfo CookedFishInfos[] =
+		{
+			FoodInfo(5, 6.0),  // Cooked fish
+			FoodInfo(6, 9.6),  // Cooked salmon
+		};
+		static const size_t NumRawFishInfos = sizeof(RawFishInfos) / sizeof(FoodInfo);
+		static const size_t NumCookedFishInfos = sizeof(CookedFishInfos) / sizeof(FoodInfo);
+
 		switch (m_ItemType)
 		{
 			// Please keep alpha-sorted.
@@ -37,7 +52,15 @@ public:
 			// Carrots handled in ItemSeeds
 			case E_ITEM_CHORUS_FRUIT:     return FoodInfo(4, 2.4);
 			case E_ITEM_COOKED_CHICKEN:   return FoodInfo(6, 7.2);
-			case E_ITEM_COOKED_FISH:      return FoodInfo(5, 6);  // TODO: Add other fish types
+			case E_ITEM_COOKED_FISH:
+			{
+				if (a_Item->m_ItemDamage >= NumCookedFishInfos)
+				{
+					LOGWARNING("Unknown cooked fish type '%d'", a_Item->m_ItemDamage);
+					return FoodInfo(0, 0);
+				}
+				return CookedFishInfos[a_Item->m_ItemDamage];
+			}
 			case E_ITEM_COOKED_MUTTON:    return FoodInfo(6, 9.6);
 			case E_ITEM_COOKED_PORKCHOP:  return FoodInfo(8, 12.8);
 			case E_ITEM_COOKED_RABBIT:    return FoodInfo(5, 6);
@@ -53,7 +76,15 @@ public:
 			case E_ITEM_RED_APPLE:        return FoodInfo(4, 2.4);
 			case E_ITEM_RAW_BEEF:         return FoodInfo(3, 1.8);
 			case E_ITEM_RAW_CHICKEN:      return FoodInfo(2, 1.2);
-			case E_ITEM_RAW_FISH:         return FoodInfo(2, 1.2);
+			case E_ITEM_RAW_FISH:
+			{
+				if (a_Item->m_ItemDamage >= NumRawFishInfos)
+				{
+					LOGWARNING("Unknown raw fish type '%d'", a_Item->m_ItemDamage);
+					return FoodInfo(0, 0);
+				}
+				return RawFishInfos[a_Item->m_ItemDamage];
+			}
 			case E_ITEM_RAW_MUTTON:       return FoodInfo(2, 1.2);
 			case E_ITEM_RAW_PORKCHOP:     return FoodInfo(3, 1.8);
 			case E_ITEM_RAW_RABBIT:       return FoodInfo(3, 1.8);
@@ -63,46 +94,6 @@ public:
 		}
 		LOGWARNING("%s: Unknown food item (%d), returning zero nutrition", __FUNCTION__, m_ItemType);
 		return FoodInfo(0, 0.f);
-	}
-
-	virtual bool GetEatEffect(cEntityEffect::eType & a_EffectType, int & a_EffectDurationTicks, short & a_EffectIntensity, float & a_Chance) override
-	{
-		switch (m_ItemType)
-		{
-			case E_ITEM_RAW_CHICKEN:
-			{
-				a_EffectType = cEntityEffect::effHunger;
-				a_EffectDurationTicks = 600;
-				a_EffectIntensity = 0;
-				a_Chance = 0.3f;
-				return true;
-			}
-			case E_ITEM_ROTTEN_FLESH:
-			{
-				a_EffectType = cEntityEffect::effHunger;
-				a_EffectDurationTicks = 600;
-				a_EffectIntensity = 0;
-				a_Chance = 0.8f;
-				return true;
-			}
-			case E_ITEM_SPIDER_EYE:
-			{
-				a_EffectType = cEntityEffect::effPoison;
-				a_EffectDurationTicks = 100;
-				a_EffectIntensity = 0;
-				a_Chance = 1.0f;
-				return true;
-			}
-			case E_ITEM_POISONOUS_POTATO:
-			{
-				a_EffectType = cEntityEffect::effPoison;
-				a_EffectDurationTicks = 100;
-				a_EffectIntensity = 0;
-				a_Chance = 0.6f;
-				return true;
-			}
-		}
-		return false;
 	}
 
 	virtual bool EatItem(cPlayer * a_Player, cItem * a_Item) override
@@ -122,6 +113,45 @@ public:
 				if (!a_Player->IsGameModeCreative())
 				{
 					a_Player->GetInventory().AddItem(cItem(E_ITEM_BOWL));
+				}
+				break;
+			}
+			case E_ITEM_RAW_FISH:
+			{
+				if (a_Item->m_ItemDamage == E_META_RAW_FISH_PUFFERFISH)
+				{
+					a_Player->AddEntityEffect(cEntityEffect::effHunger, 20 * 15, 2);
+					a_Player->AddEntityEffect(cEntityEffect::effNausea, 20 * 15, 1);
+					a_Player->AddEntityEffect(cEntityEffect::effPoison, 20 * 60, 3);
+				}
+				break;
+			}
+			case E_ITEM_RAW_CHICKEN:
+			{
+				if (GetRandomProvider().RandBool(0.3))
+				{
+					a_Player->AddEntityEffect(cEntityEffect::effHunger, 600, 0);
+				}
+				break;
+			}
+			case E_ITEM_ROTTEN_FLESH:
+			{
+				if (GetRandomProvider().RandBool(0.8))
+				{
+					a_Player->AddEntityEffect(cEntityEffect::effHunger, 600, 0);
+				}
+				break;
+			}
+			case E_ITEM_SPIDER_EYE:
+			{
+				a_Player->AddEntityEffect(cEntityEffect::effPoison, 100, 0);
+				break;
+			}
+			case E_ITEM_POISONOUS_POTATO:
+			{
+				if (GetRandomProvider().RandBool(0.6))
+				{
+					a_Player->AddEntityEffect(cEntityEffect::effPoison, 100, 0);
 				}
 				break;
 			}

--- a/src/Items/ItemGoldenApple.h
+++ b/src/Items/ItemGoldenApple.h
@@ -20,9 +20,10 @@ public:
 
 	virtual bool EatItem(cPlayer * a_Player, cItem * a_Item) override
 	{
-		// Feed the player:
-		FoodInfo Info = GetFoodInfo();
-		a_Player->Feed(Info.FoodLevel, Info.Saturation);
+		if (!super::EatItem(a_Player, a_Item))
+		{
+			return false;
+		}
 
 		// Add the effects:
 		a_Player->AddEntityEffect(cEntityEffect::effAbsorption, 2400, 0);
@@ -36,20 +37,14 @@ public:
 			a_Player->AddEntityEffect(cEntityEffect::effFireResistance, 6000, 0);
 		}
 
-		a_Player->GetInventory().RemoveOneEquippedItem();
 		return true;
 	}
 
 
-	virtual FoodInfo GetFoodInfo(void) override
+	virtual FoodInfo GetFoodInfo(const cItem * a_Item) override
 	{
+		UNUSED(a_Item);
 		return FoodInfo(4, 9.6);
-	}
-
-
-	virtual bool GetEatEffect(cEntityEffect::eType & a_EffectType, int & a_EffectDurationTicks, short & a_EffectIntensity, float & a_Chance) override
-	{
-		return false;
 	}
 
 };

--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -826,15 +826,6 @@ bool cItemHandler::GetPlacementBlockTypeMeta(
 
 
 
-bool cItemHandler::GetEatEffect(cEntityEffect::eType & a_EffectType, int & a_EffectDurationTicks, short & a_EffectIntensity, float & a_Chance)
-{
-	return false;
-}
-
-
-
-
-
 bool cItemHandler::EatItem(cPlayer * a_Player, cItem * a_Item)
 {
 	UNUSED(a_Item);
@@ -843,24 +834,10 @@ bool cItemHandler::EatItem(cPlayer * a_Player, cItem * a_Item)
 		a_Player->GetInventory().RemoveOneEquippedItem();
 	}
 
-	FoodInfo Info = GetFoodInfo();
+	FoodInfo Info = GetFoodInfo(a_Item);
 	if ((Info.FoodLevel > 0) || (Info.Saturation > 0.f))
 	{
-		bool Success = a_Player->Feed(Info.FoodLevel, Info.Saturation);
-
-		// Give effects
-		cEntityEffect::eType EffectType;
-		int EffectDurationTicks;
-		short EffectIntensity;
-		float Chance;
-		if (Success && GetEatEffect(EffectType, EffectDurationTicks, EffectIntensity, Chance))
-		{
-			if (GetRandomProvider().RandBool(Chance))
-			{
-				a_Player->AddEntityEffect(EffectType, EffectDurationTicks, EffectIntensity, Chance);
-			}
-		}
-		return Success;
+		return a_Player->Feed(Info.FoodLevel, Info.Saturation);
 	}
 	return false;
 }
@@ -869,8 +846,9 @@ bool cItemHandler::EatItem(cPlayer * a_Player, cItem * a_Item)
 
 
 
-cItemHandler::FoodInfo cItemHandler::GetFoodInfo()
+cItemHandler::FoodInfo cItemHandler::GetFoodInfo(const cItem * a_Item)
 {
+	UNUSED(a_Item);
 	return FoodInfo(0, 0);
 }
 

--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -828,7 +828,6 @@ bool cItemHandler::GetPlacementBlockTypeMeta(
 
 bool cItemHandler::EatItem(cPlayer * a_Player, cItem * a_Item)
 {
-	UNUSED(a_Item);
 	if (!a_Player->IsGameModeCreative())
 	{
 		a_Player->GetInventory().RemoveOneEquippedItem();

--- a/src/Items/ItemHandler.h
+++ b/src/Items/ItemHandler.h
@@ -127,10 +127,7 @@ public:
 	} ;
 
 	/** Returns the FoodInfo for this item. (FoodRecovery and Saturation) */
-	virtual FoodInfo GetFoodInfo();
-
-	/** If this function returns true, it sets the arguments to a effect who will be activated when you eat the item. */
-	virtual bool GetEatEffect(cEntityEffect::eType & a_EffectType, int & a_EffectDurationTicks, short & a_EffectIntensity, float & a_Chance);
+	virtual FoodInfo GetFoodInfo(const cItem * a_Item);
 
 	/** Lets the player eat a selected item. Returns true if the player ate the item */
 	virtual bool EatItem(cPlayer * a_Player, cItem * a_Item);

--- a/src/Items/ItemSeeds.h
+++ b/src/Items/ItemSeeds.h
@@ -33,8 +33,9 @@ public:
 		}
 	}
 
-	virtual FoodInfo GetFoodInfo(void) override
+	virtual FoodInfo GetFoodInfo(const cItem * a_Item) override
 	{
+		UNUSED(a_Item);
 		switch (m_ItemType)
 		{
 			case E_ITEM_CARROT: return FoodInfo(3, 3.6);

--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -169,10 +169,13 @@ void cWolf::ReceiveNearbyFightInfo(AString a_PlayerID, cPawn * a_Opponent, bool 
 
 void cWolf::OnRightClicked(cPlayer & a_Player)
 {
+	const cItem & EquippedItem = a_Player.GetEquippedItem();
+	const int EquippedItemType = EquippedItem.m_ItemType;
+
 	if (!IsTame() && !IsAngry())
 	{
 		// If the player is holding a bone, try to tame the wolf:
-		if (a_Player.GetEquippedItem().m_ItemType == E_ITEM_BONE)
+		if (EquippedItemType == E_ITEM_BONE)
 		{
 			if (!a_Player.IsGameModeCreative())
 			{
@@ -199,7 +202,7 @@ void cWolf::OnRightClicked(cPlayer & a_Player)
 	else if (IsTame())
 	{
 		// Feed the wolf, restoring its health, or dye its collar:
-		switch (a_Player.GetEquippedItem().m_ItemType)
+		switch (EquippedItemType)
 		{
 			case E_ITEM_RAW_BEEF:
 			case E_ITEM_STEAK:
@@ -211,7 +214,7 @@ void cWolf::OnRightClicked(cPlayer & a_Player)
 			{
 				if (m_Health < m_MaxHealth)
 				{
-					Heal(ItemHandler(a_Player.GetEquippedItem().m_ItemType)->GetFoodInfo().FoodLevel);
+					Heal(ItemHandler(EquippedItemType)->GetFoodInfo(&EquippedItem).FoodLevel);
 					if (!a_Player.IsGameModeCreative())
 					{
 						a_Player.GetInventory().RemoveOneEquippedItem();
@@ -223,7 +226,7 @@ void cWolf::OnRightClicked(cPlayer & a_Player)
 			{
 				if (a_Player.GetUUID() == m_OwnerUUID)  // Is the player the owner of the dog?
 				{
-					SetCollarColor(a_Player.GetEquippedItem().m_ItemDamage);
+					SetCollarColor(EquippedItem.m_ItemDamage);
 					if (!a_Player.IsGameModeCreative())
 					{
 						a_Player.GetInventory().RemoveOneEquippedItem();


### PR DESCRIPTION
* Added FoodInfo structures for all fishes.
* Now pass the cItem itself into GetFoodInfo, since we need that to distinguish fishes.
* Eliminated the GetEatEffect mechanism, because it limited food to having a single effect (the new paradigm is what golden apples have been doing from the start: Calling AddEntityEffect directly from EatItem).

Fixes #3872 (and parts of #250).

EDIT: Also fixes #3627, so this PR stomps on PR #3656.
