### PR TITLE
Fix fishing timer

### DIFF
--- a/src/Entities/Floater.cpp
+++ b/src/Entities/Floater.cpp
@@ -147,6 +147,11 @@ void cFloater::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 				}
 			}
 		}
+	}
+
+	// Check water at the top of floater otherwise it floats into the air above the water
+	if (IsBlockWater(m_World->GetBlock(POSX_TOINT, FloorC(GetPosY() + GetHeight()), POSZ_TOINT)))
+	{
 		SetSpeedY(0.7);
 	}
 


### PR DESCRIPTION
Fixes ["Fishing Speed Too Slow"](https://forum.cuberite.org/thread-3175-post-29000.html#pid29000).

Interestingly, the constants @NiLSPACE points out are actually correct:
```cpp
(Random.RandInt(100, 900) - static_cast<int>(a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100))
```
100 to 900 ticks is the correct timing of 5-45 seconds. However, the timer is only updated when the floater is in the water and the server side position was actually bobbing in and out of the water. This meant the timer took ~2-3x longer than it should.

With this change the floater position is always in the water and so the timer works as expected.