### PR TITLE
Fix Travis build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	ignore = dirty
 [submodule "lib/jsoncpp"]
 	path = lib/jsoncpp
-	url = https://github.com/open-source-parsers/jsoncpp.git
+	url = https://github.com/cuberite/jsoncpp.git
 	ignore = dirty
 [submodule "lib/TCLAP"]
 	path = lib/TCLAP

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,72 @@
 language: cpp
 sudo: false
 
-os:
-- linux
-- osx
-
-compiler:
-- clang
-- gcc
+# Use Linux by default
+os: linux
 
 matrix:
-  exclude:
-  - os: osx
-    compiler: gcc
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-    - gdb
-
-
-before_script:
-- if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-    brew update;
-    brew install gdb;
-  fi
+  include:
+    # AppleClang
+    # OSX workers are slower to start up.  Having these first in the build matrix makes travis faster overall.
+    - os: osx
+      compiler: clang
+      env: &Release
+        - TRAVIS_CUBERITE_BUILD_TYPE=RELEASE CUBERITE_PATH=./Cuberite
+    - os: osx
+      compiler: clang
+      env: &Debug
+        - TRAVIS_CUBERITE_BUILD_TYPE=DEBUG CUBERITE_PATH=./Cuberite_debug
+    # Default clang
+    - compiler: clang
+      addons: &gdb
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gdb
+      env: *Release
+    - compiler: clang
+      addons: *gdb
+      env: *Debug
+    # clang 3.5
+    - compiler: clang
+      addons: &clang35
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+          packages:
+            - clang++-3.5
+            - clang-3.5
+            - gdb
+      before_install:
+        - CC=clang-3.5;CXX=clang++-3.5
+      env: *Release
+    - compiler: clang
+      addons: *clang35
+      before_install:
+        - CC=clang-3.5;CXX=clang++-3.5
+      env: *Debug
+    # gcc 4.8
+    - compiler: gcc
+      addons: &gcc48
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+            - gcc-4.8
+            - gdb
+      before_install:
+        - CC=gcc-4.8;CXX=g++-4.8
+      env: *Release
+    - compiler: gcc
+      addons: *gcc48
+      before_install:
+        - CC=gcc-4.8;CXX=g++-4.8
+      env: *Debug
 
 script: ./CIbuild.sh
-
-env:
-  - TRAVIS_CUBERITE_BUILD_TYPE=RELEASE CUBERITE_PATH=./Cuberite
-  - TRAVIS_CUBERITE_BUILD_TYPE=DEBUG   CUBERITE_PATH=./Cuberite_debug
 
 notifications:
   email:

--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -6,11 +6,6 @@ export CUBERITE_BUILD_SERIES_NAME="Travis $CC $TRAVIS_CUBERITE_BUILD_TYPE"
 export CUBERITE_BUILD_ID=$TRAVIS_JOB_NUMBER
 export CUBERITE_BUILD_DATETIME=`date`
 
-if [ "$CXX" == "g++" ]; then
-	# This is a temporary workaround to allow the identification of GCC-4.8 by CMake, required for C++11 features
-	# Travis Docker containers don't allow sudo, which update-alternatives needs, and it seems no alternative to this command is provided, hence:
-	export CXX="/usr/bin/g++-4.8"
-fi
 cmake . -DBUILD_TOOLS=1 -DSELF_TEST=1;
 
 echo "Building..."
@@ -22,22 +17,22 @@ echo -e "define hook-quit\n\tset confirm off\nend\n" > ~/.gdbinit
 
 echo "Testing..."
 
-# OSX builds need sudo because gdb isn't signed
+# OSX builds don't have gdb
 if [ "$TRAVIS_OS_NAME" = osx ]; then
-	GDB_COMMAND="sudo gdb"
+	GDB_COMMAND=""
 else
-	GDB_COMMAND="gdb"
+	GDB_COMMAND="gdb -return-child-result -ex run -ex \"bt\" -ex \"info threads\" -ex \"thread apply all bt\" -ex \"quit\" --args"
 fi
 
 cd Server/;
 touch apiCheckFailed.flag
 if [ "$TRAVIS_CUBERITE_BUILD_TYPE" != "COVERAGE" ]; then
-	${GDB_COMMAND} -return-child-result -ex run -ex "bt" -ex "info threads" -ex "thread apply all bt" -ex "quit" --args $CUBERITE_PATH << EOF
-load APIDump
-apicheck
-restart
-stop
-EOF
+	${GDB_COMMAND} ${CUBERITE_PATH} <<- EOF
+		load APIDump
+		apicheck
+		restart
+		stop
+	EOF
 	if [ -f ./NewlyUndocumented.lua ]; then
 		echo "ERROR: Newly undocumented API symbols found:"
 		cat ./NewlyUndocumented.lua

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -77,7 +77,7 @@ Install git, make, cmake and clang (or gcc), using your platform's package manag
 ```
 sudo apt-get install git make cmake clang
 ```
-Ensure that you have modern C++ compiler and linker (Clang 3.4+, GCC 4.8+, or VS 2013+).
+Ensure that you have modern C++ compiler and linker (Clang 3.5+, GCC 4.8+, or VS 2013+).
 
 ### Getting the Source
 

--- a/Tools/ProtoProxy/Connection.cpp
+++ b/Tools/ProtoProxy/Connection.cpp
@@ -190,7 +190,7 @@ struct sChunkMeta
 
 cConnection::cConnection(SOCKET a_ClientSocket, cServer & a_Server) :
 	m_ItemIdx(0),
-	m_LogFile(NULL),
+	m_LogFile(nullptr),
 	m_Server(a_Server),
 	m_ClientSocket(a_ClientSocket),
 	m_ServerSocket(-1),
@@ -252,7 +252,7 @@ void cConnection::Run(void)
 		FD_SET(m_ServerSocket, &ReadFDs);
 		FD_SET(m_ClientSocket, &ReadFDs);
 		SOCKET MaxSocket = std::max(m_ServerSocket, m_ClientSocket);
-		int res = select(MaxSocket + 1, &ReadFDs, NULL, NULL, NULL);
+		int res = select(MaxSocket + 1, &ReadFDs, nullptr, nullptr, nullptr);
 		if (res <= 0)
 		{
 			printf("select() failed: %d; aborting client", SocketError);
@@ -2571,7 +2571,7 @@ bool cConnection::HandleServerUpdateTileEntity(void)
 	AString fnam;
 	Printf(fnam, "%s_tile_%08x.nbt", m_LogNameBase.c_str(), m_ItemIdx++);
 	FILE * f = fopen(fnam.c_str(), "wb");
-	if (f != NULL)
+	if (f != nullptr)
 	{
 		fwrite(Data.data(), 1, Data.size(), f);
 		fclose(f);
@@ -2730,7 +2730,7 @@ bool cConnection::ParseSlot(cByteBuffer & a_Buffer, AString & a_ItemDesc)
 	AString fnam;
 	Printf(fnam, "%s_item_%08x.nbt", m_LogNameBase.c_str(), m_ItemIdx++);
 	FILE * f = fopen(fnam.c_str(), "wb");
-	if (f != NULL)
+	if (f != nullptr)
 	{
 		fwrite(Metadata.data(), 1, Metadata.size(), f);
 		fclose(f);

--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -168,7 +168,7 @@ set_source_files_properties(${BINDING_OUTPUTS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/Bindings/Bindings.cpp PROPERTIES COMPILE_FLAGS -Wno-error)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-	if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5) # Workaround for VERSION_GREATER_EQUAL, which is only supported on CMake 3.7+
+	if(NOT APPLE AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5) # Workaround for VERSION_GREATER_EQUAL, which is only supported on CMake 3.7+
 		set(ADDITIONAL_FLAGS "-Wno-zero-as-null-pointer-constant")
 	endif()
 	set_source_files_properties(Bindings.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast -Wno-missing-prototypes ${ADDITIONAL_FLAGS}")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,10 +73,12 @@ bool cRoot::m_RunAsService = false;
 
 #ifndef _DEBUG
 // Because SIG_DFL or SIG_IGN could be NULL instead of nullptr, we need to disable the Clang warning here
-#if __clang_major__ >= 5
+#ifdef __clang__
 	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wunknown-warning-option"
+	#pragma clang diagnostic ignored "-Wunknown-pragmas"
 	#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
-#endif
+#endif  // __clang__
 
 static void NonCtrlHandler(int a_Signal)
 {
@@ -122,9 +124,9 @@ static void NonCtrlHandler(int a_Signal)
 	}
 }
 
-#if __clang_major__ >= 5
+#ifdef __clang__
 	#pragma clang diagnostic pop
-#endif
+#endif  // __clang__
 #endif  // _DEBUG
 
 

--- a/tests/HTTP/UrlClientTest.cpp
+++ b/tests/HTTP/UrlClientTest.cpp
@@ -19,7 +19,7 @@ public:
 	}
 
 
-	~cCallbacks()
+	virtual ~cCallbacks() override
 	{
 		LOGD("Deleting the cCallbacks instance at %p", reinterpret_cast<void *>(this));
 	}


### PR DESCRIPTION
 * Fixes the remaining clang 5.0 warnings
 * Fixes AppleClang builds
 * Adds a clang 3.5 build to travis in addition to the new default of 5.0