### PR TITLE
Prevent Squids from suffocating in water

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1681,7 +1681,8 @@ void cEntity::SetSwimState(cChunk & a_Chunk)
 	m_IsSwimming = IsBlockWater(BlockIn);
 
 	// Check if the player is submerged:
-	VERIFY(a_Chunk.UnboundedRelGetBlockType(RelX, RelY + 1, RelZ, BlockIn));
+	int HeadHeight = CeilC(GetPosY() + GetHeight()) - 1;
+	VERIFY(a_Chunk.UnboundedRelGetBlockType(RelX, HeadHeight, RelZ, BlockIn));
 	m_IsSubmerged = IsBlockWater(BlockIn);
 }
 
@@ -1713,7 +1714,7 @@ void cEntity::DoSetSpeed(double a_SpeedX, double a_SpeedY, double a_SpeedZ)
 void cEntity::HandleAir(void)
 {
 	// Ref.: https://minecraft.gamepedia.com/Chunk_format
-	// See if the entity is /submerged/ water (block above is water)
+	// See if the entity is /submerged/ water (head is in water)
 	// Get the type of block the entity is standing in:
 
 	int RespirationLevel = static_cast<int>(GetEquippedHelmet().m_Enchantments.GetLevel(cEnchantments::enchRespiration));

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1335,11 +1335,6 @@ bool cMonster::WouldBurnAt(Vector3d a_Location, cChunk & a_Chunk)
 {
 	// If the Y coord is out of range, return the most logical result without considering anything else:
 	int RelY = FloorC(a_Location.y);
-	if (RelY < 0)
-	{
-		// Never burn under the world
-		return false;
-	}
 	if (RelY >= cChunkDef::Height)
 	{
 		// Always burn above the world

--- a/src/Mobs/Squid.h
+++ b/src/Mobs/Squid.h
@@ -23,7 +23,6 @@ public:
 
 	// Squids do not drown (or float)
 	virtual void HandleAir(void) override {}
-	virtual void SetSwimState(cChunk & a_Chunk) override {}
 } ;
 
 


### PR DESCRIPTION
This fixes squids from suffocating in water, as reported by @LogicParrot in #3942. Also fixes code duplication `cMonserter:WouldBurnAt()`.

Code is tested and squids do not suffocate in water, player does suffocate normally, however I have some questions about the code that should probably be resolved before merging:

 1. What is the purpose of the `+0.1` on [line 1657](https://github.com/cuberite/cuberite/blob/master/src/Entities/Entity.cpp#L1657) of Entity.cpp - should I get rid of it?
 2. Should squids use `IsSwimming()` or `IsSubmerged()`?  Currently they suffocate if their head is out of the water, but their height is low so their head should never be out of the water.
 2. Should I create methods of the cEntity class to get the head height, or to check if the entity is out of the world (above or below)? Those operations seem to be duplicated many times in the code, and centralising them could help avoid logic bugs.

**Please do not squash-merge, the two commits here are logically separate, rebase-merge instead.**