### PR TITLE
Fixed Clang 5.0 compile errors

### DIFF
--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -168,7 +168,7 @@ set_source_files_properties(${BINDING_OUTPUTS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/Bindings/Bindings.cpp PROPERTIES COMPILE_FLAGS -Wno-error)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	set_source_files_properties(Bindings.cpp PROPERTIES COMPILE_FLAGS ${COMPILE_FLAGS} "-Wno-old-style-cast -Wno-missing-prototypes")
+	set_source_files_properties(Bindings.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast -Wno-missing-prototypes -Wno-zero-as-null-pointer-constant")
 endif()
 
 if(NOT MSVC)

--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -167,8 +167,11 @@ set_source_files_properties(${BINDING_OUTPUTS} PROPERTIES GENERATED TRUE)
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/Bindings/Bindings.cpp PROPERTIES COMPILE_FLAGS -Wno-error)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	set_source_files_properties(Bindings.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast -Wno-missing-prototypes -Wno-zero-as-null-pointer-constant")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+	if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5) # Workaround for VERSION_GREATER_EQUAL, which is only supported on CMake 3.7+
+		set(ADDITIONAL_FLAGS "-Wno-zero-as-null-pointer-constant")
+	endif()
+	set_source_files_properties(Bindings.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast -Wno-missing-prototypes ${ADDITIONAL_FLAGS}")
 endif()
 
 if(NOT MSVC)

--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -270,7 +270,7 @@ static int tolua_AllToLua_StringToMobType00(lua_State* tolua_S)
 	else
 	#endif
 	{
-		const AString a_MobString = tolua_tocppstring(LuaState, 1, 0);
+		const AString a_MobString = tolua_tocppstring(LuaState, 1, nullptr);
 		eMonsterType MobType = cMonster::StringToMobType(a_MobString);
 		tolua_pushnumber(LuaState, static_cast<lua_Number>(MobType));
 		tolua_pushcppstring(LuaState, a_MobString);

--- a/src/Bindings/LuaFunctions.h
+++ b/src/Bindings/LuaFunctions.h
@@ -6,7 +6,7 @@
 inline unsigned int GetTime()
 {
 	// NB: For caveats, please see https://stackoverflow.com/a/14505248
-	return static_cast<unsigned int>(std::chrono::seconds(time(0)).count());
+	return static_cast<unsigned int>(std::chrono::seconds(time(nullptr)).count());
 }
 
 // tolua_end

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -26,6 +26,14 @@ extern "C"
 
 
 
+// Hotpatching the Macro to prevent a Clang Warning (0 for pointer used)
+#undef  lua_tostring
+#define lua_tostring(L, i) lua_tolstring(L, (i), nullptr)
+
+
+
+
+
 // fwd: "SQLite/lsqlite3.c"
 extern "C"
 {

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -43,6 +43,14 @@
 
 
 
+// Hotpatching the Macro to prevent a Clang Warning (0 for pointer used)
+#undef  lua_tostring
+#define lua_tostring(L, i) lua_tolstring(L, (i), nullptr)
+
+
+
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // LuaCommandHandler:
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -243,6 +243,7 @@ void cEntity::Destroy(bool a_ShouldBroadcast)
 			this->GetUniqueID(), this->GetClass(),
 			ParentChunkCoords.m_ChunkX, ParentChunkCoords.m_ChunkZ
 		);
+		UNUSED(ParentChunkCoords);  // Non Debug mode only
 
 		// Make sure that RemoveEntity returned a valid smart pointer
 		// Also, not storing the returned pointer means automatic destruction
@@ -1599,6 +1600,7 @@ bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 			a_OldWorld.GetName().c_str(), a_World->GetName().c_str(),
 			OldChunkCoords.m_ChunkX, OldChunkCoords.m_ChunkZ
 		);
+		UNUSED(OldChunkCoords);  // Non Debug mode only
 		a_World->AddEntity(a_OldWorld.RemoveEntity(*this));
 		cRoot::Get()->GetPluginManager()->CallHookEntityChangedWorld(*this, a_OldWorld);
 	});

--- a/src/FurnaceRecipe.cpp
+++ b/src/FurnaceRecipe.cpp
@@ -272,7 +272,7 @@ void cFurnaceRecipe::ClearRecipes(void)
 
 const cFurnaceRecipe::cRecipe * cFurnaceRecipe::GetRecipeFrom(const cItem & a_Ingredient) const
 {
-	const cRecipe * BestRecipe = 0;
+	const cRecipe * BestRecipe = nullptr;
 	for (RecipeList::const_iterator itr = m_pState->Recipes.begin(); itr != m_pState->Recipes.end(); ++itr)
 	{
 		const cRecipe & Recipe = *itr;

--- a/src/OSSupport/NetworkLookup.h
+++ b/src/OSSupport/NetworkLookup.h
@@ -20,7 +20,7 @@ class cNetworkLookup :
 public:
 
 	cNetworkLookup();
-	~cNetworkLookup();
+	~cNetworkLookup() override;
 
 	/** Schedule a lookup task for execution. */
 	void ScheduleLookup(std::function<void()> a_Lookup);

--- a/src/Protocol/MojangAPI.cpp
+++ b/src/Protocol/MojangAPI.cpp
@@ -5,8 +5,6 @@
 
 #include "Globals.h"
 #include "MojangAPI.h"
-#include "SQLiteCpp/Database.h"
-#include "SQLiteCpp/Statement.h"
 #include "../IniFile.h"
 #include "json/json.h"
 #include "mbedTLS++/BlockingSslClientSocket.h"
@@ -14,6 +12,19 @@
 #include "../RankManager.h"
 #include "../OSSupport/IsThread.h"
 #include "../Root.h"
+
+// Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning here
+#ifdef __clang__
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
+#include "SQLiteCpp/Database.h"
+#include "SQLiteCpp/Statement.h"
+
+#ifdef __clang__
+	#pragma clang diagnostic pop
+#endif
 
 
 

--- a/src/Protocol/MojangAPI.cpp
+++ b/src/Protocol/MojangAPI.cpp
@@ -14,7 +14,7 @@
 #include "../Root.h"
 
 // Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning here
-#ifdef __clang__
+#if __clang_major__ >= 5
 	#pragma clang diagnostic push
 	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -22,7 +22,7 @@
 #include "SQLiteCpp/Database.h"
 #include "SQLiteCpp/Statement.h"
 
-#ifdef __clang__
+#if __clang_major__ >= 5
 	#pragma clang diagnostic pop
 #endif
 

--- a/src/Protocol/MojangAPI.cpp
+++ b/src/Protocol/MojangAPI.cpp
@@ -5,6 +5,8 @@
 
 #include "Globals.h"
 #include "MojangAPI.h"
+#include "SQLiteCpp/Database.h"
+#include "SQLiteCpp/Statement.h"
 #include "../IniFile.h"
 #include "json/json.h"
 #include "mbedTLS++/BlockingSslClientSocket.h"
@@ -12,19 +14,6 @@
 #include "../RankManager.h"
 #include "../OSSupport/IsThread.h"
 #include "../Root.h"
-
-// Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning here
-#if __clang_major__ >= 5
-	#pragma clang diagnostic push
-	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
-#endif
-
-#include "SQLiteCpp/Database.h"
-#include "SQLiteCpp/Statement.h"
-
-#if __clang_major__ >= 5
-	#pragma clang diagnostic pop
-#endif
 
 
 

--- a/src/RankManager.h
+++ b/src/RankManager.h
@@ -8,8 +8,19 @@
 
 #pragma once
 
+// Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning here
+#ifdef __clang__
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
 #include "SQLiteCpp/Database.h"
 #include "SQLiteCpp/Transaction.h"
+
+#ifdef __clang__
+	#pragma clang diagnostic pop
+#endif
+
 
 
 

--- a/src/RankManager.h
+++ b/src/RankManager.h
@@ -8,19 +8,8 @@
 
 #pragma once
 
-// Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning here
-#if __clang_major__ >= 5
-	#pragma clang diagnostic push
-	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
-#endif
-
 #include "SQLiteCpp/Database.h"
 #include "SQLiteCpp/Transaction.h"
-
-#if __clang_major__ >= 5
-	#pragma clang diagnostic pop
-#endif
-
 
 
 

--- a/src/RankManager.h
+++ b/src/RankManager.h
@@ -9,7 +9,7 @@
 #pragma once
 
 // Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning here
-#ifdef __clang__
+#if __clang_major__ >= 5
 	#pragma clang diagnostic push
 	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -17,7 +17,7 @@
 #include "SQLiteCpp/Database.h"
 #include "SQLiteCpp/Transaction.h"
 
-#ifdef __clang__
+#if __clang_major__ >= 5
 	#pragma clang diagnostic pop
 #endif
 

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -72,7 +72,7 @@ cRoot::cRoot(void) :
 
 cRoot::~cRoot()
 {
-	s_Root = 0;
+	s_Root = nullptr;
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,7 @@ bool cRoot::m_RunAsService = false;
 
 
 #ifndef _DEBUG
-// Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning for std::signal here
+// Because SIG_DFL or SIG_IGN could be NULL instead of nullptr, we need to disable the Clang warning here
 #ifdef __clang__
 	#pragma clang diagnostic push
 	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,12 @@ bool cRoot::m_RunAsService = false;
 
 
 #ifndef _DEBUG
+// Because SQLiteCpp uses NULL instead of nullptr, we need to disable the Clang warning for std::signal here
+#ifdef __clang__
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
 static void NonCtrlHandler(int a_Signal)
 {
 	LOGD("Terminate event raised from std::signal");
@@ -115,6 +121,10 @@ static void NonCtrlHandler(int a_Signal)
 		default: break;
 	}
 }
+
+#ifdef __clang__
+	#pragma clang diagnostic pop
+#endif
 #endif  // _DEBUG
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,7 +73,7 @@ bool cRoot::m_RunAsService = false;
 
 #ifndef _DEBUG
 // Because SIG_DFL or SIG_IGN could be NULL instead of nullptr, we need to disable the Clang warning here
-#ifdef __clang__
+#if __clang_major__ >= 5
 	#pragma clang diagnostic push
 	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -122,7 +122,7 @@ static void NonCtrlHandler(int a_Signal)
 	}
 }
 
-#ifdef __clang__
+#if __clang_major__ >= 5
 	#pragma clang diagnostic pop
 #endif
 #endif  // _DEBUG


### PR DESCRIPTION
While trying to compile the Cuberite code with Clang 5.0 I've got mostly errors of `NULL` being used instead of `nullptr`.
This commit fixed all errors.