### PR TITLE
Ignore KDevelop project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ AllFiles.lst
 .cproject
 .project
 *.cbp
+## KDevelop
+*.kdev*
 
 # world inside source
 ChunkWorx.ini


### PR DESCRIPTION
KDevelop creates a project file named `cuberite.kdev4` and a folder `.kdev4` in the project root.
This change ignores these files.