### PR TITLE
Omit frame pointer with target_compile_options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,12 @@ endif()
 # (PolarSSL also has test and example programs in their CMakeLists.txt, we don't want those)
 include(lib/polarssl.cmake EXCLUDE_FROM_ALL)
 
+if(NOT MSVC AND "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
+	# mbed TLS uses the frame pointer's register in inline assembly:
+	# https://tls.mbed.org/kb/development/arm-thumb-error-r7-cannot-be-used-in-asm-here
+	target_compile_options(mbedtls PUBLIC -fomit-frame-pointer)
+endif()
+
 set_exe_flags()
 
 add_subdirectory(src)

--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -107,13 +107,6 @@ macro(set_flags)
 			)
 		endif()
 
-		if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
-			# mbed TLS uses the frame pointer's register in inline assembly:
-			# https://tls.mbed.org/kb/development/arm-thumb-error-r7-cannot-be-used-in-asm-here
-			set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fomit-frame-pointer")
-			set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fomit-frame-pointer")
-		endif()
-
 		set(CMAKE_CXX_FLAGS          "${CMAKE_CXX_FLAGS}          -std=c++11")
 		set(CMAKE_CXX_FLAGS_DEBUG    "${CMAKE_CXX_FLAGS_DEBUG}    -std=c++11")
 		set(CMAKE_CXX_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_COVERAGE} -std=c++11")


### PR DESCRIPTION
Should really fix #3309 this time.
Putting `set(CMAKE_SYSTEM_PROCESSOR arm)` in `tc.cmake` and running cmake with `-DCMAKE_TOOLCHAIN_FILE=tc.cmake -DCMAKE_EXPORT_COMPILE_COMMADS=1` shows `-fomit-frame-pointer` is definitely used for mbedTLS comilations.