### PR TITLE
Travis: Remove gdb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,27 +18,18 @@ matrix:
         - TRAVIS_CUBERITE_BUILD_TYPE=DEBUG CUBERITE_PATH=./Cuberite_debug
     # Default clang
     - compiler: clang
-      addons: &gdb
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gdb
       env: *Release
     - compiler: clang
-      addons: *gdb
       env: *Debug
     # clang 3.5
     - compiler: clang
       addons: &clang35
         apt:
           sources:
-            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.5
           packages:
             - clang++-3.5
             - clang-3.5
-            - gdb
       before_install:
         - CC=clang-3.5;CXX=clang++-3.5
       env: *Release
@@ -56,7 +47,6 @@ matrix:
           packages:
             - g++-4.8
             - gcc-4.8
-            - gdb
       before_install:
         - CC=gcc-4.8;CXX=g++-4.8
       env: *Release

--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -12,8 +12,15 @@ echo "Building..."
 cmake --build . -- -j 2;
 ctest -j 2 -V;
 
-# Create .gdbinit in home directory. Switches off the confirmation on quit
-echo -e "define hook-quit\n\tset confirm off\nend\n" > ~/.gdbinit
+# Create .gdbinit in home directory.
+# * Switches off the confirmation on quit
+# * Stops gdb from disabling address space layout randomization.
+cat << EOF > ~/.gdbinit
+define hook-quit
+	set confirm off
+end
+set disable-randomization off
+EOF
 
 echo "Testing..."
 

--- a/CIbuild.sh
+++ b/CIbuild.sh
@@ -12,29 +12,12 @@ echo "Building..."
 cmake --build . -- -j 2;
 ctest -j 2 -V;
 
-# Create .gdbinit in home directory.
-# * Switches off the confirmation on quit
-# * Stops gdb from disabling address space layout randomization.
-cat << EOF > ~/.gdbinit
-define hook-quit
-	set confirm off
-end
-set disable-randomization off
-EOF
-
 echo "Testing..."
-
-# OSX builds don't have gdb
-if [ "$TRAVIS_OS_NAME" = osx ]; then
-	GDB_COMMAND=""
-else
-	GDB_COMMAND="gdb -return-child-result -ex run -ex \"bt\" -ex \"info threads\" -ex \"thread apply all bt\" -ex \"quit\" --args"
-fi
 
 cd Server/;
 touch apiCheckFailed.flag
 if [ "$TRAVIS_CUBERITE_BUILD_TYPE" != "COVERAGE" ]; then
-	${GDB_COMMAND} ${CUBERITE_PATH} <<- EOF
+	${CUBERITE_PATH} <<- EOF
 		load APIDump
 		apicheck
 		restart


### PR DESCRIPTION
Sudo-less workers no longer have permission to disable ASLR.
This is seen [here](https://travis-ci.org/cuberite/cuberite/builds/326872644) where each failed build has this error message from gdb:

>warning: Error disabling address space randomization: Operation not permitted