### PR TITLE
cCuboid: restore default copy construct and assign

### DIFF
--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -2995,7 +2995,7 @@ static int tolua_cLineBlockTracer_FirstSolidHitTrace(lua_State * tolua_S)
 		Vector3d hitCoords;
 		Vector3i hitBlockCoords;
 		eBlockFace hitBlockFace;
-		auto isHit = cLineBlockTracer::FirstSolidHitTrace(*world, start, end, hitCoords, hitBlockCoords, hitBlockFace);
+		auto isHit = cLineBlockTracer::FirstSolidHitTrace(*world, *start, *end, hitCoords, hitBlockCoords, hitBlockFace);
 		L.Push(isHit);
 		if (!isHit)
 		{
@@ -3093,7 +3093,7 @@ static int tolua_cLineBlockTracer_LineOfSightTrace(lua_State * tolua_S)
 		}
 		int lineOfSight = cLineBlockTracer::losAirWater;
 		L.GetStackValue(idx + 7, lineOfSight);
-		L.Push(cLineBlockTracer::LineOfSightTrace(*world, start, end, lineOfSight));
+		L.Push(cLineBlockTracer::LineOfSightTrace(*world, *start, *end, lineOfSight));
 		return 1;
 	}
 
@@ -3532,7 +3532,7 @@ static int tolua_cBoundingBox_CalcLineIntersection(lua_State * a_LuaState)
 	bool res;
 	if (L.GetStackValues(2, min, max, pt1, pt2))  // Try the static signature first
 	{
-		res = cBoundingBox::CalcLineIntersection(min, max, pt1, pt2, lineCoeff, blockFace);
+		res = cBoundingBox::CalcLineIntersection(*min, *max, *pt1, *pt2, lineCoeff, blockFace);
 	}
 	else
 	{
@@ -3543,7 +3543,7 @@ static int tolua_cBoundingBox_CalcLineIntersection(lua_State * a_LuaState)
 			tolua_error(a_LuaState, "Invalid function params. Expected either bbox:CalcLineIntersection(pt1, pt2) or cBoundingBox:CalcLineIntersection(min, max, pt1, pt2).", nullptr);
 			return 0;
 		}
-		res = bbox->CalcLineIntersection(pt1, pt2, lineCoeff, blockFace);
+		res = bbox->CalcLineIntersection(*pt1, *pt2, lineCoeff, blockFace);
 	}
 	L.Push(res);
 	if (res)

--- a/src/Cuboid.cpp
+++ b/src/Cuboid.cpp
@@ -10,14 +10,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // cCuboid:
 
-cCuboid & cCuboid::operator =(cCuboid a_Other)
-{
-	std::swap(p1, a_Other.p1);
-	std::swap(p2, a_Other.p2);
-	return *this;
-}
-
-
 void cCuboid::Assign(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2)
 {
 	p1.x = a_X1;
@@ -26,20 +18,6 @@ void cCuboid::Assign(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2)
 	p2.x = a_X2;
 	p2.y = a_Y2;
 	p2.z = a_Z2;
-}
-
-
-
-
-
-void cCuboid::Assign(const cCuboid & a_SrcCuboid)
-{
-	p1.x = a_SrcCuboid.p1.x;
-	p1.y = a_SrcCuboid.p1.y;
-	p1.z = a_SrcCuboid.p1.z;
-	p2.x = a_SrcCuboid.p2.x;
-	p2.y = a_SrcCuboid.p2.y;
-	p2.z = a_SrcCuboid.p2.z;
 }
 
 

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -16,7 +16,7 @@ public:
 	cCuboid(const Vector3i & a_p1, const Vector3i & a_p2) : p1(a_p1), p2(a_p2) {}
 	cCuboid(int a_X1, int a_Y1, int a_Z1) : p1(a_X1, a_Y1, a_Z1), p2(a_X1, a_Y1, a_Z1) {}
 
-	#if 0  // tolua isn't aware of implicitly generated copy constructors
+	#ifdef TOLUA_EXPOSITION  // tolua isn't aware of implicitly generated copy constructors
 		cCuboid(const cCuboid & a_Cuboid);
 	#endif
 

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -13,15 +13,12 @@ public:
 	Vector3i p1, p2;
 
 	cCuboid(void) {}
-	cCuboid(const cCuboid & a_Cuboid) : p1(a_Cuboid.p1), p2(a_Cuboid.p2) {}
 	cCuboid(const Vector3i & a_p1, const Vector3i & a_p2) : p1(a_p1), p2(a_p2) {}
 	cCuboid(int a_X1, int a_Y1, int a_Z1) : p1(a_X1, a_Y1, a_Z1), p2(a_X1, a_Y1, a_Z1) {}
 
-	// tolua_end
-
-	cCuboid & operator =(cCuboid a_Other);
-
-	// tolua_begin
+	#if 0  // tolua isn't aware of implicitly generated copy constructors
+		cCuboid(const cCuboid & a_Cuboid);
+	#endif
 
 	// DEPRECATED, use cCuboid(Vector3i, Vector3i) instead
 	cCuboid(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2) : p1(a_X1, a_Y1, a_Z1), p2(a_X2, a_Y2, a_Z2)
@@ -30,7 +27,7 @@ public:
 	}
 
 	void Assign(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2);
-	void Assign(const cCuboid & a_SrcCuboid);
+	void Assign(const cCuboid & a_SrcCuboid) { *this = a_SrcCuboid; }
 
 	void Sort(void);
 

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -81,7 +81,7 @@ protected:
 			{
 				Vector3d Intersection = LineStart + m_Projectile->GetSpeed() * LineCoeff;  // Point where projectile goes into the hit block
 
-				if (cPluginManager::Get()->CallHookProjectileHitBlock(*m_Projectile, a_BlockX, a_BlockY, a_BlockZ, Face, &Intersection))
+				if (cPluginManager::Get()->CallHookProjectileHitBlock(*m_Projectile, a_BlockX, a_BlockY, a_BlockZ, Face, Intersection))
 				{
 					return false;
 				}

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -476,6 +476,10 @@ using cTickTimeLong = std::chrono::duration<Int64,  cTickTime::period>;
 	#define TOLUA_TEMPLATE_BIND(x)
 #endif
 
+#ifdef TOLUA_EXPOSITION
+	#error TOLUA_EXPOSITION should never actually be defined
+#endif
+
 
 
 

--- a/src/Item.h
+++ b/src/Item.h
@@ -80,20 +80,10 @@ public:
 
 	// The constructor is disabled in code, because the compiler generates it anyway,
 	// but it needs to stay because ToLua needs to generate the binding for it
-	#if 0
+	#ifdef TOLUA_EXPOSITION
 
 	/** Creates an exact copy of the item */
-	cItem(const cItem & a_CopyFrom) :
-		m_ItemType    (a_CopyFrom.m_ItemType),
-		m_ItemCount   (a_CopyFrom.m_ItemCount),
-		m_ItemDamage  (a_CopyFrom.m_ItemDamage),
-		m_Enchantments(a_CopyFrom.m_Enchantments),
-		m_CustomName  (a_CopyFrom.m_CustomName),
-		m_Lore        (a_CopyFrom.m_Lore),
-		m_RepairCost  (a_CopyFrom.m_RepairCost),
-		m_FireworkItem(a_CopyFrom.m_FireworkItem)
-	{
-	}
+	cItem(const cItem & a_CopyFrom);
 
 	#endif
 

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -21,7 +21,7 @@ public:
 	inline Vector3(T a_x, T a_y, T a_z) : x(a_x), y(a_y), z(a_z) {}
 
 
-	#if 0  // Hardcoded copy constructors (tolua++ does not support function templates .. yet)
+	#ifdef TOLUA_EXPOSITION  // Hardcoded copy constructors (tolua++ does not support function templates .. yet)
 		Vector3(const Vector3<float>  & a_Rhs);
 		Vector3(const Vector3<double> & a_Rhs);
 		Vector3(const Vector3<int>    & a_Rhs);

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -21,18 +21,17 @@ public:
 	inline Vector3(T a_x, T a_y, T a_z) : x(a_x), y(a_y), z(a_z) {}
 
 
-	// Hardcoded copy constructors (tolua++ does not support function templates .. yet)
-	Vector3(const Vector3<float>  & a_Rhs) : x(static_cast<T>(a_Rhs.x)), y(static_cast<T>(a_Rhs.y)), z(static_cast<T>(a_Rhs.z)) {}
-	Vector3(const Vector3<double> & a_Rhs) : x(static_cast<T>(a_Rhs.x)), y(static_cast<T>(a_Rhs.y)), z(static_cast<T>(a_Rhs.z)) {}
-	Vector3(const Vector3<int>    & a_Rhs) : x(static_cast<T>(a_Rhs.x)), y(static_cast<T>(a_Rhs.y)), z(static_cast<T>(a_Rhs.z)) {}
+	#if 0  // Hardcoded copy constructors (tolua++ does not support function templates .. yet)
+		Vector3(const Vector3<float>  & a_Rhs);
+		Vector3(const Vector3<double> & a_Rhs);
+		Vector3(const Vector3<int>    & a_Rhs);
+	#endif
 
 
 	// tolua_end
-	template <typename _T>
-	Vector3(const Vector3<_T> & a_Rhs) : x(a_Rhs.x), y(a_Rhs.y), z(a_Rhs.z) {}
-
-	template <typename _T>
-	Vector3(const Vector3<_T> * a_Rhs) : x(a_Rhs->x), y(a_Rhs->y), z(a_Rhs->z) {}
+	// Conversion constructors where U is not the same as T leaving the copy-constructor implicitly generated
+	template <typename U, typename = typename std::enable_if<!std::is_same<U, T>::value>::type>
+	Vector3(const Vector3<U> & a_Rhs): x(static_cast<T>(a_Rhs.x)), y(static_cast<T>(a_Rhs.y)), z(static_cast<T>(a_Rhs.z)) {}
 	// tolua_begin
 
 	inline void Set(T a_x, T a_y, T a_z)
@@ -111,9 +110,9 @@ public:
 	/** Updates each coord to its absolute value */
 	inline void Abs()
 	{
-		x = (x < 0) ? -x : x;
-		y = (y < 0) ? -y : y;
-		z = (z < 0) ? -z : z;
+		x = std::abs(x);
+		y = std::abs(y);
+		z = std::abs(z);
 	}
 
 	/** Clamps each coord into the specified range. */
@@ -152,7 +151,7 @@ public:
 
 	inline bool EqualsEps(const Vector3<T> & a_Rhs, T a_Eps) const
 	{
-		return (Abs(x - a_Rhs.x) < a_Eps) && (Abs(y - a_Rhs.y) < a_Eps) && (Abs(z - a_Rhs.z) < a_Eps);
+		return (std::abs(x - a_Rhs.x) < a_Eps) && (std::abs(y - a_Rhs.y) < a_Eps) && (std::abs(z - a_Rhs.z) < a_Eps);
 	}
 
 	inline void Move(T a_X, T a_Y, T a_Z)
@@ -229,14 +228,6 @@ public:
 		z *= a_v;
 	}
 
-	inline Vector3<T> & operator = (const Vector3<T> & a_Rhs)
-	{
-		x = a_Rhs.x;
-		y = a_Rhs.y;
-		z = a_Rhs.z;
-		return *this;
-	}
-
 	// tolua_begin
 
 	inline Vector3<T> operator + (const Vector3<T>& a_Rhs) const
@@ -305,7 +296,7 @@ public:
 	*/
 	inline double LineCoeffToXYPlane(const Vector3<T> & a_OtherEnd, T a_Z) const
 	{
-		if (Abs(z - a_OtherEnd.z) < EPS)
+		if (std::abs(z - a_OtherEnd.z) < EPS)
 		{
 			return NO_INTERSECTION;
 		}
@@ -320,7 +311,7 @@ public:
 	*/
 	inline double LineCoeffToXZPlane(const Vector3<T> & a_OtherEnd, T a_Y) const
 	{
-		if (Abs(y - a_OtherEnd.y) < EPS)
+		if (std::abs(y - a_OtherEnd.y) < EPS)
 		{
 			return NO_INTERSECTION;
 		}
@@ -335,7 +326,7 @@ public:
 	*/
 	inline double LineCoeffToYZPlane(const Vector3<T> & a_OtherEnd, T a_X) const
 	{
-		if (Abs(x - a_OtherEnd.x) < EPS)
+		if (std::abs(x - a_OtherEnd.x) < EPS)
 		{
 			return NO_INTERSECTION;
 		}
@@ -364,16 +355,6 @@ public:
 
 	/** Return value of LineCoeffToPlane() if the line is parallel to the plane. */
 	static const double NO_INTERSECTION;
-
-protected:
-
-	/** Returns the absolute value of the given argument.
-	Templatized because the standard library differentiates between abs() and fabs(). */
-	static T Abs(T a_Value)
-	{
-		return (a_Value < 0) ? -a_Value : a_Value;
-	}
-
 };
 // tolua_end
 


### PR DESCRIPTION
This is what I was talking about in #3966.  `#if 0` blocks as a hint to tolua++ but letting the compiler do the actual implementation.  The same thing is done in [`cItem`](https://github.com/cuberite/cuberite/blob/a5869b3c0909e658ece6a9c27037292ad138b918/src/Item.h#L81-L98).

Even if you don't care about `is_nothrow_copy_constructible` or `is_trivially_copy_constructable` hopefully we can agree that achieving the same goal with less code is a good thing.  Or at the very least that the compiler is less likely to write bugs.