### PR TITLE
Exp Orbs and Pickups are destroyed instantly by cacti.

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -530,7 +530,6 @@ bool cEntity::DoTakeDamage(TakeDamageInfo & a_TDI)
 	}
 
 	m_Health -= static_cast<float>(a_TDI.FinalDamage);
-
 	m_Health = std::max(m_Health, 0.0f);
 
 	// Add knockback:
@@ -1321,20 +1320,27 @@ void cEntity::TickInVoid(cChunk & a_Chunk)
 
 void cEntity::DetectCacti(void)
 {
-	int X = POSX_TOINT, Y = POSY_TOINT, Z = POSZ_TOINT;
-	double w = m_Width / 2;
-	if (
-		((Y > 0) && (Y < cChunkDef::Height)) &&
-		((((X + 1) - GetPosX() < w) && (GetWorld()->GetBlock(X + 1, Y, Z) == E_BLOCK_CACTUS)) ||
-		((GetPosX() - X < w) && (GetWorld()->GetBlock(X - 1, Y, Z) == E_BLOCK_CACTUS)) ||
-		(((Z + 1) - GetPosZ() < w) && (GetWorld()->GetBlock(X, Y, Z + 1) == E_BLOCK_CACTUS)) ||
-		((GetPosZ() - Z < w) && (GetWorld()->GetBlock(X, Y, Z - 1) == E_BLOCK_CACTUS)) ||
-		(((Y + 1) - GetPosY() < w) && (GetWorld()->GetBlock(X, Y + 1, Z) == E_BLOCK_CACTUS)) ||
-		((GetPosY() - Y < 1) && (GetWorld()->GetBlock(X, Y - 1, Z) == E_BLOCK_CACTUS)))
-		)
+	int MinX = FloorC(GetPosX() - m_Width / 2);
+	int MaxX = FloorC(GetPosX() + m_Width / 2);
+	int MinZ = FloorC(GetPosZ() - m_Width / 2);
+	int MaxZ = FloorC(GetPosZ() + m_Width / 2);
+	int MinY = Clamp(POSY_TOINT, 0, cChunkDef::Height - 1);
+	int MaxY = Clamp(FloorC(GetPosY() + m_Height), 0, cChunkDef::Height - 1);
+
+	for (int x = MinX; x <= MaxX; x++)
 	{
-		TakeDamage(dtCactusContact, nullptr, 1, 0);
-	}
+		for (int z = MinZ; z <= MaxZ; z++)
+		{
+			for (int y = MinY; y <= MaxY; y++)
+			{
+				if (GetWorld()->GetBlock(x, y, z) == E_BLOCK_CACTUS)
+				{
+					TakeDamage(dtCactusContact, nullptr, 1, 0);
+					return;
+				}
+			}  // for y
+		}  // for z
+	}  // for x
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -862,7 +862,7 @@ void cEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		}
 
 		if (
-			IsMob() || IsPickup() || IsExpOrb() ||
+			IsMob() || IsPickup() ||
 			(IsPlayer() && !((reinterpret_cast<cPlayer *>(this))->IsGameModeCreative() || (reinterpret_cast<cPlayer *>(this))->IsGameModeSpectator()))
 		)
 		{

--- a/src/Entities/ExpOrb.cpp
+++ b/src/Entities/ExpOrb.cpp
@@ -82,16 +82,13 @@ void cExpOrb::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	}
 }
 
-
-
-
-
-void cExpOrb::DetectCacti(void)
+bool cExpOrb::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
-	auto HealthBefore = m_Health;
-	super::DetectCacti();
-	if (m_Health < HealthBefore)
+	if (a_TDI.DamageType == dtCactusContact)
 	{
 		Destroy(true);
+		return true;
 	}
+
+	return super::DoTakeDamage(a_TDI);
 }

--- a/src/Entities/ExpOrb.cpp
+++ b/src/Entities/ExpOrb.cpp
@@ -46,6 +46,8 @@ void cExpOrb::SpawnOn(cClientHandle & a_Client)
 
 void cExpOrb::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
+	DetectCacti();
+
 	// Check player proximity no more than twice per second
 	if ((m_TicksAlive % 10) == 0)
 	{
@@ -75,6 +77,20 @@ void cExpOrb::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 	m_Timer += a_Dt;
 	if (m_Timer >= std::chrono::minutes(5))
+	{
+		Destroy(true);
+	}
+}
+
+
+
+
+
+void cExpOrb::DetectCacti(void)
+{
+	auto HealthBefore = m_Health;
+	super::DetectCacti();
+	if (m_Health < HealthBefore)
 	{
 		Destroy(true);
 	}

--- a/src/Entities/ExpOrb.h
+++ b/src/Entities/ExpOrb.h
@@ -24,7 +24,7 @@ public:
 	// Override functions
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
-	virtual void DetectCacti(void) override;
+	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
 
 	virtual void SpawnOn(cClientHandle & a_Client) override;
 

--- a/src/Entities/ExpOrb.h
+++ b/src/Entities/ExpOrb.h
@@ -23,6 +23,9 @@ public:
 
 	// Override functions
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
+
+	virtual void DetectCacti(void) override;
+
 	virtual void SpawnOn(cClientHandle & a_Client) override;
 
 	// tolua_begin

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -204,14 +204,15 @@ void cPickup::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 
 
-void cPickup::DetectCacti(void)
+bool cPickup::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
-	auto HealthBefore = m_Health;
-	super::DetectCacti();
-	if (m_Health < HealthBefore)
+	if (a_TDI.DamageType == dtCactusContact)
 	{
 		Destroy(true);
+		return true;
 	}
+
+	return super::DoTakeDamage(a_TDI);
 }
 
 

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -204,6 +204,20 @@ void cPickup::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 
 
+void cPickup::DetectCacti(void)
+{
+	auto HealthBefore = m_Health;
+	super::DetectCacti();
+	if (m_Health < HealthBefore)
+	{
+		Destroy(true);
+	}
+}
+
+
+
+
+
 bool cPickup::CollectedBy(cPlayer & a_Dest)
 {
 	if (m_bCollected)
@@ -261,7 +275,3 @@ bool cPickup::CollectedBy(cPlayer & a_Dest)
 	// LOG("Pickup %d cannot be collected by \"%s\", because there's no space in the inventory.", a_Dest->GetName().c_str(), m_UniqueID);
 	return false;
 }
-
-
-
-

--- a/src/Entities/Pickup.h
+++ b/src/Entities/Pickup.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
-	virtual void DetectCacti(void) override;
+	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
 
 	virtual bool DoesPreventBlockPlacement(void) const override { return false; }
 

--- a/src/Entities/Pickup.h
+++ b/src/Entities/Pickup.h
@@ -36,6 +36,8 @@ public:
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
+	virtual void DetectCacti(void) override;
+
 	virtual bool DoesPreventBlockPlacement(void) const override { return false; }
 
 	/** Returns whether this pickup is allowed to combine with other similar pickups */


### PR DESCRIPTION
pickups appeared not to be destroyed by cacti because both when they were inside the cactus block they were not damaged, and also they could be picked up in the time before their health depleted to 0. 

The cactus detection code has been improved and pickups are destroyed immediately when taking cactus damage.