### PR TITLE
Possible spawn prepare fix

### DIFF
--- a/src/SpawnPrepare.h
+++ b/src/SpawnPrepare.h
@@ -6,10 +6,15 @@ class cWorld;
 
 
 /** Generates and lights the spawn area of the world. Runs as a separate thread. */
-class cSpawnPrepare
+class cSpawnPrepare:
+	public std::enable_shared_from_this<cSpawnPrepare>
 {
-
+	/** Private tag allows public constructors that can only be used with private access. */
+	struct sMakeSharedTag {};
 public:
+
+	cSpawnPrepare(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChunkZ, int a_PrepareDistance, int a_FirstIdx, sMakeSharedTag);
+
 	static void PrepareChunks(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChunkZ, int a_PrepareDistance);
 
 protected:
@@ -35,8 +40,6 @@ protected:
 
 	/** Number of chunks prepared when the last progress report was emitted. */
 	int m_LastReportChunkCount;
-
-	cSpawnPrepare(cWorld & a_World, int a_SpawnChunkX, int a_SpawnChunkZ, int a_PrepareDistance, int a_FirstIdx);
 
 	void PreparedChunkCallback(int a_ChunkX, int a_ChunkZ);
 


### PR DESCRIPTION
Possible fix for #2891.

I think that somehow `cSpawnPrepare::PreparedChunkCallback` is being called after it's gone out of scope in `cSpawnPrepare::PrepareChunks` which would explain the segfaults.  So this just makes sure the `cSpawnPrepare` instance stays alive while there are still references to it.