### PR TITLE
Removed outdated pathfinder comment

### DIFF
--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -61,8 +61,7 @@ public:
 
 	virtual void HandleFalling(void) override;
 
-	/** Engage pathfinder and tell it to calculate a path to a given position, and move the mob accordingly
-	Currently, the mob will only start moving to a new position after the position it is currently going to is reached. */
+	/** Engage pathfinder and tell it to calculate a path to a given position, and move the mob accordingly. */
 	virtual void MoveToPosition(const Vector3d & a_Position);  // tolua_export
 
 	// tolua_begin


### PR DESCRIPTION
It's been years since that behavior.

For anyone curious: When given a new destination, the new pathfinder may either recalculate the path immediately, or it may decide that the new destination is close enough to the older one, and keep walking to the old place for a while. It'd recalculate only when it gets close enough. This improves performance for rapidly moving targets, like players.