### PR TITLE
Add cWorld::RemoveEntity and use in cEntity

### DIFF
--- a/src/World.cpp
+++ b/src/World.cpp
@@ -3709,6 +3709,35 @@ bool cWorld::HasEntity(UInt32 a_UniqueID)
 
 
 
+OwnedEntity cWorld::RemoveEntity(cEntity & a_Entity)
+{
+	// Check if the entity is in the chunkmap:
+	auto Entity = m_ChunkMap->RemoveEntity(a_Entity);
+
+	// If not, check if the entity is in the queue to be added to the world:
+	if (Entity == nullptr)
+	{
+		cCSLock Lock(m_CSEntitiesToAdd);
+		auto itr = std::find_if(m_EntitiesToAdd.begin(), m_EntitiesToAdd.end(),
+			[&a_Entity](const OwnedEntity & a_OwnedEntity)
+			{
+				return (a_OwnedEntity.get() == &a_Entity);
+			}
+		);
+
+		if (itr != m_EntitiesToAdd.end())
+		{
+			Entity = std::move(*itr);
+			m_EntitiesToAdd.erase(itr);
+		}
+	}
+	return Entity;
+}
+
+
+
+
+
 /*
 unsigned int cWorld::GetNumPlayers(void)
 {

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -3713,23 +3713,24 @@ OwnedEntity cWorld::RemoveEntity(cEntity & a_Entity)
 {
 	// Check if the entity is in the chunkmap:
 	auto Entity = m_ChunkMap->RemoveEntity(a_Entity);
-
-	// If not, check if the entity is in the queue to be added to the world:
-	if (Entity == nullptr)
+	if (Entity != nullptr)
 	{
-		cCSLock Lock(m_CSEntitiesToAdd);
-		auto itr = std::find_if(m_EntitiesToAdd.begin(), m_EntitiesToAdd.end(),
-			[&a_Entity](const OwnedEntity & a_OwnedEntity)
-			{
-				return (a_OwnedEntity.get() == &a_Entity);
-			}
-		);
+		return Entity;
+	}
 
-		if (itr != m_EntitiesToAdd.end())
+	// Check if the entity is in the queue to be added to the world:
+	cCSLock Lock(m_CSEntitiesToAdd);
+	auto itr = std::find_if(m_EntitiesToAdd.begin(), m_EntitiesToAdd.end(),
+		[&a_Entity](const OwnedEntity & a_OwnedEntity)
 		{
-			Entity = std::move(*itr);
-			m_EntitiesToAdd.erase(itr);
+			return (a_OwnedEntity.get() == &a_Entity);
 		}
+	);
+
+	if (itr != m_EntitiesToAdd.end())
+	{
+		Entity = std::move(*itr);
+		m_EntitiesToAdd.erase(itr);
 	}
 	return Entity;
 }

--- a/src/World.h
+++ b/src/World.h
@@ -301,6 +301,10 @@ public:
 	Note: Only loaded chunks are considered. */
 	bool HasEntity(UInt32 a_UniqueID);
 
+	/** Removes the entity from the world.
+	Returns an owning reference to the found entity. */
+	OwnedEntity RemoveEntity(cEntity & a_Entity);
+
 	/** Calls the callback for each entity in the entire world; returns true if all entities processed, false if the callback aborted by returning true */
 	bool ForEachEntity(cEntityCallback & a_Callback);  // Exported in ManualBindings.cpp
 


### PR DESCRIPTION
Credit to @lkolbly for spotting this in #3971.
I have no idea if it fixes the issue but `RemoveEntity` is definitely not thread safe.