### PR TITLE
Implement anvil chunk sparsing

### DIFF
--- a/src/ChunkData.cpp
+++ b/src/ChunkData.cpp
@@ -422,6 +422,129 @@ void cChunkData::CopySkyLight(NIBBLETYPE * a_Dest) const
 
 
 
+void cChunkData::FillBlockTypes(BLOCKTYPE a_Value)
+{
+	// If needed, allocate any missing sections
+	if (a_Value != 0x00)
+	{
+		for (auto & Section : m_Sections)
+		{
+			if (Section == nullptr)
+			{
+				Section = Allocate();
+				std::fill(std::begin(Section->m_BlockMetas),    std::end(Section->m_BlockMetas),    0x00);
+				std::fill(std::begin(Section->m_BlockLight),    std::end(Section->m_BlockLight),    0x00);
+				std::fill(std::begin(Section->m_BlockSkyLight), std::end(Section->m_BlockSkyLight), 0xff);
+			}
+		}
+	}
+
+	for (auto Section : m_Sections)
+	{
+		if (Section != nullptr)
+		{
+			std::fill(std::begin(Section->m_BlockTypes), std::end(Section->m_BlockTypes), a_Value);
+		}
+	}
+}
+
+
+
+
+
+void cChunkData::FillMetas(NIBBLETYPE a_Value)
+{
+	// If needed, allocate any missing sections
+	if (a_Value != 0x00)
+	{
+		for (auto & Section : m_Sections)
+		{
+			if (Section == nullptr)
+			{
+				Section = Allocate();
+				std::fill(std::begin(Section->m_BlockTypes),    std::end(Section->m_BlockTypes),    0x00);
+				std::fill(std::begin(Section->m_BlockLight),    std::end(Section->m_BlockLight),    0x00);
+				std::fill(std::begin(Section->m_BlockSkyLight), std::end(Section->m_BlockSkyLight), 0xff);
+			}
+		}
+	}
+
+	NIBBLETYPE NewMeta = static_cast<NIBBLETYPE>((a_Value << 4) | a_Value);
+	for (auto Section : m_Sections)
+	{
+		if (Section != nullptr)
+		{
+			std::fill(std::begin(Section->m_BlockMetas), std::end(Section->m_BlockMetas), NewMeta);
+		}
+	}
+}
+
+
+
+
+
+void cChunkData::FillBlockLight(NIBBLETYPE a_Value)
+{
+	// If needed, allocate any missing sections
+	if (a_Value != 0x00)
+	{
+		for (auto & Section : m_Sections)
+		{
+			if (Section == nullptr)
+			{
+				Section = Allocate();
+				std::fill(std::begin(Section->m_BlockTypes), std::end(Section->m_BlockTypes), 0x00);
+				std::fill(std::begin(Section->m_BlockMetas), std::end(Section->m_BlockMetas), 0x00);
+				std::fill(std::begin(Section->m_BlockSkyLight), std::end(Section->m_BlockSkyLight), 0xff);
+			}
+		}
+	}
+
+	NIBBLETYPE NewLight = static_cast<NIBBLETYPE>((a_Value << 4) | a_Value);
+	for (auto Section : m_Sections)
+	{
+		if (Section != nullptr)
+		{
+			std::fill(std::begin(Section->m_BlockLight), std::end(Section->m_BlockLight), NewLight);
+		}
+	}
+}
+
+
+
+
+
+void cChunkData::FillSkyLight(NIBBLETYPE a_Value)
+{
+	// If needed, allocate any missing sections
+	if (a_Value != 0x0f)
+	{
+		for (auto & Section : m_Sections)
+		{
+			if (Section == nullptr)
+			{
+				Section = Allocate();
+				std::fill(std::begin(Section->m_BlockTypes), std::end(Section->m_BlockTypes), 0x00);
+				std::fill(std::begin(Section->m_BlockMetas), std::end(Section->m_BlockMetas), 0x00);
+				std::fill(std::begin(Section->m_BlockLight), std::end(Section->m_BlockLight), 0x00);
+			}
+		}
+	}
+
+	NIBBLETYPE NewSkyLight = static_cast<NIBBLETYPE>((a_Value << 4) | a_Value);
+	for (auto Section : m_Sections)
+	{
+		if (Section != nullptr)
+		{
+			std::fill(std::begin(Section->m_BlockSkyLight), std::end(Section->m_BlockSkyLight), NewSkyLight);
+		}
+	}
+}
+
+
+
+
+
 void cChunkData::SetBlockTypes(const BLOCKTYPE * a_Src)
 {
 	ASSERT(a_Src != nullptr);

--- a/src/ChunkData.h
+++ b/src/ChunkData.h
@@ -80,6 +80,18 @@ public:
 	/** Copies the skylight data into the specified flat array. */
 	void CopySkyLight  (NIBBLETYPE * a_Dest) const;
 
+	/** Fills the chunk with the specified block. */
+	void FillBlockTypes(BLOCKTYPE a_Value);
+
+	/** Fills the chunk with the specified meta value. */
+	void FillMetas     (NIBBLETYPE a_Value);
+
+	/** Fills the chunk with the specified block light. */
+	void FillBlockLight(NIBBLETYPE a_Value);
+
+	/** Fills the chunk with the specified sky light. */
+	void FillSkyLight  (NIBBLETYPE a_Value);
+
 	/** Copies the blocktype data from the specified flat array into the internal representation.
 	Allocates sections that are needed for the operation.
 	Requires that a_Src is a valid pointer. */

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -67,11 +67,11 @@ void cNBTChunkSerializer::Finish(void)
 		m_Writer.EndList();
 	}
 
-	// If light not valid, reset it to all zeroes:
+	// If light not valid, reset it to defaults:
 	if (!m_IsLightValid)
 	{
-		memset(m_BlockLight,    0, sizeof(m_BlockLight));
-		memset(m_BlockSkyLight, 0, sizeof(m_BlockSkyLight));
+		m_Data.FillBlockLight(0x00);
+		m_Data.FillSkyLight(0x0f);
 	}
 
 	// Check if "Entity" and "TileEntities" lists exists. MCEdit requires this.

--- a/src/WorldStorage/NBTChunkSerializer.h
+++ b/src/WorldStorage/NBTChunkSerializer.h
@@ -1,4 +1,4 @@
-
+﻿
 // NBTChunkSerializer.h
 
 // Declares the cNBTChunkSerializer class that is used for saving individual chunks into NBT format used by Anvil
@@ -55,7 +55,7 @@ class cPainting;
 
 
 class cNBTChunkSerializer :
-	public cChunkDataSeparateCollector
+	public cChunkDataCopyCollector
 {
 public:
 	cChunkDef::BiomeMap m_Biomes;
@@ -69,15 +69,12 @@ public:
 	/** Close NBT tags that we've opened */
 	void Finish(void);
 
-	bool IsLightValid(void) const {return m_IsLightValid; }
+	bool IsLightValid(void) const { return m_IsLightValid; }
 
 protected:
 
-	/* From cChunkDataSeparateCollector we inherit:
-	- m_BlockTypes[]
-	- m_BlockMetas[]
-	- m_BlockLight[]
-	- m_BlockSkyLight[] */
+	/* From cChunkDataCopyCollector we inherit:
+	- cChunkData m_Data */
 
 	cFastNBTWriter & m_Writer;
 


### PR DESCRIPTION
Note the `cChunkData::Fill[data]` functions are only needed to keep the behaviour of overwriting invalid lighting (NBTChunkSerializer.cpp line 73).  If it's possible to drop that then this becomes a much smaller change.