### PR TITLE
A player's inventory is always opened by its owner.

### DIFF
--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -328,11 +328,13 @@ bool cWindow::ClosedByPlayer(cPlayer & a_Player, bool a_CanRefuse)
 			(*itr)->OnPlayerRemoved(a_Player);
 		}  // for itr - m_SlotAreas[]
 
-		m_OpenedBy.remove(&a_Player);
-
-		if ((m_WindowType != wtInventory) && m_OpenedBy.empty())
+		if (m_WindowType != wtInventory)
 		{
-			Destroy();
+			m_OpenedBy.remove(&a_Player);
+			if (m_OpenedBy.empty())
+			{
+				Destroy();
+			}
 		}
 	}
 	if (m_IsDestroyed)


### PR DESCRIPTION
Fixes  #4093

Window updates are only broadcast to players in the `m_OpenedBy` list.  Normally players are added after sending a window open packet but no packet is sent for a player's inventory. This meant broadcasts were never sent for the inventory window.