### PR TITLE
Repair the removed constructor of cCuboid `cCuboid(otherCuboid)`

### DIFF
--- a/src/Cuboid.cpp
+++ b/src/Cuboid.cpp
@@ -10,8 +10,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 // cCuboid:
 
-
-
+cCuboid & cCuboid::operator =(cCuboid a_Other)
+{
+	std::swap(p1, a_Other.p1);
+	std::swap(p2, a_Other.p2);
+	return *this;
+}
 
 
 void cCuboid::Assign(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2)

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -17,6 +17,12 @@ public:
 	cCuboid(const Vector3i & a_p1, const Vector3i & a_p2) : p1(a_p1), p2(a_p2) {}
 	cCuboid(int a_X1, int a_Y1, int a_Z1) : p1(a_X1, a_Y1, a_Z1), p2(a_X1, a_Y1, a_Z1) {}
 
+	// tolua_end
+
+	cCuboid & operator =(cCuboid a_Other);
+
+	// tolua_begin
+
 	// DEPRECATED, use cCuboid(Vector3i, Vector3i) instead
 	cCuboid(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2) : p1(a_X1, a_Y1, a_Z1), p2(a_X2, a_Y2, a_Z2)
 	{

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -13,6 +13,7 @@ public:
 	Vector3i p1, p2;
 
 	cCuboid(void) {}
+	cCuboid(const cCuboid & a_Cuboid) : p1(a_Cuboid.p1), p2(a_Cuboid.p2) {}
 	cCuboid(const Vector3i & a_p1, const Vector3i & a_p2) : p1(a_p1), p2(a_p2) {}
 	cCuboid(int a_X1, int a_Y1, int a_Z1) : p1(a_X1, a_Y1, a_Z1), p2(a_X1, a_Y1, a_Z1) {}
 


### PR DESCRIPTION
Hi,
See: https://github.com/cuberite/cuberite/issues/3965
And also:
- https://github.com/cuberite/WorldEdit/issues/131
- https://github.com/cuberite/WorldEdit/pull/132

I just put one line removed https://github.com/cuberite/cuberite/commit/7bdbfad1bbabb84e650261ad31d2d9b47f8b12a9#diff-340f510ebeacdfbbbd90d90ff8090930L13
Probably removed by accident

Fixes #3965 