### PR TITLE
Bed piston fix

### DIFF
--- a/src/Blocks/BlockBed.cpp
+++ b/src/Blocks/BlockBed.cpp
@@ -209,7 +209,7 @@ void cBlockBedHandler::OnPlacedByPlayer(cChunkInterface & a_ChunkInterface, cWor
 
 
 
-void cBlockBedHandler::ConvertToPickups(cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+void cBlockBedHandler::ConvertToPickups(cWorldInterface & a_WorldInterface, cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	class cBedColor :
 		public cBedCallback
@@ -219,11 +219,12 @@ void cBlockBedHandler::ConvertToPickups(cEntity * a_Digger, cItems & a_Pickups, 
 
 		virtual bool Item(cBedEntity * a_Bed) override
 		{
+			LOG("Got bed color");
 			m_Color = a_Bed->GetColor();
 			return true;
 		}
 	};
 	cBedColor BedCallback;
-	a_Digger->GetWorld()->DoWithBedAt(a_BlockX, a_BlockY, a_BlockZ, BedCallback);
+        a_WorldInterface.DoWithBedAt(a_BlockX, a_BlockY, a_BlockZ, BedCallback);
 	a_Pickups.Add(cItem(E_ITEM_BED, 1, BedCallback.m_Color));
 }

--- a/src/Blocks/BlockBed.cpp
+++ b/src/Blocks/BlockBed.cpp
@@ -209,7 +209,7 @@ void cBlockBedHandler::OnPlacedByPlayer(cChunkInterface & a_ChunkInterface, cWor
 
 
 
-void cBlockBedHandler::ConvertToPickups(cWorldInterface & a_WorldInterface, cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+void cBlockBedHandler::ConvertToPickups(cWorldInterface & a_WorldInterface, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	class cBedColor :
 		public cBedCallback
@@ -219,7 +219,6 @@ void cBlockBedHandler::ConvertToPickups(cWorldInterface & a_WorldInterface, cEnt
 
 		virtual bool Item(cBedEntity * a_Bed) override
 		{
-			LOG("Got bed color");
 			m_Color = a_Bed->GetColor();
 			return true;
 		}

--- a/src/Blocks/BlockBed.cpp
+++ b/src/Blocks/BlockBed.cpp
@@ -225,6 +225,6 @@ void cBlockBedHandler::ConvertToPickups(cWorldInterface & a_WorldInterface, cEnt
 		}
 	};
 	cBedColor BedCallback;
-        a_WorldInterface.DoWithBedAt(a_BlockX, a_BlockY, a_BlockZ, BedCallback);
+	a_WorldInterface.DoWithBedAt(a_BlockX, a_BlockY, a_BlockZ, BedCallback);
 	a_Pickups.Add(cItem(E_ITEM_BED, 1, BedCallback.m_Color));
 }

--- a/src/Blocks/BlockBed.h
+++ b/src/Blocks/BlockBed.h
@@ -35,7 +35,7 @@ public:
 
 	virtual void ConvertToPickups(cItems & Pickups, NIBBLETYPE Meta) override {}
 
-	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) override;
+	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) override;
 
 	// Bed specific helper functions
 	static NIBBLETYPE RotationToMetaData(double a_Rotation)

--- a/src/Blocks/BlockBed.h
+++ b/src/Blocks/BlockBed.h
@@ -35,7 +35,7 @@ public:
 
 	virtual void ConvertToPickups(cItems & Pickups, NIBBLETYPE Meta) override {}
 
-	virtual void ConvertToPickups(cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) override;
+	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) override;
 
 	// Bed specific helper functions
 	static NIBBLETYPE RotationToMetaData(double a_Rotation)

--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -523,7 +523,7 @@ void cBlockHandler::DropBlock(cChunkInterface & a_ChunkInterface, cWorldInterfac
 				case E_BLOCK_BED:
 				{
 					// Need to access the bed entity to get the color for the item damage
-					ConvertToPickups(a_Digger, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
+					ConvertToPickups(a_WorldInterface, a_Digger, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
 				}
 				default: Pickups.Add(m_BlockType, 1, Meta); break;
 			}
@@ -531,7 +531,7 @@ void cBlockHandler::DropBlock(cChunkInterface & a_ChunkInterface, cWorldInterfac
 		else if (m_BlockType == E_BLOCK_BED)
 		{
 			// Need to access the bed entity to get the color for the item damage
-			ConvertToPickups(a_Digger, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
+			ConvertToPickups(a_WorldInterface, a_Digger, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
 		}
 		else
 		{

--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -523,7 +523,7 @@ void cBlockHandler::DropBlock(cChunkInterface & a_ChunkInterface, cWorldInterfac
 				case E_BLOCK_BED:
 				{
 					// Need to access the bed entity to get the color for the item damage
-					ConvertToPickups(a_WorldInterface, a_Digger, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
+					ConvertToPickups(a_WorldInterface, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
 				}
 				default: Pickups.Add(m_BlockType, 1, Meta); break;
 			}
@@ -531,7 +531,7 @@ void cBlockHandler::DropBlock(cChunkInterface & a_ChunkInterface, cWorldInterfac
 		else if (m_BlockType == E_BLOCK_BED)
 		{
 			// Need to access the bed entity to get the color for the item damage
-			ConvertToPickups(a_WorldInterface, a_Digger, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
+			ConvertToPickups(a_WorldInterface, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
 		}
 		else
 		{

--- a/src/Blocks/BlockHandler.h
+++ b/src/Blocks/BlockHandler.h
@@ -88,8 +88,8 @@ public:
 	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta);
 
 	/** Called when the item is mined to convert it into pickups. Pickups may specify multiple items. Appends items to a_Pickups, preserves its original contents.
-	Overloaded method with coords and digger, for blocks that needs to access the block entity, e.g. a bed */
-	virtual void ConvertToPickups(cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) {}
+	Overloaded method with coords, digger, and world interface for blocks that needs to access the block entity, e.g. a bed. Note that a_Digger could be null e.g. when a piston causes the bed to drop */
+	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) {}
 
 	/** Handles the dropping, but not destruction, of a block based on what ConvertTo(Verbatim)Pickups() returns, including the spawning of pickups and alertion of plugins
 	@param a_Digger The entity causing the drop; it may be nullptr

--- a/src/Blocks/BlockHandler.h
+++ b/src/Blocks/BlockHandler.h
@@ -88,7 +88,7 @@ public:
 	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta);
 
 	/** Called when the item is mined to convert it into pickups. Pickups may specify multiple items. Appends items to a_Pickups, preserves its original contents.
-	Overloaded method with coords, digger, and world interface for blocks that needs to access the block entity, e.g. a bed. Note that a_Digger could be null e.g. when a piston causes the bed to drop */
+	Overloaded method with coords and world interface for blocks that needs to access the block entity, e.g. a bed. Note that a_Digger could be null e.g. when a piston causes the bed to drop */
 	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) {}
 
 	/** Handles the dropping, but not destruction, of a block based on what ConvertTo(Verbatim)Pickups() returns, including the spawning of pickups and alertion of plugins

--- a/src/Blocks/BlockHandler.h
+++ b/src/Blocks/BlockHandler.h
@@ -88,7 +88,7 @@ public:
 	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta);
 
 	/** Called when the item is mined to convert it into pickups. Pickups may specify multiple items. Appends items to a_Pickups, preserves its original contents.
-	Overloaded method with coords and world interface for blocks that needs to access the block entity, e.g. a bed. Note that a_Digger could be null e.g. when a piston causes the bed to drop */
+	Overloaded method with coords and world interface for blocks that needs to access the block entity, e.g. a bed. */
 	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) {}
 
 	/** Handles the dropping, but not destruction, of a block based on what ConvertTo(Verbatim)Pickups() returns, including the spawning of pickups and alertion of plugins

--- a/src/Blocks/BlockHandler.h
+++ b/src/Blocks/BlockHandler.h
@@ -89,7 +89,7 @@ public:
 
 	/** Called when the item is mined to convert it into pickups. Pickups may specify multiple items. Appends items to a_Pickups, preserves its original contents.
 	Overloaded method with coords, digger, and world interface for blocks that needs to access the block entity, e.g. a bed. Note that a_Digger could be null e.g. when a piston causes the bed to drop */
-	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cEntity * a_Digger, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) {}
+	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) {}
 
 	/** Handles the dropping, but not destruction, of a block based on what ConvertTo(Verbatim)Pickups() returns, including the spawning of pickups and alertion of plugins
 	@param a_Digger The entity causing the drop; it may be nullptr

--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -115,9 +115,7 @@ void cBlockPistonHandler::PushBlocks(
 	for (auto & moveBlockPos : sortedBlocks)
 	{
 		a_World.GetBlockTypeMeta(moveBlockPos.x, moveBlockPos.y, moveBlockPos.z, moveBlock, moveMeta);
-		a_World.SetBlock(moveBlockPos.x, moveBlockPos.y, moveBlockPos.z, E_BLOCK_AIR, 0);
 
-		moveBlockPos += a_PushDir;
 		if (cBlockInfo::IsPistonBreakable(moveBlock))
 		{
 			// Block is breakable, drop it
@@ -130,10 +128,13 @@ void cBlockPistonHandler::PushBlocks(
 					moveBlockPos.x, moveBlockPos.y, moveBlockPos.z
 				);
 			}
+			a_World.SetBlock(moveBlockPos.x, moveBlockPos.y, moveBlockPos.z, E_BLOCK_AIR, 0);
 		}
 		else
 		{
 			// Not breakable, just move it
+			a_World.SetBlock(moveBlockPos.x, moveBlockPos.y, moveBlockPos.z, E_BLOCK_AIR, 0);
+			moveBlockPos += a_PushDir;
 			a_World.SetBlock(moveBlockPos.x, moveBlockPos.y, moveBlockPos.z, moveBlock, moveMeta);
 		}
 	}

--- a/src/Blocks/WorldInterface.h
+++ b/src/Blocks/WorldInterface.h
@@ -28,6 +28,8 @@ public:
 
 	virtual void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, eExplosionSource a_Source, void * a_SourceData) = 0;
 
+	virtual bool DoWithBedAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBedCallback & a_Callback) = 0;
+
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities: */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool IsPlayerCreated = false) = 0;
 

--- a/src/World.h
+++ b/src/World.h
@@ -548,7 +548,7 @@ public:
 	bool DoWithBeaconAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBeaconCallback & a_Callback);  // Exported in ManualBindings.cpp
 
 	/** Calls the callback for the bed at the specified coords; returns false if there's no bed at those coords, true if found */
-	bool DoWithBedAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBedCallback & a_Callback);  // Exported in ManualBindings.cpp
+	virtual bool DoWithBedAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBedCallback & a_Callback) override;  // Exported in ManualBindings.cpp
 
 	/** Calls the callback for the brewingstand at the specified coords; returns false if there's no brewingstand at those coords, true if found */
 	bool DoWithBrewingstandAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBrewingstandCallback & a_Callback);  // Lua-acessible


### PR DESCRIPTION
When a block is turned into drops by a piston, the a_Digger argument is nullptr, because no entity is the digger. Beds use the GetWorld() method of a_Digger to figure out what color they are.

This PR passes a cWorldInterface directly to the ConvertToPickups method. It also changes how piston's PushBlocks method sets the original block to air, to make sure the block still exists when DropBlock is called.

With credit to @Seadragon91, who figured out that pistons were clearing the block before the DropBlock method was called.

Fixes #3954.
