### PR TITLE
Changed type of FastRandom in monster drop calculation.

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1099,7 +1099,7 @@ cMonster * cMonster::NewMonsterFromType(eMonsterType a_MobType)
 
 void cMonster::AddRandomDropItem(cItems & a_Drops, unsigned int a_Min, unsigned int a_Max, short a_Item, short a_ItemHealth)
 {
-	auto Count = GetRandomProvider().RandInt<char>(static_cast<char>(a_Min), static_cast<char>(a_Max));
+	auto Count = GetRandomProvider().RandInt<unsigned int>(a_Min, a_Max);
 	if (Count > 0)
 	{
 		a_Drops.emplace_back(a_Item, Count, a_ItemHealth);

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -5,6 +5,7 @@
 #include "../Root.h"
 #include "../Server.h"
 #include "../ClientHandle.h"
+#include "../Items/ItemHandler.h"
 #include "../World.h"
 #include "../EffectID.h"
 #include "../Entities/Player.h"
@@ -1100,8 +1101,14 @@ cMonster * cMonster::NewMonsterFromType(eMonsterType a_MobType)
 void cMonster::AddRandomDropItem(cItems & a_Drops, unsigned int a_Min, unsigned int a_Max, short a_Item, short a_ItemHealth)
 {
 	auto Count = GetRandomProvider().RandInt<unsigned int>(a_Min, a_Max);
+	auto MaxStackSize = ItemHandler(a_Item)->GetMaxStackSize();
 	if (Count > 0)
 	{
+		while (Count > MaxStackSize)
+		{
+			a_Drops.emplace_back(a_Item, MaxStackSize, a_ItemHealth);
+			Count -= MaxStackSize;
+		}
 		a_Drops.emplace_back(a_Item, Count, a_ItemHealth);
 	}
 }

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1101,14 +1101,14 @@ cMonster * cMonster::NewMonsterFromType(eMonsterType a_MobType)
 void cMonster::AddRandomDropItem(cItems & a_Drops, unsigned int a_Min, unsigned int a_Max, short a_Item, short a_ItemHealth)
 {
 	auto Count = GetRandomProvider().RandInt<unsigned int>(a_Min, a_Max);
-	auto MaxStackSize = ItemHandler(a_Item)->GetMaxStackSize();
+	auto MaxStackSize = static_cast<unsigned char>(ItemHandler(a_Item)->GetMaxStackSize());
+	while (Count > MaxStackSize)
+	{
+		a_Drops.emplace_back(a_Item, MaxStackSize, a_ItemHealth);
+		Count -= MaxStackSize;
+	}
 	if (Count > 0)
 	{
-		while (Count > MaxStackSize)
-		{
-			a_Drops.emplace_back(a_Item, MaxStackSize, a_ItemHealth);
-			Count -= MaxStackSize;
-		}
 		a_Drops.emplace_back(a_Item, Count, a_ItemHealth);
 	}
 }


### PR DESCRIPTION
The issue was for a_Max > 127, a_Max got truncated and became negative, thus failing an assertion in FastRandom.h.

Fixes #3919 (for Looting level up to several billion).
