### PR TITLE
SetFlags: Omit frame pointer in C arm debug builds

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -108,6 +108,8 @@ macro(set_flags)
 		endif()
 
 		if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
+			# mbed TLS uses the frame pointer's register in inline assembly:
+			# https://tls.mbed.org/kb/development/arm-thumb-error-r7-cannot-be-used-in-asm-here
 			set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fomit-frame-pointer")
 			set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fomit-frame-pointer")
 		endif()

--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -109,6 +109,7 @@ macro(set_flags)
 
 		if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
 			set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fomit-frame-pointer")
+			set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fomit-frame-pointer")
 		endif()
 
 		set(CMAKE_CXX_FLAGS          "${CMAKE_CXX_FLAGS}          -std=c++11")


### PR DESCRIPTION
Should fix  #3309 if this [knowledge base entry](https://tls.mbed.org/kb/development/arm-thumb-error-r7-cannot-be-used-in-asm-here) is right.