### PR TITLE
Update submodule's url in compile

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -470,6 +470,7 @@ fi
 
 # Git: Submodules.
 echo " --- Updating submodules..."
+git submodule sync
 git submodule update --init
 
 


### PR DESCRIPTION
People who had checked out the code earlier will find the build script not working.

(jsoncpp and libevent commit hash not found).

git submodule sync restores the urls so they point to the proper repositories, and can find the correct commits (cuberite/jsoncpp, instead of the previous one).