### PR TITLE
Added check to deactivate existing entity effects when new entity effects are added

### DIFF
--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -197,6 +197,13 @@ void cPawn::AddEntityEffect(cEntityEffect::eType a_EffectType, int a_Duration, s
 	}
 	a_Duration = static_cast<int>(a_Duration * a_DistanceModifier);
 
+	// If we already have the effect, we have to deactivate it or else it will act cumulatively
+	auto ExistingEffect = m_EntityEffects.find(a_EffectType);
+	if (ExistingEffect != m_EntityEffects.end())
+	{
+		ExistingEffect->second->OnDeactivate(*this);
+	}
+
 	auto Res = m_EntityEffects.emplace(a_EffectType, cEntityEffect::CreateEntityEffect(a_EffectType, a_Duration, a_Intensity, a_DistanceModifier));
 	m_World->BroadcastEntityEffect(*this, a_EffectType, a_Intensity, static_cast<short>(a_Duration));
 	cEntityEffect * Effect = Res.first->second.get();


### PR DESCRIPTION
If an entity effect is added which already exists, the old entity effect does not get OnDeactivate called, which for the Speed and Slowness potions means that the effect will act cumulatively.

This PR adds a check to call OnDeactivate.

Probably a better fix might be to modify SendPlayerMaxSpeed so that it sends the effects as modifiers, rather than the effects changing the actual base player speed. That might effect how mobs deal with potions applied to them, though, so this is a spot fix for now.

Fixes #3947.
