### PR TITLE
Added check in cEntity::TickBurning for whether the entity is plannig to change worlds.

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1173,6 +1173,12 @@ void cEntity::ApplyFriction(Vector3d & a_Speed, double a_SlowdownMultiplier, flo
 
 void cEntity::TickBurning(cChunk & a_Chunk)
 {
+	// If we're about to change worlds, then we can't accurately determine whether we're in lava (#3939)
+	if (m_IsWorldChangeScheduled)
+	{
+		return;
+	}
+
 	// Remember the current burning state:
 	bool HasBeenBurning = (m_TicksLeftBurning > 0);
 


### PR DESCRIPTION
If a player respawns, ScheduleMoveToWorld is called, but the player is not actually moved until a later tick. However, the TickBurning method is called before the player is actually moved, but after the Respawn method has made the player stop burning. Thus, if the player is in contact with fire or lava, it will start burning immediately before actually moving.

Fixes #3939.
