### PR TITLE
Added assert to cProtocolRecognizer::GetPacketId.

### DIFF
--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -131,9 +131,6 @@ public:
 	/** Called when client sends some data */
 	virtual void DataReceived(const char * a_Data, size_t a_Size) = 0;
 
-	/** Returns the protocol-specific packet ID given the protocol-agnostic packet enum (see PacketID.cpp for implementations) */
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) = 0;
-
 	// Sending stuff to clients (alphabetically sorted):
 	virtual void SendAttachEntity               (const cEntity & a_Entity, const cEntity & a_Vehicle) = 0;
 	virtual void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType) = 0;
@@ -239,6 +236,9 @@ protected:
 
 	/** Buffer for composing packet length (so that each cPacketizer instance doesn't allocate a new cPacketBuffer) */
 	cByteBuffer m_OutPacketLenBuffer;
+
+	/** Returns the protocol-specific packet ID given the protocol-agnostic packet enum (see PacketID.cpp for implementations) */
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) = 0;
 
 	/** A generic data-sending routine, all outgoing packet data needs to be routed through this so that descendants may override it. */
 	virtual void SendData(const char * a_Data, size_t a_Size) = 0;

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -52,13 +52,6 @@ public:
 	/** Translates protocol version number into protocol version text: 49 -> "1.4.4" */
 	static AString GetVersionTextFromInt(int a_ProtocolVersion);
 
-	/** GetPacketId is implemented in each protocol version class */
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override
-	{
-		ASSERT(!"cProtocolRecognizer::GetPacketId should never be called! Something is horribly wrong! (this method being called implies that someone other than a Protocol-derived class is calling GetPacketId)");
-		return 0;
-	}
-
 	/** Called when client sends some data: */
 	virtual void DataReceived(const char * a_Data, size_t a_Size) override;
 
@@ -162,6 +155,13 @@ protected:
 
 	/** Is a server list ping for an unrecognized version currently occuring? */
 	bool m_InPingForUnrecognizedVersion;
+
+	/** GetPacketId is implemented in each protocol version class */
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override
+	{
+		ASSERT(!"cProtocolRecognizer::GetPacketId should never be called! Something is horribly wrong! (this method being called implies that someone other than a Protocol-derived class is calling GetPacketId)");
+		return 0;
+	}
 
 	// Packet handlers while in status state (m_InPingForUnrecognizedVersion == true)
 	void HandlePacketStatusRequest();

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -53,7 +53,11 @@ public:
 	static AString GetVersionTextFromInt(int a_ProtocolVersion);
 
 	/** GetPacketId is implemented in each protocol version class */
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override { return 0; }
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override
+	{
+		ASSERT(!"cProtocolRecognizer::GetPacketId should never be called! Something is horribly wrong! (it implies that someone other than a Protocol-derived class is calling GetPacketId)");
+		return 0;
+	}
 
 	/** Called when client sends some data: */
 	virtual void DataReceived(const char * a_Data, size_t a_Size) override;

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -55,7 +55,7 @@ public:
 	/** GetPacketId is implemented in each protocol version class */
 	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override
 	{
-		ASSERT(!"cProtocolRecognizer::GetPacketId should never be called! Something is horribly wrong! (it implies that someone other than a Protocol-derived class is calling GetPacketId)");
+		ASSERT(!"cProtocolRecognizer::GetPacketId should never be called! Something is horribly wrong! (this method being called implies that someone other than a Protocol-derived class is calling GetPacketId)");
 		return 0;
 	}
 

--- a/src/Protocol/Protocol_1_12.h
+++ b/src/Protocol/Protocol_1_12.h
@@ -30,8 +30,6 @@ class cProtocol_1_12 :
 public:
 	cProtocol_1_12(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override;
-
 	virtual void SendCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, int a_Count) override;
 	virtual void SendHideTitle(void) override;
 	virtual void SendResetTitle(void) override;
@@ -45,6 +43,10 @@ protected:
 	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
 	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) override;
 	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override;
+
+protected:
+
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override;
 };
 
 
@@ -59,9 +61,9 @@ class cProtocol_1_12_1 :
 public:
 	cProtocol_1_12_1(cClientHandle * a_Client, const AString &a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
+protected:
 	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override;
 
-protected:
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
 };

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -45,9 +45,6 @@ public:
 
 	cProtocol_1_8_0(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
-	/** Nobody inherits 1.8, so it doesn't use this method */
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override { return 0; }
-
 	/** Called when client sends some data: */
 	virtual void DataReceived(const char * a_Data, size_t a_Size) override;
 
@@ -175,6 +172,9 @@ protected:
 
 	/** Adds the received (unencrypted) data to m_ReceivedData, parses complete packets */
 	void AddReceivedData(const char * a_Data, size_t a_Size);
+
+	/** Nobody inherits 1.8, so it doesn't use this method */
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override { ASSERT(!"GetPacketId for cProtocol_1_8_0 is not implemented."); return 0; }
 
 	/** Reads and handles the packet. The packet length and type have already been read.
 	Returns true if the packet was understood, false if it was an unknown packet

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -174,7 +174,11 @@ protected:
 	void AddReceivedData(const char * a_Data, size_t a_Size);
 
 	/** Nobody inherits 1.8, so it doesn't use this method */
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override { ASSERT(!"GetPacketId for cProtocol_1_8_0 is not implemented."); return 0; }
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override
+	{
+		ASSERT(!"GetPacketId for cProtocol_1_8_0 is not implemented.");
+		return 0;
+	}
 
 	/** Reads and handles the packet. The packet length and type have already been read.
 	Returns true if the packet was understood, false if it was an unknown packet

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -51,9 +51,6 @@ public:
 
 	cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
-	/** Get the packet ID for a given packet */
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override;
-
 	/** Called when client sends some data: */
 	virtual void DataReceived(const char * a_Data, size_t a_Size) override;
 
@@ -185,6 +182,9 @@ protected:
 
 	/** Adds the received (unencrypted) data to m_ReceivedData, parses complete packets */
 	void AddReceivedData(const char * a_Data, size_t a_Size);
+
+	/** Get the packet ID for a given packet */
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override;
 
 	/** Reads and handles the packet. The packet length and type have already been read.
 	Returns true if the packet was understood, false if it was an unknown packet. */
@@ -339,13 +339,15 @@ class cProtocol_1_9_4 :
 public:
 	cProtocol_1_9_4(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
-	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override;
-
 	// cProtocol_1_9_2 overrides:
 	virtual void SendChunkData       (int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer) override;
 	virtual void SendUpdateSign      (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) override;
 
 	virtual void HandlePacketStatusRequest(cByteBuffer & a_ByteBuffer) override;
+
+protected:
+
+	virtual UInt32 GetPacketId(eOutgoingPackets a_Packet) override;
 
 } ;
 


### PR DESCRIPTION
As @tigerw mentioned in #3977, calling cProtocolRecognizer::GetPacketId may return an unexpected result if you expect it to return the packet ID.

This PR adds an assert. An alternative solution might be to return m_Protocol->GetPacketId, but I believe this is better because protocol IDs should stay hidden inside the protocol structure (and so nobody should be calling this and expecting results).
