### PR TITLE
Removed incorrect assert in SendRespawn

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2826,9 +2826,6 @@ void cClientHandle::SendResetTitle()
 
 void cClientHandle::SendRespawn(eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks)
 {
-	// If a_ShouldIgnoreDimensionChecks is true, we must be traveling to the same dimension
-	ASSERT((!a_ShouldIgnoreDimensionChecks) || (a_Dimension == m_LastSentDimension));
-
 	if ((!a_ShouldIgnoreDimensionChecks) && (a_Dimension == m_LastSentDimension))
 	{
 		// The client goes crazy if we send a respawn packet with the dimension of the current world


### PR DESCRIPTION
If a player respawns to a different dimension (sleep in the overworld, die in the nether), they call SendRespawn with a_ShouldIgnoreDimensionChecks=true, which leads to an assertion error because the dimensions are in fact different.

My 1.12 client was fine with respawning across dimensions, both from a plugin-triggered respawn and a death-triggered respawn.

While not directly causing any bugs I know of, this hides the true cause of #3913 (since the debugger crashes on the assert error).
