### PR TITLE
cBlockArea: Fix fill performance

### DIFF
--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -835,7 +835,14 @@ void cBlockArea::Fill(int a_DataTypes, BLOCKTYPE a_BlockType, NIBBLETYPE a_Block
 	// If the area contains block entities, remove those not matching and replace with whatever block entity block was filled
 	if (HasBlockEntities() && ((a_DataTypes & baTypes) != 0))
 	{
-		RescanBlockEntities();
+		if (cBlockEntity::IsBlockEntityBlockType(a_BlockType))
+		{
+			RescanBlockEntities();
+		}
+		else
+		{
+			ClearBlockEntities(*m_BlockEntities);
+		}
 	}
 }
 
@@ -888,7 +895,14 @@ void cBlockArea::FillRelCuboid(int a_MinRelX, int a_MaxRelX, int a_MinRelY, int 
 	// If the area contains block entities, remove those in the affected cuboid and replace with whatever block entity block was filled:
 	if (HasBlockEntities() && ((a_DataTypes & baTypes) != 0))
 	{
-		RescanBlockEntities();
+		if (cBlockEntity::IsBlockEntityBlockType(a_BlockType))
+		{
+			RescanBlockEntities();
+		}
+		else
+		{
+			ClearBlockEntities(*m_BlockEntities);
+		}
 	}
 }
 


### PR DESCRIPTION
In #4005 I changed `cBlockArea::Create` to use `Fill` internally.  This caused a large regression in performance because of the extra call to `RescanBlockEntities`.  In my profiles it was almost 100x slowdown and as it's used in `cChunkDesc`'s constructor, it caused a significant (~15%) slowdown for the chunk generator.

This fixes the performance of both fill functions for the cases where adding block entities isn't needed.