### PR TITLE
Personalized scoreboards

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1409,6 +1409,16 @@ end
 					},
 					Notes = "Returns the view distance that the player request, not the used view distance.",
 				},
+				GetScoreBoard =
+				{
+					Returns =
+					{
+						{
+							Type = "cScoreboard",
+						},
+					},
+					Notes = "Returns the personalized scoreboard for this client. NOTE: This scoreboard should never be used when the world scoreboard for the world the player is in is also in use (never use both at the same time).",
+				},
 				GetUniqueID =
 				{
 					Returns =
@@ -1694,6 +1704,17 @@ end
 						},
 					},
 					Notes = "Sets the locale that Cuberite keeps on record. Initially the locale is initialized in protocol handshake, this function allows plugins to override the stored value (but only server-side and only until the user disconnects).",
+				},
+				SetShouldUseGlobalScoreBoard =
+				{
+					Params =
+					{
+						{
+							Name = "ShouldUseGlobalScoreBoard",
+							Type = "boolean",
+						},
+					},
+					Notes = "This should be in a HOOK_LOGIN call. If true (default), then when the player joins they will be sent the world scoreboard. If false, then the player will be initialized with the personal scoreboard.",
 				},
 				SetUsername =
 				{
@@ -11435,7 +11456,7 @@ end
 		cScoreboard =
 		{
 			Desc = [[
-				This class manages the objectives and teams of a single world.
+				This class manages objectives and teams of a scoreboard. Every world has a scoreboard, as well as every cClientHandle. Only one of these should be used - a server should either use the per-world scoreboard or the personalized per-client scoreboard, never both at the same time. For the personalized per-client scoreboard, the only functional objective type is the dummy objective.
 			]],
 			Functions =
 			{

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1714,7 +1714,7 @@ end
 							Type = "boolean",
 						},
 					},
-					Notes = "This should be in a HOOK_LOGIN call. If true (default), then when the player joins they will be sent the world scoreboard. If false, then the player will be initialized with the personal scoreboard.",
+					Notes = "This should be called in a HOOK_LOGIN call. If true (default), then when the player joins they will be initialized with their world's scoreboard. If false, then the player will be initialized with their personal scoreboard.",
 				},
 				SetUsername =
 				{

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,6 +138,7 @@ SET (HDRS
 	RCONServer.h
 	Root.h
 	Scoreboard.h
+	ScoreboardAttachee.h
 	Server.h
 	SetChunkData.h
 	SettingsRepositoryInterface.h

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -69,6 +69,7 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 	m_RequestedViewDistance(a_ViewDistance),
 	m_IPString(a_IPString),
 	m_Player(nullptr),
+	m_Scoreboard(this),
 	m_CachedSentChunk(0, 0),
 	m_HasSentDC(false),
 	m_LastStreamedChunkX(0x7fffffff),  // bogus chunk coords to force streaming upon login
@@ -93,8 +94,7 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 	m_HasSentPlayerChunk(false),
 	m_Locale("en_GB"),
 	m_LastPlacedSign(0, -1, 0),
-	m_ProtocolVersion(0),
-	m_Scoreboard(this)
+	m_ProtocolVersion(0)
 {
 	m_Protocol = cpp14::make_unique<cProtocolRecognizer>(this);
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2874,7 +2874,7 @@ void cClientHandle::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 
 
 
-void cClientHandle::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode)
+void cClientHandle::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, eObjectiveAction a_Mode)
 {
 	m_Protocol->SendScoreboardObjective(a_Name, a_DisplayName, a_Mode);
 }
@@ -2883,7 +2883,7 @@ void cClientHandle::SendScoreboardObjective(const AString & a_Name, const AStrin
 
 
 
-void cClientHandle::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode)
+void cClientHandle::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreAction a_Mode)
 {
 	m_Protocol->SendScoreUpdate(a_Objective, a_Player, a_Score, a_Mode);
 }

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -93,7 +93,8 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 	m_HasSentPlayerChunk(false),
 	m_Locale("en_GB"),
 	m_LastPlacedSign(0, -1, 0),
-	m_ProtocolVersion(0)
+	m_ProtocolVersion(0),
+	m_Scoreboard(this)
 {
 	m_Protocol = cpp14::make_unique<cProtocolRecognizer>(this);
 
@@ -427,7 +428,14 @@ void cClientHandle::Authenticate(const AString & a_Name, const AString & a_UUID,
 	m_Player->UpdateTeam();
 
 	// Send scoreboard data
-	World->GetScoreBoard().SendTo(*this);
+	if (false)//World->UseGlobalScoreBoard())
+	{
+		World->GetScoreBoard().SendTo(*this);
+	}
+	else
+	{
+		m_Scoreboard.SendTo(*this);
+	}
 
 	// Send statistics
 	SendStatistics(m_Player->GetStatManager());

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -428,7 +428,7 @@ void cClientHandle::Authenticate(const AString & a_Name, const AString & a_UUID,
 	m_Player->UpdateTeam();
 
 	// Send scoreboard data
-	if (false)//World->UseGlobalScoreBoard())
+	if (m_ShouldUseGlobalScoreboard)
 	{
 		World->GetScoreBoard().SendTo(*this);
 	}
@@ -2874,7 +2874,7 @@ void cClientHandle::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 
 
 
-void cClientHandle::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
+void cClientHandle::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode)
 {
 	m_Protocol->SendScoreboardObjective(a_Name, a_DisplayName, a_Mode);
 }
@@ -2883,7 +2883,7 @@ void cClientHandle::SendScoreboardObjective(const AString & a_Name, const AStrin
 
 
 
-void cClientHandle::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
+void cClientHandle::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode)
 {
 	m_Protocol->SendScoreUpdate(a_Objective, a_Player, a_Score, a_Mode);
 }

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -21,6 +21,7 @@
 #include "json/json.h"
 #include "ChunkSender.h"
 #include "EffectID.h"
+#include "ScoreboardAttachee.h"
 
 
 #include <array>
@@ -50,8 +51,9 @@ typedef std::shared_ptr<cClientHandle> cClientHandlePtr;
 
 
 
-class cClientHandle  // tolua_export
-	: public cTCPLink::cCallbacks
+class cClientHandle :  // tolua_export
+	public cTCPLink::cCallbacks,
+	public cScoreboardAttachee
 {  // tolua_export
 public:  // tolua_export
 
@@ -80,6 +82,8 @@ public:  // tolua_export
 	void SetIPString(const AString & a_IPString) { m_IPString = a_IPString; }
 
 	cPlayer * GetPlayer(void) { return m_Player; }  // tolua_export
+
+	cScoreboard & GetScoreBoard(void) { return m_Scoreboard; }  // tolua_export
 
 	/** Returns the player's UUID, as used by the protocol, in the short form (no dashes) */
 	const AString & GetUUID(void) const { return m_UUID; }  // tolua_export
@@ -168,7 +172,7 @@ public:  // tolua_export
 	void SendDestroyEntity              (const cEntity & a_Entity);
 	void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);
 	void SendDisconnect                 (const AString & a_Reason);
-	void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display);
+	virtual void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) override;
 	void SendEditSign                   (int a_BlockX, int a_BlockY, int a_BlockZ);
 	void SendEntityAnimation            (const cEntity & a_Entity, char a_Animation);  // tolua_export
 	void SendEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, short a_Duration);
@@ -207,8 +211,8 @@ public:  // tolua_export
 	void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID);
 	void SendResetTitle                 (void);  // tolua_export
 	void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks = false);
-	void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode);
-	void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode);
+	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) override;
+	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) override;
 	void SendSetSubTitle                (const cCompositeChat & a_SubTitle);  // tolua_export
 	void SendSetRawSubTitle             (const AString & a_SubTitle);  // tolua_export
 	void SendSetTitle                   (const cCompositeChat & a_Title);  // tolua_export
@@ -424,6 +428,9 @@ private:
 	Vector3d m_ConfirmPosition;
 
 	cPlayer * m_Player;
+
+	/** Personalized per-player scoreboards */
+	cScoreboard m_Scoreboard;
 
 	/** This is an optimization which saves you an iteration of m_SentChunks if you just want to know
 	whether or not the player is standing at a sent chunk.

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -213,8 +213,8 @@ public:  // tolua_export
 	void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID);
 	void SendResetTitle                 (void);  // tolua_export
 	void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks = false);
-	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode) override;
-	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode) override;
+	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreAction a_Mode) override;
+	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, eObjectiveAction a_Mode) override;
 	void SendSetSubTitle                (const cCompositeChat & a_SubTitle);  // tolua_export
 	void SendSetRawSubTitle             (const AString & a_SubTitle);  // tolua_export
 	void SendSetTitle                   (const cCompositeChat & a_Title);  // tolua_export

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -85,6 +85,8 @@ public:  // tolua_export
 
 	cScoreboard & GetScoreBoard(void) { return m_Scoreboard; }  // tolua_export
 
+	void SetShouldUseGlobalScoreBoard(bool a_ShouldUseGlobal) { m_ShouldUseGlobalScoreboard = a_ShouldUseGlobal; }  // tolua_export
+
 	/** Returns the player's UUID, as used by the protocol, in the short form (no dashes) */
 	const AString & GetUUID(void) const { return m_UUID; }  // tolua_export
 
@@ -211,8 +213,8 @@ public:  // tolua_export
 	void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID);
 	void SendResetTitle                 (void);  // tolua_export
 	void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks = false);
-	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) override;
-	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) override;
+	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode) override;
+	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode) override;
 	void SendSetSubTitle                (const cCompositeChat & a_SubTitle);  // tolua_export
 	void SendSetRawSubTitle             (const AString & a_SubTitle);  // tolua_export
 	void SendSetTitle                   (const cCompositeChat & a_Title);  // tolua_export
@@ -494,6 +496,10 @@ private:
 	However, if it only uses m_State for a quick bail out, or it doesn't break if the client disconnects in the middle of it,
 	it may just read m_State without locking m_CSState. */
 	std::atomic<eState> m_State;
+
+	/** If set to false before authenticate(), then sends the personal
+	scoreboard to the client instead of the global scoreboard. */
+	bool m_ShouldUseGlobalScoreboard;
 
 	/** If set to true during csDownloadingWorld, the tick thread calls CheckIfWorldDownloaded() */
 	bool m_ShouldCheckDownloaded;

--- a/src/Scoreboard.cpp
+++ b/src/Scoreboard.cpp
@@ -79,11 +79,11 @@ cObjective::eType cObjective::StringToType(const AString & a_Name)
 
 
 
-cObjective::cObjective(const AString & a_Name, const AString & a_DisplayName, cObjective::eType a_Type, cWorld * a_World)
+cObjective::cObjective(const AString & a_Name, const AString & a_DisplayName, cObjective::eType a_Type, cScoreboardAttachee * a_Attachee)
 	: m_DisplayName(a_DisplayName)
 	, m_Name(a_Name)
 	, m_Type(a_Type)
-	, m_World(a_World)
+	, m_Attachee(a_Attachee)
 {
 }
 
@@ -95,7 +95,18 @@ void cObjective::Reset(void)
 {
 	for (cScoreMap::iterator it = m_Scores.begin(); it != m_Scores.end(); ++it)
 	{
-		m_World->BroadcastScoreUpdate(m_Name, it->first, 0, 1);
+		m_Attachee->SendScoreUpdate(m_Name, it->first, 0, 1);
+		/*if (m_World != nullptr)
+		{
+			ASSERT(m_ClientHandle == nullptr);
+			m_World->BroadcastScoreUpdate(m_Name, it->first, 0, 1);
+		}
+		else
+		{
+			ASSERT(m_World == nullptr);
+			m_ClientHandle->SendScoreUpdate(m_Name, it->first, 0, 1);
+			}*/
+		//m_World->BroadcastScoreUpdate(m_Name, it->first, 0, 1);
 	}
 
 	m_Scores.clear();
@@ -127,7 +138,18 @@ void cObjective::SetScore(const AString & a_Name, cObjective::Score a_Score)
 {
 	m_Scores[a_Name] = a_Score;
 
-	m_World->BroadcastScoreUpdate(m_Name, a_Name, a_Score, 0);
+	m_Attachee->SendScoreUpdate(m_Name, a_Name, a_Score, 0);
+	//m_World->BroadcastScoreUpdate(m_Name, a_Name, a_Score, 0);
+	/*if (m_World != nullptr)
+	{
+		ASSERT(m_ClientHandle == nullptr);
+		m_World->BroadcastScoreUpdate(m_Name, a_Name, a_Score, 0);
+	}
+	else
+	{
+		ASSERT(m_World == nullptr);
+		m_ClientHandle->SendScoreUpdate(m_Name, a_Name, a_Score, 0);
+		}*/
 }
 
 
@@ -138,7 +160,18 @@ void cObjective::ResetScore(const AString & a_Name)
 {
 	m_Scores.erase(a_Name);
 
-	m_World->BroadcastScoreUpdate(m_Name, a_Name, 0, 1);
+	m_Attachee->SendScoreUpdate(m_Name, a_Name, 0, 1);
+	//m_World->BroadcastScoreUpdate(m_Name, a_Name, 0, 1);
+	/*if (m_World != nullptr)
+	{
+		ASSERT(m_ClientHandle == nullptr);
+		m_World->BroadcastScoreUpdate(m_Name, a_Name, 0, 1);
+	}
+	else
+	{
+		ASSERT(m_World == nullptr);
+		m_ClientHandle->SendScoreUpdate(m_Name, a_Name, 0, 1);
+		}*/
 }
 
 
@@ -177,7 +210,18 @@ void cObjective::SetDisplayName(const AString & a_Name)
 {
 	m_DisplayName = a_Name;
 
-	m_World->BroadcastScoreboardObjective(m_Name, m_DisplayName, 2);
+	m_Attachee->SendScoreboardObjective(m_Name, m_DisplayName, 2);
+	//m_World->BroadcastScoreboardObjective(m_Name, m_DisplayName, 2);
+	/*if (m_World != nullptr)
+	{
+		ASSERT(m_ClientHandle == nullptr);
+		m_World->BroadcastScoreboardObjective(m_Name, m_DisplayName, 2);
+	}
+	else
+	{
+		ASSERT(m_World == nullptr);
+		m_ClientHandle->SendScoreboardObjective(m_Name, m_DisplayName, 2);
+		}*/
 }
 
 
@@ -274,7 +318,7 @@ size_t cTeam::GetNumPlayers(void) const
 
 
 
-cScoreboard::cScoreboard(cWorld * a_World) : m_World(a_World)
+cScoreboard::cScoreboard(cScoreboardAttachee * a_Attachee) : m_Attachee(a_Attachee)
 {
 	for (int i = 0; i < static_cast<int>(dsCount); ++i)
 	{
@@ -288,14 +332,25 @@ cScoreboard::cScoreboard(cWorld * a_World) : m_World(a_World)
 
 cObjective * cScoreboard::RegisterObjective(const AString & a_Name, const AString & a_DisplayName, cObjective::eType a_Type)
 {
-	cObjective Objective(a_Name, a_DisplayName, a_Type, m_World);
+	cObjective Objective(a_Name, a_DisplayName, a_Type, m_Attachee);
 
 	std::pair<cObjectiveMap::iterator, bool> Status = m_Objectives.insert(cNamedObjective(a_Name, Objective));
 
 	if (Status.second)
 	{
-		ASSERT(m_World != nullptr);
-		m_World->BroadcastScoreboardObjective(a_Name, a_DisplayName, 0);
+		ASSERT(m_Attachee != nullptr);
+		m_Attachee->SendScoreboardObjective(a_Name, a_DisplayName, 0);
+		//m_World->BroadcastScoreboardObjective(a_Name, a_DisplayName, 0);
+		/*if (m_World != nullptr)
+		{
+			ASSERT(m_ClientHandle == nullptr);
+			m_World->BroadcastScoreboardObjective(a_Name, a_DisplayName, 0);
+		}
+		else
+		{
+			ASSERT(m_World == nullptr);
+			m_ClientHandle->SendScoreboardObjective(a_Name, a_DisplayName, 0);
+			}*/
 
 		return &Status.first->second;
 	}
@@ -320,8 +375,17 @@ bool cScoreboard::RemoveObjective(const AString & a_Name)
 		return false;
 	}
 
-	ASSERT(m_World != nullptr);
-	m_World->BroadcastScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), 1);
+	m_Attachee->SendScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), 1);
+	/*if (m_World != nullptr)
+	{
+		ASSERT(m_ClientHandle == nullptr);
+		m_World->BroadcastScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), 1);
+	}
+	else
+	{
+		ASSERT(m_World == nullptr);
+		m_ClientHandle->SendScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), 1);
+		}*/
 
 	for (unsigned int i = 0; i < static_cast<unsigned int>(dsCount); ++i)
 	{
@@ -468,8 +532,19 @@ void cScoreboard::SetDisplay(cObjective * a_Objective, eDisplaySlot a_Slot)
 {
 	m_Display[a_Slot] = a_Objective;
 
-	ASSERT(m_World != nullptr);
-	m_World->BroadcastDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
+	m_Attachee->SendDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
+	//ASSERT(m_World != nullptr);
+	//m_World->BroadcastDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
+	/*if (m_World != nullptr)
+	{
+		ASSERT(m_ClientHandle == nullptr);
+		m_World->BroadcastDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
+	}
+	else
+	{
+		ASSERT(m_World == nullptr);
+		m_ClientHandle->SendDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
+		}*/
 }
 
 

--- a/src/Scoreboard.cpp
+++ b/src/Scoreboard.cpp
@@ -95,18 +95,7 @@ void cObjective::Reset(void)
 {
 	for (cScoreMap::iterator it = m_Scores.begin(); it != m_Scores.end(); ++it)
 	{
-		m_Attachee->SendScoreUpdate(m_Name, it->first, 0, 1);
-		/*if (m_World != nullptr)
-		{
-			ASSERT(m_ClientHandle == nullptr);
-			m_World->BroadcastScoreUpdate(m_Name, it->first, 0, 1);
-		}
-		else
-		{
-			ASSERT(m_World == nullptr);
-			m_ClientHandle->SendScoreUpdate(m_Name, it->first, 0, 1);
-			}*/
-		//m_World->BroadcastScoreUpdate(m_Name, it->first, 0, 1);
+		m_Attachee->SendScoreUpdate(m_Name, it->first, 0, eScoreActions::SCORE_REMOVE);
 	}
 
 	m_Scores.clear();
@@ -138,18 +127,7 @@ void cObjective::SetScore(const AString & a_Name, cObjective::Score a_Score)
 {
 	m_Scores[a_Name] = a_Score;
 
-	m_Attachee->SendScoreUpdate(m_Name, a_Name, a_Score, 0);
-	//m_World->BroadcastScoreUpdate(m_Name, a_Name, a_Score, 0);
-	/*if (m_World != nullptr)
-	{
-		ASSERT(m_ClientHandle == nullptr);
-		m_World->BroadcastScoreUpdate(m_Name, a_Name, a_Score, 0);
-	}
-	else
-	{
-		ASSERT(m_World == nullptr);
-		m_ClientHandle->SendScoreUpdate(m_Name, a_Name, a_Score, 0);
-		}*/
+	m_Attachee->SendScoreUpdate(m_Name, a_Name, a_Score, eScoreActions::SCORE_CREATE_OR_UPDATE);
 }
 
 
@@ -160,18 +138,7 @@ void cObjective::ResetScore(const AString & a_Name)
 {
 	m_Scores.erase(a_Name);
 
-	m_Attachee->SendScoreUpdate(m_Name, a_Name, 0, 1);
-	//m_World->BroadcastScoreUpdate(m_Name, a_Name, 0, 1);
-	/*if (m_World != nullptr)
-	{
-		ASSERT(m_ClientHandle == nullptr);
-		m_World->BroadcastScoreUpdate(m_Name, a_Name, 0, 1);
-	}
-	else
-	{
-		ASSERT(m_World == nullptr);
-		m_ClientHandle->SendScoreUpdate(m_Name, a_Name, 0, 1);
-		}*/
+	m_Attachee->SendScoreUpdate(m_Name, a_Name, 0, eScoreActions::SCORE_REMOVE);
 }
 
 
@@ -210,18 +177,7 @@ void cObjective::SetDisplayName(const AString & a_Name)
 {
 	m_DisplayName = a_Name;
 
-	m_Attachee->SendScoreboardObjective(m_Name, m_DisplayName, 2);
-	//m_World->BroadcastScoreboardObjective(m_Name, m_DisplayName, 2);
-	/*if (m_World != nullptr)
-	{
-		ASSERT(m_ClientHandle == nullptr);
-		m_World->BroadcastScoreboardObjective(m_Name, m_DisplayName, 2);
-	}
-	else
-	{
-		ASSERT(m_World == nullptr);
-		m_ClientHandle->SendScoreboardObjective(m_Name, m_DisplayName, 2);
-		}*/
+	m_Attachee->SendScoreboardObjective(m_Name, m_DisplayName, eObjectiveActions::OBJECTIVE_UPDATE_DISPLAY);
 }
 
 
@@ -230,11 +186,11 @@ void cObjective::SetDisplayName(const AString & a_Name)
 
 void cObjective::SendTo(cClientHandle & a_Client)
 {
-	a_Client.SendScoreboardObjective(m_Name, m_DisplayName, 0);
+	a_Client.SendScoreboardObjective(m_Name, m_DisplayName, eObjectiveActions::OBJECTIVE_CREATE);
 
 	for (cScoreMap::const_iterator it = m_Scores.begin(); it != m_Scores.end(); ++it)
 	{
-		a_Client.SendScoreUpdate(m_Name, it->first, it->second, 0);
+		a_Client.SendScoreUpdate(m_Name, it->first, it->second, eScoreActions::SCORE_CREATE_OR_UPDATE);
 	}
 }
 
@@ -339,18 +295,7 @@ cObjective * cScoreboard::RegisterObjective(const AString & a_Name, const AStrin
 	if (Status.second)
 	{
 		ASSERT(m_Attachee != nullptr);
-		m_Attachee->SendScoreboardObjective(a_Name, a_DisplayName, 0);
-		//m_World->BroadcastScoreboardObjective(a_Name, a_DisplayName, 0);
-		/*if (m_World != nullptr)
-		{
-			ASSERT(m_ClientHandle == nullptr);
-			m_World->BroadcastScoreboardObjective(a_Name, a_DisplayName, 0);
-		}
-		else
-		{
-			ASSERT(m_World == nullptr);
-			m_ClientHandle->SendScoreboardObjective(a_Name, a_DisplayName, 0);
-			}*/
+		m_Attachee->SendScoreboardObjective(a_Name, a_DisplayName, eObjectiveActions::OBJECTIVE_CREATE);
 
 		return &Status.first->second;
 	}
@@ -375,17 +320,7 @@ bool cScoreboard::RemoveObjective(const AString & a_Name)
 		return false;
 	}
 
-	m_Attachee->SendScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), 1);
-	/*if (m_World != nullptr)
-	{
-		ASSERT(m_ClientHandle == nullptr);
-		m_World->BroadcastScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), 1);
-	}
-	else
-	{
-		ASSERT(m_World == nullptr);
-		m_ClientHandle->SendScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), 1);
-		}*/
+	m_Attachee->SendScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), eObjectiveActions::OBJECTIVE_REMOVE);
 
 	for (unsigned int i = 0; i < static_cast<unsigned int>(dsCount); ++i)
 	{
@@ -533,18 +468,6 @@ void cScoreboard::SetDisplay(cObjective * a_Objective, eDisplaySlot a_Slot)
 	m_Display[a_Slot] = a_Objective;
 
 	m_Attachee->SendDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
-	//ASSERT(m_World != nullptr);
-	//m_World->BroadcastDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
-	/*if (m_World != nullptr)
-	{
-		ASSERT(m_ClientHandle == nullptr);
-		m_World->BroadcastDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
-	}
-	else
-	{
-		ASSERT(m_World == nullptr);
-		m_ClientHandle->SendDisplayObjective(a_Objective ? a_Objective->GetName() : "", a_Slot);
-		}*/
 }
 
 

--- a/src/Scoreboard.cpp
+++ b/src/Scoreboard.cpp
@@ -95,7 +95,7 @@ void cObjective::Reset(void)
 {
 	for (cScoreMap::iterator it = m_Scores.begin(); it != m_Scores.end(); ++it)
 	{
-		m_Attachee->SendScoreUpdate(m_Name, it->first, 0, eScoreActions::SCORE_REMOVE);
+		m_Attachee->SendScoreUpdate(m_Name, it->first, 0, cScoreboardAttachee::saRemove);
 	}
 
 	m_Scores.clear();
@@ -127,7 +127,7 @@ void cObjective::SetScore(const AString & a_Name, cObjective::Score a_Score)
 {
 	m_Scores[a_Name] = a_Score;
 
-	m_Attachee->SendScoreUpdate(m_Name, a_Name, a_Score, eScoreActions::SCORE_CREATE_OR_UPDATE);
+	m_Attachee->SendScoreUpdate(m_Name, a_Name, a_Score, cScoreboardAttachee::saCreateOrUpdate);
 }
 
 
@@ -138,7 +138,7 @@ void cObjective::ResetScore(const AString & a_Name)
 {
 	m_Scores.erase(a_Name);
 
-	m_Attachee->SendScoreUpdate(m_Name, a_Name, 0, eScoreActions::SCORE_REMOVE);
+	m_Attachee->SendScoreUpdate(m_Name, a_Name, 0, cScoreboardAttachee::saRemove);
 }
 
 
@@ -177,7 +177,7 @@ void cObjective::SetDisplayName(const AString & a_Name)
 {
 	m_DisplayName = a_Name;
 
-	m_Attachee->SendScoreboardObjective(m_Name, m_DisplayName, eObjectiveActions::OBJECTIVE_UPDATE_DISPLAY);
+	m_Attachee->SendScoreboardObjective(m_Name, m_DisplayName, cScoreboardAttachee::objUpdateDisplay);
 }
 
 
@@ -186,11 +186,11 @@ void cObjective::SetDisplayName(const AString & a_Name)
 
 void cObjective::SendTo(cClientHandle & a_Client)
 {
-	a_Client.SendScoreboardObjective(m_Name, m_DisplayName, eObjectiveActions::OBJECTIVE_CREATE);
+	a_Client.SendScoreboardObjective(m_Name, m_DisplayName, cScoreboardAttachee::objCreate);
 
 	for (cScoreMap::const_iterator it = m_Scores.begin(); it != m_Scores.end(); ++it)
 	{
-		a_Client.SendScoreUpdate(m_Name, it->first, it->second, eScoreActions::SCORE_CREATE_OR_UPDATE);
+		a_Client.SendScoreUpdate(m_Name, it->first, it->second, cScoreboardAttachee::saCreateOrUpdate);
 	}
 }
 
@@ -295,7 +295,7 @@ cObjective * cScoreboard::RegisterObjective(const AString & a_Name, const AStrin
 	if (Status.second)
 	{
 		ASSERT(m_Attachee != nullptr);
-		m_Attachee->SendScoreboardObjective(a_Name, a_DisplayName, eObjectiveActions::OBJECTIVE_CREATE);
+		m_Attachee->SendScoreboardObjective(a_Name, a_DisplayName, cScoreboardAttachee::objCreate);
 
 		return &Status.first->second;
 	}
@@ -320,7 +320,7 @@ bool cScoreboard::RemoveObjective(const AString & a_Name)
 		return false;
 	}
 
-	m_Attachee->SendScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), eObjectiveActions::OBJECTIVE_REMOVE);
+	m_Attachee->SendScoreboardObjective(it->second.GetName(), it->second.GetDisplayName(), cScoreboardAttachee::objRemove);
 
 	for (unsigned int i = 0; i < static_cast<unsigned int>(dsCount); ++i)
 	{

--- a/src/Scoreboard.h
+++ b/src/Scoreboard.h
@@ -14,6 +14,7 @@
 
 
 class cObjective;
+class cScoreboardAttachee;
 class cTeam;
 class cWorld;
 
@@ -60,7 +61,7 @@ public:
 
 public:
 
-	cObjective(const AString & a_Name, const AString & a_DisplayName, eType a_Type, cWorld * a_World);
+	cObjective(const AString & a_Name, const AString & a_DisplayName, eType a_Type, cScoreboardAttachee * a_Attachee);
 
 	// tolua_begin
 
@@ -113,7 +114,10 @@ private:
 
 	eType m_Type;
 
-	cWorld * m_World;
+	// We're either attached to the world or to a specific client handle
+	/*cWorld * m_World;
+	  cClientHandle * m_ClientHandle;*/
+	cScoreboardAttachee * m_Attachee;
 
 	friend class cScoreboardSerializer;
 
@@ -222,7 +226,7 @@ public:
 
 public:
 
-	cScoreboard(cWorld * a_World);
+	cScoreboard(cScoreboardAttachee * a_Attachee);
 
 	// tolua_begin
 
@@ -278,6 +282,8 @@ public:
 
 	void SetDisplay(cObjective * a_Objective, eDisplaySlot a_Slot);
 
+	//void SetClientHandle(cClientHandle * a_ClientHandle) { m_ClientHandle = a_ClientHandle; }
+
 
 private:
 
@@ -294,7 +300,10 @@ private:
 	cCriticalSection m_CSTeams;
 	cTeamMap m_Teams;
 
-	cWorld * m_World;
+	// We're either attached to the world or to a specific client handle
+	/*cWorld * m_World;
+	  cClientHandle * m_ClientHandle;*/
+	cScoreboardAttachee * m_Attachee;
 
 	cObjective * m_Display[dsCount];
 

--- a/src/Scoreboard.h
+++ b/src/Scoreboard.h
@@ -115,8 +115,6 @@ private:
 	eType m_Type;
 
 	// We're either attached to the world or to a specific client handle
-	/*cWorld * m_World;
-	  cClientHandle * m_ClientHandle;*/
 	cScoreboardAttachee * m_Attachee;
 
 	friend class cScoreboardSerializer;
@@ -282,8 +280,6 @@ public:
 
 	void SetDisplay(cObjective * a_Objective, eDisplaySlot a_Slot);
 
-	//void SetClientHandle(cClientHandle * a_ClientHandle) { m_ClientHandle = a_ClientHandle; }
-
 
 private:
 
@@ -301,8 +297,6 @@ private:
 	cTeamMap m_Teams;
 
 	// We're either attached to the world or to a specific client handle
-	/*cWorld * m_World;
-	  cClientHandle * m_ClientHandle;*/
 	cScoreboardAttachee * m_Attachee;
 
 	cObjective * m_Display[dsCount];

--- a/src/ScoreboardAttachee.h
+++ b/src/ScoreboardAttachee.h
@@ -1,0 +1,15 @@
+
+// ScoreboardAttachee.h
+
+// Provides the interface that scoreboards call to update whomever the board is
+// attached to (e.g. the World, or a ClientHandle)
+
+#pragma once
+
+class cScoreboardAttachee
+{
+public:
+	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) = 0;
+	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) = 0;
+	virtual void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) = 0;
+};

--- a/src/ScoreboardAttachee.h
+++ b/src/ScoreboardAttachee.h
@@ -9,29 +9,24 @@
 class cScoreboardAttachee
 {
 public:
-	enum eScoreActions : Byte
+	enum eScoreAction : Byte
 	{
-		SCORE_CREATE_OR_UPDATE = 0,
-		SCORE_REMOVE = 1,
+		saCreateOrUpdate = 0,
+		saRemove = 1,
 	};
 
-	enum eObjectiveActions : Byte
+	enum eObjectiveAction : Byte
 	{
-		OBJECTIVE_CREATE = 0,
-		OBJECTIVE_REMOVE = 1,
-		OBJECTIVE_UPDATE_DISPLAY = 2,
+		objCreate = 0,
+		objRemove = 1,
+		objUpdateDisplay = 2,
 	};
 
-	/** Called to send a change in score for the given objective.
-	If a_Mode = 0, then this will create or update the score.
-	If a_Mode = 1, then this will remove the score entry. */
-	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode) = 0;
+	/** Called to send a change in score for the given objective. */
+	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreAction a_Mode) = 0;
 
-	/** Called to modify an objective on the scoreboard.
-	If a_Mode = 0, then this function is to create the objective.
-	If a_Mode = 1, then this function is to remove the objective.
-	If a_Mode = 2, then this function is to update the display text. */
-	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode) = 0;
+	/** Called to modify an objective on the scoreboard. */
+	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, eObjectiveAction a_Mode) = 0;
 
 	/** Called to set where the given objective is displayed. */
 	virtual void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) = 0;

--- a/src/ScoreboardAttachee.h
+++ b/src/ScoreboardAttachee.h
@@ -9,6 +9,8 @@
 class cScoreboardAttachee
 {
 public:
+	virtual ~cScoreboardAttachee() {}
+
 	enum eScoreAction : Byte
 	{
 		saCreateOrUpdate = 0,

--- a/src/ScoreboardAttachee.h
+++ b/src/ScoreboardAttachee.h
@@ -9,7 +9,30 @@
 class cScoreboardAttachee
 {
 public:
-	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) = 0;
-	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) = 0;
+	enum eScoreActions : Byte
+	{
+		SCORE_CREATE_OR_UPDATE = 0,
+		SCORE_REMOVE = 1,
+	};
+
+	enum eObjectiveActions : Byte
+	{
+		OBJECTIVE_CREATE = 0,
+		OBJECTIVE_REMOVE = 1,
+		OBJECTIVE_UPDATE_DISPLAY = 2,
+	};
+
+	/** Called to send a change in score for the given objective.
+	If a_Mode = 0, then this will create or update the score.
+	If a_Mode = 1, then this will remove the score entry. */
+	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode) = 0;
+
+	/** Called to modify an objective on the scoreboard.
+	If a_Mode = 0, then this function is to create the objective.
+	If a_Mode = 1, then this function is to remove the objective.
+	If a_Mode = 2, then this function is to update the display text. */
+	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode) = 0;
+
+	/** Called to set where the given objective is displayed. */
 	virtual void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) = 0;
 };

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2700,7 +2700,7 @@ void cWorld::BroadcastRemoveEntityEffect(const cEntity & a_Entity, int a_EffectI
 
 
 
-void cWorld::BroadcastScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
+void cWorld::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
 {
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
@@ -2718,7 +2718,7 @@ void cWorld::BroadcastScoreboardObjective(const AString & a_Name, const AString 
 
 
 
-void cWorld::BroadcastScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
+void cWorld::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
 {
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
@@ -2736,7 +2736,7 @@ void cWorld::BroadcastScoreUpdate(const AString & a_Objective, const AString & a
 
 
 
-void cWorld::BroadcastDisplayObjective(const AString & a_Objective, cScoreboard::eDisplaySlot a_Display)
+void cWorld::SendDisplayObjective(const AString & a_Objective, cScoreboard::eDisplaySlot a_Display)
 {
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2700,7 +2700,7 @@ void cWorld::BroadcastRemoveEntityEffect(const cEntity & a_Entity, int a_EffectI
 
 
 
-void cWorld::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode)
+void cWorld::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, eObjectiveAction a_Mode)
 {
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
@@ -2718,7 +2718,7 @@ void cWorld::SendScoreboardObjective(const AString & a_Name, const AString & a_D
 
 
 
-void cWorld::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode)
+void cWorld::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreAction a_Mode)
 {
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2700,7 +2700,7 @@ void cWorld::BroadcastRemoveEntityEffect(const cEntity & a_Entity, int a_EffectI
 
 
 
-void cWorld::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, Byte a_Mode)
+void cWorld::SendScoreboardObjective(const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode)
 {
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
@@ -2718,7 +2718,7 @@ void cWorld::SendScoreboardObjective(const AString & a_Name, const AString & a_D
 
 
 
-void cWorld::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode)
+void cWorld::SendScoreUpdate(const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode)
 {
 	cCSLock Lock(m_CSPlayers);
 	for (cPlayerList::iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)

--- a/src/World.h
+++ b/src/World.h
@@ -91,7 +91,7 @@ class cWorld :
 	public cForEachChunkProvider,
 	public cWorldInterface,
 	public cBroadcastInterface,
-	public cScoreboardAttachee
+	public cScoreboardAttachee  // No need to export this dependency
 {
 public:
 
@@ -213,12 +213,9 @@ public:
 	void BroadcastPlayerListUpdatePing       (const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID, const cClientHandle * a_Exclude = nullptr);
-	virtual void SendScoreUpdate             (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) override;
-	virtual void SendScoreboardObjective     (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) override;
+	virtual void SendScoreUpdate             (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode) override;
+	virtual void SendScoreboardObjective     (const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode) override;
 	virtual void SendDisplayObjective        (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) override;
-	//void BroadcastScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode);
-	//void BroadcastScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode);
-	//void BroadcastDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display);
 	void BroadcastSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export
 	virtual void BroadcastSoundParticleEffect        (const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export
 	void BroadcastSpawnEntity                (cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr);

--- a/src/World.h
+++ b/src/World.h
@@ -29,6 +29,7 @@
 #include "Blocks/WorldInterface.h"
 #include "Blocks/BroadcastInterface.h"
 #include "EffectID.h"
+#include "ScoreboardAttachee.h"
 
 
 
@@ -89,7 +90,8 @@ typedef std::function<bool (cEntity *)>    cLambdaEntityCallback;
 class cWorld :
 	public cForEachChunkProvider,
 	public cWorldInterface,
-	public cBroadcastInterface
+	public cBroadcastInterface,
+	public cScoreboardAttachee
 {
 public:
 
@@ -211,9 +213,12 @@ public:
 	void BroadcastPlayerListUpdatePing       (const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID, const cClientHandle * a_Exclude = nullptr);
-	void BroadcastScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode);
-	void BroadcastScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode);
-	void BroadcastDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display);
+	virtual void SendScoreUpdate             (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) override;
+	virtual void SendScoreboardObjective     (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) override;
+	virtual void SendDisplayObjective        (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) override;
+	//void BroadcastScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode);
+	//void BroadcastScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode);
+	//void BroadcastDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display);
 	void BroadcastSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export
 	virtual void BroadcastSoundParticleEffect        (const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export
 	void BroadcastSpawnEntity                (cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr);

--- a/src/World.h
+++ b/src/World.h
@@ -91,7 +91,7 @@ class cWorld :
 	public cForEachChunkProvider,
 	public cWorldInterface,
 	public cBroadcastInterface,
-	public cScoreboardAttachee  // No need to export this dependency
+	public cScoreboardAttachee
 {
 public:
 
@@ -213,8 +213,8 @@ public:
 	void BroadcastPlayerListUpdatePing       (const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID, const cClientHandle * a_Exclude = nullptr);
-	virtual void SendScoreUpdate             (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreActions a_Mode) override;
-	virtual void SendScoreboardObjective     (const AString & a_Name, const AString & a_DisplayName, eObjectiveActions a_Mode) override;
+	virtual void SendScoreUpdate             (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, eScoreAction a_Mode) override;
+	virtual void SendScoreboardObjective     (const AString & a_Name, const AString & a_DisplayName, eObjectiveAction a_Mode) override;
 	virtual void SendDisplayObjective        (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) override;
 	void BroadcastSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export
 	virtual void BroadcastSoundParticleEffect        (const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export


### PR DESCRIPTION
This is a first stab at per-player scoreboards. This is useful in minigames to provide a scoreboard showing various stats, where each player sees a different scoreboard.

The personal scoreboard is accessed through the cClientHandle of the client using GetScoreBoard().

This scoreboard co-exists awkwardly with the world scoreboards. Both are technically active, but confusion can ensue if the server (or the plugins on it) use a combination of the world scoreboards and personal scoreboards, especially if there are naming collisions. The intended usage is either a plugin sticks with the old way of world-wide scoreboards, or entirely uses personalized scoreboards, ignoring the global scoreboards.

When a player logs in (HOOK_LOGIN), plugins can use the SetShouldUseGlobalScoreboard method to denote which they would like to use with the player, and this determines which scoreboard is initially sent to the player. That defaults to true, and so this PR's API changes are 100% backward compatible.

(on a related note, I think there's a bug where when a player changes worlds they don't get sent the updated scoreboard of the world they're changing to, but I haven't found any opened issues on the subject so I'll have to do some more testing)

Also, the personalized scoreboards only support dummy objectives for now.

Unlike the world scoreboard, the personal scoreboard is not saved to disk. I was thinking, if that's a desired feature, it could be saved alongside the player's .json file in players/ (maybe players/UUID_scoreboard.dat).

As far as code goes, this PR creates a pure-virtual cScoreboardAttachee class, which is the interface for an object that a scoreboard can be attached to (cWorld and cClientHandle implement this interface). cScoreboard keeps a pointer to a cScoreboardAttachee object, and calls methods on that instead of directly on a cWorld.

Fixes #3238 and parts of #2373 and #3458.
