### PR TITLE
Update m_LastSentPosition in TeleportToCoords and DoMoveToWorld.

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1541,7 +1541,7 @@ bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 	auto OldChunkCoords = cChunkDef::BlockToChunk(GetPosition());
 
 	// Set position to the new position
-	SetPosition(a_NewPosition);
+	ResetPosition(a_NewPosition);
 
 	// Stop all mobs from targeting this entity
 	// Stop this entity from targeting other mobs
@@ -1759,6 +1759,16 @@ void cEntity::HandleAir(void)
 
 
 
+void cEntity::ResetPosition(Vector3d a_NewPos)
+{
+	SetPosition(a_NewPos);
+	m_LastSentPosition = GetPosition();
+}
+
+
+
+
+
 void cEntity::OnStartedBurning(void)
 {
 	// Broadcast the change:
@@ -1850,7 +1860,7 @@ void cEntity::TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ)
 	//  ask the plugins to allow teleport to the new position.
 	if (!cRoot::Get()->GetPluginManager()->CallHookEntityTeleport(*this, m_LastPosition, Vector3d(a_PosX, a_PosY, a_PosZ)))
 	{
-		SetPosition(a_PosX, a_PosY, a_PosZ);
+		ResetPosition({a_PosX, a_PosY, a_PosZ});
 		m_World->BroadcastTeleportEntity(*this);
 	}
 }

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -666,6 +666,10 @@ protected:
 	m_IsHeadInWater */
 	virtual void SetSwimState(cChunk & a_Chunk);
 
+	/** Set the entities position and last sent position.
+	Only to be used when the caller will broadcast a teleport or equivalent to clients. */
+	void ResetPosition(Vector3d a_NewPos);
+
 private:
 
 	/** Whether the entity is ticking or not. If not, it is scheduled for removal or world-teleportation. */

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1607,7 +1607,7 @@ void cPlayer::TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ)
 	//  ask plugins to allow teleport to the new position.
 	if (!cRoot::Get()->GetPluginManager()->CallHookEntityTeleport(*this, m_LastPosition, Vector3d(a_PosX, a_PosY, a_PosZ)))
 	{
-		SetPosition(a_PosX, a_PosY, a_PosZ);
+		ResetPosition({a_PosX, a_PosY, a_PosZ});
 		FreezeInternal(GetPosition(), false);
 		m_LastGroundHeight = a_PosY;
 		m_bIsTeleporting = true;
@@ -1996,7 +1996,7 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 		VERIFY(!GetWorld()->RemovePlayer(*this, false));
 
 		// Set position to the new position
-		SetPosition(a_NewPosition);
+		ResetPosition(a_NewPosition);
 		FreezeInternal(a_NewPosition, false);
 
 		// Stop all mobs from targeting this player


### PR DESCRIPTION
Fixes #4049 or at least the version described by @mathiascode.

The issue is that when a player is teleported, it can be spawned on clients before a movement update has been processed.  Since 5d64451f74af1839177f9b93d76cd393b7a58ad1 uses `m_LastSentPosition`, this means the spawn packets contain the position from _before_ being teleported.  Presumably the client then ignores packets from players teleporting from outside of the clients loaded chunks. 

This is fixed by updating `m_LastSentPosition` immediately when a player teleports.