### PR TITLE
cppcheck found an out of bound array access.

### DIFF
--- a/Tools/BlockZapper/Zapper.cpp
+++ b/Tools/BlockZapper/Zapper.cpp
@@ -162,7 +162,7 @@ void cZapper::LoadChunkData(cFile & a_InFile, int a_ChunkHeaderValue, AString & 
 	a_InFile.Read(ChunkHeader, sizeof(ChunkHeader));
 	if (ChunkHeader[4] != 2)
 	{
-		fprintf(stderr, "Chunk [%d, %d] is compressed in an unknown scheme (%d), skipping", a_ChunkX, a_ChunkZ, ChunkHeader[5]);
+		fprintf(stderr, "Chunk [%d, %d] is compressed in an unknown scheme (%d), skipping", a_ChunkX, a_ChunkZ, ChunkHeader[4]);
 		return;
 	}
 	int ActualSize = (ChunkHeader[0] << 24) |  (ChunkHeader[1] << 16) | (ChunkHeader[2] << 8) | ChunkHeader[3];


### PR DESCRIPTION
The ChunkHeader array is five unsigned chars big, they're indexed
0..4 - but in the error message (when ChunkHeader[4] isn't 2 -
indicating zlib compression, which seems to be the only allowed
compression method for chunks) the contents of ChunkHeader[5]
is printed. Maybe not so dangerous, but it'll give garbage results
in the log.