### PR TITLE
Fix error with implicit cast from long long to long

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -90,7 +90,7 @@ void cRoot::InputThread(cRoot & a_Params)
 			static const std::chrono::microseconds PollPeriod = std::chrono::milliseconds{ 100 };
 
 			timeval Timeout{ 0, 0 };
-			Timeout.tv_usec = PollPeriod.count();
+			Timeout.tv_usec = static_cast<long>(PollPeriod.count());
 
 			fd_set ReadSet;
 			FD_ZERO(&ReadSet);


### PR DESCRIPTION
@peterbell10, the previous code failed on the [x86 build](https://builds.cuberite.org/job/Cuberite%20Linux%20x86%20Master/883/console) on the buildserver. Let me know if this fix is appropriate.