### PR TITLE
Deal with covered switches consistently

### DIFF
--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -993,9 +993,8 @@ void cLuaState::Push(cEntity * a_Entity)
 						// Push the generic entity class type:
 						return "cEntity";
 					}
-
-					COVERED_SWITCH;
 				}  // switch (EntityType)
+				UNREACHABLE("Unsupported entity type");
 			}();
 		tolua_pushusertype(m_LuaState, a_Entity, ClassName);
 	}

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -993,6 +993,8 @@ void cLuaState::Push(cEntity * a_Entity)
 						// Push the generic entity class type:
 						return "cEntity";
 					}
+
+					COVERED_SWITCH;
 				}  // switch (EntityType)
 			}();
 		tolua_pushusertype(m_LuaState, a_Entity, ClassName);

--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -2458,120 +2458,124 @@ void cBlockArea::MergeByStrategy(const cBlockArea & a_Src, int a_RelX, int a_Rel
 	int DstOffZ = std::max(0,  a_RelZ);  // Offset in Dst where to start writing
 	int SizeZ   = std::min(a_Src.GetSizeZ() - SrcOffZ, GetSizeZ() - DstOffZ);  // How many blocks to copy
 
-	switch (a_Strategy)
+	[&]
 	{
-		case cBlockArea::msOverwrite:
+		switch (a_Strategy)
 		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorOverwrite<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msOverwrite
+			case cBlockArea::msOverwrite:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorOverwrite<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msOverwrite
 
-		case cBlockArea::msFillAir:
-		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorFillAir<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msFillAir
+			case cBlockArea::msFillAir:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorFillAir<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msFillAir
 
-		case cBlockArea::msImprint:
-		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorImprint<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msImprint
+			case cBlockArea::msImprint:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorImprint<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msImprint
 
-		case cBlockArea::msLake:
-		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorLake<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msLake
+			case cBlockArea::msLake:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorLake<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msLake
 
-		case cBlockArea::msSpongePrint:
-		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorSpongePrint<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msSpongePrint
+			case cBlockArea::msSpongePrint:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorSpongePrint<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msSpongePrint
 
-		case cBlockArea::msDifference:
-		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorDifference<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msDifference
+			case cBlockArea::msDifference:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorDifference<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msDifference
 
-		case cBlockArea::msSimpleCompare:
-		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorSimpleCompare<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msSimpleCompare
+			case cBlockArea::msSimpleCompare:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorSimpleCompare<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msSimpleCompare
 
-		case cBlockArea::msMask:
-		{
-			InternalMergeBlocks<MetasValid, MergeCombinatorMask<MetasValid> >(
-				GetBlockTypes(), a_Src.GetBlockTypes(),
-				DstMetas, SrcMetas,
-				SizeX, SizeY, SizeZ,
-				SrcOffX, SrcOffY, SrcOffZ,
-				DstOffX, DstOffY, DstOffZ,
-				a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
-				m_Size.x, m_Size.y, m_Size.z
-			);
-			break;
-		}  // case msMask
-	}  // switch (a_Strategy)
+			case cBlockArea::msMask:
+			{
+				InternalMergeBlocks<MetasValid, MergeCombinatorMask<MetasValid> >(
+					GetBlockTypes(), a_Src.GetBlockTypes(),
+					DstMetas, SrcMetas,
+					SizeX, SizeY, SizeZ,
+					SrcOffX, SrcOffY, SrcOffZ,
+					DstOffX, DstOffY, DstOffZ,
+					a_Src.GetSizeX(), a_Src.GetSizeY(), a_Src.GetSizeZ(),
+					m_Size.x, m_Size.y, m_Size.z
+				);
+				return;
+			}  // case msMask
+		}  // switch (a_Strategy)
+		UNREACHABLE("Unsupported block area merge strategy");
+	}();
 
 	if (HasBlockEntities())
 	{

--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -2571,8 +2571,6 @@ void cBlockArea::MergeByStrategy(const cBlockArea & a_Src, int a_RelX, int a_Rel
 			);
 			break;
 		}  // case msMask
-
-		COVERED_SWITCH;
 	}  // switch (a_Strategy)
 
 	if (HasBlockEntities())

--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -2572,14 +2572,7 @@ void cBlockArea::MergeByStrategy(const cBlockArea & a_Src, int a_RelX, int a_Rel
 			break;
 		}  // case msMask
 
-		#ifndef __clang__  // Clang complains about a default case in a switch with all cases covered
-		default:
-		{
-			LOGWARNING("Unknown block area merge strategy: %d", a_Strategy);
-			ASSERT(!"Unknown block area merge strategy");
-			return;
-		}
-		#endif
+		COVERED_SWITCH;
 	}  // switch (a_Strategy)
 
 	if (HasBlockEntities())

--- a/src/BlockID.cpp
+++ b/src/BlockID.cpp
@@ -387,8 +387,8 @@ AString DamageTypeToString(eDamageType a_DamageType)
 		case dtStarving:        return "dtStarving";
 		case dtSuffocating:     return "dtSuffocation";
 		case dtExplosion:       return "dtExplosion";
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported damage type");
 }
 
 

--- a/src/BlockID.cpp
+++ b/src/BlockID.cpp
@@ -387,13 +387,8 @@ AString DamageTypeToString(eDamageType a_DamageType)
 		case dtStarving:        return "dtStarving";
 		case dtSuffocating:     return "dtSuffocation";
 		case dtExplosion:       return "dtExplosion";
+		COVERED_SWITCH;
 	}
-
-	// Unknown damage type:
-	ASSERT(!"Unknown DamageType");
-	#ifndef __clang__
-		return Printf("dtUnknown_%d", static_cast<int>(a_DamageType));
-	#endif
 }
 
 

--- a/src/Blocks/BlockButton.h
+++ b/src/Blocks/BlockButton.h
@@ -91,11 +91,8 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return 0x0;
 			}
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)

--- a/src/Blocks/BlockButton.h
+++ b/src/Blocks/BlockButton.h
@@ -91,8 +91,8 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return 0x0;
 			}
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)

--- a/src/Blocks/BlockCocoaPod.h
+++ b/src/Blocks/BlockCocoaPod.h
@@ -81,11 +81,8 @@ public:
 				ASSERT(!"Unknown face");
 				return 0;
 			}
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 
 	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) override

--- a/src/Blocks/BlockCocoaPod.h
+++ b/src/Blocks/BlockCocoaPod.h
@@ -81,8 +81,8 @@ public:
 				ASSERT(!"Unknown face");
 				return 0;
 			}
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 
 	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) override

--- a/src/Blocks/BlockLadder.h
+++ b/src/Blocks/BlockLadder.h
@@ -59,11 +59,8 @@ public:
 			{
 				return 0x2;
 			}
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 
 	static eBlockFace MetaDataToDirection(NIBBLETYPE a_MetaData)

--- a/src/Blocks/BlockLadder.h
+++ b/src/Blocks/BlockLadder.h
@@ -59,8 +59,8 @@ public:
 			{
 				return 0x2;
 			}
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 
 	static eBlockFace MetaDataToDirection(NIBBLETYPE a_MetaData)

--- a/src/Blocks/BlockLever.h
+++ b/src/Blocks/BlockLever.h
@@ -64,8 +64,8 @@ public:
 			case BLOCK_FACE_ZM:   return 0x4;
 			case BLOCK_FACE_YM:   return 0x0;
 			case BLOCK_FACE_NONE: return 0x6;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)

--- a/src/Blocks/BlockLever.h
+++ b/src/Blocks/BlockLever.h
@@ -64,11 +64,8 @@ public:
 			case BLOCK_FACE_ZM:   return 0x4;
 			case BLOCK_FACE_YM:   return 0x0;
 			case BLOCK_FACE_NONE: return 0x6;
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)

--- a/src/Blocks/BlockQuartz.h
+++ b/src/Blocks/BlockQuartz.h
@@ -62,11 +62,9 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return a_QuartzMeta;  // No idea, give a special meta (all sides the same)
 			}
+
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 
 	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) override

--- a/src/Blocks/BlockQuartz.h
+++ b/src/Blocks/BlockQuartz.h
@@ -62,9 +62,8 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return a_QuartzMeta;  // No idea, give a special meta (all sides the same)
 			}
-
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 
 	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) override

--- a/src/Blocks/BlockSideways.h
+++ b/src/Blocks/BlockSideways.h
@@ -63,9 +63,8 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return a_Meta | 0xC;  // No idea, give a special meta
 			}
-
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 } ;
 

--- a/src/Blocks/BlockSideways.h
+++ b/src/Blocks/BlockSideways.h
@@ -63,11 +63,9 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return a_Meta | 0xC;  // No idea, give a special meta
 			}
+
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 } ;
 

--- a/src/Blocks/BlockTrapdoor.h
+++ b/src/Blocks/BlockTrapdoor.h
@@ -82,11 +82,8 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return 0;
 			}
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)

--- a/src/Blocks/BlockTrapdoor.h
+++ b/src/Blocks/BlockTrapdoor.h
@@ -82,8 +82,8 @@ public:
 				ASSERT(!"Unhandled block face!");
 				return 0;
 			}
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)

--- a/src/Blocks/BlockTripwireHook.h
+++ b/src/Blocks/BlockTripwireHook.h
@@ -44,11 +44,8 @@ public:
 				ASSERT(!"Unhandled tripwire hook direction!");
 				return 0x0;
 			}
+			COVERED_SWITCH;
 		}
-		#if !defined(__clang__)
-			ASSERT(!"Unknown BLOCK_FACE");
-			return 0;
-		#endif
 	}
 
 	inline static eBlockFace MetadataToDirection(NIBBLETYPE a_Meta)

--- a/src/Blocks/BlockTripwireHook.h
+++ b/src/Blocks/BlockTripwireHook.h
@@ -44,8 +44,8 @@ public:
 				ASSERT(!"Unhandled tripwire hook direction!");
 				return 0x0;
 			}
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported block face");
 	}
 
 	inline static eBlockFace MetadataToDirection(NIBBLETYPE a_Meta)

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -277,8 +277,7 @@ inline const char * ClickActionToString(int a_ClickAction)
 
 		case caUnknown:                      return "caUnknown";
 	}
-	ASSERT(!"Unknown click action");
-	return "caUnknown";
+	UNREACHABLE("Unknown click action");
 }
 
 
@@ -300,8 +299,8 @@ inline eBlockFace MirrorBlockFaceY(eBlockFace a_BlockFace)
 		{
 			return a_BlockFace;
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported block face");
 }
 
 
@@ -323,8 +322,8 @@ inline eBlockFace RotateBlockFaceCCW(eBlockFace a_BlockFace)
 		{
 			return a_BlockFace;
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported block face");
 }
 
 
@@ -345,8 +344,8 @@ inline eBlockFace RotateBlockFaceCW(eBlockFace a_BlockFace)
 		{
 			return a_BlockFace;
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported block face");
 }
 
 
@@ -364,8 +363,8 @@ inline eBlockFace ReverseBlockFace(eBlockFace  a_BlockFace)
 		case BLOCK_FACE_XM:   return BLOCK_FACE_XP;
 		case BLOCK_FACE_ZM:   return BLOCK_FACE_ZP;
 		case BLOCK_FACE_NONE: return a_BlockFace;
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported block face");
 }
 
 
@@ -384,8 +383,8 @@ inline AString BlockFaceToString(eBlockFace a_BlockFace)
 		case BLOCK_FACE_ZM: return "BLOCK_FACE_ZM";
 		case BLOCK_FACE_ZP: return "BLOCK_FACE_ZP";
 		case BLOCK_FACE_NONE: return "BLOCK_FACE_NONE";
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported block face");
 }
 
 

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -299,12 +299,9 @@ inline eBlockFace MirrorBlockFaceY(eBlockFace a_BlockFace)
 		case BLOCK_FACE_YP:
 		{
 			return a_BlockFace;
-		};
+		}
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown BLOCK_FACE");
-		return a_BlockFace;
-	#endif
 }
 
 
@@ -326,11 +323,8 @@ inline eBlockFace RotateBlockFaceCCW(eBlockFace a_BlockFace)
 		{
 			return a_BlockFace;
 		}
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown BLOCK_FACE");
-		return a_BlockFace;
-	#endif
 }
 
 
@@ -350,12 +344,9 @@ inline eBlockFace RotateBlockFaceCW(eBlockFace a_BlockFace)
 		case BLOCK_FACE_YP:
 		{
 			return a_BlockFace;
-		};
+		}
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown BLOCK_FACE");
-		return a_BlockFace;
-	#endif
 }
 
 
@@ -373,11 +364,8 @@ inline eBlockFace ReverseBlockFace(eBlockFace  a_BlockFace)
 		case BLOCK_FACE_XM:   return BLOCK_FACE_XP;
 		case BLOCK_FACE_ZM:   return BLOCK_FACE_ZP;
 		case BLOCK_FACE_NONE: return a_BlockFace;
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown BLOCK_FACE");
-		return a_BlockFace;
-	#endif
 }
 
 
@@ -396,11 +384,8 @@ inline AString BlockFaceToString(eBlockFace a_BlockFace)
 		case BLOCK_FACE_ZM: return "BLOCK_FACE_ZM";
 		case BLOCK_FACE_ZP: return "BLOCK_FACE_ZP";
 		case BLOCK_FACE_NONE: return "BLOCK_FACE_NONE";
+		COVERED_SWITCH;
 	}
-	// clang optimisises this line away then warns that it has done so.
-	#if !defined(__clang__)
-		return Printf("Unknown BLOCK_FACE: %d", a_BlockFace);
-	#endif
 }
 
 

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -65,11 +65,8 @@ bool cArrowEntity::CanPickup(const cPlayer & a_Player) const
 		case psNoPickup:             return false;
 		case psInSurvivalOrCreative: return (a_Player.IsGameModeSurvival() || a_Player.IsGameModeCreative());
 		case psInCreative:           return a_Player.IsGameModeCreative();
+		COVERED_SWITCH;
 	}
-	ASSERT(!"Unhandled pickup state");
-	#ifndef __clang__
-		return false;
-	#endif
 }
 
 

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -65,8 +65,8 @@ bool cArrowEntity::CanPickup(const cPlayer & a_Player) const
 		case psNoPickup:             return false;
 		case psInSurvivalOrCreative: return (a_Player.IsGameModeSurvival() || a_Player.IsGameModeCreative());
 		case psInCreative:           return a_Player.IsGameModeCreative();
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported arrow pickup state");
 }
 
 

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -206,8 +206,8 @@ AString cBoat::MaterialToString(eMaterial a_Material)
 		case bmJungle:  return "jungle";
 		case bmAcacia:  return "acacia";
 		case bmDarkOak: return "dark_oak";
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported boat material");
 }
 
 
@@ -260,8 +260,8 @@ cItem cBoat::MaterialToItem(eMaterial a_Material)
 		case bmJungle:  return cItem(E_ITEM_JUNGLE_BOAT);
 		case bmAcacia:  return cItem(E_ITEM_ACACIA_BOAT);
 		case bmDarkOak: return cItem(E_ITEM_DARK_OAK_BOAT);
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported boat material");
 }
 
 

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -206,11 +206,8 @@ AString cBoat::MaterialToString(eMaterial a_Material)
 		case bmJungle:  return "jungle";
 		case bmAcacia:  return "acacia";
 		case bmDarkOak: return "dark_oak";
+		COVERED_SWITCH;
 	}
-	ASSERT(!"Unhandled boat material");
-	#ifndef __clang__
-		return "oak";
-	#endif
 }
 
 
@@ -263,10 +260,8 @@ cItem cBoat::MaterialToItem(eMaterial a_Material)
 		case bmJungle:  return cItem(E_ITEM_JUNGLE_BOAT);
 		case bmAcacia:  return cItem(E_ITEM_ACACIA_BOAT);
 		case bmDarkOak: return cItem(E_ITEM_DARK_OAK_BOAT);
+		COVERED_SWITCH;
 	}
-	#ifndef __clang__
-		return cItem(E_ITEM_BOAT);
-	#endif
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -639,11 +639,8 @@ bool cEntity::ArmorCoversAgainst(eDamageType a_DamageType)
 		{
 			return true;
 		}
+		COVERED_SWITCH;
 	}
-	ASSERT(!"Invalid damage type!");
-	#ifndef __clang__
-		return false;
-	#endif
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -639,8 +639,8 @@ bool cEntity::ArmorCoversAgainst(eDamageType a_DamageType)
 		{
 			return true;
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported damage type");
 }
 
 

--- a/src/Entities/EntityEffect.cpp
+++ b/src/Entities/EntityEffect.cpp
@@ -216,8 +216,8 @@ std::unique_ptr<cEntityEffect> cEntityEffect::CreateEntityEffect(cEntityEffect::
 		case cEntityEffect::effWaterBreathing: return cpp14::make_unique<cEntityEffectWaterBreathing>(a_Duration, a_Intensity, a_DistanceModifier);
 		case cEntityEffect::effWeakness:       return cpp14::make_unique<cEntityEffectWeakness      >(a_Duration, a_Intensity, a_DistanceModifier);
 		case cEntityEffect::effWither:         return cpp14::make_unique<cEntityEffectWither        >(a_Duration, a_Intensity, a_DistanceModifier);
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported entity effect");
 }
 
 

--- a/src/Entities/EntityEffect.cpp
+++ b/src/Entities/EntityEffect.cpp
@@ -216,12 +216,8 @@ std::unique_ptr<cEntityEffect> cEntityEffect::CreateEntityEffect(cEntityEffect::
 		case cEntityEffect::effWaterBreathing: return cpp14::make_unique<cEntityEffectWaterBreathing>(a_Duration, a_Intensity, a_DistanceModifier);
 		case cEntityEffect::effWeakness:       return cpp14::make_unique<cEntityEffectWeakness      >(a_Duration, a_Intensity, a_DistanceModifier);
 		case cEntityEffect::effWither:         return cpp14::make_unique<cEntityEffectWither        >(a_Duration, a_Intensity, a_DistanceModifier);
+		COVERED_SWITCH;
 	}
-
-	ASSERT(!"Unhandled entity effect type!");
-	#ifndef __clang__
-		return {};
-	#endif
 }
 
 

--- a/src/Entities/HangingEntity.h
+++ b/src/Entities/HangingEntity.h
@@ -60,40 +60,34 @@ protected:
 	/** Converts protocol hanging item facing to eBlockFace values */
 	inline static eBlockFace ProtocolFaceToBlockFace(Byte a_ProtocolFace)
 	{
-		eBlockFace Dir;
-
 		// The client uses different values for item frame directions and block faces. Our constants are for the block faces, so we convert them here to item frame faces
 		switch (a_ProtocolFace)
 		{
-			case 0: Dir = BLOCK_FACE_ZP; break;
-			case 2: Dir = BLOCK_FACE_ZM; break;
-			case 1: Dir = BLOCK_FACE_XM; break;
-			case 3: Dir = BLOCK_FACE_XP; break;
+			case 0: return BLOCK_FACE_ZP;
+			case 2: return BLOCK_FACE_ZM;
+			case 1: return BLOCK_FACE_XM;
+			case 3: return BLOCK_FACE_XP;
 			default:
 			{
 				LOGINFO("Invalid facing (%d) in a cHangingEntity, adjusting to BLOCK_FACE_XP.", a_ProtocolFace);
 				ASSERT(!"Tried to convert a bad facing!");
 
-				Dir = cHangingEntity::ProtocolFaceToBlockFace(3);
+				return cHangingEntity::ProtocolFaceToBlockFace(3);
 			}
 		}
-
-		return Dir;
 	}
 
 
 	/** Converts eBlockFace values to protocol hanging item faces */
 	inline static Byte BlockFaceToProtocolFace(eBlockFace a_BlockFace)
 	{
-		Byte Dir;
-
 		// The client uses different values for item frame directions and block faces. Our constants are for the block faces, so we convert them here to item frame faces
 		switch (a_BlockFace)
 		{
-			case BLOCK_FACE_ZP: Dir = 0; break;
-			case BLOCK_FACE_ZM: Dir = 2; break;
-			case BLOCK_FACE_XM: Dir = 1; break;
-			case BLOCK_FACE_XP: Dir = 3; break;
+			case BLOCK_FACE_ZP: return 0;
+			case BLOCK_FACE_ZM: return 2;
+			case BLOCK_FACE_XM: return 1;
+			case BLOCK_FACE_XP: return 3;
 			case BLOCK_FACE_YP:
 			case BLOCK_FACE_YM:
 			case BLOCK_FACE_NONE:
@@ -102,13 +96,10 @@ protected:
 				// LOGINFO("Invalid facing (%d) in a cHangingEntity, adjusting to BLOCK_FACE_XP.", a_BlockFace);
 				// ASSERT(!"Tried to convert a bad facing!");
 
-				Dir = cHangingEntity::BlockFaceToProtocolFace(BLOCK_FACE_XP);
-				break;
+				return cHangingEntity::BlockFaceToProtocolFace(BLOCK_FACE_XP);
 			}
-			COVERED_SWITCH;
 		}
-
-		return Dir;
+		UNREACHABLE("Unsupported block face");
 	}
 };  // tolua_export
 

--- a/src/Entities/HangingEntity.h
+++ b/src/Entities/HangingEntity.h
@@ -105,13 +105,7 @@ protected:
 				Dir = cHangingEntity::BlockFaceToProtocolFace(BLOCK_FACE_XP);
 				break;
 			}
-			#if !defined(__clang__)
-			default:
-			{
-				ASSERT(!"Unknown BLOCK_FACE");
-				return 0;
-			}
-			#endif
+			COVERED_SWITCH;
 		}
 
 		return Dir;

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1060,29 +1060,31 @@ void cPlayer::KilledBy(TakeDamageInfo & a_TDI)
 
 	if ((a_TDI.Attacker == nullptr) && m_World->ShouldBroadcastDeathMessages())
 	{
-		AString DamageText;
-		switch (a_TDI.DamageType)
-		{
-			case dtRangedAttack: DamageText = "was shot"; break;
-			case dtLightning: DamageText = "was plasmified by lightining"; break;
-			case dtFalling: DamageText = GetRandomProvider().RandBool() ? "fell to death" : "hit the ground too hard"; break;
-			case dtDrowning: DamageText = "drowned"; break;
-			case dtSuffocating: DamageText = GetRandomProvider().RandBool() ? "git merge'd into a block" : "fused with a block"; break;
-			case dtStarving: DamageText = "forgot the importance of food"; break;
-			case dtCactusContact: DamageText = "was impaled on a cactus"; break;
-			case dtLavaContact: DamageText = "was melted by lava"; break;
-			case dtPoisoning: DamageText = "died from septicaemia"; break;
-			case dtWithering: DamageText = "is a husk of their former selves"; break;
-			case dtOnFire: DamageText = "forgot to stop, drop, and roll"; break;
-			case dtFireContact: DamageText = "burnt themselves to death"; break;
-			case dtInVoid: DamageText = "somehow fell out of the world"; break;
-			case dtPotionOfHarming: DamageText = "was magicked to death"; break;
-			case dtEnderPearl: DamageText = "misused an ender pearl"; break;
-			case dtAdmin: DamageText = "was administrator'd"; break;
-			case dtExplosion: DamageText = "blew up"; break;
-			case dtAttack: DamageText = "was attacked by thin air"; break;
-			COVERED_SWITCH;
-		}
+		const AString DamageText = [&]
+			{
+				switch (a_TDI.DamageType)
+				{
+					case dtRangedAttack:    return "was shot";
+					case dtLightning:       return "was plasmified by lightining";
+					case dtFalling:         return GetRandomProvider().RandBool() ? "fell to death" : "hit the ground too hard";
+					case dtDrowning:        return "drowned";
+					case dtSuffocating:     return GetRandomProvider().RandBool() ? "git merge'd into a block" : "fused with a block";
+					case dtStarving:        return "forgot the importance of food";
+					case dtCactusContact:   return "was impaled on a cactus";
+					case dtLavaContact:     return "was melted by lava";
+					case dtPoisoning:       return "died from septicaemia";
+					case dtWithering:       return "is a husk of their former selves";
+					case dtOnFire:          return "forgot to stop, drop, and roll";
+					case dtFireContact:     return "burnt themselves to death";
+					case dtInVoid:          return "somehow fell out of the world";
+					case dtPotionOfHarming: return "was magicked to death";
+					case dtEnderPearl:      return "misused an ender pearl";
+					case dtAdmin:           return "was administrator'd";
+					case dtExplosion:       return "blew up";
+					case dtAttack:          return "was attacked by thin air";
+				}
+				UNREACHABLE("Unsupported damage type");
+			}();
 		AString DeathMessage = Printf("%s %s", GetName().c_str(), DamageText.c_str());
 		PluginManager->CallHookKilled(*this, a_TDI, DeathMessage);
 		if (DeathMessage != AString(""))

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1081,14 +1081,7 @@ void cPlayer::KilledBy(TakeDamageInfo & a_TDI)
 			case dtAdmin: DamageText = "was administrator'd"; break;
 			case dtExplosion: DamageText = "blew up"; break;
 			case dtAttack: DamageText = "was attacked by thin air"; break;
-			#ifndef __clang__
-			default:
-			{
-				ASSERT(!"Unknown damage type");
-				DamageText = "died, somehow; we've no idea how though";
-				break;
-			}
-			#endif  // __clang__
+			COVERED_SWITCH;
 		}
 		AString DeathMessage = Printf("%s %s", GetName().c_str(), DamageText.c_str());
 		PluginManager->CallHookKilled(*this, a_TDI, DeathMessage);

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -355,11 +355,8 @@ AString cProjectileEntity::GetMCAClassName(void) const
 		case pkWitherSkull:   return "WitherSkull";
 		case pkFirework:      return "Firework";
 		case pkFishingFloat:  return "";  // Unknown, perhaps MC doesn't save this?
+		COVERED_SWITCH;
 	}
-	ASSERT(!"Unhandled projectile entity kind!");
-	#ifndef __clang__
-		return "";
-	#endif
 }
 
 

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -355,8 +355,8 @@ AString cProjectileEntity::GetMCAClassName(void) const
 		case pkWitherSkull:   return "WitherSkull";
 		case pkFirework:      return "Firework";
 		case pkFishingFloat:  return "";  // Unknown, perhaps MC doesn't save this?
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported projectile kind");
 }
 
 

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -786,13 +786,7 @@ void cMineShaftCorridor::PlaceChest(cChunkDesc & a_ChunkDesc)
 			Meta = E_META_CHEST_FACING_XP;
 			break;
 		}
-		#if !defined(__clang__)
-		default:
-		{
-			ASSERT(!"Unknown direction");
-			return;
-		}
-		#endif
+		COVERED_SWITCH;
 	}  // switch (Dir)
 
 	if (

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -767,27 +767,34 @@ void cMineShaftCorridor::PlaceChest(cChunkDesc & a_ChunkDesc)
 	int BlockZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;
 	int x, z;
 	NIBBLETYPE Meta = 0;
-	switch (m_Direction)
-	{
-		case dirXM:
-		case dirXP:
+	std::tie(x, z, Meta) = [&]() -> std::tuple<int, int, NIBBLETYPE>
 		{
-			x = m_BoundingBox.p1.x + m_ChestPosition - BlockX;
-			z = m_BoundingBox.p1.z - BlockZ;
-			Meta = E_META_CHEST_FACING_ZP;
-			break;
-		}
+			switch (m_Direction)
+			{
+				case dirXM:
+				case dirXP:
+				{
+					return
+					{
+						m_BoundingBox.p1.x + m_ChestPosition - BlockX,
+						m_BoundingBox.p1.z - BlockZ,
+						E_META_CHEST_FACING_ZP
+					};
+				}
 
-		case dirZM:
-		case dirZP:
-		{
-			x = m_BoundingBox.p1.x - BlockX;
-			z = m_BoundingBox.p1.z + m_ChestPosition - BlockZ;
-			Meta = E_META_CHEST_FACING_XP;
-			break;
-		}
-		COVERED_SWITCH;
-	}  // switch (Dir)
+				case dirZM:
+				case dirZP:
+				{
+					return
+					{
+						m_BoundingBox.p1.x - BlockX,
+						m_BoundingBox.p1.z + m_ChestPosition - BlockZ,
+						E_META_CHEST_FACING_XP
+					};
+				}
+			}  // switch (Dir)
+			UNREACHABLE("Unsupported corridor direction");
+		}();
 
 	if (
 		(x >= 0) && (x < cChunkDef::Width) &&

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -767,32 +767,30 @@ void cMineShaftCorridor::PlaceChest(cChunkDesc & a_ChunkDesc)
 	int BlockZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;
 	int x, z;
 	NIBBLETYPE Meta = 0;
-	std::tie(x, z, Meta) = [&]
+	[&]
+	{
+		switch (m_Direction)
 		{
-			switch (m_Direction)
+			case dirXM:
+			case dirXP:
 			{
-				case dirXM:
-				case dirXP:
-				{
-					return std::tuple<int, int, NIBBLETYPE>(
-						m_BoundingBox.p1.x + m_ChestPosition - BlockX,
-						m_BoundingBox.p1.z - BlockZ,
-						E_META_CHEST_FACING_ZP
-					);
-				}
+				x = m_BoundingBox.p1.x + m_ChestPosition - BlockX;
+				z = m_BoundingBox.p1.z - BlockZ;
+				Meta = E_META_CHEST_FACING_ZP;
+				return;
+			}
 
-				case dirZM:
-				case dirZP:
-				{
-					return std::tuple<int, int, NIBBLETYPE>(
-						m_BoundingBox.p1.x - BlockX,
-						m_BoundingBox.p1.z + m_ChestPosition - BlockZ,
-						E_META_CHEST_FACING_XP
-					);
-				}
-			}  // switch (Dir)
-			UNREACHABLE("Unsupported corridor direction");
-		}();
+			case dirZM:
+			case dirZP:
+			{
+				x = m_BoundingBox.p1.x - BlockX;
+				z = m_BoundingBox.p1.z + m_ChestPosition - BlockZ;
+				Meta = E_META_CHEST_FACING_XP;
+				return;
+			}
+		}  // switch (Dir)
+		UNREACHABLE("Unsupported corridor direction");
+	}();
 
 	if (
 		(x >= 0) && (x < cChunkDef::Width) &&

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -767,30 +767,28 @@ void cMineShaftCorridor::PlaceChest(cChunkDesc & a_ChunkDesc)
 	int BlockZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;
 	int x, z;
 	NIBBLETYPE Meta = 0;
-	std::tie(x, z, Meta) = [&]() -> std::tuple<int, int, NIBBLETYPE>
+	std::tie(x, z, Meta) = [&]
 		{
 			switch (m_Direction)
 			{
 				case dirXM:
 				case dirXP:
 				{
-					return
-					{
+					return std::tuple<int, int, NIBBLETYPE>(
 						m_BoundingBox.p1.x + m_ChestPosition - BlockX,
 						m_BoundingBox.p1.z - BlockZ,
 						E_META_CHEST_FACING_ZP
-					};
+					);
 				}
 
 				case dirZM:
 				case dirZP:
 				{
-					return
-					{
+					return std::tuple<int, int, NIBBLETYPE>(
 						m_BoundingBox.p1.x - BlockX,
 						m_BoundingBox.p1.z + m_ChestPosition - BlockZ,
 						E_META_CHEST_FACING_XP
-					};
+					);
 				}
 			}  // switch (Dir)
 			UNREACHABLE("Unsupported corridor direction");

--- a/src/Generating/PiecePool.cpp
+++ b/src/Generating/PiecePool.cpp
@@ -199,11 +199,8 @@ Vector3i cPiece::cConnector::AddDirection(const Vector3i & a_Pos, eDirection a_D
 		case dirYP_XM_ZP: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
 		case dirYP_XP_ZM: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
 		case dirYP_XP_ZP: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown connector direction");
-		return a_Pos;
-	#endif
 }
 
 
@@ -228,11 +225,8 @@ const char * cPiece::cConnector::DirectionToString(eDirection a_Direction)
 		case dirYP_XM_ZP: return "y+x-z+";
 		case dirYP_XP_ZM: return "y+x+z-";
 		case dirYP_XP_ZP: return "y+x+z+";
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown connector direction");
-		return "<unknown>";
-	#endif
 }
 
 
@@ -287,11 +281,8 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirection(eDirection a_
 		case dirYP_XM_ZP: return dirYP_XP_ZM;
 		case dirYP_XP_ZM: return dirYP_XM_ZP;
 		case dirYP_XP_ZP: return dirYP_XM_ZM;
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown connector direction");
-		return a_Direction;
-	#endif
 }
 
 
@@ -317,11 +308,8 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirectionCCW(eDirection
 		case dirYP_XM_ZP: return dirYP_XP_ZP;
 		case dirYP_XP_ZM: return dirYP_XM_ZM;
 		case dirYP_XP_ZP: return dirYP_XP_ZM;
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown connector direction");
-		return a_Direction;
-	#endif
 }
 
 
@@ -347,11 +335,8 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirectionCW(eDirection 
 		case dirYP_XM_ZP: return dirYP_XM_ZM;
 		case dirYP_XP_ZM: return dirYP_XP_ZP;
 		case dirYP_XP_ZP: return dirYP_XM_ZP;
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown connector direction");
-		return a_Direction;
-	#endif
 }
 
 

--- a/src/Generating/PiecePool.cpp
+++ b/src/Generating/PiecePool.cpp
@@ -200,7 +200,7 @@ Vector3i cPiece::cConnector::AddDirection(const Vector3i & a_Pos, eDirection a_D
 		case dirYP_XP_ZM: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
 		case dirYP_XP_ZP: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
 	}
-	UNREACHABLE("Unsupported piece direction");
+	UNREACHABLE("Unsupported connector direction");
 }
 
 
@@ -226,7 +226,7 @@ const char * cPiece::cConnector::DirectionToString(eDirection a_Direction)
 		case dirYP_XP_ZM: return "y+x+z-";
 		case dirYP_XP_ZP: return "y+x+z+";
 	}
-	UNREACHABLE("Unsupported piece direction");
+	UNREACHABLE("Unsupported connector direction");
 }
 
 
@@ -282,7 +282,7 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirection(eDirection a_
 		case dirYP_XP_ZM: return dirYP_XM_ZP;
 		case dirYP_XP_ZP: return dirYP_XM_ZM;
 	}
-	UNREACHABLE("Unsupported piece direction");
+	UNREACHABLE("Unsupported connector direction");
 }
 
 
@@ -309,7 +309,7 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirectionCCW(eDirection
 		case dirYP_XP_ZM: return dirYP_XM_ZM;
 		case dirYP_XP_ZP: return dirYP_XP_ZM;
 	}
-	UNREACHABLE("Unsupported piece direction");
+	UNREACHABLE("Unsupported connector direction");
 }
 
 
@@ -336,7 +336,7 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirectionCW(eDirection 
 		case dirYP_XP_ZM: return dirYP_XP_ZP;
 		case dirYP_XP_ZP: return dirYP_XM_ZP;
 	}
-	UNREACHABLE("Unsupported piece direction");
+	UNREACHABLE("Unsupported connector direction");
 }
 
 

--- a/src/Generating/PiecePool.cpp
+++ b/src/Generating/PiecePool.cpp
@@ -199,8 +199,8 @@ Vector3i cPiece::cConnector::AddDirection(const Vector3i & a_Pos, eDirection a_D
 		case dirYP_XM_ZP: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
 		case dirYP_XP_ZM: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
 		case dirYP_XP_ZP: return Vector3i(a_Pos.x,     a_Pos.y + 1, a_Pos.z);
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported piece direction");
 }
 
 
@@ -225,8 +225,8 @@ const char * cPiece::cConnector::DirectionToString(eDirection a_Direction)
 		case dirYP_XM_ZP: return "y+x-z+";
 		case dirYP_XP_ZM: return "y+x+z-";
 		case dirYP_XP_ZP: return "y+x+z+";
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported piece direction");
 }
 
 
@@ -281,8 +281,8 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirection(eDirection a_
 		case dirYP_XM_ZP: return dirYP_XP_ZM;
 		case dirYP_XP_ZM: return dirYP_XM_ZP;
 		case dirYP_XP_ZP: return dirYP_XM_ZM;
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported piece direction");
 }
 
 
@@ -308,8 +308,8 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirectionCCW(eDirection
 		case dirYP_XM_ZP: return dirYP_XP_ZP;
 		case dirYP_XP_ZM: return dirYP_XM_ZM;
 		case dirYP_XP_ZP: return dirYP_XP_ZM;
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported piece direction");
 }
 
 
@@ -335,8 +335,8 @@ cPiece::cConnector::eDirection cPiece::cConnector::RotateDirectionCW(eDirection 
 		case dirYP_XM_ZP: return dirYP_XM_ZM;
 		case dirYP_XP_ZM: return dirYP_XP_ZP;
 		case dirYP_XP_ZP: return dirYP_XM_ZP;
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported piece direction");
 }
 
 

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -273,6 +273,7 @@ int cStructGenTrees::GetNumTrees(
 				ASSERT(!"Invalid biome in cStructGenTrees::GetNumTrees");
 				return 0;
 			}
+			COVERED_SWITCH;
 		}
 	};
 

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -273,8 +273,8 @@ int cStructGenTrees::GetNumTrees(
 				ASSERT(!"Invalid biome in cStructGenTrees::GetNumTrees");
 				return 0;
 			}
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported biome");
 	};
 
 	int NumTrees = 0;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -355,14 +355,6 @@ template class SizeChecker<UInt8,  1>;
 /** Use to mark code that should be impossible to reach. */
 #define UNREACHABLE(x) do { FLOGERROR("Hit unreachable code: {0}, file {1}, line {2}", #x, __FILE__, __LINE__); PrintStackTrace(); std::terminate(); } while (false)
 
-/** Use to mark switches over enums which cover all enum values.
-The behavior is undefined if the switch receieves a value without a corresponding case. */
-#ifdef __clang__
-	#define COVERED_SWITCH
-#else
-	#define COVERED_SWITCH default: UNREACHABLE("Covered switch should never hit default")
-#endif
-
 
 
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -352,6 +352,15 @@ template class SizeChecker<UInt8,  1>;
 	#define assert_test(x) ( !!(x) || (assert(!#x), exit(1), 0))
 #endif
 
+#define UNREACHABLE(x) do { FLOGERROR("Hit unreachable code: {0}, file {1}, line {2}", #x, __FILE__, __LINE__); PrintStackTrace(); std::terminate(); } while (false)
+
+// Use in switches over enums which cover all enum values
+#ifdef __clang__
+	#define COVERED_SWITCH
+#else
+	#define COVERED_SWITCH default: UNREACHABLE("Covered switch should never hit default")
+#endif
+
 
 
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -352,9 +352,11 @@ template class SizeChecker<UInt8,  1>;
 	#define assert_test(x) ( !!(x) || (assert(!#x), exit(1), 0))
 #endif
 
+/** Use to mark code that should be impossible to reach. */
 #define UNREACHABLE(x) do { FLOGERROR("Hit unreachable code: {0}, file {1}, line {2}", #x, __FILE__, __LINE__); PrintStackTrace(); std::terminate(); } while (false)
 
-// Use in switches over enums which cover all enum values
+/** Use to mark switches over enums which cover all enum values.
+The behavior is undefined if the switch receieves a value without a corresponding case. */
 #ifdef __clang__
 	#define COVERED_SWITCH
 #else

--- a/src/HTTP/NameValueParser.cpp
+++ b/src/HTTP/NameValueParser.cpp
@@ -403,11 +403,8 @@ bool cNameValueParser::Finish(void)
 			m_State = psFinished;
 			return true;
 		}
+		COVERED_SWITCH;
 	}
-	ASSERT(!"Unhandled parser state!");
-	#ifndef __clang__
-		return false;
-	#endif
 }
 
 

--- a/src/HTTP/NameValueParser.cpp
+++ b/src/HTTP/NameValueParser.cpp
@@ -403,8 +403,8 @@ bool cNameValueParser::Finish(void)
 			m_State = psFinished;
 			return true;
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported name value parser state");
 }
 
 

--- a/src/Items/ItemAxe.h
+++ b/src/Items/ItemAxe.h
@@ -26,8 +26,8 @@ public:
 			case dlaAttackEntity:       return 2;
 			case dlaBreakBlock:         return 1;
 			case dlaBreakBlockInstant:  return 0;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported durability loss action");
 	}
 
 

--- a/src/Items/ItemAxe.h
+++ b/src/Items/ItemAxe.h
@@ -26,6 +26,7 @@ public:
 			case dlaAttackEntity:       return 2;
 			case dlaBreakBlock:         return 1;
 			case dlaBreakBlockInstant:  return 0;
+			COVERED_SWITCH;
 		}
 	}
 

--- a/src/Items/ItemHoe.h
+++ b/src/Items/ItemHoe.h
@@ -74,6 +74,7 @@ public:
 			case dlaAttackEntity:       return 1;
 			case dlaBreakBlock:         return 0;
 			case dlaBreakBlockInstant:  return 0;
+			COVERED_SWITCH;
 		}
 	}
 } ;

--- a/src/Items/ItemHoe.h
+++ b/src/Items/ItemHoe.h
@@ -74,7 +74,7 @@ public:
 			case dlaAttackEntity:       return 1;
 			case dlaBreakBlock:         return 0;
 			case dlaBreakBlockInstant:  return 0;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported durability loss action");
 	}
 } ;

--- a/src/Items/ItemPickaxe.h
+++ b/src/Items/ItemPickaxe.h
@@ -25,8 +25,8 @@ public:
 			case dlaAttackEntity:       return 2;
 			case dlaBreakBlock:         return 1;
 			case dlaBreakBlockInstant:  return 0;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported durability loss action");
 	}
 
 

--- a/src/Items/ItemPickaxe.h
+++ b/src/Items/ItemPickaxe.h
@@ -25,6 +25,7 @@ public:
 			case dlaAttackEntity:       return 2;
 			case dlaBreakBlock:         return 1;
 			case dlaBreakBlockInstant:  return 0;
+			COVERED_SWITCH;
 		}
 	}
 

--- a/src/Items/ItemShears.h
+++ b/src/Items/ItemShears.h
@@ -68,8 +68,8 @@ public:
 			case dlaAttackEntity:       return 0;
 			case dlaBreakBlock:         return 0;
 			case dlaBreakBlockInstant:  return 1;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported durability loss action");
 	}
 
 

--- a/src/Items/ItemShears.h
+++ b/src/Items/ItemShears.h
@@ -68,6 +68,7 @@ public:
 			case dlaAttackEntity:       return 0;
 			case dlaBreakBlock:         return 0;
 			case dlaBreakBlockInstant:  return 1;
+			COVERED_SWITCH;
 		}
 	}
 

--- a/src/Items/ItemShovel.h
+++ b/src/Items/ItemShovel.h
@@ -30,8 +30,8 @@ public:
 			case dlaAttackEntity:      return 2;
 			case dlaBreakBlock:        return 1;
 			case dlaBreakBlockInstant: return 0;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported durability loss action");
 	}
 
 

--- a/src/Items/ItemShovel.h
+++ b/src/Items/ItemShovel.h
@@ -30,6 +30,7 @@ public:
 			case dlaAttackEntity:      return 2;
 			case dlaBreakBlock:        return 1;
 			case dlaBreakBlockInstant: return 0;
+			COVERED_SWITCH;
 		}
 	}
 

--- a/src/Items/ItemSword.h
+++ b/src/Items/ItemSword.h
@@ -49,8 +49,8 @@ public:
 			case dlaAttackEntity:       return 1;
 			case dlaBreakBlock:         return 2;
 			case dlaBreakBlockInstant:  return 0;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported durability loss action");
 	}
 
 

--- a/src/Items/ItemSword.h
+++ b/src/Items/ItemSword.h
@@ -49,6 +49,7 @@ public:
 			case dlaAttackEntity:       return 1;
 			case dlaBreakBlock:         return 2;
 			case dlaBreakBlockInstant:  return 0;
+			COVERED_SWITCH;
 		}
 	}
 

--- a/src/MobCensus.cpp
+++ b/src/MobCensus.cpp
@@ -47,11 +47,8 @@ int cMobCensus::GetCapMultiplier(cMonster::eFamily a_MobFamily)
 			ASSERT(!"Unhandled mob family");
 			return -1;
 		}
+		COVERED_SWITCH;
 	}
-	#if !defined(__clang__)
-		ASSERT(!"Unknown mob family");
-		return -1;
-	#endif
 }
 
 

--- a/src/MobCensus.cpp
+++ b/src/MobCensus.cpp
@@ -47,8 +47,8 @@ int cMobCensus::GetCapMultiplier(cMonster::eFamily a_MobFamily)
 			ASSERT(!"Unhandled mob family");
 			return -1;
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported mob family");
 }
 
 

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -152,13 +152,7 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk & a_Chunk, const Vector3d 
 				return ePathFinderStatus::PATH_FOUND;
 			}
 		}
-		#ifndef __clang__
-		default:
-		{
-			return ePathFinderStatus::PATH_FOUND;
-			// Fixes GCC warning: "control reaches end of non-void function".
-		}
-		#endif
+		COVERED_SWITCH;
 	}
 }
 

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -152,8 +152,8 @@ ePathFinderStatus cPathFinder::GetNextWayPoint(cChunk & a_Chunk, const Vector3d 
 				return ePathFinderStatus::PATH_FOUND;
 			}
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported path finder status");
 }
 
 

--- a/src/Protocol/PacketID.cpp
+++ b/src/Protocol/PacketID.cpp
@@ -78,8 +78,8 @@ UInt32 cProtocol_1_9_0::GetPacketId(eOutgoingPackets a_Packet)
 		case sendWindowItems:           return 0x14;
 		case sendWindowOpen:            return 0x13;
 		case sendWindowProperty:        return 0x15;
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported outgoing packet type");
 }
 
 

--- a/src/Protocol/PacketID.cpp
+++ b/src/Protocol/PacketID.cpp
@@ -78,12 +78,8 @@ UInt32 cProtocol_1_9_0::GetPacketId(eOutgoingPackets a_Packet)
 		case sendWindowItems:           return 0x14;
 		case sendWindowOpen:            return 0x13;
 		case sendWindowProperty:        return 0x15;
+		COVERED_SWITCH;
 	}
-	ASSERT(!"Retrieving packet ID for unknown packet type");
-	#ifndef __clang__
-		LOGWARNING("Retrieving packet ID for unknown packet type %d!", a_Packet);
-		return 0;
-	#endif
 }
 
 

--- a/src/Scoreboard.cpp
+++ b/src/Scoreboard.cpp
@@ -30,9 +30,8 @@ AString cObjective::TypeToString(eType a_Type)
 		case otStatBlockMine:      return "stat.mineBlock";
 		case otStatEntityKill:     return "stat.killEntity";
 		case otStatEntityKilledBy: return "stat.entityKilledBy";
-		COVERED_SWITCH;
 	}
-
+	UNREACHABLE("Unsupported objective type");
 }
 
 

--- a/src/Scoreboard.cpp
+++ b/src/Scoreboard.cpp
@@ -30,11 +30,7 @@ AString cObjective::TypeToString(eType a_Type)
 		case otStatBlockMine:      return "stat.mineBlock";
 		case otStatEntityKill:     return "stat.killEntity";
 		case otStatEntityKilledBy: return "stat.entityKilledBy";
-
-		// clang optimisises this line away then warns that it has done so.
-		#if !defined(__clang__)
-		default: return "";
-		#endif
+		COVERED_SWITCH;
 	}
 
 }

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -491,8 +491,8 @@ int cWorld::GetDefaultWeatherInterval(eWeather a_Weather)
 		{
 			return Random.RandInt(m_MinThunderStormTicks, m_MaxThunderStormTicks);
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported weather");
 }
 
 
@@ -856,8 +856,8 @@ eWeather cWorld::ChooseNewWeather()
 			// 1 / 8 chance of turning into a thunderstorm
 			return GetRandomProvider().RandBool(0.125) ? eWeather_ThunderStorm : eWeather_Sunny;
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported weather");
 }
 
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -491,12 +491,8 @@ int cWorld::GetDefaultWeatherInterval(eWeather a_Weather)
 		{
 			return Random.RandInt(m_MinThunderStormTicks, m_MaxThunderStormTicks);
 		}
+		COVERED_SWITCH;
 	}
-
-	#ifndef __clang__
-		ASSERT(!"Unknown weather");
-		return -1;
-	#endif
 }
 
 
@@ -851,19 +847,17 @@ eWeather cWorld::ChooseNewWeather()
 	switch (m_Weather)
 	{
 		case eWeather_Sunny:
-		case eWeather_ThunderStorm: return eWeather_Rain;
-
+		case eWeather_ThunderStorm:
+		{
+			return eWeather_Rain;
+		}
 		case eWeather_Rain:
 		{
 			// 1 / 8 chance of turning into a thunderstorm
 			return GetRandomProvider().RandBool(0.125) ? eWeather_ThunderStorm : eWeather_Sunny;
 		}
+		COVERED_SWITCH;
 	}
-
-	#ifndef __clang__
-		ASSERT(!"Unknown weather");
-		return eWeather_Sunny;
-	#endif
 }
 
 

--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -30,77 +30,110 @@ static const int MAX_LIST_ITEMS = 10000;
 	#define PROPAGATE_ERROR(X) do { auto Err = (X); if (Err != eNBTParseError::npSuccess) return Err; } while (false)
 #endif
 
-#define AS_INT(x) static_cast<int>(x)
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // cNBTParseErrorCategory:
 
+namespace
+{
+
+class cNBTParseErrorCategory final :
+	public std::error_category
+{
+	cNBTParseErrorCategory() = default;
+public:
+	/** Category name */
+	virtual const char * name() const NOEXCEPT override
+	{
+		return "NBT parse error";
+	}
+
+	/** Maps a parse error code to an error message */
+	virtual AString message(int a_Condition) const override;
+
+	/** Returns the canonical error category instance. */
+	static const cNBTParseErrorCategory & Get() NOEXCEPT
+	{
+		static const cNBTParseErrorCategory Category;
+		return Category;
+	}
+};
+
+
+
+
+
 AString cNBTParseErrorCategory::message(int a_Condition) const
 {
-	switch (a_Condition)
+	switch (static_cast<eNBTParseError>(a_Condition))
 	{
-		case AS_INT(eNBTParseError::npSuccess):
+		case eNBTParseError::npSuccess:
 		{
 			return "Parsing succeded";
 		}
-		case AS_INT(eNBTParseError::npNeedBytes):
+		case eNBTParseError::npNeedBytes:
 		{
 			return "Expected more data";
 		}
-		case AS_INT(eNBTParseError::npNoTopLevelCompound):
+		case eNBTParseError::npNoTopLevelCompound:
 		{
 			return "No top level compound tag";
 		}
-		case AS_INT(eNBTParseError::npStringMissingLength):
+		case eNBTParseError::npStringMissingLength:
 		{
 			return "Expected a string length but had insufficient data";
 		}
-		case AS_INT(eNBTParseError::npStringInvalidLength):
+		case eNBTParseError::npStringInvalidLength:
 		{
 			return "String length invalid";
 		}
-		case AS_INT(eNBTParseError::npCompoundImbalancedTag):
+		case eNBTParseError::npCompoundImbalancedTag:
 		{
 			return "Compound tag was unmatched at end of file";
 		}
-		case AS_INT(eNBTParseError::npListMissingType):
+		case eNBTParseError::npListMissingType:
 		{
 			return "Expected a list type but had insuffiecient data";
 		}
-		case AS_INT(eNBTParseError::npListMissingLength):
+		case eNBTParseError::npListMissingLength:
 		{
 			return "Expected a list length but had insufficient data";
 		}
-		case AS_INT(eNBTParseError::npListInvalidLength):
+		case eNBTParseError::npListInvalidLength:
 		{
 			return "List length invalid";
 		}
-		case AS_INT(eNBTParseError::npSimpleMissing):
+		case eNBTParseError::npSimpleMissing:
 		{
 			return "Expected a numeric type but had insufficient data";
 		}
-		case AS_INT(eNBTParseError::npArrayMissingLength):
+		case eNBTParseError::npArrayMissingLength:
 		{
 			return "Expected an array length but had insufficient data";
 		}
-		case AS_INT(eNBTParseError::npArrayInvalidLength):
+		case eNBTParseError::npArrayInvalidLength:
 		{
 			return "Array length invalid";
 		}
-		case AS_INT(eNBTParseError::npUnknownTag):
+		case eNBTParseError::npUnknownTag:
 		{
 			return "Unknown tag";
 		}
-		default:
-		{
-			return "<unrecognized error>";
-		}
+		COVERED_SWITCH;
 	}
 }
 
-#undef AS_INT
+}  // namespace (anonymous)
+
+
+
+
+
+std::error_code make_error_code(eNBTParseError a_Err) NOEXCEPT
+{
+	return { static_cast<int>(a_Err), cNBTParseErrorCategory::Get() };
+}
 
 
 

--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -120,8 +120,8 @@ AString cNBTParseErrorCategory::message(int a_Condition) const
 		{
 			return "Unknown tag";
 		}
-		COVERED_SWITCH;
 	}
+	UNREACHABLE("Unsupported nbt parse error");
 }
 
 }  // namespace (anonymous)
@@ -367,9 +367,8 @@ eNBTParseError cParsedNBT::ReadTag(void)
 		{
 			return eNBTParseError::npUnknownTag;
 		}
-
-		COVERED_SWITCH;
 	}  // switch (iType)
+	UNREACHABLE("Unsupported nbt tag type");
 }
 
 #undef CASE_SIMPLE_TAG

--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -55,7 +55,7 @@ public:
 	/** Returns the canonical error category instance. */
 	static const cNBTParseErrorCategory & Get() NOEXCEPT
 	{
-		static const cNBTParseErrorCategory Category;
+		static cNBTParseErrorCategory Category;
 		return Category;
 	}
 };

--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -30,6 +30,8 @@ static const int MAX_LIST_ITEMS = 10000;
 	#define PROPAGATE_ERROR(X) do { auto Err = (X); if (Err != eNBTParseError::npSuccess) return Err; } while (false)
 #endif
 
+#define AS_INT(x) static_cast<int>(x)
+
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -37,77 +39,68 @@ static const int MAX_LIST_ITEMS = 10000;
 
 AString cNBTParseErrorCategory::message(int a_Condition) const
 {
-	switch (static_cast<eNBTParseError>(a_Condition))
+	switch (a_Condition)
 	{
-		case eNBTParseError::npSuccess:
+		case AS_INT(eNBTParseError::npSuccess):
 		{
 			return "Parsing succeded";
 		}
-		case eNBTParseError::npNeedBytes:
+		case AS_INT(eNBTParseError::npNeedBytes):
 		{
 			return "Expected more data";
 		}
-		case eNBTParseError::npNoTopLevelCompound:
+		case AS_INT(eNBTParseError::npNoTopLevelCompound):
 		{
 			return "No top level compound tag";
 		}
-		case eNBTParseError::npStringMissingLength:
+		case AS_INT(eNBTParseError::npStringMissingLength):
 		{
 			return "Expected a string length but had insufficient data";
 		}
-		case eNBTParseError::npStringInvalidLength:
+		case AS_INT(eNBTParseError::npStringInvalidLength):
 		{
 			return "String length invalid";
 		}
-		case eNBTParseError::npCompoundImbalancedTag:
+		case AS_INT(eNBTParseError::npCompoundImbalancedTag):
 		{
 			return "Compound tag was unmatched at end of file";
 		}
-		case eNBTParseError::npListMissingType:
+		case AS_INT(eNBTParseError::npListMissingType):
 		{
 			return "Expected a list type but had insuffiecient data";
 		}
-		case eNBTParseError::npListMissingLength:
+		case AS_INT(eNBTParseError::npListMissingLength):
 		{
 			return "Expected a list length but had insufficient data";
 		}
-		case eNBTParseError::npListInvalidLength:
+		case AS_INT(eNBTParseError::npListInvalidLength):
 		{
 			return "List length invalid";
 		}
-		case eNBTParseError::npSimpleMissing:
+		case AS_INT(eNBTParseError::npSimpleMissing):
 		{
 			return "Expected a numeric type but had insufficient data";
 		}
-		case eNBTParseError::npArrayMissingLength:
+		case AS_INT(eNBTParseError::npArrayMissingLength):
 		{
 			return "Expected an array length but had insufficient data";
 		}
-		case eNBTParseError::npArrayInvalidLength:
+		case AS_INT(eNBTParseError::npArrayInvalidLength):
 		{
 			return "Array length invalid";
 		}
-		case eNBTParseError::npUnknownTag:
+		case AS_INT(eNBTParseError::npUnknownTag):
 		{
 			return "Unknown tag";
 		}
-
-		#ifdef __clang__
-			#pragma clang diagnostic push
-			#pragma clang diagnostic ignored "-Wcovered-switch-default"
-			#pragma clang diagnostic ignored "-Wunreachable-code"
-		#endif
-
 		default:
 		{
 			return "<unrecognized error>";
 		}
-
-		#ifdef __clang__
-			#pragma clang diagnostic pop
-		#endif
 	}
 }
+
+#undef AS_INT
 
 
 
@@ -337,13 +330,12 @@ eNBTParseError cParsedNBT::ReadTag(void)
 			return eNBTParseError::npSuccess;
 		}
 
-		#if !defined(__clang__)
-		default:
-		#endif
 		case TAG_Min:
 		{
 			return eNBTParseError::npUnknownTag;
 		}
+
+		COVERED_SWITCH;
 	}  // switch (iType)
 }
 

--- a/src/WorldStorage/FastNBT.h
+++ b/src/WorldStorage/FastNBT.h
@@ -125,41 +125,8 @@ enum class eNBTParseError
 	npUnknownTag,
 };
 
-
-
-
-
-class cNBTParseErrorCategory final:
-	public std::error_category
-{
-	cNBTParseErrorCategory() = default;
-public:
-	/** Category name */
-	virtual const char * name() const NOEXCEPT override
-	{
-		return "NBT parse error";
-	}
-
-	/** Maps a parse error code to an error message */
-	virtual AString message(int a_Condition) const override;
-
-	/** Returns the canonical error category instance. */
-	static const cNBTParseErrorCategory & Get()
-	{
-		static cNBTParseErrorCategory Category;
-		return Category;
-	}
-};
-
-
-
-
-
 // The following is required to make an error_code constructible from an eNBTParseError
-inline std::error_code make_error_code(eNBTParseError a_Err) NOEXCEPT
-{
-	return { static_cast<int>(a_Err), cNBTParseErrorCategory::Get() };
-}
+std::error_code make_error_code(eNBTParseError a_Err) NOEXCEPT;
 
 namespace std
 {

--- a/src/mbedTLS++/SslConfig.cpp
+++ b/src/mbedTLS++/SslConfig.cpp
@@ -146,7 +146,7 @@ void cSslConfig::SetAuthMode(const eSslAuthMode a_AuthMode)
 			case eSslAuthMode::Required: return MBEDTLS_SSL_VERIFY_REQUIRED;
 			case eSslAuthMode::Unset:    return MBEDTLS_SSL_VERIFY_UNSET;
 		}
-		UNREACHABLE("Unsupported durability loss action");
+		UNREACHABLE("Unsupported SSL auth mode");
 	}();
 
 	mbedtls_ssl_conf_authmode(&m_Config, Mode);

--- a/src/mbedTLS++/SslConfig.cpp
+++ b/src/mbedTLS++/SslConfig.cpp
@@ -145,8 +145,8 @@ void cSslConfig::SetAuthMode(const eSslAuthMode a_AuthMode)
 			case eSslAuthMode::Optional: return MBEDTLS_SSL_VERIFY_OPTIONAL;
 			case eSslAuthMode::Required: return MBEDTLS_SSL_VERIFY_REQUIRED;
 			case eSslAuthMode::Unset:    return MBEDTLS_SSL_VERIFY_UNSET;
-			COVERED_SWITCH;
 		}
+		UNREACHABLE("Unsupported durability loss action");
 	}();
 
 	mbedtls_ssl_conf_authmode(&m_Config, Mode);

--- a/src/mbedTLS++/SslConfig.cpp
+++ b/src/mbedTLS++/SslConfig.cpp
@@ -145,9 +145,7 @@ void cSslConfig::SetAuthMode(const eSslAuthMode a_AuthMode)
 			case eSslAuthMode::Optional: return MBEDTLS_SSL_VERIFY_OPTIONAL;
 			case eSslAuthMode::Required: return MBEDTLS_SSL_VERIFY_REQUIRED;
 			case eSslAuthMode::Unset:    return MBEDTLS_SSL_VERIFY_UNSET;
-			#ifndef __clang__
-				default:                 return MBEDTLS_SSL_VERIFY_OPTIONAL;
-			#endif
+			COVERED_SWITCH;
 		}
 	}();
 

--- a/tests/HTTP/CMakeLists.txt
+++ b/tests/HTTP/CMakeLists.txt
@@ -15,6 +15,8 @@ set (HTTP_SRCS
 	${CMAKE_SOURCE_DIR}/src/HTTP/TransferEncodingParser.cpp
 	${CMAKE_SOURCE_DIR}/src/HTTP/UrlClient.cpp
 	${CMAKE_SOURCE_DIR}/src/HTTP/UrlParser.cpp
+	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
 	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
 )
 
@@ -25,6 +27,8 @@ set (HTTP_HDRS
 	${CMAKE_SOURCE_DIR}/src/HTTP/TransferEncodingParser.h
 	${CMAKE_SOURCE_DIR}/src/HTTP/UrlClient.h
 	${CMAKE_SOURCE_DIR}/src/HTTP/UrlParser.h
+	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
 	${CMAKE_SOURCE_DIR}/src/StringUtils.h
 )
 

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -18,7 +18,9 @@ set (Network_SRCS
 	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkLookup.cpp
 	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkSingleton.cpp
 	${CMAKE_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.cpp
+	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
 	${CMAKE_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.cpp
+	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
 	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CtrDrbgContext.cpp
 	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CryptoKey.cpp
 	${CMAKE_SOURCE_DIR}/src/mbedTLS++/EntropyContext.cpp
@@ -39,8 +41,10 @@ set (Network_HDRS
 	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkLookup.h
 	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkSingleton.h
 	${CMAKE_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.h
+	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
 	${CMAKE_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.h
 	${CMAKE_SOURCE_DIR}/src/OSSupport/Queue.h
+	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
 	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CtrDrbgContext.h
 	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CryptoKey.h
 	${CMAKE_SOURCE_DIR}/src/mbedTLS++/EntropyContext.h


### PR DESCRIPTION
Fixes a number of `<function>: not all control paths return a value`  warnings on MSVC.

Currently almost every switch that gets added seems to end up with several revisions to fix warnings on one or more of the compilers. So I've also introduced the `COVERED_SWITCH` global macro so these can be handled more consistently in future.  