### PR TITLE
Switched player statistic store to save with UUID filenames.

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2203,7 +2203,7 @@ bool cPlayer::LoadFromFile(const AString & a_FileName, cWorldPtr & a_World)
 
 	// Load the player stats.
 	// We use the default world name (like bukkit) because stats are shared between dimensions / worlds.
-	cStatSerializer StatSerializer(cRoot::Get()->GetDefaultWorld()->GetName(), GetName(), &m_Stats);
+	cStatSerializer StatSerializer(cRoot::Get()->GetDefaultWorld()->GetName(), GetName(), GetUUID().ToLongString(), &m_Stats);
 	StatSerializer.Load();
 
 	LOGD("Player %s was read from file \"%s\", spawning at {%.2f, %.2f, %.2f} in world \"%s\"",
@@ -2301,7 +2301,7 @@ bool cPlayer::SaveToDisk()
 
 	// Save the player stats.
 	// We use the default world name (like bukkit) because stats are shared between dimensions / worlds.
-	cStatSerializer StatSerializer(cRoot::Get()->GetDefaultWorld()->GetName(), GetName(), &m_Stats);
+	cStatSerializer StatSerializer(cRoot::Get()->GetDefaultWorld()->GetName(), GetName(), GetUUID().ToLongString(), &m_Stats);
 	if (!StatSerializer.Save())
 	{
 		LOGWARNING("Could not save stats for player %s", GetName().c_str());

--- a/src/WorldStorage/StatSerializer.cpp
+++ b/src/WorldStorage/StatSerializer.cpp
@@ -11,7 +11,7 @@
 
 
 
-cStatSerializer::cStatSerializer(const AString & a_WorldName, const AString & a_PlayerName, cStatManager * a_Manager)
+cStatSerializer::cStatSerializer(const AString & a_WorldName, const AString & a_PlayerName, const AString & a_FileName, cStatManager * a_Manager)
 	: m_Manager(a_Manager)
 {
 	// Even though stats are shared between worlds, they are (usually) saved
@@ -20,7 +20,8 @@ cStatSerializer::cStatSerializer(const AString & a_WorldName, const AString & a_
 	AString StatsPath;
 	Printf(StatsPath, "%s%cstats", a_WorldName.c_str(), cFile::PathSeparator);
 
-	m_Path = StatsPath + "/" + a_PlayerName + ".json";
+	m_LegacyPath = StatsPath + "/" + a_PlayerName + ".json";
+	m_Path = StatsPath + "/" + a_FileName + ".json";
 
 	// Ensure that the directory exists.
 	cFile::CreateFolder(FILE_IO_PREFIX + StatsPath);
@@ -35,7 +36,11 @@ bool cStatSerializer::Load(void)
 	AString Data = cFile::ReadWholeFile(FILE_IO_PREFIX + m_Path);
 	if (Data.empty())
 	{
-		return false;
+		Data = cFile::ReadWholeFile(FILE_IO_PREFIX + m_LegacyPath);
+		if (Data.empty())
+		{
+			return false;
+		}
 	}
 
 	Json::Value Root;

--- a/src/WorldStorage/StatSerializer.h
+++ b/src/WorldStorage/StatSerializer.h
@@ -25,7 +25,7 @@ class cStatSerializer
 {
 public:
 
-	cStatSerializer(const AString & a_WorldName, const AString & a_PlayerName, cStatManager * a_Manager);
+	cStatSerializer(const AString & a_WorldName, const AString & a_PlayerName, const AString & a_FileName, cStatManager * a_Manager);
 
 	/* Try to load the player statistics. Returns whether the operation was successful or not. */
 	bool Load(void);
@@ -45,6 +45,7 @@ private:
 
 	cStatManager * m_Manager;
 
+	AString m_LegacyPath;  // The old <username>.json path to try to read from if the uuid path doesn't exist on load
 	AString m_Path;
 
 


### PR DESCRIPTION
With code to load from old playername.json format for backward compatibility.

Fixes #3804.
