### PR TITLE
cChunk and cChunkData: Use vectors for block get and set functions

### DIFF
--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -2895,7 +2895,7 @@ void cBlockArea::cChunkReader::ChunkData(const cChunkData & a_BlockBuffer)
 				{
 					int InChunkX = BaseX + x;
 					int AreaX = OffX + x;
-					m_Area.m_BlockTypes[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetBlock(InChunkX, InChunkY, InChunkZ);
+					m_Area.m_BlockTypes[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetBlock({ InChunkX, InChunkY, InChunkZ });
 				}  // for x
 			}  // for z
 		}  // for y
@@ -2916,7 +2916,7 @@ void cBlockArea::cChunkReader::ChunkData(const cChunkData & a_BlockBuffer)
 				{
 					int InChunkX = BaseX + x;
 					int AreaX = OffX + x;
-					m_Area.m_BlockMetas[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetMeta(InChunkX, InChunkY, InChunkZ);
+					m_Area.m_BlockMetas[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetMeta({ InChunkX, InChunkY, InChunkZ });
 				}  // for x
 			}  // for z
 		}  // for y
@@ -2937,7 +2937,7 @@ void cBlockArea::cChunkReader::ChunkData(const cChunkData & a_BlockBuffer)
 				{
 					int InChunkX = BaseX + x;
 					int AreaX = OffX + x;
-					m_Area.m_BlockLight[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetBlockLight(InChunkX, InChunkY, InChunkZ);
+					m_Area.m_BlockLight[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetBlockLight({ InChunkX, InChunkY, InChunkZ });
 				}  // for x
 			}  // for z
 		}  // for y
@@ -2958,7 +2958,7 @@ void cBlockArea::cChunkReader::ChunkData(const cChunkData & a_BlockBuffer)
 				{
 					int InChunkX = BaseX + x;
 					int AreaX = OffX + x;
-					m_Area.m_BlockSkyLight[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetSkyLight(InChunkX, InChunkY, InChunkZ);
+					m_Area.m_BlockSkyLight[m_Area.MakeIndex(AreaX, AreaY, AreaZ)] = a_BlockBuffer.GetSkyLight({ InChunkX, InChunkY, InChunkZ });
 				}  // for x
 			}  // for z
 		}  // for y

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -2471,32 +2471,22 @@ bool cChunk::GetSignLines(int a_BlockX, int a_BlockY, int a_BlockZ, AString & a_
 
 
 
-BLOCKTYPE cChunk::GetBlock(int a_RelX, int a_RelY, int a_RelZ) const
+void cChunk::GetBlockTypeMeta(Vector3i a_RelPos, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const
 {
-	return m_ChunkData.GetBlock({ a_RelX, a_RelY, a_RelZ });
+	a_BlockType = GetBlock(a_RelPos);
+	a_BlockMeta = GetMeta(a_RelPos);
 }
 
 
 
 
 
-void cChunk::GetBlockTypeMeta(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const
+void cChunk::GetBlockInfo(Vector3i a_RelPos, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight)
 {
-	a_BlockType = GetBlock(a_RelX, a_RelY, a_RelZ);
-	a_BlockMeta = m_ChunkData.GetMeta({ a_RelX, a_RelY, a_RelZ });
-}
-
-
-
-
-
-void cChunk::GetBlockInfo(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight)
-{
-	Vector3i RelPos{ a_RelX, a_RelY, a_RelZ };
-	a_BlockType  = GetBlock(RelPos);
-	a_Meta       = m_ChunkData.GetMeta(RelPos);
-	a_SkyLight   = m_ChunkData.GetSkyLight(RelPos);
-	a_BlockLight = m_ChunkData.GetBlockLight(RelPos);
+	a_BlockType  = GetBlock(a_RelPos);
+	a_Meta       = m_ChunkData.GetMeta(a_RelPos);
+	a_SkyLight   = m_ChunkData.GetSkyLight(a_RelPos);
+	a_BlockLight = m_ChunkData.GetBlockLight(a_RelPos);
 }
 
 

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1659,7 +1659,7 @@ void cChunk::FastSetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockT
 	ASSERT(IsValid());
 
 	const BLOCKTYPE OldBlockType = GetBlock(a_RelX, a_RelY, a_RelZ);
-	const BLOCKTYPE OldBlockMeta = m_ChunkData.GetMeta(a_RelX, a_RelY, a_RelZ);
+	const BLOCKTYPE OldBlockMeta = m_ChunkData.GetMeta({ a_RelX, a_RelY, a_RelZ });
 	if ((OldBlockType == a_BlockType) && (OldBlockMeta == a_BlockMeta))
 	{
 		return;
@@ -1677,7 +1677,7 @@ void cChunk::FastSetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockT
 		MarkDirty();
 	}
 
-	m_ChunkData.SetBlock(a_RelX, a_RelY, a_RelZ, a_BlockType);
+	m_ChunkData.SetBlock({ a_RelX, a_RelY, a_RelZ }, a_BlockType);
 
 	// Queue block to be sent only if ...
 	if (
@@ -1696,7 +1696,7 @@ void cChunk::FastSetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockT
 		m_PendingSendBlocks.push_back(sSetBlock(m_PosX, m_PosZ, a_RelX, a_RelY, a_RelZ, a_BlockType, a_BlockMeta));
 	}
 
-	m_ChunkData.SetMeta(a_RelX, a_RelY, a_RelZ, a_BlockMeta);
+	m_ChunkData.SetMeta({ a_RelX, a_RelY, a_RelZ }, a_BlockMeta);
 
 	// ONLY recalculate lighting if it's necessary!
 	if (
@@ -2473,7 +2473,7 @@ bool cChunk::GetSignLines(int a_BlockX, int a_BlockY, int a_BlockZ, AString & a_
 
 BLOCKTYPE cChunk::GetBlock(int a_RelX, int a_RelY, int a_RelZ) const
 {
-	return m_ChunkData.GetBlock(a_RelX, a_RelY, a_RelZ);
+	return m_ChunkData.GetBlock({ a_RelX, a_RelY, a_RelZ });
 }
 
 
@@ -2483,7 +2483,7 @@ BLOCKTYPE cChunk::GetBlock(int a_RelX, int a_RelY, int a_RelZ) const
 void cChunk::GetBlockTypeMeta(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const
 {
 	a_BlockType = GetBlock(a_RelX, a_RelY, a_RelZ);
-	a_BlockMeta = m_ChunkData.GetMeta(a_RelX, a_RelY, a_RelZ);
+	a_BlockMeta = m_ChunkData.GetMeta({ a_RelX, a_RelY, a_RelZ });
 }
 
 
@@ -2492,10 +2492,11 @@ void cChunk::GetBlockTypeMeta(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_
 
 void cChunk::GetBlockInfo(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight)
 {
-	a_BlockType  = GetBlock(a_RelX, a_RelY, a_RelZ);
-	a_Meta       = m_ChunkData.GetMeta(a_RelX, a_RelY, a_RelZ);
-	a_SkyLight   = m_ChunkData.GetSkyLight(a_RelX, a_RelY, a_RelZ);
-	a_BlockLight = m_ChunkData.GetBlockLight(a_RelX, a_RelY, a_RelZ);
+	Vector3i RelPos{ a_RelX, a_RelY, a_RelZ };
+	a_BlockType  = GetBlock(RelPos);
+	a_Meta       = m_ChunkData.GetMeta(RelPos);
+	a_SkyLight   = m_ChunkData.GetSkyLight(RelPos);
+	a_BlockLight = m_ChunkData.GetBlockLight(RelPos);
 }
 
 

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -154,7 +154,7 @@ public:
 
 	void SetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_SendToClients = true);
 	// SetBlock() does a lot of work (heightmap, tickblocks, blockentities) so a BlockIdx version doesn't make sense
-	void SetBlock( const Vector3i & a_RelBlockPos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) { SetBlock( a_RelBlockPos.x, a_RelBlockPos.y, a_RelBlockPos.z, a_BlockType, a_BlockMeta); }
+	void SetBlock(Vector3i a_RelBlockPos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) { SetBlock( a_RelBlockPos.x, a_RelBlockPos.y, a_RelBlockPos.z, a_BlockType, a_BlockMeta); }
 
 	/** Queues block for ticking (m_ToTickQueue) */
 	void QueueTickBlock(int a_RelX, int a_RelY, int a_RelZ);
@@ -163,10 +163,25 @@ public:
 	void QueueTickBlockNeighbors(int a_RelX, int a_RelY, int a_RelZ);
 
 	void FastSetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockType, BLOCKTYPE a_BlockMeta, bool a_SendToClients = true);  // Doesn't force block updates on neighbors, use for simple changes such as grass growing etc.
-	BLOCKTYPE GetBlock(int a_RelX, int a_RelY, int a_RelZ) const;
-	BLOCKTYPE GetBlock(const Vector3i & a_RelCoords) const { return GetBlock(a_RelCoords.x, a_RelCoords.y, a_RelCoords.z); }
-	void      GetBlockTypeMeta(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const;
-	void      GetBlockInfo    (int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight);
+	void FastSetBlock(Vector3i a_RelPos, BLOCKTYPE a_BlockType, BLOCKTYPE a_BlockMeta, bool a_SendToClients = true)
+	{
+		FastSetBlock(a_RelPos.x, a_RelPos.y, a_RelPos.z, a_BlockType, a_BlockMeta, a_SendToClients);
+	}
+
+	BLOCKTYPE GetBlock(int a_RelX, int a_RelY, int a_RelZ) const { return m_ChunkData.GetBlock({ a_RelX, a_RelY, a_RelZ }); }
+	BLOCKTYPE GetBlock(Vector3i a_RelCoords) const { return m_ChunkData.GetBlock(a_RelCoords); }
+
+	void GetBlockTypeMeta(Vector3i a_RelPos, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const;
+	void GetBlockTypeMeta(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const
+	{
+		GetBlockTypeMeta({ a_RelX, a_RelY, a_RelZ }, a_BlockType, a_BlockMeta);
+	}
+
+	void GetBlockInfo(Vector3i a_RelPos, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight);
+	void GetBlockInfo(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_Meta, NIBBLETYPE & a_SkyLight, NIBBLETYPE & a_BlockLight)
+	{
+		GetBlockInfo({ a_RelX, a_RelY, a_RelZ }, a_BlockType, a_Meta, a_SkyLight, a_BlockLight);
+	}
 
 	/** Convert absolute coordinates into relative coordinates.
 	Returns false on failure to obtain a valid chunk. Returns true otherwise.
@@ -395,12 +410,19 @@ public:
 		return m_ChunkData.GetMeta({ a_RelX, a_RelY, a_RelZ });
 	}
 
+	NIBBLETYPE GetMeta(Vector3i a_RelPos) const { return m_ChunkData.GetMeta(a_RelPos); }
+
+	void SetMeta(int a_RelX, int a_RelY, int a_RelZ, NIBBLETYPE a_Meta, bool a_ShouldMarkDirty = true, bool a_ShouldInformClients = true)
+	{
+		SetMeta({ a_RelX, a_RelY, a_RelZ }, a_Meta, a_ShouldMarkDirty, a_ShouldInformClients);
+	}
+
 	/** Set a meta value, with the option of not informing the client and / or not marking dirty.
 	Used for setting metas that are of little value for saving to disk and / or for sending to the client,
 	such as leaf decay flags. */
-	inline void SetMeta(int a_RelX, int a_RelY, int a_RelZ, NIBBLETYPE a_Meta, bool a_ShouldMarkDirty = true, bool a_ShouldInformClients = true)
+	inline void SetMeta(Vector3i a_RelPos, NIBBLETYPE a_Meta, bool a_ShouldMarkDirty = true, bool a_ShouldInformClients = true)
 	{
-		bool hasChanged = m_ChunkData.SetMeta({ a_RelX, a_RelY, a_RelZ }, a_Meta);
+		bool hasChanged = m_ChunkData.SetMeta(a_RelPos, a_Meta);
 		if (hasChanged)
 		{
 			if (a_ShouldMarkDirty)
@@ -409,7 +431,7 @@ public:
 			}
 			if (a_ShouldInformClients)
 			{
-				m_PendingSendBlocks.push_back(sSetBlock(m_PosX, m_PosZ, a_RelX, a_RelY, a_RelZ, GetBlock(a_RelX, a_RelY, a_RelZ), a_Meta));
+				m_PendingSendBlocks.push_back(sSetBlock(m_PosX, m_PosZ, a_RelPos.x, a_RelPos.y, a_RelPos.z, GetBlock(a_RelPos), a_Meta));
 			}
 		}
 	}
@@ -418,13 +440,16 @@ public:
 	NIBBLETYPE GetTimeAlteredLight(NIBBLETYPE a_Skylight) const;
 
 	/** Get the level of artificial light illuminating the block (0 - 15) */
+	inline NIBBLETYPE GetBlockLight(Vector3i a_RelPos) const { return m_ChunkData.GetBlockLight(a_RelPos); }
 	inline NIBBLETYPE GetBlockLight(int a_RelX, int a_RelY, int a_RelZ) const { return m_ChunkData.GetBlockLight({ a_RelX, a_RelY, a_RelZ }); }
 
 	/** Get the level of sky light illuminating the block (0 - 15) independent of daytime. */
+	inline NIBBLETYPE GetSkyLight(Vector3i a_RelPos) const { return m_ChunkData.GetSkyLight(a_RelPos); }
 	inline NIBBLETYPE GetSkyLight(int a_RelX, int a_RelY, int a_RelZ) const { return m_ChunkData.GetSkyLight({ a_RelX, a_RelY, a_RelZ }); }
 
 	/** Get the level of sky light illuminating the block (0 - 15), taking daytime into a account. */
-	inline NIBBLETYPE GetSkyLightAltered(int a_RelX, int a_RelY, int a_RelZ) const { return GetTimeAlteredLight(m_ChunkData.GetSkyLight({ a_RelX, a_RelY, a_RelZ })); }
+	inline NIBBLETYPE GetSkyLightAltered(Vector3i a_RelPos) const { return GetTimeAlteredLight(m_ChunkData.GetSkyLight(a_RelPos)); }
+	inline NIBBLETYPE GetSkyLightAltered(int a_RelX, int a_RelY, int a_RelZ) const { return GetSkyLightAltered({ a_RelX, a_RelY, a_RelZ }); }
 
 	/** Same as GetBlock(), but relative coords needn't be in this chunk (uses m_Neighbor-s or m_ChunkMap in such a case); returns true on success */
 	bool UnboundedRelGetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const;

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -392,7 +392,7 @@ public:
 
 	inline NIBBLETYPE GetMeta(int a_RelX, int a_RelY, int a_RelZ) const
 	{
-		return m_ChunkData.GetMeta(a_RelX, a_RelY, a_RelZ);
+		return m_ChunkData.GetMeta({ a_RelX, a_RelY, a_RelZ });
 	}
 
 	/** Set a meta value, with the option of not informing the client and / or not marking dirty.
@@ -400,31 +400,31 @@ public:
 	such as leaf decay flags. */
 	inline void SetMeta(int a_RelX, int a_RelY, int a_RelZ, NIBBLETYPE a_Meta, bool a_ShouldMarkDirty = true, bool a_ShouldInformClients = true)
 	{
-			bool hasChanged = m_ChunkData.SetMeta(a_RelX, a_RelY, a_RelZ, a_Meta);
-			if (hasChanged)
+		bool hasChanged = m_ChunkData.SetMeta({ a_RelX, a_RelY, a_RelZ }, a_Meta);
+		if (hasChanged)
+		{
+			if (a_ShouldMarkDirty)
 			{
-				if (a_ShouldMarkDirty)
-				{
-					MarkDirty();
-				}
-				if (a_ShouldInformClients)
-				{
-					m_PendingSendBlocks.push_back(sSetBlock(m_PosX, m_PosZ, a_RelX, a_RelY, a_RelZ, GetBlock(a_RelX, a_RelY, a_RelZ), a_Meta));
-				}
+				MarkDirty();
 			}
+			if (a_ShouldInformClients)
+			{
+				m_PendingSendBlocks.push_back(sSetBlock(m_PosX, m_PosZ, a_RelX, a_RelY, a_RelZ, GetBlock(a_RelX, a_RelY, a_RelZ), a_Meta));
+			}
+		}
 	}
 
 	/** Light alterations based on time */
 	NIBBLETYPE GetTimeAlteredLight(NIBBLETYPE a_Skylight) const;
 
 	/** Get the level of artificial light illuminating the block (0 - 15) */
-	inline NIBBLETYPE GetBlockLight(int a_RelX, int a_RelY, int a_RelZ) const {return m_ChunkData.GetBlockLight(a_RelX, a_RelY, a_RelZ); }
+	inline NIBBLETYPE GetBlockLight(int a_RelX, int a_RelY, int a_RelZ) const { return m_ChunkData.GetBlockLight({ a_RelX, a_RelY, a_RelZ }); }
 
 	/** Get the level of sky light illuminating the block (0 - 15) independent of daytime. */
-	inline NIBBLETYPE GetSkyLight  (int a_RelX, int a_RelY, int a_RelZ) const {return m_ChunkData.GetSkyLight(a_RelX, a_RelY, a_RelZ); }
+	inline NIBBLETYPE GetSkyLight(int a_RelX, int a_RelY, int a_RelZ) const { return m_ChunkData.GetSkyLight({ a_RelX, a_RelY, a_RelZ }); }
 
 	/** Get the level of sky light illuminating the block (0 - 15), taking daytime into a account. */
-	inline NIBBLETYPE GetSkyLightAltered  (int a_RelX, int a_RelY, int a_RelZ) const {return GetTimeAlteredLight(m_ChunkData.GetSkyLight(a_RelX, a_RelY, a_RelZ)); }
+	inline NIBBLETYPE GetSkyLightAltered(int a_RelX, int a_RelY, int a_RelZ) const { return GetTimeAlteredLight(m_ChunkData.GetSkyLight({ a_RelX, a_RelY, a_RelZ })); }
 
 	/** Same as GetBlock(), but relative coords needn't be in this chunk (uses m_Neighbor-s or m_ChunkMap in such a case); returns true on success */
 	bool UnboundedRelGetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta) const;

--- a/src/ChunkData.h
+++ b/src/ChunkData.h
@@ -48,15 +48,15 @@ public:
 	/** Move assign from another cChunkData */
 	void Assign(cChunkData && a_Other);
 
-	BLOCKTYPE GetBlock(int a_X, int a_Y, int a_Z) const;
-	void SetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Block);
+	BLOCKTYPE GetBlock(Vector3i a_RelPos) const;
+	void SetBlock(Vector3i a_RelPos, BLOCKTYPE a_Block);
 
-	NIBBLETYPE GetMeta(int a_RelX, int a_RelY, int a_RelZ) const;
-	bool SetMeta(int a_RelX, int a_RelY, int a_RelZ, NIBBLETYPE a_Nibble);
+	NIBBLETYPE GetMeta(Vector3i a_RelPos) const;
+	bool SetMeta(Vector3i a_RelPos, NIBBLETYPE a_Nibble);
 
-	NIBBLETYPE GetBlockLight(int a_RelX, int a_RelY, int a_RelZ) const;
+	NIBBLETYPE GetBlockLight(Vector3i a_RelPos) const;
 
-	NIBBLETYPE GetSkyLight(int a_RelX, int a_RelY, int a_RelZ) const;
+	NIBBLETYPE GetSkyLight(Vector3i a_RelPos) const;
 
 	/** Return a pointer to the chunk section or nullptr if all air */
 	const sChunkSection * GetSection(size_t a_SectionNum) const;

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -144,6 +144,16 @@ public:
 		return ((a_Width >= 0) && (a_Width < Width));
 	}
 
+	/** Validates a chunk relative coordinate. Returns false if the coordiante is out of bounds for a chunk. */
+	inline static bool IsValidRelPos(Vector3i a_RelPos)
+	{
+		return (
+			IsValidWidth(a_RelPos.x) &&
+			IsValidHeight(a_RelPos.y) &&
+			IsValidWidth(a_RelPos.z)
+		);
+	}
+
 	/** Converts absolute block coords to chunk coords: */
 	inline static void BlockToChunk(int a_X, int a_Z, int & a_ChunkX, int & a_ChunkZ)
 	{

--- a/tests/ChunkData/ArraytoCoord.cpp
+++ b/tests/ChunkData/ArraytoCoord.cpp
@@ -10,19 +10,19 @@ int main(int argc, char** argv)
 
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
+	{
 		virtual cChunkData::sChunkSection * Allocate()
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
+
 		virtual void Free(cChunkData::sChunkSection * a_Ptr)
 		{
 			delete a_Ptr;
 		}
 	} Pool;
 	{
-	
+
 		// Test first segment
 		cChunkData buffer(Pool);
 
@@ -30,25 +30,25 @@ int main(int argc, char** argv)
 		memset(SrcBlockBuffer, 0x00, sizeof(SrcBlockBuffer));
 		SrcBlockBuffer[7 + (4 * 16) + (5 * 16 * 16)] = 0xcd;
 		buffer.SetBlockTypes(SrcBlockBuffer);
-		testassert(buffer.GetBlock(7, 5, 4) == 0xcd);
-	
+		testassert(buffer.GetBlock({ 7, 5, 4 }) == 0xcd);
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (2 * 16 * 16)) / 2] = 0xe;
 		buffer.SetMetas(SrcNibbleBuffer);
-		testassert(buffer.GetMeta(6, 2, 1) == 0xe);
-	
+		testassert(buffer.GetMeta({ 6, 2, 1 }) == 0xe);
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (2 * 16 * 16)) / 2] = 0xe;
 		buffer.SetBlockLight(SrcNibbleBuffer);
-		testassert(buffer.GetBlockLight(6, 2, 1) == 0xe);
-	
+		testassert(buffer.GetBlockLight({ 6, 2, 1 }) == 0xe);
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (2 * 16 * 16)) / 2] = 0xe;
 		buffer.SetSkyLight(SrcNibbleBuffer);
-		testassert(buffer.GetSkyLight(6, 2, 1) == 0xe);
+		testassert(buffer.GetSkyLight({ 6, 2, 1 }) == 0xe);
 	}
-	
+
 	{
 		// test following segment
 		cChunkData buffer(Pool);
@@ -57,25 +57,25 @@ int main(int argc, char** argv)
 		memset(SrcBlockBuffer, 0x00, sizeof(SrcBlockBuffer));
 		SrcBlockBuffer[7 + (4 * 16) + (24 * 16 * 16)] = 0xcd;
 		buffer.SetBlockTypes(SrcBlockBuffer);
-		testassert(buffer.GetBlock(7, 24, 4) == 0xcd);
-	
+		testassert(buffer.GetBlock({ 7, 24, 4 }) == 0xcd);
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (24 * 16 * 16)) / 2] = 0xe;
 		buffer.SetMetas(SrcNibbleBuffer);
-		testassert(buffer.GetMeta(6, 24, 1) == 0xe);
-	
+		testassert(buffer.GetMeta({ 6, 24, 1 }) == 0xe);
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + 1 * 16 + 24 * 16 * 16) / 2] = 0xe;
 		buffer.SetBlockLight(SrcNibbleBuffer);
-		testassert(buffer.GetBlockLight(6, 24, 1) == 0xe);
-	
+		testassert(buffer.GetBlockLight({ 6, 24, 1 }) == 0xe);
+
 		memset(SrcNibbleBuffer, 0xff, sizeof(SrcNibbleBuffer));
 		SrcNibbleBuffer[(6 + (1 * 16) + (24 * 16 * 16)) / 2] = 0xe;
 		buffer.SetSkyLight(SrcNibbleBuffer);
-		testassert(buffer.GetSkyLight(6, 24, 1) == 0xe);
+		testassert(buffer.GetSkyLight({ 6, 24, 1 }) == 0xe);
 	}
-	
+
 	{
 		// test zeros
 		cChunkData buffer(Pool);
@@ -83,22 +83,22 @@ int main(int argc, char** argv)
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		memset(SrcBlockBuffer, 0x00, sizeof(SrcBlockBuffer));
 		buffer.SetBlockTypes(SrcBlockBuffer);
-		testassert(buffer.GetBlock(7, 24, 4) == 0x00);
-	
+		testassert(buffer.GetBlock({ 7, 24, 4 }) == 0x00);
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		buffer.SetMetas(SrcNibbleBuffer);
-		testassert(buffer.GetMeta(6, 24, 1) == 0x0);
-	
+		testassert(buffer.GetMeta({ 6, 24, 1 }) == 0x0);
+
 		memset(SrcNibbleBuffer, 0x00, sizeof(SrcNibbleBuffer));
 		buffer.SetBlockLight(SrcNibbleBuffer);
-		testassert(buffer.GetBlockLight(6, 24, 1) == 0x0);
-	
+		testassert(buffer.GetBlockLight({ 6, 24, 1 }) == 0x0);
+
 		memset(SrcNibbleBuffer, 0xff, sizeof(SrcNibbleBuffer));
 		buffer.SetSkyLight(SrcNibbleBuffer);
-		testassert(buffer.GetSkyLight(6, 24, 1) == 0xf);
+		testassert(buffer.GetSkyLight({ 6, 24, 1 }) == 0xf);
 	}
-	
+
 	// All tests passed:
 	return 0;
 }

--- a/tests/ChunkData/Coordinates.cpp
+++ b/tests/ChunkData/Coordinates.cpp
@@ -25,98 +25,98 @@ int main(int argc, char** argv)
 		cChunkData buffer(Pool);
 
 		// Empty chunks
-		buffer.SetBlock(0, 0, 0, 0xAB);
-		testassert(buffer.GetBlock(0, 0, 0) == 0xAB);
-		buffer.SetMeta(0, 16, 0, 0xC);
-		testassert(buffer.GetMeta(0, 16, 0) == 0xC);
+		buffer.SetBlock({ 0, 0, 0 }, 0xAB);
+		testassert(buffer.GetBlock({ 0, 0, 0 }) == 0xAB);
+		buffer.SetMeta({ 0, 16, 0 }, 0xC);
+		testassert(buffer.GetMeta({ 0, 16, 0 }) == 0xC);
 
 		// loaded but not written segments
-		testassert(buffer.GetBlock(1, 0, 0) == 0x0);
-		testassert(buffer.GetMeta(1, 16, 0) == 0x0);
+		testassert(buffer.GetBlock({ 1, 0, 0 }) == 0x0);
+		testassert(buffer.GetMeta({ 1, 16, 0 }) == 0x0);
 
 		// Notloaded segments
-		testassert(buffer.GetBlock(0, 32, 0) == 0x0);
-		testassert(buffer.GetMeta(0, 48, 0) == 0x0);
+		testassert(buffer.GetBlock({ 0, 32, 0 }) == 0x0);
+		testassert(buffer.GetMeta({ 0, 48, 0 }) == 0x0);
 
 		// Out of range SetBlock
 		CheckAsserts(
-			buffer.SetBlock(-1, 0, 0, 0);
+			buffer.SetBlock({ -1, 0, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetBlock(0, -1, 0, 0);
+			buffer.SetBlock({ 0, -1, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetBlock(0, 0, -1, 0);
+			buffer.SetBlock({ 0, 0, -1 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetBlock(256, 0, 0, 0);
+			buffer.SetBlock({ 256, 0, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetBlock(0, 256, 0, 0);
+			buffer.SetBlock({ 0, 256, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetBlock(0, 0, 256, 0);
+			buffer.SetBlock({ 0, 0, 256 }, 0);
 		);
 		// Out of range SetMeta
 		CheckAsserts(
-			buffer.SetMeta(-1, 0, 0, 0);
+			buffer.SetMeta({ -1, 0, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetMeta(0, -1, 0, 0);
+			buffer.SetMeta({ 0, -1, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetMeta(0, 0, -1, 0);
+			buffer.SetMeta({ 0, 0, -1 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetMeta(256, 0, 0, 0);
+			buffer.SetMeta({ 256, 0, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetMeta(0, 256, 0, 0);
+			buffer.SetMeta({ 0, 256, 0 }, 0);
 		);
 		CheckAsserts(
-			buffer.SetMeta(0, 0, 256, 0);
+			buffer.SetMeta({ 0, 0, 256 }, 0);
 		);
 
 		// Reading out of range blocks should return air
-		testassert(buffer.GetBlock(-1, 0, 0) == 0);
-		testassert(buffer.GetBlock(0, -1, 0) == 0);
-		testassert(buffer.GetBlock(0, 0, -1) == 0);
-		testassert(buffer.GetBlock(256, 0, 0) == 0);
-		testassert(buffer.GetBlock(0, 256, 0) == 0);
-		testassert(buffer.GetBlock(0, 0, 256) == 0);
+		testassert(buffer.GetBlock({ -1, 0, 0 }) == 0);
+		testassert(buffer.GetBlock({ 0, -1, 0 }) == 0);
+		testassert(buffer.GetBlock({ 0, 0, -1 }) == 0);
+		testassert(buffer.GetBlock({ 256, 0, 0 }) == 0);
+		testassert(buffer.GetBlock({ 0, 256, 0 }) == 0);
+		testassert(buffer.GetBlock({ 0, 0, 256 }) == 0);
 
 		// Reading out of range metas should return 0
-		testassert(buffer.GetMeta(-1, 0, 0) == 0);
-		testassert(buffer.GetMeta(0, -1, 0) == 0);
-		testassert(buffer.GetMeta(0, 0, -1) == 0);
-		testassert(buffer.GetMeta(256, 0, 0) == 0);
-		testassert(buffer.GetMeta(0, 256, 0) == 0);
-		testassert(buffer.GetMeta(0, 0, 256) == 0);
+		testassert(buffer.GetMeta({ -1, 0, 0 }) == 0);
+		testassert(buffer.GetMeta({ 0, -1, 0 }) == 0);
+		testassert(buffer.GetMeta({ 0, 0, -1 }) == 0);
+		testassert(buffer.GetMeta({ 256, 0, 0 }) == 0);
+		testassert(buffer.GetMeta({ 0, 256, 0 }) == 0);
+		testassert(buffer.GetMeta({ 0, 0, 256 }) == 0);
 	}
 
 	{
 		cChunkData buffer(Pool);
 
 		// Zero's
-		buffer.SetBlock(0, 0, 0, 0x0);
-		buffer.SetBlock(0, 0, 1, 0xab);
-		testassert(buffer.GetBlock(0, 0, 0) == 0x0);
-		testassert(buffer.GetBlock(0, 0, 1) == 0xab);
+		buffer.SetBlock({ 0, 0, 0 }, 0x0);
+		buffer.SetBlock({ 0, 0, 1 }, 0xab);
+		testassert(buffer.GetBlock({ 0, 0, 0 }) == 0x0);
+		testassert(buffer.GetBlock({ 0, 0, 1 }) == 0xab);
 
-		buffer.SetMeta(0, 16, 0, 0x0);
-		buffer.SetMeta(0, 16, 1, 0xc);
-		testassert(buffer.GetMeta(0, 16, 0) == 0x0);
-		testassert(buffer.GetMeta(0, 16, 1) == 0xc);
+		buffer.SetMeta({ 0, 16, 0 }, 0x0);
+		buffer.SetMeta({ 0, 16, 1 }, 0xc);
+		testassert(buffer.GetMeta({ 0, 16, 0 }) == 0x0);
+		testassert(buffer.GetMeta({ 0, 16, 1 }) == 0xc);
 	}
 
 
 	{
 		// Operator =
 		cChunkData buffer(Pool);
-		buffer.SetBlock(0, 0, 0, 0x42);
+		buffer.SetBlock({ 0, 0, 0 }, 0x42);
 		cChunkData copy(Pool);
 		copy = std::move(buffer);
-		testassert(copy.GetBlock(0, 0, 0) == 0x42);
+		testassert(copy.GetBlock({ 0, 0, 0 }) == 0x42);
 	}
 
 	return 0;

--- a/tests/ChunkData/Copies.cpp
+++ b/tests/ChunkData/Copies.cpp
@@ -10,12 +10,12 @@ int main(int argc, char** argv)
 
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
+	{
 		virtual cChunkData::sChunkSection * Allocate()
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
+
 		virtual void Free(cChunkData::sChunkSection * a_Ptr)
 		{
 			delete a_Ptr;
@@ -23,15 +23,15 @@ int main(int argc, char** argv)
 	} Pool;
 	{
 		cChunkData buffer(Pool);
-	
-		buffer.SetBlock(3, 1, 4, 0xDE);
-		buffer.SetMeta(3, 1, 4, 0xA);
-	
+
+		buffer.SetBlock({ 3, 1, 4 }, 0xDE);
+		buffer.SetMeta({ 3, 1, 4 }, 0xA);
+
 		cChunkData copy(Pool);
 		copy.Assign(buffer);
-		testassert(copy.GetBlock(3, 1, 4) == 0xDE);
-		testassert(copy.GetMeta(3, 1, 4) == 0xA);
-	
+		testassert(copy.GetBlock({ 3, 1, 4 }) == 0xDE);
+		testassert(copy.GetMeta({ 3, 1, 4 }) == 0xA);
+
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		for (int i = 0; i < 16 * 16 * 256; i += 4)
 		{
@@ -40,21 +40,21 @@ int main(int argc, char** argv)
 			SrcBlockBuffer[i + 2] = 0xbe;
 			SrcBlockBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetBlockTypes(SrcBlockBuffer);
 		BLOCKTYPE DstBlockBuffer[16 * 16 * 256];
 		buffer.CopyBlockTypes(DstBlockBuffer);
 		testassert(memcmp(SrcBlockBuffer, DstBlockBuffer, (16 * 16 * 256) - 1) == 0);
-		
+
 		memset(SrcBlockBuffer, 0x00, 16 * 16 * 256);
 		buffer.SetBlockTypes(SrcBlockBuffer);
 		buffer.CopyBlockTypes(DstBlockBuffer);
 		testassert(memcmp(SrcBlockBuffer, DstBlockBuffer, (16 * 16 * 256) - 1) == 0);
 	}
-	
+
 	{
 		cChunkData buffer(Pool);
-	
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		for (int i = 0; i < 16 * 16 * 256 / 2; i += 4)
 		{
@@ -63,21 +63,21 @@ int main(int argc, char** argv)
 			SrcNibbleBuffer[i + 2] = 0xbe;
 			SrcNibbleBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetMetas(SrcNibbleBuffer);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256/ 2];
 		buffer.CopyMetas(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-		
+
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 /2);
 		buffer.SetMetas(SrcNibbleBuffer);
 		buffer.CopyMetas(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
 	}
-	
+
 	{
 		cChunkData buffer(Pool);
-		
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		for (int i = 0; i < 16 * 16 * 256 / 2; i += 4)
 		{
@@ -86,21 +86,21 @@ int main(int argc, char** argv)
 			SrcNibbleBuffer[i + 2] = 0xbe;
 			SrcNibbleBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetBlockLight(SrcNibbleBuffer);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256 / 2];
 		buffer.CopyBlockLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 /2) - 1) == 0);
-		
+
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 /2);
 		buffer.SetBlockLight(SrcNibbleBuffer);
 		buffer.CopyBlockLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 /2) - 1) == 0);
 	}
-	
+
 	{
 		cChunkData buffer(Pool);
-		
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		for (int i = 0; i < 16 * 16 * 256 / 2; i += 4)
 		{
@@ -109,42 +109,42 @@ int main(int argc, char** argv)
 			SrcNibbleBuffer[i + 2] = 0xbe;
 			SrcNibbleBuffer[i + 3] = 0xef;
 		}
-	
+
 		buffer.SetSkyLight(SrcNibbleBuffer);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256/ 2];
 		buffer.CopySkyLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-	
+
 		memset(SrcNibbleBuffer, 0xFF, 16 * 16 * 256 / 2);
 		buffer.SetSkyLight(SrcNibbleBuffer);
 		buffer.CopySkyLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
 	}
-	
+
 	{
 		cChunkData buffer(Pool);
-		
+
 		BLOCKTYPE SrcBlockBuffer[16 * 16 * 256];
 		memset(SrcBlockBuffer, 0x00, 16 * 16 * 256);
 		BLOCKTYPE DstBlockBuffer[16 * 16 * 256];
 		buffer.CopyBlockTypes(DstBlockBuffer);
 		testassert(memcmp(SrcBlockBuffer, DstBlockBuffer, (16 * 16 * 256) - 1) == 0);
-	
+
 		NIBBLETYPE SrcNibbleBuffer[16 * 16 * 256 / 2];
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 / 2);
 		NIBBLETYPE DstNibbleBuffer[16 * 16 * 256 / 2];
 		buffer.CopyMetas(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-	
+
 		memset(SrcNibbleBuffer, 0x00, 16 * 16 * 256 / 2);
 		buffer.CopyBlockLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
-	
+
 		memset(SrcNibbleBuffer, 0xFF, 16 * 16 * 256 / 2);
 		buffer.CopySkyLight(DstNibbleBuffer);
 		testassert(memcmp(SrcNibbleBuffer, DstNibbleBuffer, (16 * 16 * 256 / 2) - 1) == 0);
 	}
-	
+
 	// All tests successful:
 	return 0;
 }


### PR DESCRIPTION
I opted to keep both the 3 `int` and `Vector3i` overloads for `cChunk` to keep the changes localised for now.