### PR TITLE
.editorconfig fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,4 @@ charset = utf-8
 end_of_line = lf
 indent_style = tab
 insert_final_newline = true
-spaces_around_operators = true
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,9 +2,9 @@
 root = true
 
 [*]
-indent_style = tab
 charset = utf-8
-trim_trailing_whitespace = true
+end_of_line = lf
+indent_style = tab
 insert_final_newline = true
 spaces_around_operators = true
-
+trim_trailing_whitespace = true


### PR DESCRIPTION
Added specification for the type of line endings preferred and removed `spaces_around_operators` as it does not appear in the specification.