### PR TITLE
cLightingThread: Faster chunk reading

### DIFF
--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -20,7 +20,6 @@ class cReader :
 	virtual void ChunkData(const cChunkData & a_ChunkBuffer) override
 	{
 		BLOCKTYPE * OutputRows = m_BlockTypes;
-		int InputIdx = 0;
 		int OutputIdx = m_ReadingChunkX + m_ReadingChunkZ * cChunkDef::Width * 3;
 		for (size_t i = 0; i != cChunkData::NumSections; ++i)
 		{

--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -22,19 +22,30 @@ class cReader :
 		BLOCKTYPE * OutputRows = m_BlockTypes;
 		int InputIdx = 0;
 		int OutputIdx = m_ReadingChunkX + m_ReadingChunkZ * cChunkDef::Width * 3;
-		int MaxHeight = std::min(+cChunkDef::Height, m_MaxHeight + 16);  // Need 16 blocks above the highest
-		for (int y = 0; y < MaxHeight; y++)
+		for (size_t i = 0; i != cChunkData::NumSections; ++i)
 		{
-			for (int z = 0; z < cChunkDef::Width; z++)
+			auto * Section = a_ChunkBuffer.GetSection(i);
+			if (Section == nullptr)
 			{
-				a_ChunkBuffer.CopyBlockTypes(OutputRows + OutputIdx * 16, static_cast<size_t>(InputIdx * 16), 16);
-				InputIdx++;
-				OutputIdx += 3;
-			}  // for z
-			// Skip into the next y-level in the 3x3 chunk blob; each level has cChunkDef::Width * 9 rows
-			// We've already walked cChunkDef::Width * 3 in the "for z" cycle, that makes cChunkDef::Width * 6 rows left to skip
-			OutputIdx += cChunkDef::Width * 6;
-		}  // for y
+				// Skip to the next section
+				OutputIdx += 9 * cChunkData::SectionHeight * cChunkDef::Width;
+				continue;
+			}
+
+			for (size_t OffsetY = 0; OffsetY != cChunkData::SectionHeight; ++OffsetY)
+			{
+				for (size_t Z = 0; Z != cChunkDef::Width; ++Z)
+				{
+					auto InPtr = Section->m_BlockTypes + Z * cChunkDef::Width + OffsetY * cChunkDef::Width * cChunkDef::Width;
+					std::copy_n(InPtr, cChunkDef::Width, OutputRows + OutputIdx * cChunkDef::Width);
+
+					OutputIdx += 3;
+				}
+				// Skip into the next y-level in the 3x3 chunk blob; each level has cChunkDef::Width * 9 rows
+				// We've already walked cChunkDef::Width * 3 in the "for z" cycle, that makes cChunkDef::Width * 6 rows left to skip
+				OutputIdx += cChunkDef::Width * 6;
+			}
+		}
 	}  // BlockTypes()
 
 
@@ -78,6 +89,7 @@ public:
 		m_BlockTypes(a_BlockTypes),
 		m_HeightMap(a_HeightMap)
 	{
+		std::fill_n(m_BlockTypes, cChunkDef::NumBlocks * 9, E_BLOCK_AIR);
 	}
 } ;
 


### PR DESCRIPTION
Doesn't look like much but I'm measuring `cLightingThread::ReadChunks` to be ~10x faster.