### PR TITLE
cBlockInfo: Remove/deprecate place sound

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -202,7 +202,7 @@ return
 							Type = "string",
 						},
 					},
-					Notes = "Returns the name of the sound that is played when placing the block of this type.",
+					Notes = "(<b>DEPRECATED</b>) Not used by cuberite internally and always returns an empty string.",
 				},
 				GetSpreadLightFalloff =
 				{
@@ -377,16 +377,6 @@ return
 				{
 					Type = "bool",
 					Notes = "Can a piston break this block?",
-				},
-				m_PlaceSound =
-				{
-					Type = "string",
-					Notes = "The name of the sound that is placed when a block is placed.",
-				},
-				m_RequiresSpecialTool =
-				{
-					Type = "bool",
-					Notes = "Does this block require a tool to drop?",
 				},
 				m_SpreadLightFalloff =
 				{

--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -291,6 +291,62 @@ tolua_lerror:
 
 
 
+static int tolua_cBlockInfo_GetPlaceSound(lua_State * tolua_S)
+{
+	cLuaState L(tolua_S);
+	if (
+		!L.CheckParamStaticSelf("cBlockInfo") ||
+		!L.CheckParamNumber(2)
+	)
+	{
+		return 0;
+	}
+
+	L.Push("");
+	LOGWARNING("cBlockInfo:GetPlaceSound() is deprecated");
+	L.LogStackTrace(0);
+	return 1;
+}
+
+
+
+
+
+static int tolua_get_cBlockInfo_m_PlaceSound(lua_State * tolua_S)
+{
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("const cBlockInfo"))
+	{
+		return 0;
+	}
+
+	L.Push("");
+	LOGWARNING("cBlockInfo.m_PlaceSound is deprecated");
+	L.LogStackTrace(0);
+	return 1;
+}
+
+
+
+
+
+static int tolua_set_cBlockInfo_m_PlaceSound(lua_State * tolua_S)
+{
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("cBlockInfo"))
+	{
+		return 0;
+	}
+
+	LOGWARNING("cBlockInfo.m_PlaceSound is deprecated");
+	L.LogStackTrace(0);
+	return 0;
+}
+
+
+
+
+
 /* method: Trace of class  cTracer */
 static int tolua_cTracer_Trace(lua_State * a_LuaState)
 {
@@ -438,6 +494,11 @@ void DeprecatedBindings::Bind(lua_State * tolua_S)
 	tolua_array(tolua_S, "g_BlockFullyOccupiesVoxel",  tolua_get_AllToLua_g_BlockFullyOccupiesVoxel,  nullptr);
 
 	tolua_function(tolua_S, "StringToMobType", tolua_AllToLua_StringToMobType00);
+
+	tolua_beginmodule(tolua_S, "cBlockInfo");
+		tolua_function(tolua_S, "GetPlaceSound", tolua_cBlockInfo_GetPlaceSound);
+		tolua_variable(tolua_S, "m_PlaceSound", tolua_get_cBlockInfo_m_PlaceSound, tolua_set_cBlockInfo_m_PlaceSound);
+	tolua_endmodule(tolua_S);
 
 	tolua_beginmodule(tolua_S, "cTracer");
 		tolua_function(tolua_S, "Trace", tolua_cTracer_Trace);

--- a/src/BlockInfo.h
+++ b/src/BlockInfo.h
@@ -55,9 +55,6 @@ public:
 	/** Block height */
 	float m_BlockHeight;
 
-	/** Sound when placing this block */
-	AString m_PlaceSound;
-
 	/** Block's hardness. The greater the value the longer the player needs to break the block. */
 	float m_Hardness;
 
@@ -85,7 +82,6 @@ public:
 	inline static bool FullyOccupiesVoxel         (BLOCKTYPE a_Type) { return Get(a_Type).m_FullyOccupiesVoxel;  }
 	inline static bool CanBeTerraformed           (BLOCKTYPE a_Type) { return Get(a_Type).m_CanBeTerraformed;    }
 	inline static float GetBlockHeight            (BLOCKTYPE a_Type) { return Get(a_Type).m_BlockHeight;         }
-	inline static AString GetPlaceSound           (BLOCKTYPE a_Type) { return Get(a_Type).m_PlaceSound;          }
 	inline static float GetHardness               (BLOCKTYPE a_Type) { return Get(a_Type).m_Hardness;            }
 
 	// tolua_end
@@ -105,7 +101,6 @@ public:
 		, m_FullyOccupiesVoxel(false)
 		, m_CanBeTerraformed(false)
 		, m_BlockHeight(1.0)
-		, m_PlaceSound()
 		, m_Hardness(0.0f)
 		, m_Handler()
 	{}


### PR DESCRIPTION
The `cBlockInfo::m_PlaceSound` strings are not used internally and are never actually populated.  This just removes it completely.