### PR TITLE
Snow and rail placement fixes

### DIFF
--- a/src/Blocks/BlockRail.h
+++ b/src/Blocks/BlockRail.h
@@ -36,7 +36,14 @@ public:
 	{
 		a_BlockType = m_BlockType;
 		a_BlockMeta = FindMeta(a_ChunkInterface, a_BlockX, a_BlockY, a_BlockZ);
-		return true;
+		Vector3i Pos{ a_BlockX, a_BlockY, a_BlockZ };
+		return a_Player.GetWorld()->DoWithChunkAt(Pos,
+			[this, Pos, &a_ChunkInterface](cChunk & a_Chunk)
+			{
+				auto RelPos = cChunkDef::AbsoluteToRelative(Pos);
+				return CanBeAt(a_ChunkInterface, RelPos.x, RelPos.y, RelPos.z, a_Chunk);
+			}
+		);
 	}
 
 	virtual void OnPlaced(cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface, int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) override


### PR DESCRIPTION
Fixes #3507 and #2920.
Makes me wonder if allowing placement from `GetPlacementBlockTypeMeta` and checking `CanBeAt` ought to be the same logic for all blocks.  Are there any counterexamples?