### PR TITLE
Remove double includes part 2

### DIFF
--- a/Tools/GrownBiomeGenVisualiser/Globals.h
+++ b/Tools/GrownBiomeGenVisualiser/Globals.h
@@ -210,7 +210,10 @@ typedef unsigned char Byte;
 #include <map>
 #include <algorithm>
 #include <memory>
-
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
 
 
 

--- a/Tools/GrownBiomeGenVisualiser/Globals.h
+++ b/Tools/GrownBiomeGenVisualiser/Globals.h
@@ -258,5 +258,6 @@ public:
 } ;
 
 
+#include "BiomeDef.h"
 
 

--- a/Tools/MCADefrag/Globals.h
+++ b/Tools/MCADefrag/Globals.h
@@ -239,5 +239,8 @@ public:
 } ;
 
 
+#include "BiomeDef.h"
+
+
 
 

--- a/Tools/MCADefrag/Globals.h
+++ b/Tools/MCADefrag/Globals.h
@@ -187,7 +187,10 @@ typedef unsigned char Byte;
 #include <map>
 #include <algorithm>
 #include <memory>
-
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
 
 
 

--- a/Tools/NoiseSpeedTest/Globals.h
+++ b/Tools/NoiseSpeedTest/Globals.h
@@ -187,6 +187,10 @@ typedef unsigned char Byte;
 #include <map>
 #include <algorithm>
 #include <memory>
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
 
 
 

--- a/Tools/ProtoProxy/Globals.h
+++ b/Tools/ProtoProxy/Globals.h
@@ -168,6 +168,7 @@ typedef unsigned char Byte;
 
 
 // STL stuff:
+#include <chrono>
 #include <vector>
 #include <list>
 #include <deque>
@@ -175,6 +176,10 @@ typedef unsigned char Byte;
 #include <map>
 #include <algorithm>
 #include <memory>
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
 
 
 

--- a/src/AllocationPool.h
+++ b/src/AllocationPool.h
@@ -1,8 +1,6 @@
 
 #pragma once
 
-#include <memory>
-
 
 
 

--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -6,7 +6,6 @@
 #include "tolua++/include/tolua++.h"
 
 
-#include "../BlockInfo.h"
 #include "../World.h"
 #include "../Entities/Player.h"
 #include "LuaState.h"

--- a/src/Bindings/LuaFunctions.h
+++ b/src/Bindings/LuaFunctions.h
@@ -2,7 +2,6 @@
 
 #include "Logger.h"
 #include <time.h>
-#include <chrono>
 // tolua_begin
 
 inline unsigned int GetTime()

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -35,8 +35,6 @@ extern "C"
 	#include "lua/src/lauxlib.h"
 }
 
-#include <atomic>
-#include "../Vector3.h"
 #include "../Defines.h"
 #include "PluginManager.h"
 #include "LuaState_Typedefs.inc"

--- a/src/Bindings/LuaWindow.h
+++ b/src/Bindings/LuaWindow.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <atomic>
 #include "LuaState.h"
 #include "../UI/Window.h"
 #include "../ItemGrid.h"

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -5,7 +5,6 @@
 #undef TOLUA_TEMPLATE_BIND
 #include <sstream>
 #include <iomanip>
-#include <array>
 #include "tolua++/include/tolua++.h"
 #include "polarssl/md5.h"
 #include "polarssl/sha1.h"

--- a/src/BiomeDef.cpp
+++ b/src/BiomeDef.cpp
@@ -4,7 +4,6 @@
 // Implements biome helper functions
 
 #include "Globals.h"
-#include "BiomeDef.h"
 
 
 

--- a/src/BiomeDef.h
+++ b/src/BiomeDef.h
@@ -10,7 +10,7 @@
 #pragma once
 
 
-#include "StringUtils.h"
+
 
 
 // tolua_begin

--- a/src/BlockArea.h
+++ b/src/BlockArea.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "ForEachChunkProvider.h"
-#include "Vector3.h"
 #include "ChunkDataCallback.h"
 #include "Cuboid.h"
 

--- a/src/BlockID.cpp
+++ b/src/BlockID.cpp
@@ -3,7 +3,6 @@
 // Implements the helper functions for converting Block ID string to int etc.
 
 #include "Globals.h"
-#include "BlockID.h"
 #include "IniFile.h"
 #include "Item.h"
 #include "Mobs/Monster.h"

--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -1,7 +1,6 @@
 
 #include "Globals.h"
 
-#include "BlockInfo.h"
 #include "Blocks/BlockHandler.h"
 
 

--- a/src/Blocks/BlockDirt.h
+++ b/src/Blocks/BlockDirt.h
@@ -3,7 +3,6 @@
 
 #include "BlockHandler.h"
 #include "../FastRandom.h"
-#include "../BlockInfo.h"
 #include "Root.h"
 #include "Bindings/PluginManager.h"
 

--- a/src/Blocks/BlockFence.h
+++ b/src/Blocks/BlockFence.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "BlockHandler.h"
-#include "BlockID.h"
 #include "../BoundingBox.h"
 
 

--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -7,9 +7,6 @@
 #include "BlockInServerPluginInterface.h"
 #include "ChunkInterface.h"
 
-#include <vector>
-#include <array>
-
 
 
 

--- a/src/Blocks/BlockStone.h
+++ b/src/Blocks/BlockStone.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "BlockHandler.h"
-#include "BlockID.h"
 
 
 

--- a/src/BoundingBox.h
+++ b/src/BoundingBox.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "Vector3.h"
 #include "Defines.h"
 
 

--- a/src/Broadcaster.h
+++ b/src/Broadcaster.h
@@ -1,8 +1,6 @@
 
 class cWorld;
 
-#include <array>
-
 class cBroadcaster
 {
 

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "Entities/Entity.h"
-#include "ChunkDef.h"
 #include "ChunkData.h"
 
 #include "Simulator/FireSimulator.h"

--- a/src/ChunkData.h
+++ b/src/ChunkData.h
@@ -12,9 +12,6 @@
 
 #include <cstring>
 
-
-#include "ChunkDef.h"
-
 #include "AllocationPool.h"
 
 

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -9,9 +9,6 @@
 
 #pragma once
 
-#include "Vector3.h"
-#include "BiomeDef.h"
-
 
 
 

--- a/src/ChunkSender.h
+++ b/src/ChunkSender.h
@@ -26,7 +26,6 @@ Note that it may be called by world's BroadcastToChunk() if the client is still 
 #pragma once
 
 #include "OSSupport/IsThread.h"
-#include "ChunkDef.h"
 #include "ChunkDataCallback.h"
 
 #include <unordered_set>

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -11,8 +11,6 @@
 
 #include "OSSupport/Network.h"
 #include "Defines.h"
-#include "Vector3.h"
-#include "ChunkDef.h"
 #include "ByteBuffer.h"
 #include "Scoreboard.h"
 #include "Map.h"
@@ -23,8 +21,7 @@
 #include "EffectID.h"
 
 
-#include <array>
-#include <atomic>
+
 
 
 // fwd:

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -1,8 +1,6 @@
 
 #pragma once
 
-#include "Vector3.h"
-
 
 
 

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -1,9 +1,6 @@
 
 #pragma once
 
-#include <limits>
-#include <cmath>
-
 
 
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "../Item.h"
-#include "../Vector3.h"
 
 
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1,7 +1,6 @@
 
 #include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
 
-#include <cmath>
 #include <unordered_map>
 
 #include "Player.h"
@@ -17,7 +16,6 @@
 #include "../Root.h"
 #include "../Chunk.h"
 #include "../Items/ItemHandler.h"
-#include "../Vector3.h"
 #include "../FastRandom.h"
 #include "../ClientHandle.h"
 

--- a/src/FastRandom.cpp
+++ b/src/FastRandom.cpp
@@ -5,9 +5,6 @@
 #include "Globals.h"
 #include "FastRandom.h"
 
-#include <mutex>
-#include <random>
-
 #if defined (__GNUC__)
 	#define ATTRIBUTE_TLS static __thread
 #elif defined (_MSC_VER)

--- a/src/Generating/BioGen.cpp
+++ b/src/Generating/BioGen.cpp
@@ -5,7 +5,6 @@
 
 #include "Globals.h"
 #include "BioGen.h"
-#include <chrono>
 #include <iostream>
 #include "IntGen.h"
 #include "ProtIntGen.h"

--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "../BlockArea.h"
-#include "../ChunkDef.h"
 #include "../Cuboid.h"
 
 

--- a/src/Generating/ChunkGenerator.h
+++ b/src/Generating/ChunkGenerator.h
@@ -19,7 +19,6 @@ If the generator queue is overloaded, the generator skips chunks with no clients
 #pragma once
 
 #include "../OSSupport/IsThread.h"
-#include "../ChunkDef.h"
 
 
 

--- a/src/Generating/CompoGen.cpp
+++ b/src/Generating/CompoGen.cpp
@@ -9,7 +9,6 @@
 
 #include "Globals.h"
 #include "CompoGen.h"
-#include "../BlockID.h"
 #include "../Item.h"
 #include "../LinearUpscale.h"
 #include "../IniFile.h"

--- a/src/Generating/DistortedHeightmap.cpp
+++ b/src/Generating/DistortedHeightmap.cpp
@@ -6,7 +6,6 @@
 #include "Globals.h"
 
 #include "DistortedHeightmap.h"
-#include "../OSSupport/File.h"
 #include "../IniFile.h"
 #include "../LinearUpscale.h"
 

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -10,7 +10,6 @@
 #include "Globals.h"
 
 #include "FinishGen.h"
-#include "../BlockID.h"
 #include "../Simulator/FluidSimulator.h"  // for cFluidSimulator::CanWashAway()
 #include "../Simulator/FireSimulator.h"
 #include "../World.h"

--- a/src/Generating/IntGen.h
+++ b/src/Generating/IntGen.h
@@ -30,7 +30,6 @@ by using templates.
 #pragma once
 
 #include <tuple>
-#include "../BiomeDef.h"
 #include "../Noise/Noise.h"
 
 

--- a/src/Generating/Noise3DGenerator.cpp
+++ b/src/Generating/Noise3DGenerator.cpp
@@ -5,7 +5,6 @@
 
 #include "Globals.h"
 #include "Noise3DGenerator.h"
-#include "../OSSupport/File.h"
 #include "../IniFile.h"
 #include "../LinearInterpolation.h"
 #include "../LinearUpscale.h"

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -3,7 +3,6 @@
 
 #include "Globals.h"
 #include "StructGen.h"
-#include "../BlockID.h"
 #include "Trees.h"
 #include "../BlockArea.h"
 #include "../LinearUpscale.h"

--- a/src/Generating/Trees.cpp
+++ b/src/Generating/Trees.cpp
@@ -5,7 +5,6 @@
 
 #include "Globals.h"
 #include "Trees.h"
-#include "../BlockID.h"
 #include "../World.h"
 
 

--- a/src/Generating/Trees.h
+++ b/src/Generating/Trees.h
@@ -17,7 +17,6 @@ logs can overwrite others(leaves), but others shouldn't overwrite logs. This is 
 
 #pragma once
 
-#include "../ChunkDef.h"
 #include "../Noise/Noise.h"
 
 class cWorld;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -211,7 +211,6 @@ template class SizeChecker<UInt8,  1>;
 	#include <dirent.h>
 	#include <errno.h>
 	#include <iostream>
-	#include <cstdio>
 	#include <cstring>
 	#include <pthread.h>
 	#include <semaphore.h>
@@ -256,6 +255,9 @@ template class SizeChecker<UInt8,  1>;
 #include <random>
 #include <type_traits>
 #include <atomic>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
 
 
 
@@ -479,8 +481,9 @@ using cTickTimeLong = std::chrono::duration<Int64,  cTickTime::period>;
 
 
 // Common headers (part 2, with macros):
-#include "ChunkDef.h"
+#include "Vector3.h"
 #include "BiomeDef.h"
+#include "ChunkDef.h"
 #include "BlockID.h"
 #include "BlockInfo.h"
 

--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -2,9 +2,7 @@
 
 #include "ItemHandler.h"
 #include "../Entities/Player.h"
-#include "Vector3.h"
 #include "../LineBlockTracer.h"
-#include "BlockInfo.h"
 
 
 

--- a/src/LightingThread.h
+++ b/src/LightingThread.h
@@ -32,7 +32,6 @@ Chunks from m_PostponedQueue are moved back into m_Queue when their neighbors ge
 #pragma once
 
 #include "OSSupport/IsThread.h"
-#include "ChunkDef.h"
 #include "ChunkStay.h"
 
 

--- a/src/LineBlockTracer.cpp
+++ b/src/LineBlockTracer.cpp
@@ -5,7 +5,6 @@
 
 #include "Globals.h"
 #include "LineBlockTracer.h"
-#include "Vector3.h"
 #include "World.h"
 #include "Chunk.h"
 #include "BoundingBox.h"

--- a/src/LoggerListeners.cpp
+++ b/src/LoggerListeners.cpp
@@ -3,13 +3,9 @@
 
 #include "LoggerListeners.h"
 
-#include <chrono>
-
 #if defined(_WIN32)
 	#include <io.h>  // Needed for _isatty(), not available on Linux
 	#include <time.h>
-#elif defined(__linux)
-	#include <unistd.h>  // Needed for isatty() on Linux
 #endif
 
 

--- a/src/LoggerListeners.h
+++ b/src/LoggerListeners.h
@@ -1,6 +1,5 @@
 
 #include "Logger.h"
-#include "OSSupport/File.h"
 
 std::unique_ptr<cLogger::cListener> MakeConsoleListener(bool a_IsService);
 std::pair<bool, std::unique_ptr<cLogger::cListener>> MakeFileListener();

--- a/src/Map.h
+++ b/src/Map.h
@@ -13,12 +13,6 @@
 
 
 
-#include "BlockID.h"
-
-
-
-
-
 class cClientHandle;
 class cWorld;
 class cPlayer;

--- a/src/MobFamilyCollecter.h
+++ b/src/MobFamilyCollecter.h
@@ -1,9 +1,6 @@
 
 #pragma once
 
-#include <map>
-#include <set>
-#include "BlockID.h"
 #include "Mobs/Monster.h"  // This is a side-effect of keeping Mobfamily inside Monster class. I'd prefer to keep both (Mobfamily and Monster) inside a "Monster" namespace MG TODO : do it
 
 

--- a/src/MobProximityCounter.h
+++ b/src/MobProximityCounter.h
@@ -1,8 +1,6 @@
 
 #pragma once
 
-#include <set>
-
 class cChunk;
 class cEntity;
 

--- a/src/MobSpawner.h
+++ b/src/MobSpawner.h
@@ -1,9 +1,6 @@
 
 #pragma once
 
-#include <set>
-#include "BlockID.h"
-#include "ChunkDef.h"
 #include "Chunk.h"
 #include "Mobs/Monster.h"  // This is a side-effect of keeping Mobfamily inside Monster class. I'd prefer to keep both (Mobfamily and Monster) inside a "Monster" namespace MG TODO : do it
 

--- a/src/Mobs/Bat.cpp
+++ b/src/Mobs/Bat.cpp
@@ -2,7 +2,6 @@
 #include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
 
 #include "Bat.h"
-#include "../Vector3.h"
 #include "../Chunk.h"
 
 

--- a/src/Mobs/Guardian.cpp
+++ b/src/Mobs/Guardian.cpp
@@ -2,7 +2,6 @@
 #include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
 
 #include "Guardian.h"
-#include "../Vector3.h"
 #include "../Chunk.h"
 
 

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -3,7 +3,6 @@
 
 #include "../Entities/Pawn.h"
 #include "../Defines.h"
-#include "../BlockID.h"
 #include "../Item.h"
 #include "../Enchantments.h"
 #include "MonsterTypes.h"

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -1,8 +1,6 @@
 
 #include "Globals.h"
 
-#include <cmath>
-
 #include "Path.h"
 #include "../Chunk.h"
 

--- a/src/Mobs/Sheep.cpp
+++ b/src/Mobs/Sheep.cpp
@@ -2,7 +2,6 @@
 #include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
 
 #include "Sheep.h"
-#include "../BlockID.h"
 #include "../Entities/Player.h"
 #include "../World.h"
 #include "../EffectID.h"

--- a/src/Mobs/Squid.cpp
+++ b/src/Mobs/Squid.cpp
@@ -2,7 +2,6 @@
 #include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
 
 #include "Squid.h"
-#include "../Vector3.h"
 #include "../Chunk.h"
 
 

--- a/src/NetherPortalScanner.h
+++ b/src/NetherPortalScanner.h
@@ -1,7 +1,6 @@
 
 #pragma once
 
-#include "Vector3.h"
 #include "ChunkStay.h"
 
 

--- a/src/Noise/Noise.h
+++ b/src/Noise/Noise.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <cmath>
-
 /** The datatype used by all the noise generators. */
 typedef float NOISE_DATATYPE;
 

--- a/src/OSSupport/CriticalSection.h
+++ b/src/OSSupport/CriticalSection.h
@@ -1,7 +1,5 @@
 
 #pragma once
-#include <mutex>
-#include <thread>
 
 
 

--- a/src/OSSupport/Event.h
+++ b/src/OSSupport/Event.h
@@ -10,9 +10,6 @@
 
 #pragma once
 
-#include <mutex>
-#include <condition_variable>
-
 
 
 

--- a/src/OSSupport/IsThread.h
+++ b/src/OSSupport/IsThread.h
@@ -16,8 +16,6 @@ In the descending class' constructor call the Start() method to start the thread
 
 
 #pragma once
-#include <thread>
-#include <atomic>
 
 
 

--- a/src/OSSupport/NetworkSingleton.h
+++ b/src/OSSupport/NetworkSingleton.h
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <event2/event.h>
 #include "Network.h"
 #include "NetworkLookup.h"

--- a/src/PolarSSL++/BlockingSslClientSocket.h
+++ b/src/PolarSSL++/BlockingSslClientSocket.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <atomic>
 #include "OSSupport/Network.h"
 #include "CallbackSslContext.h"
 

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -17,7 +17,6 @@
 #include "../ByteBuffer.h"
 #include "../EffectID.h"
 
-#include <array>
 
 
 

--- a/src/Root.h
+++ b/src/Root.h
@@ -6,8 +6,6 @@
 #include "HTTP/HTTPServer.h"
 #include "Defines.h"
 #include "RankManager.h"
-#include <thread>
-#include <atomic>
 
 
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -7,7 +7,6 @@
 #include "Mobs/Monster.h"
 #include "Root.h"
 #include "World.h"
-#include "ChunkDef.h"
 #include "Bindings/PluginManager.h"
 #include "ChatColor.h"
 #include "Entities/Player.h"
@@ -20,7 +19,6 @@
 #include "FastRandom.h"
 
 #include "IniFile.h"
-#include "Vector3.h"
 
 #include <fstream>
 #include <sstream>

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -3,7 +3,6 @@
 
 #include "FireSimulator.h"
 #include "../World.h"
-#include "../BlockID.h"
 #include "../Defines.h"
 #include "../Chunk.h"
 #include "Root.h"

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneHandler.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "World.h"
-#include "Vector3.h"
 
 
 

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneSimulatorChunkData.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneSimulatorChunkData.h
@@ -1,7 +1,6 @@
 
 #pragma once
 
-#include "Vector3.h"
 #include "RedstoneHandler.h"
 #include "../RedstoneSimulator.h"
 #include <unordered_map>

--- a/src/Simulator/RedstoneSimulator.h
+++ b/src/Simulator/RedstoneSimulator.h
@@ -1,7 +1,6 @@
 
 #pragma once
 
-#include "ChunkDef.h"
 #include "Simulator/Simulator.h"
 
 

--- a/src/Simulator/SandSimulator.cpp
+++ b/src/Simulator/SandSimulator.cpp
@@ -3,7 +3,6 @@
 
 #include "SandSimulator.h"
 #include "../World.h"
-#include "../BlockID.h"
 #include "../Defines.h"
 #include "../Entities/FallingBlock.h"
 #include "../Chunk.h"

--- a/src/Simulator/Simulator.cpp
+++ b/src/Simulator/Simulator.cpp
@@ -2,7 +2,6 @@
 #include "Globals.h"
 
 #include "../World.h"
-#include "../BlockID.h"
 #include "../Defines.h"
 #include "../Chunk.h"
 #include "../Cuboid.h"

--- a/src/SpawnPrepare.h
+++ b/src/SpawnPrepare.h
@@ -1,8 +1,6 @@
 
 #pragma once
 
-#include <atomic>
-
 class cWorld;
 
 

--- a/src/Stopwatch.h
+++ b/src/Stopwatch.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <chrono>
-
 
 
 

--- a/src/StringUtils.h
+++ b/src/StringUtils.h
@@ -8,9 +8,6 @@
 
 #pragma once
 
-#include <string>
-#include <limits>
-
 
 
 typedef std::string AString;

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -1,10 +1,6 @@
 
 #pragma once
 
-#include "Vector3.h"
-
-#include <array>
-
 
 
 

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -3,11 +3,6 @@
 
 
 
-#include <list>
-#include <vector>
-
-
-
 
 
 template <typename T>

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2,7 +2,6 @@
 #include "Globals.h"  // NOTE: MSVC stupidness requires this to be the same across all modules
 
 #include "World.h"
-#include "ChunkDef.h"
 #include "ClientHandle.h"
 #include "Server.h"
 #include "Root.h"

--- a/src/World.h
+++ b/src/World.h
@@ -1,12 +1,6 @@
 
 #pragma once
 
-#ifndef _WIN32
-	#include "BlockID.h"
-#else
-	enum ENUM_ITEM_ID : short;
-#endif
-
 #define MAX_PLAYERS 65535
 
 #include <functional>
@@ -15,7 +9,6 @@
 #include "ChunkMap.h"
 #include "WorldStorage/WorldStorage.h"
 #include "Generating/ChunkGenerator.h"
-#include "Vector3.h"
 #include "ChunkSender.h"
 #include "Defines.h"
 #include "LightingThread.h"

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -5,7 +5,6 @@
 #include "Globals.h"
 #include "NBTChunkSerializer.h"
 #include "EnchantmentSerializer.h"
-#include "../BlockID.h"
 #include "../ItemGrid.h"
 #include "../StringCompression.h"
 #include "FastNBT.h"

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -10,7 +10,6 @@
 #include "zlib/zlib.h"
 #include "json/json.h"
 #include "../World.h"
-#include "../BlockID.h"
 #include "../Item.h"
 #include "../ItemGrid.h"
 #include "../StringCompression.h"

--- a/src/WorldStorage/WorldStorage.h
+++ b/src/WorldStorage/WorldStorage.h
@@ -11,10 +11,7 @@
 
 
 #pragma once
-#ifndef WORLDSTORAGE_H_INCLUDED
-#define WORLDSTORAGE_H_INCLUDED
 
-#include "../ChunkDef.h"
 #include "../OSSupport/IsThread.h"
 #include "../OSSupport/Queue.h"
 
@@ -112,12 +109,6 @@ protected:
 	/** Saves one chunk from the queue (if any queued); returns true if there are more chunks in the save queue */
 	bool SaveOneChunk(void);
 } ;
-
-
-
-
-
-#endif  // WORLDSTORAGE_H_INCLUDED
 
 
 


### PR DESCRIPTION
Removed includes that were already included from Globals.h

Also moved some headers that were indirectly included from Globals.h into the file itself to make them clearer.