### PR TITLE
Shortened DoIntervalsIntersect to two comparisons, made inline.

### DIFF
--- a/src/Cuboid.cpp
+++ b/src/Cuboid.cpp
@@ -81,23 +81,6 @@ int cCuboid::GetVolume(void) const
 
 
 
-bool cCuboid::DoesIntersect(const cCuboid & a_Other) const
-{
-	ASSERT(IsSorted());
-	ASSERT(a_Other.IsSorted());
-
-	// In order for cuboids to intersect, each of their coord intervals need to intersect
-	return (
-		DoIntervalsIntersect(p1.x, p2.x, a_Other.p1.x, a_Other.p2.x) &&
-		DoIntervalsIntersect(p1.y, p2.y, a_Other.p1.y, a_Other.p2.y) &&
-		DoIntervalsIntersect(p1.z, p2.z, a_Other.p1.z, a_Other.p2.z)
-	);
-}
-
-
-
-
-
 bool cCuboid::IsCompletelyInside(const cCuboid & a_Outer) const
 {
 	ASSERT(IsSorted());

--- a/src/Cuboid.cpp
+++ b/src/Cuboid.cpp
@@ -13,7 +13,7 @@ static inline bool DoIntervalsIntersect(int a_Min1, int a_Max1, int a_Min2, int 
 	ASSERT(a_Min1 <= a_Max1);
 	ASSERT(a_Min2 <= a_Max2);
 	return (
-		(a_Min1 <= a_Max1) &&
+		(a_Min1 <= a_Max2) &&
 		(a_Max1 >= a_Min2)
 	);
 }

--- a/src/Cuboid.cpp
+++ b/src/Cuboid.cpp
@@ -8,12 +8,13 @@
 
 
 /** Returns true if the two specified intervals have a non-empty union */
-static bool DoIntervalsIntersect(int a_Min1, int a_Max1, int a_Min2, int a_Max2)
+static inline bool DoIntervalsIntersect(int a_Min1, int a_Max1, int a_Min2, int a_Max2)
 {
-	return (
-		((a_Min1 >= a_Min2) && (a_Min1 <= a_Max2)) ||  // Start of first  interval is within the second interval
-		((a_Max1 >= a_Min2) && (a_Max1 <= a_Max2)) ||  // End   of first  interval is within the second interval
-		((a_Min2 >= a_Min1) && (a_Min2 <= a_Max1))     // Start of second interval is within the first interval
+	ASSERT(a_Min1 <= a_Max1);
+	ASSERT(a_Min2 <= a_Max2);
+	return !(
+		(a_Min1 > a_Max1) ||
+		(a_Max1 < a_Min2)
 	);
 }
 

--- a/src/Cuboid.cpp
+++ b/src/Cuboid.cpp
@@ -7,21 +7,6 @@
 
 
 
-/** Returns true if the two specified intervals have a non-empty union */
-static inline bool DoIntervalsIntersect(int a_Min1, int a_Max1, int a_Min2, int a_Max2)
-{
-	ASSERT(a_Min1 <= a_Max1);
-	ASSERT(a_Min2 <= a_Max2);
-	return (
-		(a_Min1 <= a_Max2) &&
-		(a_Max1 >= a_Min2)
-	);
-}
-
-
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // cCuboid:
 

--- a/src/Cuboid.cpp
+++ b/src/Cuboid.cpp
@@ -12,9 +12,9 @@ static inline bool DoIntervalsIntersect(int a_Min1, int a_Max1, int a_Min2, int 
 {
 	ASSERT(a_Min1 <= a_Max1);
 	ASSERT(a_Min2 <= a_Max2);
-	return !(
-		(a_Min1 > a_Max1) ||
-		(a_Max1 < a_Min2)
+	return (
+		(a_Min1 <= a_Max1) &&
+		(a_Max1 >= a_Min2)
 	);
 }
 

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -97,6 +97,17 @@ public:
 
 	/** If needed, expands the cuboid so that it contains the specified point. Assumes sorted. Doesn't contract. */
 	void Engulf(const Vector3i & a_Point);
+
+private:
+
+	/** Returns true if the two specified intervals have a non-empty union */
+	inline static bool DoIntervalsIntersect(int a_Min1, int a_Max1, int a_Min2, int a_Max2)
+	{
+		ASSERT(a_Min1 <= a_Max1);
+		ASSERT(a_Min2 <= a_Max2);
+		return ((a_Min1 <= a_Max2) && (a_Max1 >= a_Min2));
+	}
+
 } ;
 // tolua_end
 

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -52,7 +52,7 @@ public:
 			DoIntervalsIntersect(p1.x, p2.x, a_Other.p1.x, a_Other.p2.x) &&
 			DoIntervalsIntersect(p1.y, p2.y, a_Other.p1.y, a_Other.p2.y) &&
 			DoIntervalsIntersect(p1.z, p2.z, a_Other.p1.z, a_Other.p2.z)
-			);
+		);
 	}
 
 	bool IsInside(const Vector3i & v) const

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -42,7 +42,18 @@ public:
 
 	/** Returns true if the cuboids have at least one voxel in common. Both coords are considered inclusive.
 	Assumes both cuboids are sorted. */
-	bool DoesIntersect(const cCuboid & a_Other) const;
+	inline bool DoesIntersect(const cCuboid & a_Other) const
+	{
+		ASSERT(IsSorted());
+		ASSERT(a_Other.IsSorted());
+
+		// In order for cuboids to intersect, each of their coord intervals need to intersect
+		return (
+			DoIntervalsIntersect(p1.x, p2.x, a_Other.p1.x, a_Other.p2.x) &&
+			DoIntervalsIntersect(p1.y, p2.y, a_Other.p1.y, a_Other.p2.y) &&
+			DoIntervalsIntersect(p1.z, p2.z, a_Other.p1.z, a_Other.p2.z)
+			);
+	}
 
 	bool IsInside(const Vector3i & v) const
 	{


### PR DESCRIPTION
r.e. the conversation in #3853, this shortens what's apparently a commonly called function.

The arguments are in fact sorted (min < max), because there are asserts in cCuboid::DoesIntersect.
