### PR TITLE
Handle Teleport Confirmation Packet

### DIFF
--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -1044,7 +1044,6 @@ void cProtocol_1_9_0::SendPlayerMoveLook(void)
 	Pkt.WriteBEFloat(static_cast<float>(Player->GetPitch()));
 	Pkt.WriteBEUInt8(0);
 	Pkt.WriteVarInt32(++m_OutstandingTeleportId);
-	LOG("Sent PlayerMoveLook Y=%f TPID=%d", Player->GetPosY(), m_OutstandingTeleportId);
 
 	// This teleport ID hasn't been confirmed yet
 	m_IsTeleportIdConfirmed = false;
@@ -2417,8 +2416,6 @@ void cProtocol_1_9_0::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 void cProtocol_1_9_0::HandleConfirmTeleport(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, TeleportID);
-	// We don't actually validate that this packet is sent or anything yet, but it still needs to be read.
-	LOG("Got teleport confirm TPID=%d", TeleportID);
 
 	// Can we stop throwing away packets?
 	if (TeleportID == m_OutstandingTeleportId)
@@ -2524,7 +2521,6 @@ void cProtocol_1_9_0::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
 
 void cProtocol_1_9_0::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 {
-	LOG("Got player pos packet");
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosX);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosZ);
@@ -2542,7 +2538,6 @@ void cProtocol_1_9_0::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 
 void cProtocol_1_9_0::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
 {
-	LOG("Got player pos look packet");
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosX);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosZ);

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -119,7 +119,9 @@ cProtocol_1_9_0::cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_Ser
 	m_ServerPort(a_ServerPort),
 	m_State(a_State),
 	m_ReceivedData(32 KiB),
-	m_IsEncrypted(false)
+	m_IsEncrypted(false),
+	m_IsTeleportIdConfirmed(true),
+	m_OutstandingTeleportId(0)
 {
 
 	// BungeeCord handling:
@@ -2417,7 +2419,7 @@ void cProtocol_1_9_0::HandleConfirmTeleport(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, TeleportID);
 
-	// Can we stop throwing away packets?
+	// Can we stop throwing away incoming player position packets?
 	if (TeleportID == m_OutstandingTeleportId)
 	{
 		m_IsTeleportIdConfirmed = true;

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -118,10 +118,10 @@ cProtocol_1_9_0::cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_Ser
 	m_ServerAddress(a_ServerAddress),
 	m_ServerPort(a_ServerPort),
 	m_State(a_State),
-	m_ReceivedData(32 KiB),
-	m_IsEncrypted(false),
 	m_IsTeleportIdConfirmed(true),
-	m_OutstandingTeleportId(0)
+	m_OutstandingTeleportId(0),
+	m_ReceivedData(32 KiB),
+	m_IsEncrypted(false)
 {
 
 	// BungeeCord handling:

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -175,7 +175,7 @@ protected:
 
 	/** The current teleport ID, and whether it has been confirmed by the client */
 	bool m_IsTeleportIdConfirmed;
-	Int32 m_OutstandingTeleportId;
+	UInt32 m_OutstandingTeleportId;
 
 	/** Buffer for the received data */
 	cByteBuffer m_ReceivedData;

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -174,8 +174,8 @@ protected:
 	UInt32 m_State;
 
 	/** The current teleport ID, and whether it has been confirmed by the client */
-	Int32 m_OutstandingTeleportId;
 	bool m_IsTeleportIdConfirmed;
+	Int32 m_OutstandingTeleportId;
 
 	/** Buffer for the received data */
 	cByteBuffer m_ReceivedData;

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -173,6 +173,10 @@ protected:
 	/** State of the protocol. 1 = status, 2 = login, 3 = game */
 	UInt32 m_State;
 
+	/** The current teleport ID, and whether it has been confirmed by the client */
+	Int32 m_OutstandingTeleportId;
+	bool m_IsTeleportIdConfirmed;
+
 	/** Buffer for the received data */
 	cByteBuffer m_ReceivedData;
 


### PR DESCRIPTION
Implements the teleport ID confirmation in protocol 1.9 (tested with a 1.12 client).

Fixes #3054, a bug where cPlayer::TeleportToCoords sometimes causes fall damage.

### Bug Cause
What happens is, a plugin calls TeleportToCoords to teleport from the "old" position to the "new" position. cPlayer sets the position and the LastGroundHeight, freezes the player, and sends a MoveLook packet to the client.

cPlayer promptly unfreezes the client (on the next tick?), if the chunk it's teleporting to is already loaded. Meanwhile, the client is still sending player position packets from the old position, it has not yet updated to the updated position. Once the cPlayer is unfrozen, it resets its position to the old position, including LastGroundHeight.

Then the client gets around to updating its position to the new position and sending it, sending a teleport confirmation packet along with the new player positions.

Right now, the server just sees that the client has moved back to the new position (having already seen it jump back to the old position after the teleport), and so applies fall damage.

### Testing
I don't have a handy test case, but it should occur in any plugin that teleports you downward far enough to get fall damage. It's a race condition, so it may take some fiddling. I tested using a 1.12 client with the plugin I was working on.

### PR Description
This PR discards all incoming Move and MoveLook packets between when the outgoing teleport packet is sent and when the teleport confirmation is received (it keeps an incrementing counter for the outbound packets, and drops packets until it sees a teleport confirmation matching the most recently sent outbound teleport). Implemented just in protocol 1.9 (and so by inheritance 1.10, 1.11, and 1.12).

If the server is continuously sending teleports out, it's possible that the teleport confirmations will never catch up. If the client moves, these changes won't be reflected on the server, but that's okay, because the server's teleports are overriding the motions anyway.

I don't know whether I should have implemented it just for 1.12, or whether I should backport it to 1.8 as well (which is 3 years old in a month, how the time flies by).
