### PR TITLE
cItemHandler: Update max stack size of old doors.

### DIFF
--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -612,6 +612,7 @@ char cItemHandler::GetMaxStackSize(void)
 		case E_ITEM_HEAD:                 return 64;
 		case E_ITEM_JUNGLE_DOOR:          return 64;
 		case E_ITEM_IRON:                 return 64;
+		case E_ITEM_IRON_DOOR:            return 64;
 		case E_ITEM_IRON_NUGGET:          return 64;
 		case E_ITEM_ITEM_FRAME:           return 64;
 		case E_ITEM_LEAD:                 return 64;
@@ -659,6 +660,7 @@ char cItemHandler::GetMaxStackSize(void)
 		case E_ITEM_SUGAR_CANE:           return 64;
 		case E_ITEM_TIPPED_ARROW:         return 64;
 		case E_ITEM_WHEAT:                return 64;
+		case E_ITEM_WOODEN_DOOR:          return 64;
 		// By default items don't stack:
 		default:                          return 1;
 	}


### PR DESCRIPTION
Fixes #4070

Worth noting that the other doors items like `E_ITEM_DARK_OAK_DOOR` were already stacking to 64.