### PR TITLE
Added ShouldSendRespawn parameter to ScheduleMoveToWorld

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3946,8 +3946,13 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 							Type = "boolean",
 							IsOptional = true,
 						},
+						{
+							Name = "ShouldSendRespawn",
+							Type = "boolean",
+							IsOptional  = true,
+						},
 					},
-					Notes = "Schedules a MoveToWorld call to occur on the next Tick of the entity. If ShouldSetPortalCooldown is false (default), doesn't set any portal cooldown, if it is true, the default portal cooldown is applied to the entity.",
+					Notes = "Schedules a MoveToWorld call to occur on the next Tick of the entity. If ShouldSetPortalCooldown is false (default), doesn't set any portal cooldown, if it is true, the default portal cooldown is applied to the entity. If ShouldSendRespawn is false (default), no respawn packet is sent, if it is true then a respawn packet is sent to the client.",
 				},
 				SetGravity =
 				{

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1353,12 +1353,13 @@ void cEntity::DetectCacti(void)
 
 
 
-void cEntity::ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_SetPortalCooldown)
+void cEntity::ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_SetPortalCooldown, bool a_ShouldSendRespawn)
 {
 	m_NewWorld = a_World;
 	m_NewWorldPosition = a_NewPosition;
 	m_IsWorldChangeScheduled = true;
 	m_WorldChangeSetPortalCooldown = a_SetPortalCooldown;
+	m_WorldChangeSendRespawn = a_ShouldSendRespawn;
 }
 
 
@@ -1378,7 +1379,7 @@ bool cEntity::DetectPortal()
 			m_PortalCooldownData.m_ShouldPreventTeleportation = true;
 		}
 
-		MoveToWorld(m_NewWorld, false, m_NewWorldPosition);
+		MoveToWorld(m_NewWorld, m_WorldChangeSendRespawn, m_NewWorldPosition);
 		return true;
 	}
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -428,7 +428,7 @@ public:
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
 
 	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
-	void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false);
+	void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = false);
 
 	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition);
 
@@ -592,6 +592,7 @@ protected:
 	/** State variables for ScheduleMoveToWorld. */
 	bool m_IsWorldChangeScheduled;
 	bool m_WorldChangeSetPortalCooldown;
+	bool m_WorldChangeSendRespawn;
 	cWorld * m_NewWorld;
 	Vector3d m_NewWorldPosition;
 


### PR DESCRIPTION
As part of a fix for #3976, this PR adds a ShouldSendRespawn parameter to ScheduleMoveToWorld.

See the Core PR https://github.com/cuberite/Core/pull/203
