### PR TITLE
tolua++ bindings use nullptr.

### DIFF
--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -168,10 +168,7 @@ set_source_files_properties(${BINDING_OUTPUTS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/Bindings/Bindings.cpp PROPERTIES COMPILE_FLAGS -Wno-error)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-	if(NOT APPLE AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5) # Workaround for VERSION_GREATER_EQUAL, which is only supported on CMake 3.7+
-		set(ADDITIONAL_FLAGS "-Wno-zero-as-null-pointer-constant")
-	endif()
-	set_source_files_properties(Bindings.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast -Wno-missing-prototypes ${ADDITIONAL_FLAGS}")
+	set_source_files_properties(Bindings.cpp PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast -Wno-missing-prototypes")
 endif()
 
 if(NOT MSVC)


### PR DESCRIPTION
Fixes #4215, compilation now works with `-Wzero-as-null-pointer-constant` (and removes @bibo38's hack).