### PR TITLE
Fix cUrlClient leak

### DIFF
--- a/src/HTTP/UrlClient.cpp
+++ b/src/HTTP/UrlClient.cpp
@@ -330,8 +330,8 @@ public:
 	// cHTTPResponseParser::cCallbacks overrides:
 	virtual void OnError(const AString & a_ErrorDescription) override
 	{
-		m_ParentRequest.CallErrorCallback(a_ErrorDescription);
 		m_Link = nullptr;
+		m_ParentRequest.CallErrorCallback(a_ErrorDescription);
 	}
 
 

--- a/src/HTTP/UrlClient.cpp
+++ b/src/HTTP/UrlClient.cpp
@@ -430,6 +430,8 @@ public:
 		else
 		{
 			m_ParentRequest.GetCallbacks().OnBodyFinished();
+			// Finished recieving data, shutdown the link
+			m_Link->Shutdown();
 		}
 	}
 

--- a/src/HTTP/UrlClient.cpp
+++ b/src/HTTP/UrlClient.cpp
@@ -54,8 +54,7 @@ public:
 		m_Callbacks->OnError(a_ErrorMessage);
 
 		// Terminate the request's TCP link:
-		auto link = m_Link.lock();
-		if (link != nullptr)
+		if (auto link = m_Link.lock())
 		{
 			link->Close();
 		}
@@ -497,7 +496,11 @@ void cUrlClientRequest::RedirectTo(const AString & a_RedirectUrl)
 	auto Self = m_Self.lock();
 
 	// Do the actual redirect:
-	m_Link.lock()->Close();
+	if (auto Link = m_Link.lock())
+	{
+		Link->Close();
+	}
+
 	m_Url = a_RedirectUrl;
 	m_NumRemainingRedirects = m_NumRemainingRedirects - 1;
 	auto res = DoRequest(Self);

--- a/src/OSSupport/NetworkSingleton.h
+++ b/src/OSSupport/NetworkSingleton.h
@@ -24,12 +24,12 @@
 
 // fwd:
 struct event_base;
-class cTCPLinkImpl;
-typedef std::shared_ptr<cTCPLinkImpl> cTCPLinkImplPtr;
-typedef std::vector<cTCPLinkImplPtr> cTCPLinkImplPtrs;
-class cServerHandleImpl;
-typedef std::shared_ptr<cServerHandleImpl> cServerHandleImplPtr;
-typedef std::vector<cServerHandleImplPtr> cServerHandleImplPtrs;
+class cTCPLink;
+typedef std::shared_ptr<cTCPLink> cTCPLinkPtr;
+typedef std::vector<cTCPLinkPtr> cTCPLinkPtrs;
+class cServerHandle;
+typedef std::shared_ptr<cServerHandle> cServerHandlePtr;
+typedef std::vector<cServerHandlePtr> cServerHandlePtrs;
 
 
 
@@ -61,20 +61,20 @@ public:
 
 	/** Adds the specified link to m_Connections.
 	Used by the underlying link implementation when a new link is created. */
-	void AddLink(cTCPLinkImplPtr a_Link);
+	void AddLink(cTCPLinkPtr a_Link);
 
 	/** Removes the specified link from m_Connections.
 	Used by the underlying link implementation when the link is closed / errored. */
-	void RemoveLink(const cTCPLinkImpl * a_Link);
+	void RemoveLink(const cTCPLink * a_Link);
 
 	/** Adds the specified link to m_Servers.
 	Used by the underlying server handle implementation when a new listening server is created.
 	Only servers that succeed in listening are added. */
-	void AddServer(cServerHandleImplPtr a_Server);
+	void AddServer(cServerHandlePtr a_Server);
 
 	/** Removes the specified server from m_Servers.
 	Used by the underlying server handle implementation when the server is closed. */
-	void RemoveServer(const cServerHandleImpl * a_Server);
+	void RemoveServer(const cServerHandle * a_Server);
 
 protected:
 
@@ -82,10 +82,10 @@ protected:
 	event_base * m_EventBase;
 
 	/** Container for all client connections, including ones with pending-connect. */
-	cTCPLinkImplPtrs m_Connections;
+	cTCPLinkPtrs m_Connections;
 
 	/** Container for all servers that are currently active. */
-	cServerHandleImplPtrs m_Servers;
+	cServerHandlePtrs m_Servers;
 
 	/** Mutex protecting all containers against multithreaded access. */
 	cCriticalSection m_CS;

--- a/tests/HTTP/UrlClientTest.cpp
+++ b/tests/HTTP/UrlClientTest.cpp
@@ -6,6 +6,11 @@
 
 
 
+namespace
+{
+
+/** Track number of cCallbacks instances alive. */
+std::atomic<int> g_ActiveCallbacks{ 0 };
 
 /** Simple callbacks that dump the events to the console and signalize a cEvent when the request is finished. */
 class cCallbacks:
@@ -15,12 +20,14 @@ public:
 	cCallbacks(cEvent & a_Event):
 		m_Event(a_Event)
 	{
+		++g_ActiveCallbacks;
 		LOGD("Created a cCallbacks instance at %p", reinterpret_cast<void *>(this));
 	}
 
 
 	virtual ~cCallbacks() override
 	{
+		--g_ActiveCallbacks;
 		LOGD("Deleting the cCallbacks instance at %p", reinterpret_cast<void *>(this));
 	}
 
@@ -102,7 +109,7 @@ protected:
 
 
 
-static int TestRequest1()
+int TestRequest1()
 {
 	LOG("Running test 1");
 	cEvent evtFinished;
@@ -126,7 +133,7 @@ static int TestRequest1()
 
 
 
-static int TestRequest2()
+int TestRequest2()
 {
 	LOG("Running test 2");
 	cEvent evtFinished;
@@ -148,7 +155,7 @@ static int TestRequest2()
 
 
 
-static int TestRequest3()
+int TestRequest3()
 {
 	LOG("Running test 3");
 	cEvent evtFinished;
@@ -172,7 +179,7 @@ static int TestRequest3()
 
 
 
-static int TestRequest4()
+int TestRequest4()
 {
 	LOG("Running test 4");
 	cEvent evtFinished;
@@ -194,7 +201,7 @@ static int TestRequest4()
 
 
 
-static int TestRequests()
+int TestRequests()
 {
 	std::function<int(void)> tests[] =
 	{
@@ -215,6 +222,8 @@ static int TestRequests()
 	return 0;
 }
 
+}  // namespace (anonymous)
+
 
 
 
@@ -231,6 +240,11 @@ int main()
 
 	LOGD("Terminating cNetwork...");
 	cNetworkSingleton::Get().Terminate();
+
+	// No leaked callback instances
+	LOGD("cCallback instances still alive: %d", g_ActiveCallbacks.load());
+	assert_test(g_ActiveCallbacks == 0);
+
 	LOGD("cUrlClient test finished");
 
 	return res;


### PR DESCRIPTION
Fixes #4040 

* The TCP connection is now shutdown after `OnBodyFinished`
* Any open connections are closed when `cNetworkSingleton::Terminate()` is called.
* Removed ownership cycles in `cUrlClientRequest`

I also added a check to the test to ensure there are no leaks.