### PR TITLE
cBlockInfo: Deprecate direct access to variables.

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -74,7 +74,7 @@ return
 		cBlockInfo =
 		{
 			Desc = [[
-				This class is used to query and register block properties.
+				This class is used to query block properties.
 			]],
 			Functions =
 			{
@@ -130,7 +130,7 @@ return
 							Type = "cBlockInfo",
 						},
 					},
-					Notes = "Returns the {{cBlockInfo}} structure for the specified block type.",
+					Notes = "Returns the {{cBlockInfo}} structure for the specified block type. <b>OBSOLETE</b>, use static functions instead",
 				},
 				GetHardness =
 				{
@@ -372,57 +372,57 @@ return
 				m_BlockHeight =
 				{
 					Type = "number",
-					Notes = "The height of the block, a value between 0.0 and 1.0",
+					Notes = "The height of the block, a value between 0.0 and 1.0. <b>OBSOLETE</b>, use cBlockInfo:GetBlockHeight() instead.",
 				},
 				m_CanBeTerraformed =
 				{
 					Type = "bool",
-					Notes = "Is this block suited to be terraformed?",
+					Notes = "Is this block suited to be terraformed? <b>OBSOLETE</b>, use cBlockInfo:CanBeTerraformed() instead.",
 				},
 				m_FullyOccupiesVoxel =
 				{
 					Type = "bool",
-					Notes = "Does this block fully occupy its voxel - is it a 'full' block?",
+					Notes = "Does this block fully occupy its voxel - is it a 'full' block? <b>OBSOLETE</b>, use cBlockInfo:FullyOccupiesVoxel() instead.",
 				},
 				m_Hardness =
 				{
 					Type = "number",
-					Notes = "The greater the value the longer the player needs to break the block.",
+					Notes = "The greater the value the longer the player needs to break the block. <b>OBSOLETE</b>, use cBlockInfo:GetHardness() instead.",
 				},
 				m_IsSnowable =
 				{
 					Type = "bool",
-					Notes = "Can this block hold snow atop?",
+					Notes = "Can this block hold snow atop? <b>OBSOLETE</b>, use cBlockInfo:IsSnowable() instead",
 				},
 				m_IsSolid =
 				{
 					Type = "bool",
-					Notes = "Is this block solid (player cannot walk through)?",
+					Notes = "Is this block solid (player cannot walk through)? <b>OBSOLETE</b>, use cBlockInfo:IsSolid() instead.",
 				},
 				m_LightValue =
 				{
 					Type = "number",
-					Notes = "How much light do the blocks emit on their own?",
+					Notes = "How much light do the blocks emit on their own? <b>OBSOLETE</b>, use cBlockInfo:GetLightValue() instead.",
 				},
 				m_OneHitDig =
 				{
 					Type = "bool",
-					Notes = "Is a block destroyed after a single hit?",
+					Notes = "Is a block destroyed after a single hit? <b>OBSOLETE</b>, use cBlockInfo:IsOneHitDig() instead.",
 				},
 				m_PistonBreakable =
 				{
 					Type = "bool",
-					Notes = "Can a piston break this block?",
+					Notes = "Can a piston break this block? <b>OBSOLETE</b>, use cBlockInfo:IsPistonBreakable instead.",
 				},
 				m_SpreadLightFalloff =
 				{
 					Type = "number",
-					Notes = "How much light do the blocks consume?",
+					Notes = "How much light do the blocks consume? <b>OBSOLETE</b>, use cBlockInfo:GetSpreadLightFalloff() instead.",
 				},
 				m_Transparent =
 				{
 					Type = "bool",
-					Notes = "Is a block completely transparent? (light doesn't get decreased(?))",
+					Notes = "Is a block completely transparent? (light doesn't get decreased(?)). <b>OBSOLETE</b>, use cBlockInfo:IsTransparent() instead.",
 				},
 			},
 		},

--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -291,6 +291,32 @@ tolua_lerror:
 
 
 
+static int tolua_cBlockInfo_Get(lua_State * tolua_S)
+{
+	cLuaState L(tolua_S);
+	if (
+		!L.CheckParamStaticSelf("cBlockInfo") ||
+		!L.CheckParamNumber(2)
+	)
+	{
+		return 0;
+	}
+
+	BLOCKTYPE BlockType{};
+	L.GetStackValue(2, BlockType);
+
+	LOGWARNING("cBlockInfo:Get() is deprecated, use the static querying functions instead");
+	L.LogStackTrace(0);
+
+	cBlockInfo & BlockInfo = const_cast<cBlockInfo &>(cBlockInfo::Get(BlockType));
+	L.Push(&BlockInfo);
+	return 1;
+}
+
+
+
+
+
 static int tolua_cBlockInfo_GetPlaceSound(lua_State * tolua_S)
 {
 	cLuaState L(tolua_S);
@@ -347,7 +373,11 @@ static int tolua_set_cBlockInfo_m_PlaceSound(lua_State * tolua_S)
 
 
 
-static int tolua_get_cBlockInfo_m_IsSnowable(lua_State * tolua_S)
+/** cBlockInfo variables: access the corresponding getter function instead of the variable.
+\tparam VariableType The type of the variable being accessed.
+\tparam GetterFunction The function called to get the value returned to lua. */
+template <typename VariableType, VariableType (*GetterFunction)(BLOCKTYPE)>
+static int tolua_get_cBlockInfo(lua_State * tolua_S)
 {
 	cLuaState L(tolua_S);
 	if (!L.CheckParamSelf("const cBlockInfo"))
@@ -358,9 +388,10 @@ static int tolua_get_cBlockInfo_m_IsSnowable(lua_State * tolua_S)
 	const cBlockInfo * Self = nullptr;
 	L.GetStackValue(1, Self);
 
-	L.Push(cBlockInfo::IsSnowable(Self->m_BlockType));
-	LOGWARNING("cBlockInfo.m_IsSnowable is deprecated");
+	L.Push(GetterFunction(Self->m_BlockType));
+	LOGWARNING("cBlockInfo variables are deprecated, use the static functions instead.");
 	L.LogStackTrace(0);
+
 	return 1;
 }
 
@@ -368,7 +399,8 @@ static int tolua_get_cBlockInfo_m_IsSnowable(lua_State * tolua_S)
 
 
 
-static int tolua_set_cBlockInfo_m_IsSnowable(lua_State * tolua_S)
+/** cBlockInfo variables: Print deprecation message on assignment. */
+static int tolua_set_cBlockInfo(lua_State * tolua_S)
 {
 	cLuaState L(tolua_S);
 	if (!L.CheckParamSelf("cBlockInfo"))
@@ -376,7 +408,7 @@ static int tolua_set_cBlockInfo_m_IsSnowable(lua_State * tolua_S)
 		return 0;
 	}
 
-	LOGWARNING("cBlockInfo.m_IsSnowable is deprecated in favour of cBlockInfo::IsSnowable()");
+	LOGWARNING("cBlockInfo variables are deprecated in favour of the static functions.");
 	L.LogStackTrace(0);
 	return 0;
 }
@@ -417,7 +449,7 @@ static int tolua_set_cItem_m_Lore(lua_State * tolua_S)
 	if (
 		!L.CheckParamSelf("cItem") ||
 		!L.CheckParamString(2)
-		)
+	)
 	{
 		return 0;
 	}
@@ -586,9 +618,23 @@ void DeprecatedBindings::Bind(lua_State * tolua_S)
 	tolua_function(tolua_S, "StringToMobType", tolua_AllToLua_StringToMobType00);
 
 	tolua_beginmodule(tolua_S, "cBlockInfo");
-		tolua_function(tolua_S, "GetPlaceSound", tolua_cBlockInfo_GetPlaceSound);
-		tolua_variable(tolua_S, "m_PlaceSound", tolua_get_cBlockInfo_m_PlaceSound, tolua_set_cBlockInfo_m_PlaceSound);
-		tolua_variable(tolua_S, "m_IsSnowable", tolua_get_cBlockInfo_m_IsSnowable, tolua_set_cBlockInfo_m_IsSnowable);
+		tolua_function(tolua_S, "Get",                    tolua_cBlockInfo_Get);
+		tolua_function(tolua_S, "GetPlaceSound",          tolua_cBlockInfo_GetPlaceSound);
+		tolua_variable(tolua_S, "m_PlaceSound",           tolua_get_cBlockInfo_m_PlaceSound, tolua_set_cBlockInfo_m_PlaceSound);
+		tolua_variable(tolua_S, "m_LightValue",           tolua_get_cBlockInfo<NIBBLETYPE, cBlockInfo::GetLightValue        >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_SpreadLightFalloff",   tolua_get_cBlockInfo<NIBBLETYPE, cBlockInfo::GetSpreadLightFalloff>, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_Transparent",          tolua_get_cBlockInfo<bool,       cBlockInfo::IsTransparent        >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_OneHitDig",            tolua_get_cBlockInfo<bool,       cBlockInfo::IsOneHitDig          >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_PistonBreakable",      tolua_get_cBlockInfo<bool,       cBlockInfo::IsPistonBreakable    >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_IsRainBlocker",        tolua_get_cBlockInfo<bool,       cBlockInfo::IsRainBlocker        >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_IsSkylightDispersant", tolua_get_cBlockInfo<bool,       cBlockInfo::IsSkylightDispersant >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_IsSnowable",           tolua_get_cBlockInfo<bool,       cBlockInfo::IsSnowable           >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_IsSolid",              tolua_get_cBlockInfo<bool,       cBlockInfo::IsSolid              >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_UseableBySpectator",   tolua_get_cBlockInfo<bool,       cBlockInfo::IsUseableBySpectator >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_FullyOccupiesVoxel",   tolua_get_cBlockInfo<bool,       cBlockInfo::FullyOccupiesVoxel   >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_CanBeTerraformed",     tolua_get_cBlockInfo<bool,       cBlockInfo::CanBeTerraformed     >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_BlockHeight",          tolua_get_cBlockInfo<float,      cBlockInfo::GetBlockHeight       >, tolua_set_cBlockInfo);
+		tolua_variable(tolua_S, "m_Hardness",             tolua_get_cBlockInfo<float,      cBlockInfo::GetHardness          >, tolua_set_cBlockInfo);
 	tolua_endmodule(tolua_S);
 
 	tolua_beginmodule(tolua_S, "cItem");

--- a/src/BlockInfo.h
+++ b/src/BlockInfo.h
@@ -15,12 +15,70 @@ class cBlockHandler;
 class cBlockInfo
 {
 public:
+	// tolua_end
 
-	/** Returns the associated BlockInfo structure for the specified block type. */
+	/** The block type associated with this cBlockInfo. Needed for DeprecatedBindings.cpp */
+	BLOCKTYPE m_BlockType;
 
-	/** This accessor makes sure that the cBlockInfo structures are properly initialized exactly once.
+	/** Returns the associated BlockInfo structure for the specified block type.
+	This accessor makes sure that the cBlockInfo structures are properly initialized exactly once.
 	It does so by using the C++ singleton approximation - storing the actual singleton as the function's static variable. */
-	static cBlockInfo & Get(BLOCKTYPE a_Type);
+	inline static const cBlockInfo & Get(BLOCKTYPE a_Type);
+
+	// tolua_begin
+
+	inline static NIBBLETYPE GetLightValue        (BLOCKTYPE a_Type) { return Get(a_Type).m_LightValue;          }
+	inline static NIBBLETYPE GetSpreadLightFalloff(BLOCKTYPE a_Type) { return Get(a_Type).m_SpreadLightFalloff;  }
+	inline static bool IsTransparent              (BLOCKTYPE a_Type) { return Get(a_Type).m_Transparent;         }
+	inline static bool IsOneHitDig                (BLOCKTYPE a_Type) { return Get(a_Type).m_OneHitDig;           }
+	inline static bool IsPistonBreakable          (BLOCKTYPE a_Type) { return Get(a_Type).m_PistonBreakable;     }
+	inline static bool IsRainBlocker              (BLOCKTYPE a_Type) { return Get(a_Type).m_IsRainBlocker;       }
+	inline static bool IsSkylightDispersant       (BLOCKTYPE a_Type)
+	{
+		return ((Get(a_Type).m_IsSkylightDispersant) || (Get(a_Type).m_SpreadLightFalloff > 1));
+	}
+	inline static bool IsSnowable                 (BLOCKTYPE a_Type)
+	{
+		return (
+			(a_Type == E_BLOCK_ICE) ||
+			(a_Type == E_BLOCK_LEAVES) ||
+			(!IsTransparent(a_Type) && (a_Type != E_BLOCK_PACKED_ICE))
+		);
+	}
+	inline static bool IsSolid                    (BLOCKTYPE a_Type) { return Get(a_Type).m_IsSolid;             }
+	inline static bool IsUseableBySpectator       (BLOCKTYPE a_Type) { return Get(a_Type).m_UseableBySpectator;  }
+	inline static bool FullyOccupiesVoxel         (BLOCKTYPE a_Type) { return Get(a_Type).m_FullyOccupiesVoxel;  }
+	inline static bool CanBeTerraformed           (BLOCKTYPE a_Type) { return Get(a_Type).m_CanBeTerraformed;    }
+	inline static float GetBlockHeight            (BLOCKTYPE a_Type) { return Get(a_Type).m_BlockHeight;         }
+	inline static float GetHardness               (BLOCKTYPE a_Type) { return Get(a_Type).m_Hardness;            }
+
+	// tolua_end
+
+	inline static cBlockHandler * GetHandler      (BLOCKTYPE a_Type) { return Get(a_Type).m_Handler.get();       }
+
+	/** Creates a default BlockInfo structure, initializes all values to their defaults */
+	cBlockInfo():
+		m_BlockType(E_BLOCK_STONE),
+		m_LightValue(0x00),
+		m_SpreadLightFalloff(0x0f),
+		m_Transparent(false),
+		m_OneHitDig(false),
+		m_PistonBreakable(false),
+		m_IsRainBlocker(false),
+		m_IsSkylightDispersant(false),
+		m_IsSolid(true),
+		m_UseableBySpectator(false),
+		m_FullyOccupiesVoxel(false),
+		m_CanBeTerraformed(false),
+		m_BlockHeight(1.0),
+		m_Hardness(0.0f),
+		m_Handler()
+	{
+	}
+
+private:
+	/** Storage for all the BlockInfo structures. */
+	class cBlockInfoArray;
 
 	/** How much light do the blocks emit on their own? */
 	NIBBLETYPE m_LightValue;
@@ -61,8 +119,6 @@ public:
 	/** Block's hardness. The greater the value the longer the player needs to break the block. */
 	float m_Hardness;
 
-	// tolua_end
-
 	/** Custom deleter allows cBlockHandler to be an incomplete type. */
 	struct sHandlerDeleter
 	{
@@ -71,63 +127,6 @@ public:
 
 	/** Associated block handler. */
 	std::unique_ptr<cBlockHandler, sHandlerDeleter> m_Handler;
-
-	/** The block type associated with this cBlockInfo. Needed for DeprecatedBindings.cpp */
-	BLOCKTYPE m_BlockType;
-
-	// tolua_begin
-
-	inline static NIBBLETYPE GetLightValue        (BLOCKTYPE a_Type) { return Get(a_Type).m_LightValue;          }
-	inline static NIBBLETYPE GetSpreadLightFalloff(BLOCKTYPE a_Type) { return Get(a_Type).m_SpreadLightFalloff;  }
-	inline static bool IsTransparent              (BLOCKTYPE a_Type) { return Get(a_Type).m_Transparent;         }
-	inline static bool IsOneHitDig                (BLOCKTYPE a_Type) { return Get(a_Type).m_OneHitDig;           }
-	inline static bool IsPistonBreakable          (BLOCKTYPE a_Type) { return Get(a_Type).m_PistonBreakable;     }
-	inline static bool IsRainBlocker              (BLOCKTYPE a_Type) { return Get(a_Type).m_IsRainBlocker;       }
-	inline static bool IsSkylightDispersant       (BLOCKTYPE a_Type)
-	{
-		return ((Get(a_Type).m_IsSkylightDispersant) || (Get(a_Type).m_SpreadLightFalloff > 1));
-	}
-	inline static bool IsSnowable                 (BLOCKTYPE a_Type)
-	{
-		return (
-			(a_Type == E_BLOCK_ICE)
-			|| (a_Type == E_BLOCK_LEAVES)
-			|| (!Get(a_Type).m_Transparent && (a_Type != E_BLOCK_PACKED_ICE))
-		);
-	}
-	inline static bool IsSolid                    (BLOCKTYPE a_Type) { return Get(a_Type).m_IsSolid;             }
-	inline static bool IsUseableBySpectator       (BLOCKTYPE a_Type) { return Get(a_Type).m_UseableBySpectator;  }
-	inline static bool FullyOccupiesVoxel         (BLOCKTYPE a_Type) { return Get(a_Type).m_FullyOccupiesVoxel;  }
-	inline static bool CanBeTerraformed           (BLOCKTYPE a_Type) { return Get(a_Type).m_CanBeTerraformed;    }
-	inline static float GetBlockHeight            (BLOCKTYPE a_Type) { return Get(a_Type).m_BlockHeight;         }
-	inline static float GetHardness               (BLOCKTYPE a_Type) { return Get(a_Type).m_Hardness;            }
-
-	// tolua_end
-
-	inline static cBlockHandler * GetHandler      (BLOCKTYPE a_Type) { return Get(a_Type).m_Handler.get();       }
-
-	/** Creates a default BlockInfo structure, initializes all values to their defaults */
-	cBlockInfo()
-		: m_LightValue(0x00)
-		, m_SpreadLightFalloff(0x0f)
-		, m_Transparent(false)
-		, m_OneHitDig(false)
-		, m_PistonBreakable(false)
-		, m_IsRainBlocker(false)
-		, m_IsSkylightDispersant(false)
-		, m_IsSolid(true)
-		, m_UseableBySpectator(false)
-		, m_FullyOccupiesVoxel(false)
-		, m_CanBeTerraformed(false)
-		, m_BlockHeight(1.0)
-		, m_Hardness(0.0f)
-		, m_Handler()
-		, m_BlockType(E_BLOCK_AIR)
-	{}
-
-private:
-	/** Storage for all the BlockInfo structures. */
-	class cBlockInfoArray;
 };  // tolua_export
 
 
@@ -146,9 +145,9 @@ public:
 
 
 
-inline cBlockInfo & cBlockInfo::Get(BLOCKTYPE a_Type)
+inline const cBlockInfo & cBlockInfo::Get(BLOCKTYPE a_Type)
 {
-	static cBlockInfoArray ms_Info;
+	static const cBlockInfoArray ms_Info;
 	return ms_Info[a_Type];
 }
 
@@ -159,5 +158,5 @@ inline cBlockInfo & cBlockInfo::Get(BLOCKTYPE a_Type)
 // Shortcut to get the blockhandler for a specific block
 inline cBlockHandler * BlockHandler(BLOCKTYPE a_BlockType)
 {
-	return cBlockInfo::Get(a_BlockType).m_Handler.get();
+	return cBlockInfo::GetHandler(a_BlockType);
 }


### PR DESCRIPTION
Closes #3797

I've generalised the lua binding changes from #4105 to all of the variables and made them private.  This makes the API more consistent and gives more flexibility in how the static functions are implemented.