### PR TITLE
OnLogin now kicks players properly

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -722,9 +722,10 @@ bool cClientHandle::HandleLogin(const AString & a_Username)
 		// Let the plugins know about this event, they may refuse the player:
 		if (cRoot::Get()->GetPluginManager()->CallHookLogin(*this, m_ProtocolVersion, a_Username))
 		{
-			Destroy();
+			SendDisconnect("Login Rejected!");
 			return false;
 		}
+
 		m_State = csAuthenticating;
 	}  // lock(m_CSState)
 


### PR DESCRIPTION
Fixes #3868 

The code is tested and works.

Related to this - maybe my understanding of the code is off, but I couldn't see any way that kicking is enforced after the disconnect packet is sent. Am I missing something?