### PR TITLE
Fixed compilation for clang 4.0 & gcc 7.1

### DIFF
--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -35,6 +35,9 @@ extern "C"
 	#include "lua/src/lauxlib.h"
 }
 
+
+#include <functional>
+
 #include "../Defines.h"
 #include "PluginManager.h"
 #include "LuaState_Typedefs.inc"

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -6,6 +6,8 @@
 #pragma once
 
 
+#include <functional>
+
 #include "ChunkDataCallback.h"
 #include "EffectID.h"
 


### PR DESCRIPTION
Cuberite would not compile on Fedora 26, as both gcc & clang require an explicit include of functional to use std::function.