### PR TITLE
Fix explosion interaction with block entities.

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -452,14 +452,15 @@ void cChunk::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlock
 	}  // for y
 
 	// Erase all affected block entities:
-	cCuboid affectedArea(
-		{OffX, a_MinBlockY, OffZ},
-		{OffX + SizeX - 1, a_MinBlockY + SizeY - 1, OffZ + SizeZ - 1}
+	cCuboid affectedArea(  // In world coordinates
+		{BlockStartX, a_MinBlockY, BlockStartZ},
+		{BlockEndX, a_MinBlockY + SizeY - 1, BlockEndZ}
 	);
 	for (auto itr = m_BlockEntities.begin(); itr != m_BlockEntities.end();)
 	{
 		if (affectedArea.IsInside(itr->second->GetPos()))
 		{
+			delete itr->second;
 			itr = m_BlockEntities.erase(itr);
 		}
 		else

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -19,6 +19,7 @@
 #include "Blocks/ChunkInterface.h"
 #include "Entities/Pickup.h"
 #include "DeadlockDetect.h"
+#include "BlockEntities/BlockEntity.h"
 
 #ifndef _WIN32
 	#include <cstdlib>  // abs
@@ -1764,6 +1765,18 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 								{
 									m_World->SpawnFallingBlock(bx + x, by + y + 5, bz + z, Block, area.GetBlockMeta(bx + x, by + y, bz + z));
 								}
+							}
+
+							// Destroy any block entities
+							if (cBlockEntity::IsBlockEntityBlockType(Block))
+							{
+								Vector3i BlockPos(bx + x, by + y, bz + z);
+								DoWithBlockEntityAt(BlockPos.x, BlockPos.y, BlockPos.z, [](cBlockEntity & a_BE)
+									{
+										a_BE.Destroy();
+										return true;
+									}
+								);
 							}
 
 							area.SetBlockTypeMeta(bx + x, by + y, bz + z, E_BLOCK_AIR, 0);


### PR DESCRIPTION
Fixes  #4051.

`OffX` and `OffZ` are chunk relative coords but `cBlockEntity::GetPos` is is world coords so `affectedArea.IsInside` didn't work properly.

Edit:  There's a problem with this.  If a chest is in the explosion area but isn't blown up, its items will still drop.
Edit2: I've fixed it by moving the call to destroy into `DoExplosionAt`.