### PR TITLE
cWorld: Move most work from Start into the constructor

### DIFF
--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -47,7 +47,7 @@ cChunkGenerator::~cChunkGenerator()
 
 
 
-bool cChunkGenerator::Start(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile)
+bool cChunkGenerator::Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile)
 {
 	m_PluginInterface = &a_PluginInterface;
 	m_ChunkSink = &a_ChunkSink;
@@ -86,8 +86,7 @@ bool cChunkGenerator::Start(cPluginInterface & a_PluginInterface, cChunkSink & a
 	}
 
 	m_Generator->Initialize(a_IniFile);
-
-	return super::Start();
+	return true;
 }
 
 

--- a/src/Generating/ChunkGenerator.h
+++ b/src/Generating/ChunkGenerator.h
@@ -33,7 +33,7 @@ class cChunkDesc;
 
 
 class cChunkGenerator :
-	cIsThread
+	public cIsThread
 {
 	typedef cIsThread super;
 
@@ -110,7 +110,9 @@ public:
 	cChunkGenerator (void);
 	virtual ~cChunkGenerator() override;
 
-	bool Start(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile);
+	/** Read settings from the ini file and initialize in preperation for being started. */
+	bool Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile);
+
 	void Stop(void);
 
 	/** Queues the chunk for generation

--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -88,9 +88,9 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // cLightingThread:
 
-cLightingThread::cLightingThread(void) :
+cLightingThread::cLightingThread(cWorld & a_World):
 	super("cLightingThread"),
-	m_World(nullptr),
+	m_World(a_World),
 	m_MaxHeight(0),
 	m_NumSeeds(0)
 {
@@ -103,18 +103,6 @@ cLightingThread::cLightingThread(void) :
 cLightingThread::~cLightingThread()
 {
 	Stop();
-}
-
-
-
-
-
-bool cLightingThread::Start(cWorld * a_World)
-{
-	ASSERT(m_World == nullptr);  // Not started yet
-	m_World = a_World;
-
-	return super::Start();
 }
 
 
@@ -150,8 +138,6 @@ void cLightingThread::Stop(void)
 
 void cLightingThread::QueueChunk(int a_ChunkX, int a_ChunkZ, std::unique_ptr<cChunkCoordCallback> a_CallbackAfter)
 {
-	ASSERT(m_World != nullptr);  // Did you call Start() properly?
-
 	cChunkStay * ChunkStay = new cLightingChunkStay(*this, a_ChunkX, a_ChunkZ, std::move(a_CallbackAfter));
 	{
 		// The ChunkStay will enqueue itself using the QueueChunkStay() once it is fully loaded
@@ -159,7 +145,7 @@ void cLightingThread::QueueChunk(int a_ChunkX, int a_ChunkZ, std::unique_ptr<cCh
 		cCSLock Lock(m_CS);
 		m_PendingQueue.push_back(ChunkStay);
 	}
-	ChunkStay->Enable(*m_World->GetChunkMap());
+	ChunkStay->Enable(*m_World.GetChunkMap());
 }
 
 
@@ -238,7 +224,7 @@ void cLightingThread::Execute(void)
 void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 {
 	// If the chunk is already lit, skip it (report as success):
-	if (m_World->IsChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ))
+	if (m_World.IsChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ))
 	{
 		if (a_Item.m_CallbackAfter != nullptr)
 		{
@@ -319,7 +305,7 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 	CompressLight(m_BlockLight, BlockLight);
 	CompressLight(m_SkyLight, SkyLight);
 
-	m_World->ChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ, BlockLight, SkyLight);
+	m_World.ChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ, BlockLight, SkyLight);
 
 	if (a_Item.m_CallbackAfter != nullptr)
 	{
@@ -341,7 +327,7 @@ void cLightingThread::ReadChunks(int a_ChunkX, int a_ChunkZ)
 		for (int x = 0; x < 3; x++)
 		{
 			Reader.m_ReadingChunkX = x;
-			VERIFY(m_World->GetChunkData(a_ChunkX + x - 1, a_ChunkZ + z - 1, Reader));
+			VERIFY(m_World.GetChunkData(a_ChunkX + x - 1, a_ChunkZ + z - 1, Reader));
 		}  // for z
 	}  // for x
 

--- a/src/LightingThread.h
+++ b/src/LightingThread.h
@@ -52,10 +52,8 @@ class cLightingThread :
 
 public:
 
-	cLightingThread(void);
+	cLightingThread(cWorld & a_World);
 	virtual ~cLightingThread() override;
-
-	bool Start(cWorld * a_World);
 
 	void Stop(void);
 
@@ -94,7 +92,7 @@ protected:
 	typedef std::list<cChunkStay *> cChunkStays;
 
 
-	cWorld * m_World;
+	cWorld & m_World;
 
 	/** The mutex to protect m_Queue and m_PendingQueue */
 	cCriticalSection m_CS;

--- a/src/Root.h
+++ b/src/Root.h
@@ -228,7 +228,7 @@ private:
 	void LoadGlobalSettings();
 
 	/** Loads the worlds from settings.ini, creates the worldmap */
-	void LoadWorlds(cSettingsRepositoryInterface & a_Settings, bool a_IsNewIniFile);
+	void LoadWorlds(cDeadlockDetect & a_dd, cSettingsRepositoryInterface & a_Settings, bool a_IsNewIniFile);
 
 	/** Starts each world's life */
 	void StartWorlds(cDeadlockDetect & a_DeadlockDetect);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -196,6 +196,7 @@ cWorld::cWorld(
 	m_MapManager(this),
 	m_GeneratorCallbacks(*this),
 	m_ChunkSender(*this),
+	m_Lighting(*this),
 	m_TickThread(*this)
 {
 	LOGD("cWorld::cWorld(\"%s\")", a_WorldName.c_str());
@@ -405,6 +406,7 @@ cWorld::cWorld(
 	m_SimulatorManager->RegisterSimulator(m_SandSimulator.get(), 1);
 	m_SimulatorManager->RegisterSimulator(m_FireSimulator.get(), 1);
 
+	m_Storage.Initialize(*this, m_StorageSchema, m_StorageCompressionFactor);
 	m_Generator.Initialize(m_GeneratorCallbacks, m_GeneratorCallbacks, IniFile);
 
 	m_MapManager.LoadMapData();
@@ -607,8 +609,8 @@ void cWorld::InitializeSpawn(void)
 
 void cWorld::Start()
 {
-	m_Lighting.Start(this);
-	m_Storage.Start(this, m_StorageSchema, m_StorageCompressionFactor);
+	m_Lighting.Start();
+	m_Storage.Start();
 	m_Generator.Start();
 	m_ChunkSender.Start();
 	m_TickThread.Start();

--- a/src/World.h
+++ b/src/World.h
@@ -731,9 +731,8 @@ public:
 
 	void InitializeSpawn(void);
 
-	/** Starts threads that belong to this world.
-	a_DeadlockDetect is used for tracking this world's age, detecting a possible deadlock. */
-	void Start(cDeadlockDetect & a_DeadlockDetect);
+	/** Starts threads that belong to this world. */
+	void Start();
 
 	/** Stops threads that belong to this world (part of deinit).
 	a_DeadlockDetect is used for tracking this world's age, detecting a possible deadlock. */
@@ -1066,8 +1065,15 @@ private:
 	/** Queue for the chunk data to be set into m_ChunkMap by the tick thread. Protected by m_CSSetChunkDataQueue */
 	cSetChunkDataPtrs m_SetChunkDataQueue;
 
-
-	cWorld(const AString & a_WorldName, const AString & a_DataPath, eDimension a_Dimension = dimOverworld, const AString & a_LinkedOverworldName = "");
+	/** Construct the world and read settings from its ini file.
+	@param a_DeadlockDetect is used for tracking this world's age, detecting a possible deadlock.
+	@param a_WorldNames is a list of all world names, used to validate linked worlds
+	*/
+	cWorld(
+		const AString & a_WorldName, const AString & a_DataPath,
+		cDeadlockDetect & a_DeadlockDetect, const AStringVector & a_WorldNames,
+		eDimension a_Dimension = dimOverworld, const AString & a_LinkedOverworldName = {}
+	);
 	virtual ~cWorld() override;
 
 	void Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_LastTickDurationMSec);

--- a/src/World.h
+++ b/src/World.h
@@ -962,7 +962,7 @@ private:
 	cCriticalSection m_CSPlayers;
 	cPlayerList      m_Players;
 
-	cWorldStorage     m_Storage;
+	cWorldStorage    m_Storage;
 
 	unsigned int m_MaxPlayers;
 

--- a/src/WorldStorage/WorldStorage.cpp
+++ b/src/WorldStorage/WorldStorage.cpp
@@ -60,13 +60,11 @@ cWorldStorage::~cWorldStorage()
 
 
 
-bool cWorldStorage::Start(cWorld * a_World, const AString & a_StorageSchemaName, int a_StorageCompressionFactor)
+void cWorldStorage::Initialize(cWorld & a_World, const AString & a_StorageSchemaName, int a_StorageCompressionFactor)
 {
-	m_World = a_World;
+	m_World = &a_World;
 	m_StorageSchemaName = a_StorageSchemaName;
 	InitSchemas(a_StorageCompressionFactor);
-
-	return super::Start();
 }
 
 

--- a/src/WorldStorage/WorldStorage.h
+++ b/src/WorldStorage/WorldStorage.h
@@ -69,7 +69,8 @@ public:
 	The callback, if specified, will be called with the result of the save operation. */
 	void QueueSaveChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * a_Callback = nullptr);
 
-	bool Start(cWorld * a_World, const AString & a_StorageSchemaName, int a_StorageCompressionFactor);  // Hide the cIsThread's Start() method, we need to provide args
+	/** Initializes the storage schemas, ready to be started. */
+	void Initialize(cWorld & a_World, const AString & a_StorageSchemaName, int a_StorageCompressionFactor);
 	void Stop(void);  // Hide the cIsThread's Stop() method, we need to signal the event
 	void WaitForFinish(void);
 	void WaitForLoadQueueEmpty(void);


### PR DESCRIPTION
Fixes #4042. Tested with the script from the issue.

`Start` now does nothing other than starting the world's threads.  This means everything is initialised properly before the plugins are loaded.  Also, as the threads are still not started in the constructor, you keep the guarantee that chunks can't be generated before hooks are registered.