### PR TITLE
CMake: Fix test builds on MSVC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,14 @@
 version: 1.0.{build}
 configuration: Debug
 clone_depth: 50
+
 before_build:
 - echo %TIME%
 - git submodule update --init
 - echo %TIME%
-- cmake -G "Visual Studio 12" .
+- cmake -G "Visual Studio 12" -DSELF_TEST=1 -DBUILD_TOOLS=1 .
 - echo %TIME%
+
 build:
   project: Cuberite.sln
   parallel: true

--- a/tests/OSSupport/CMakeLists.txt
+++ b/tests/OSSupport/CMakeLists.txt
@@ -23,6 +23,7 @@ if (WIN32)
 		${OSSupport_SRCS}
 		${OSSupport_HDRS}
 	)
+	target_link_libraries(OSSupport PUBLIC fmt::fmt)
 endif()
 
 # Define individual tests:


### PR DESCRIPTION
[Linux builds on Jenkins](https://builds.cuberite.org/job/Cuberite%20Linux%20x64%20Master/928/console) are failing with this cmake error:
```
CMake Error at CMakeLists.txt:95 (add_executable):
  Target "ProtoProxy" links to target "fmt::fmt" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
```
because ProtoProxy is being built as the master project and it is missing the call to `add_subdirectory` for `fmt`.  This adds the missing calls and solves the resulting duplication caused when the tools are built as a subproject.

Questions:
* Is it worth adding a `cmake` folder or should I just put the scripts at top level?  If it stays then it might be worth moving `CheckLua.cmake` and `SetFlags.cmake` into the folder as well.
* After finding the solution in `cmake/NoDuplicateSubdirectories.cmake` I realised it's probably solving the same issue as `lib/mbedtls.cmake` but in a more general way.  Which solution should be preferred and should the other be rewritten in the same way?
  