### PR TITLE
cUUID: Fix FromHexDigit for digits >= 'a'

### DIFF
--- a/src/UUID.cpp
+++ b/src/UUID.cpp
@@ -68,11 +68,11 @@ static Byte FromHexDigit(char a_Hex)
 	}
 	if (('a' <= a_Hex) && (a_Hex <= 'f'))
 	{
-		return static_cast<Byte>(a_Hex - 'a');
+		return static_cast<Byte>(10 + (a_Hex - 'a'));
 	}
 	if (('A' <= a_Hex) && (a_Hex <= 'F'))
 	{
-		return static_cast<Byte>(a_Hex - 'A');
+		return static_cast<Byte>(10 + (a_Hex - 'A'));
 	}
 	return 0xff;
 }


### PR DESCRIPTION
Fixes #3974.

I should really write some tests for `cUUID`.