### PR TITLE
NetworkLookup: Added "virtual" keyword to overridden dtor.

### DIFF
--- a/src/OSSupport/NetworkLookup.h
+++ b/src/OSSupport/NetworkLookup.h
@@ -20,7 +20,7 @@ class cNetworkLookup :
 public:
 
 	cNetworkLookup();
-	~cNetworkLookup() override;
+	virtual ~cNetworkLookup() override;
 
 	/** Schedule a lookup task for execution. */
 	void ScheduleLookup(std::function<void()> a_Lookup);


### PR DESCRIPTION
Cosmetics, more or less, but makes the code consistent.