### PR TITLE
Now checking Variable prefixes with Clang-Tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,13 @@
 Checks: '-*,readability-identifier-naming'
 CheckOptions:
-- key:             readability-identifier-naming.PrivateMemberPrefix
+- key:             readability-identifier-naming.MemberPrefix
+  value:           'm_'
+- key:             readability-identifier-naming.ParameterPrefix
+  value:           'a_'
+- key:             readability-identifier-naming.GlobalVariablePrefix
+  value:           'g_'
+# Disables the 'g_' prefix for static member variables
+- key:             readability-identifier-naming.ClassMemberPrefix
   value:           'm_'
 - key:             readability-identifier-naming.ClassConstantCase
   value:           aNy_CasE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,9 @@ Here are the conventions:
    - `SomeFunction()<Space><Space>//<Space>Note the two spaces prefixed to me and the space after the slashes.`
  - All variable names and function names use CamelCase style, with the exception of single letter variables.  
    - `ThisIsAProperFunction()` `This_is_bad()` `this_is_bad()` `GoodVariableName` `badVariableName`.
- - All member variables start with `m_`, all function parameters start with `a_`, all class names start with `c`.
-   - `class cMonster { int m_Health; int DecreaseHealth(int a_Amount); }`
+ - All member variables start with `m_`, all function parameters start with `a_`, all global variables start with `g_`, all class names start with `c`.
+   - `class cMonster { int m_Health; int DecreaseHealth(int a_Amount); };`
+   - `static const bool g_ICanProgram = true;`
  - Function parameters that are coordinates should be passed using an appropriate storage container, and not as three separate arguments.
    - e.g. for a block position, Vector3i. For an entity position, Vector3d. For a chunk coordinate, cChunkCoords.
    - For a 3-dimensional box of blocks, use cCuboid. For an axis-aligned bounding box, use cBoundingBox.

--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -17,24 +17,24 @@
 
 /* get function: g_BlockLightValue */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockLightValue
-static int tolua_get_AllToLua_g_BlockLightValue(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockLightValue(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::GetLightValue(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -47,24 +47,24 @@ static int tolua_get_AllToLua_g_BlockLightValue(lua_State* tolua_S)
 
 /* get function: g_BlockSpreadLightFalloff */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockSpreadLightFalloff
-static int tolua_get_AllToLua_g_BlockSpreadLightFalloff(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockSpreadLightFalloff(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::GetSpreadLightFalloff(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -77,24 +77,24 @@ static int tolua_get_AllToLua_g_BlockSpreadLightFalloff(lua_State* tolua_S)
 
 /* get function: g_BlockTransparent */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockTransparent
-static int tolua_get_AllToLua_g_BlockTransparent(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockTransparent(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::IsTransparent(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -107,24 +107,24 @@ static int tolua_get_AllToLua_g_BlockTransparent(lua_State* tolua_S)
 
 /* get function: g_BlockOneHitDig */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockOneHitDig
-static int tolua_get_AllToLua_g_BlockOneHitDig(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockOneHitDig(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::IsOneHitDig(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -137,24 +137,24 @@ static int tolua_get_AllToLua_g_BlockOneHitDig(lua_State* tolua_S)
 
 /* get function: g_BlockPistonBreakable */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockPistonBreakable
-static int tolua_get_AllToLua_g_BlockPistonBreakable(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockPistonBreakable(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::IsPistonBreakable(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -167,24 +167,24 @@ static int tolua_get_AllToLua_g_BlockPistonBreakable(lua_State* tolua_S)
 
 /* get function: g_BlockIsSnowable */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockIsSnowable
-static int tolua_get_AllToLua_g_BlockIsSnowable(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockIsSnowable(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::IsSnowable(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -197,24 +197,24 @@ static int tolua_get_AllToLua_g_BlockIsSnowable(lua_State* tolua_S)
 
 /* get function: g_BlockIsSolid */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockIsSolid
-static int tolua_get_AllToLua_g_BlockIsSolid(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockIsSolid(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::IsSolid(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -227,24 +227,24 @@ static int tolua_get_AllToLua_g_BlockIsSolid(lua_State* tolua_S)
 
 /* get function: g_BlockFullyOccupiesVoxel */
 #ifndef TOLUA_DISABLE_tolua_get_AllToLua_g_BlockFullyOccupiesVoxel
-static int tolua_get_AllToLua_g_BlockFullyOccupiesVoxel(lua_State* tolua_S)
+static int tolua_get_AllToLua_g_BlockFullyOccupiesVoxel(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	int BlockType = 0;
 	#ifndef TOLUA_RELEASE
 	{
 		tolua_Error tolua_err;
-		if (!tolua_isnumber(tolua_S, 2, 0, &tolua_err))
+		if (!tolua_isnumber(a_tolua_S, 2, 0, &tolua_err))
 		{
-			tolua_error(tolua_S, "#vinvalid type in array indexing.", &tolua_err);
+			tolua_error(a_tolua_S, "#vinvalid type in array indexing.", &tolua_err);
 		}
 	}
 	#endif
 	LuaState.GetStackValue(2, BlockType);
 	if ((BlockType < 0) || (BlockType > E_BLOCK_MAX_TYPE_ID))
 	{
-		tolua_error(tolua_S, "array indexing out of range.", nullptr);
+		tolua_error(a_tolua_S, "array indexing out of range.", nullptr);
 	}
 	LuaState.Push(cBlockInfo::FullyOccupiesVoxel(static_cast<BLOCKTYPE>(BlockType)));
 	return 1;
@@ -256,15 +256,15 @@ static int tolua_get_AllToLua_g_BlockFullyOccupiesVoxel(lua_State* tolua_S)
 
 
 /* function: StringToMobType */
-static int tolua_AllToLua_StringToMobType00(lua_State* tolua_S)
+static int tolua_AllToLua_StringToMobType00(lua_State* a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	#ifndef TOLUA_RELEASE
 	tolua_Error tolua_err;
 	if (
-		!tolua_iscppstring(tolua_S, 1, 0, &tolua_err) ||
-		!tolua_isnoobj(tolua_S, 2, &tolua_err)
+		!tolua_iscppstring(a_tolua_S, 1, 0, &tolua_err) ||
+		!tolua_isnoobj(a_tolua_S, 2, &tolua_err)
 		)
 		goto tolua_lerror;
 	else
@@ -291,9 +291,9 @@ tolua_lerror:
 
 
 
-static int tolua_cBlockInfo_Get(lua_State * tolua_S)
+static int tolua_cBlockInfo_Get(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamStaticSelf("cBlockInfo") ||
 		!L.CheckParamNumber(2)
@@ -317,9 +317,9 @@ static int tolua_cBlockInfo_Get(lua_State * tolua_S)
 
 
 
-static int tolua_cBlockInfo_GetPlaceSound(lua_State * tolua_S)
+static int tolua_cBlockInfo_GetPlaceSound(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamStaticSelf("cBlockInfo") ||
 		!L.CheckParamNumber(2)
@@ -338,9 +338,9 @@ static int tolua_cBlockInfo_GetPlaceSound(lua_State * tolua_S)
 
 
 
-static int tolua_get_cBlockInfo_m_PlaceSound(lua_State * tolua_S)
+static int tolua_get_cBlockInfo_m_PlaceSound(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("const cBlockInfo"))
 	{
 		return 0;
@@ -356,9 +356,9 @@ static int tolua_get_cBlockInfo_m_PlaceSound(lua_State * tolua_S)
 
 
 
-static int tolua_set_cBlockInfo_m_PlaceSound(lua_State * tolua_S)
+static int tolua_set_cBlockInfo_m_PlaceSound(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("cBlockInfo"))
 	{
 		return 0;
@@ -377,9 +377,9 @@ static int tolua_set_cBlockInfo_m_PlaceSound(lua_State * tolua_S)
 \tparam VariableType The type of the variable being accessed.
 \tparam GetterFunction The function called to get the value returned to lua. */
 template <typename VariableType, VariableType (*GetterFunction)(BLOCKTYPE)>
-static int tolua_get_cBlockInfo(lua_State * tolua_S)
+static int tolua_get_cBlockInfo(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("const cBlockInfo"))
 	{
 		return 0;
@@ -400,9 +400,9 @@ static int tolua_get_cBlockInfo(lua_State * tolua_S)
 
 
 /** cBlockInfo variables: Print deprecation message on assignment. */
-static int tolua_set_cBlockInfo(lua_State * tolua_S)
+static int tolua_set_cBlockInfo(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("cBlockInfo"))
 	{
 		return 0;
@@ -417,10 +417,10 @@ static int tolua_set_cBlockInfo(lua_State * tolua_S)
 
 
 
-static int tolua_get_cItem_m_Lore(lua_State * tolua_S)
+static int tolua_get_cItem_m_Lore(lua_State * a_tolua_S)
 {
 	// Maintain legacy m_Lore variable as Lore table split by ` (grave-accent)
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("const cItem"))
 	{
 		return 0;
@@ -442,10 +442,10 @@ static int tolua_get_cItem_m_Lore(lua_State * tolua_S)
 
 
 
-static int tolua_set_cItem_m_Lore(lua_State * tolua_S)
+static int tolua_set_cItem_m_Lore(lua_State * a_tolua_S)
 {
 	// Maintain legacy m_Lore variable as Lore table split by ` (grave-accent)
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamSelf("cItem") ||
 		!L.CheckParamString(2)
@@ -511,9 +511,9 @@ static int tolua_cTracer_Trace(lua_State * a_LuaState)
 
 
 /** function: cWorld:SetSignLines */
-static int tolua_cWorld_SetSignLines(lua_State * tolua_S)
+static int tolua_cWorld_SetSignLines(lua_State * a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 
 	#ifndef TOLUA_RELEASE
 	if (
@@ -602,69 +602,69 @@ int tolua_Vector3_Clamp(lua_State * a_LuaState)
 
 
 
-void DeprecatedBindings::Bind(lua_State * tolua_S)
+void DeprecatedBindings::Bind(lua_State * a_tolua_S)
 {
-	tolua_beginmodule(tolua_S, nullptr);
+	tolua_beginmodule(a_tolua_S, nullptr);
 
-	tolua_array(tolua_S, "g_BlockLightValue",          tolua_get_AllToLua_g_BlockLightValue,          nullptr);
-	tolua_array(tolua_S, "g_BlockSpreadLightFalloff",  tolua_get_AllToLua_g_BlockSpreadLightFalloff,  nullptr);
-	tolua_array(tolua_S, "g_BlockTransparent",         tolua_get_AllToLua_g_BlockTransparent,         nullptr);
-	tolua_array(tolua_S, "g_BlockOneHitDig",           tolua_get_AllToLua_g_BlockOneHitDig,           nullptr);
-	tolua_array(tolua_S, "g_BlockPistonBreakable",     tolua_get_AllToLua_g_BlockPistonBreakable,     nullptr);
-	tolua_array(tolua_S, "g_BlockIsSnowable",          tolua_get_AllToLua_g_BlockIsSnowable,          nullptr);
-	tolua_array(tolua_S, "g_BlockIsSolid",             tolua_get_AllToLua_g_BlockIsSolid,             nullptr);
-	tolua_array(tolua_S, "g_BlockFullyOccupiesVoxel",  tolua_get_AllToLua_g_BlockFullyOccupiesVoxel,  nullptr);
+	tolua_array(a_tolua_S, "g_BlockLightValue",          tolua_get_AllToLua_g_BlockLightValue,          nullptr);
+	tolua_array(a_tolua_S, "g_BlockSpreadLightFalloff",  tolua_get_AllToLua_g_BlockSpreadLightFalloff,  nullptr);
+	tolua_array(a_tolua_S, "g_BlockTransparent",         tolua_get_AllToLua_g_BlockTransparent,         nullptr);
+	tolua_array(a_tolua_S, "g_BlockOneHitDig",           tolua_get_AllToLua_g_BlockOneHitDig,           nullptr);
+	tolua_array(a_tolua_S, "g_BlockPistonBreakable",     tolua_get_AllToLua_g_BlockPistonBreakable,     nullptr);
+	tolua_array(a_tolua_S, "g_BlockIsSnowable",          tolua_get_AllToLua_g_BlockIsSnowable,          nullptr);
+	tolua_array(a_tolua_S, "g_BlockIsSolid",             tolua_get_AllToLua_g_BlockIsSolid,             nullptr);
+	tolua_array(a_tolua_S, "g_BlockFullyOccupiesVoxel",  tolua_get_AllToLua_g_BlockFullyOccupiesVoxel,  nullptr);
 
-	tolua_function(tolua_S, "StringToMobType", tolua_AllToLua_StringToMobType00);
+	tolua_function(a_tolua_S, "StringToMobType", tolua_AllToLua_StringToMobType00);
 
-	tolua_beginmodule(tolua_S, "cBlockInfo");
-		tolua_function(tolua_S, "Get",                    tolua_cBlockInfo_Get);
-		tolua_function(tolua_S, "GetPlaceSound",          tolua_cBlockInfo_GetPlaceSound);
-		tolua_variable(tolua_S, "m_PlaceSound",           tolua_get_cBlockInfo_m_PlaceSound, tolua_set_cBlockInfo_m_PlaceSound);
-		tolua_variable(tolua_S, "m_LightValue",           tolua_get_cBlockInfo<NIBBLETYPE, cBlockInfo::GetLightValue        >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_SpreadLightFalloff",   tolua_get_cBlockInfo<NIBBLETYPE, cBlockInfo::GetSpreadLightFalloff>, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_Transparent",          tolua_get_cBlockInfo<bool,       cBlockInfo::IsTransparent        >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_OneHitDig",            tolua_get_cBlockInfo<bool,       cBlockInfo::IsOneHitDig          >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_PistonBreakable",      tolua_get_cBlockInfo<bool,       cBlockInfo::IsPistonBreakable    >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_IsRainBlocker",        tolua_get_cBlockInfo<bool,       cBlockInfo::IsRainBlocker        >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_IsSkylightDispersant", tolua_get_cBlockInfo<bool,       cBlockInfo::IsSkylightDispersant >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_IsSnowable",           tolua_get_cBlockInfo<bool,       cBlockInfo::IsSnowable           >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_IsSolid",              tolua_get_cBlockInfo<bool,       cBlockInfo::IsSolid              >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_UseableBySpectator",   tolua_get_cBlockInfo<bool,       cBlockInfo::IsUseableBySpectator >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_FullyOccupiesVoxel",   tolua_get_cBlockInfo<bool,       cBlockInfo::FullyOccupiesVoxel   >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_CanBeTerraformed",     tolua_get_cBlockInfo<bool,       cBlockInfo::CanBeTerraformed     >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_BlockHeight",          tolua_get_cBlockInfo<float,      cBlockInfo::GetBlockHeight       >, tolua_set_cBlockInfo);
-		tolua_variable(tolua_S, "m_Hardness",             tolua_get_cBlockInfo<float,      cBlockInfo::GetHardness          >, tolua_set_cBlockInfo);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cBlockInfo");
+		tolua_function(a_tolua_S, "Get",                    tolua_cBlockInfo_Get);
+		tolua_function(a_tolua_S, "GetPlaceSound",          tolua_cBlockInfo_GetPlaceSound);
+		tolua_variable(a_tolua_S, "m_PlaceSound",           tolua_get_cBlockInfo_m_PlaceSound, tolua_set_cBlockInfo_m_PlaceSound);
+		tolua_variable(a_tolua_S, "m_LightValue",           tolua_get_cBlockInfo<NIBBLETYPE, cBlockInfo::GetLightValue        >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_SpreadLightFalloff",   tolua_get_cBlockInfo<NIBBLETYPE, cBlockInfo::GetSpreadLightFalloff>, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_Transparent",          tolua_get_cBlockInfo<bool,       cBlockInfo::IsTransparent        >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_OneHitDig",            tolua_get_cBlockInfo<bool,       cBlockInfo::IsOneHitDig          >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_PistonBreakable",      tolua_get_cBlockInfo<bool,       cBlockInfo::IsPistonBreakable    >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_IsRainBlocker",        tolua_get_cBlockInfo<bool,       cBlockInfo::IsRainBlocker        >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_IsSkylightDispersant", tolua_get_cBlockInfo<bool,       cBlockInfo::IsSkylightDispersant >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_IsSnowable",           tolua_get_cBlockInfo<bool,       cBlockInfo::IsSnowable           >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_IsSolid",              tolua_get_cBlockInfo<bool,       cBlockInfo::IsSolid              >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_UseableBySpectator",   tolua_get_cBlockInfo<bool,       cBlockInfo::IsUseableBySpectator >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_FullyOccupiesVoxel",   tolua_get_cBlockInfo<bool,       cBlockInfo::FullyOccupiesVoxel   >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_CanBeTerraformed",     tolua_get_cBlockInfo<bool,       cBlockInfo::CanBeTerraformed     >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_BlockHeight",          tolua_get_cBlockInfo<float,      cBlockInfo::GetBlockHeight       >, tolua_set_cBlockInfo);
+		tolua_variable(a_tolua_S, "m_Hardness",             tolua_get_cBlockInfo<float,      cBlockInfo::GetHardness          >, tolua_set_cBlockInfo);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "cItem");
-		tolua_variable(tolua_S, "m_Lore", tolua_get_cItem_m_Lore, tolua_set_cItem_m_Lore);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cItem");
+		tolua_variable(a_tolua_S, "m_Lore", tolua_get_cItem_m_Lore, tolua_set_cItem_m_Lore);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "cTracer");
-		tolua_function(tolua_S, "Trace", tolua_cTracer_Trace);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cTracer");
+		tolua_function(a_tolua_S, "Trace", tolua_cTracer_Trace);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "cWorld");
-		tolua_function(tolua_S, "UpdateSign", tolua_cWorld_SetSignLines);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cWorld");
+		tolua_function(a_tolua_S, "UpdateSign", tolua_cWorld_SetSignLines);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "Vector3i");
-		tolua_function(tolua_S,"abs",   tolua_Vector3_Abs<int>);
-		tolua_function(tolua_S,"clamp", tolua_Vector3_Clamp<int>);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "Vector3i");
+		tolua_function(a_tolua_S,"abs",   tolua_Vector3_Abs<int>);
+		tolua_function(a_tolua_S,"clamp", tolua_Vector3_Clamp<int>);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "Vector3f");
-		tolua_function(tolua_S,"abs",   tolua_Vector3_Abs<float>);
-		tolua_function(tolua_S,"clamp", tolua_Vector3_Clamp<float>);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "Vector3f");
+		tolua_function(a_tolua_S,"abs",   tolua_Vector3_Abs<float>);
+		tolua_function(a_tolua_S,"clamp", tolua_Vector3_Clamp<float>);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "Vector3d");
-		tolua_function(tolua_S,"abs",   tolua_Vector3_Abs<double>);
-		tolua_function(tolua_S,"clamp", tolua_Vector3_Clamp<double>);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "Vector3d");
+		tolua_function(a_tolua_S,"abs",   tolua_Vector3_Abs<double>);
+		tolua_function(a_tolua_S,"clamp", tolua_Vector3_Clamp<double>);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_endmodule(tolua_S);
+	tolua_endmodule(a_tolua_S);
 }
 
 

--- a/src/Bindings/DeprecatedBindings.h
+++ b/src/Bindings/DeprecatedBindings.h
@@ -4,5 +4,5 @@ struct lua_State;
 class DeprecatedBindings
 {
 public:
-	static void Bind( lua_State* tolua_S);
+	static void Bind( lua_State* a_tolua_S);
 };

--- a/src/Bindings/LuaChunkStay.cpp
+++ b/src/Bindings/LuaChunkStay.cpp
@@ -57,10 +57,10 @@ bool cLuaChunkStay::AddChunks(const cLuaState::cStackTable & a_ChunkCoordsTable)
 
 
 
-void cLuaChunkStay::AddChunkCoord(cLuaState & L, int a_Index)
+void cLuaChunkStay::AddChunkCoord(cLuaState & a_L, int a_Index)
 {
 	// Check that the element has 2 coords:
-	int NumCoords = luaL_getn(L, -1);
+	int NumCoords = luaL_getn(a_L, -1);
 	if (NumCoords != 2)
 	{
 		LOGWARNING("%s: Element #%d doesn't contain 2 coords (got %d). Ignoring the element.",
@@ -70,11 +70,11 @@ void cLuaChunkStay::AddChunkCoord(cLuaState & L, int a_Index)
 	}
 
 	// Read the two coords from the element:
-	lua_rawgeti(L, -1, 1);
-	lua_rawgeti(L, -2, 2);
-	int ChunkX = luaL_checkint(L, -2);
-	int ChunkZ = luaL_checkint(L, -1);
-	lua_pop(L, 2);
+	lua_rawgeti(a_L, -1, 1);
+	lua_rawgeti(a_L, -2, 2);
+	int ChunkX = luaL_checkint(a_L, -2);
+	int ChunkZ = luaL_checkint(a_L, -1);
+	lua_pop(a_L, 2);
 
 	// Check that a coord is not yet present:
 	for (cChunkCoordsVector::iterator itr = m_Chunks.begin(), end = m_Chunks.end(); itr != end; ++itr)

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -37,13 +37,13 @@ extern "C"
 // fwd: "SQLite/lsqlite3.c"
 extern "C"
 {
-	int luaopen_lsqlite3(lua_State * L);
+	int luaopen_lsqlite3(lua_State * a_L);
 }
 
 // fwd: "LuaExpat/lxplib.c":
 extern "C"
 {
-	int luaopen_lxp(lua_State * L);
+	int luaopen_lxp(lua_State * a_L);
 }
 
 
@@ -2005,7 +2005,7 @@ void cLuaState::LogStackTrace(lua_State * a_LuaState, int a_StartingDepth)
 
 
 
-int cLuaState::ApiParamError(const char * a_MsgFormat, fmt::ArgList argp)
+int cLuaState::ApiParamError(const char * a_MsgFormat, fmt::ArgList a_argp)
 {
 	// Retrieve current function name
 	lua_Debug entry;
@@ -2013,7 +2013,7 @@ int cLuaState::ApiParamError(const char * a_MsgFormat, fmt::ArgList argp)
 	VERIFY(lua_getinfo(m_LuaState, "n", &entry));
 
 	// Compose the error message:
-	AString msg = Printf(a_MsgFormat, argp);
+	AString msg = Printf(a_MsgFormat, a_argp);
 	AString errorMsg = fmt::format("{0}: {1}", (entry.name != nullptr) ? entry.name : "<unknown function>", msg);
 
 	// Log everything into the console:

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -295,7 +295,7 @@ public:
 		Returns true if callback has been called.
 		Returns false if the Lua state isn't valid anymore. */
 		template <typename... Args>
-		bool Call(Args &&... args)
+		bool Call(Args &&... a_args)
 		{
 			auto cs = m_CS.load();
 			if (cs == nullptr)
@@ -307,7 +307,7 @@ public:
 			{
 				return false;
 			}
-			return cLuaState(m_Ref.GetLuaState()).Call(m_Ref, std::forward<Args>(args)...);
+			return cLuaState(m_Ref.GetLuaState()).Call(m_Ref, std::forward<Args>(a_args)...);
 		}
 
 		/** Set the contained callback to the function in the specified Lua state's stack position.
@@ -377,7 +377,7 @@ public:
 		Returns true if callback has been called.
 		Returns false if the Lua state isn't valid anymore, or the function doesn't exist. */
 		template <typename... Args>
-		bool CallTableFn(const char * a_FnName, Args &&... args)
+		bool CallTableFn(const char * a_FnName, Args &&... a_args)
 		{
 			auto cs = m_CS.load();
 			if (cs == nullptr)
@@ -389,7 +389,7 @@ public:
 			{
 				return false;
 			}
-			return cLuaState(m_Ref.GetLuaState()).CallTableFn(m_Ref, a_FnName, std::forward<Args>(args)...);
+			return cLuaState(m_Ref.GetLuaState()).CallTableFn(m_Ref, a_FnName, std::forward<Args>(a_args)...);
 		}
 
 		/** Calls the Lua function stored under the specified name in the referenced table, if still available.
@@ -397,7 +397,7 @@ public:
 		Returns true if callback has been called.
 		Returns false if the Lua state isn't valid anymore, or the function doesn't exist. */
 		template <typename... Args>
-		bool CallTableFnWithSelf(const char * a_FnName, Args &&... args)
+		bool CallTableFnWithSelf(const char * a_FnName, Args &&... a_args)
 		{
 			auto cs = m_CS.load();
 			if (cs == nullptr)
@@ -409,7 +409,7 @@ public:
 			{
 				return false;
 			}
-			return cLuaState(m_Ref.GetLuaState()).CallTableFn(m_Ref, a_FnName, m_Ref, std::forward<Args>(args)...);
+			return cLuaState(m_Ref.GetLuaState()).CallTableFn(m_Ref, a_FnName, m_Ref, std::forward<Args>(a_args)...);
 		}
 
 		/** Set the contained reference to the table in the specified Lua state's stack position.
@@ -664,9 +664,9 @@ public:
 
 	// template to catch all of the various c++ integral types without overload conflicts
 	template <class T>
-	bool GetStackValue(int a_StackPos, T & a_ReturnedVal, typename std::enable_if<std::is_integral<T>::value>::type * unused = nullptr)
+	bool GetStackValue(int a_StackPos, T & a_ReturnedVal, typename std::enable_if<std::is_integral<T>::value>::type * a_unused = nullptr)
 	{
-		UNUSED(unused);
+		UNUSED(a_unused);
 		if (!lua_isnumber(m_LuaState, a_StackPos))  // Also accepts strings representing a number: https://pgl.yoyo.org/luai/i/lua_isnumber
 		{
 			return false;
@@ -741,7 +741,7 @@ public:
 	A special param of cRet & signifies the end of param list and the start of return values.
 	Example call: Call(Fn, Param1, Param2, Param3, cLuaState::Return, Ret1, Ret2) */
 	template <typename FnT, typename... Args>
-	bool Call(const FnT & a_Function, Args &&... args)
+	bool Call(const FnT & a_Function, Args &&... a_args)
 	{
 		cStackBalancePopper balancer(*this);
 		m_NumCurrentFunctionArgs = -1;
@@ -750,19 +750,19 @@ public:
 			// Pushing the function failed
 			return false;
 		}
-		auto res = PushCallPop(std::forward<Args>(args)...);
+		auto res = PushCallPop(std::forward<Args>(a_args)...);
 		return res;
 	}
 
 	/** Retrieves a list of values from the Lua stack, starting at the specified index. */
 	template <typename Arg1, typename... Args>
-	inline bool GetStackValues(int a_StartStackPos, Arg1 && a_Arg1, Args &&... args)
+	inline bool GetStackValues(int a_StartStackPos, Arg1 && a_Arg1, Args &&... a_args)
 	{
 		if (!GetStackValue(a_StartStackPos, std::forward<Arg1>(a_Arg1)))
 		{
 			return false;
 		}
-		return GetStackValues(a_StartStackPos + 1, std::forward<Args>(args)...);
+		return GetStackValues(a_StartStackPos + 1, std::forward<Args>(a_args)...);
 	}
 
 	/** Returns true if the specified parameters on the stack are of the specified usertable type; also logs warning if not. Used for static functions */
@@ -809,10 +809,10 @@ public:
 	bool IsParamNumber(int a_Param);
 
 	/** If the status is nonzero, prints the text on the top of Lua stack and returns true */
-	bool ReportErrors(int status);
+	bool ReportErrors(int a_status);
 
 	/** If the status is nonzero, prints the text on the top of Lua stack and returns true */
-	static bool ReportErrors(lua_State * a_LuaState, int status);
+	static bool ReportErrors(lua_State * a_LuaState, int a_status);
 
 	/** Logs all items in the current stack trace to the server console */
 	void LogStackTrace(int a_StartingDepth = 0);
@@ -913,14 +913,14 @@ protected:
 	A special param of cRet & signifies the end of param list and the start of return values.
 	Example call: CallTableFn(TableRef, "FnName", Param1, Param2, Param3, cLuaState::Return, Ret1, Ret2) */
 	template <typename... Args>
-	bool CallTableFn(const cRef & a_TableRef, const char * a_FnName, Args &&... args)
+	bool CallTableFn(const cRef & a_TableRef, const char * a_FnName, Args &&... a_args)
 	{
 		if (!PushFunction(a_TableRef, a_FnName))
 		{
 			// Pushing the function failed
 			return false;
 		}
-		return PushCallPop(std::forward<Args>(args)...);
+		return PushCallPop(std::forward<Args>(a_args)...);
 	}
 
 	/** Variadic template terminator: If there's nothing more to push / pop, just call the function.
@@ -932,16 +932,16 @@ protected:
 
 	/** Variadic template recursor: More params to push. Push them and recurse. */
 	template <typename T, typename... Args>
-	inline bool PushCallPop(T && a_Param, Args &&... args)
+	inline bool PushCallPop(T && a_Param, Args &&... a_args)
 	{
 		Push(std::forward<T>(a_Param));
 		m_NumCurrentFunctionArgs += 1;
-		return PushCallPop(std::forward<Args>(args)...);
+		return PushCallPop(std::forward<Args>(a_args)...);
 	}
 
 	/** Variadic template terminator: If there's nothing more to push, but return values to collect, call the function and collect the returns. */
 	template <typename... Args>
-	bool PushCallPop(cLuaState::cRet, Args &&... args)
+	bool PushCallPop(cLuaState::cRet, Args &&... a_args)
 	{
 		// Calculate the number of return values (number of args left):
 		int NumReturns = sizeof...(args);
@@ -953,7 +953,7 @@ protected:
 		}
 
 		// Collect the return values:
-		GetStackValues(-NumReturns, std::forward<Args>(args)...);
+		GetStackValues(-NumReturns, std::forward<Args>(a_args)...);
 		lua_pop(m_LuaState, NumReturns);
 
 		// All successful:

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -96,19 +96,19 @@ protected:
 // cManualBindings:
 
 // Better error reporting for Lua
-int cManualBindings::tolua_do_error(lua_State * L, const char * a_pMsg, tolua_Error * a_pToLuaError)
+int cManualBindings::tolua_do_error(lua_State * a_L, const char * a_pMsg, tolua_Error * a_pToLuaError)
 {
 	// Retrieve current function name
 	lua_Debug entry;
-	VERIFY(lua_getstack(L, 0, &entry));
-	VERIFY(lua_getinfo(L, "n", &entry));
+	VERIFY(lua_getstack(a_L, 0, &entry));
+	VERIFY(lua_getinfo(a_L, "n", &entry));
 
 	// Insert function name into error msg
 	AString msg(a_pMsg);
 	ReplaceString(msg, "#funcname#", entry.name?entry.name:"?");
 
 	// Send the error to Lua
-	tolua_error(L, msg.c_str(), a_pToLuaError);
+	tolua_error(a_L, msg.c_str(), a_pToLuaError);
 	return 0;
 }
 
@@ -116,23 +116,23 @@ int cManualBindings::tolua_do_error(lua_State * L, const char * a_pMsg, tolua_Er
 
 
 
-int cManualBindings::lua_do_error(lua_State * L, const char * a_pFormat, fmt::ArgList a_ArgList)
+int cManualBindings::lua_do_error(lua_State * a_L, const char * a_pFormat, fmt::ArgList a_ArgList)
 {
 	// Retrieve current function name
 	lua_Debug entry;
-	VERIFY(lua_getstack(L, 0, &entry));
-	VERIFY(lua_getinfo(L, "n", &entry));
+	VERIFY(lua_getstack(a_L, 0, &entry));
+	VERIFY(lua_getinfo(a_L, "n", &entry));
 
 	// Insert function name into error msg
 	AString msg(a_pFormat);
 	ReplaceString(msg, "#funcname#", (entry.name != nullptr) ? entry.name : "?");
 
 	// Copied from luaL_error and modified
-	luaL_where(L, 1);
+	luaL_where(a_L, 1);
 	AString FmtMsg = Printf(msg.c_str(), a_ArgList);
-	lua_pushlstring(L, FmtMsg.data(), FmtMsg.size());
-	lua_concat(L, 2);
-	return lua_error(L);
+	lua_pushlstring(a_L, FmtMsg.data(), FmtMsg.size());
+	lua_concat(a_L, 2);
+	return lua_error(a_L);
 }
 
 
@@ -140,9 +140,9 @@ int cManualBindings::lua_do_error(lua_State * L, const char * a_pFormat, fmt::Ar
 
 
 // Lua bound functions with special return types
-static int tolua_Clamp(lua_State * tolua_S)
+static int tolua_Clamp(lua_State * a_tolua_S)
 {
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 	int NumArgs = lua_gettop(LuaState);
 	if (NumArgs != 3)
 	{
@@ -167,9 +167,9 @@ static int tolua_Clamp(lua_State * tolua_S)
 
 
 
-static int tolua_CompressStringZLIB(lua_State * tolua_S)
+static int tolua_CompressStringZLIB(lua_State * a_tolua_S)
 {
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		!S.CheckParamString(1) ||
 		(
@@ -178,7 +178,7 @@ static int tolua_CompressStringZLIB(lua_State * tolua_S)
 		)
 	)
 	{
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
@@ -198,15 +198,15 @@ static int tolua_CompressStringZLIB(lua_State * tolua_S)
 
 
 
-static int tolua_UncompressStringZLIB(lua_State * tolua_S)
+static int tolua_UncompressStringZLIB(lua_State * a_tolua_S)
 {
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		!S.CheckParamString(1) ||
 		!S.CheckParamNumber(2)
 	)
 	{
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
@@ -226,15 +226,15 @@ static int tolua_UncompressStringZLIB(lua_State * tolua_S)
 
 
 
-static int tolua_CompressStringGZIP(lua_State * tolua_S)
+static int tolua_CompressStringGZIP(lua_State * a_tolua_S)
 {
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		!S.CheckParamString(1) ||
 		!S.CheckParamEnd(2)
 	)
 	{
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
@@ -253,15 +253,15 @@ static int tolua_CompressStringGZIP(lua_State * tolua_S)
 
 
 
-static int tolua_UncompressStringGZIP(lua_State * tolua_S)
+static int tolua_UncompressStringGZIP(lua_State * a_tolua_S)
 {
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		!S.CheckParamString(1) ||
 		!S.CheckParamEnd(2)
 	)
 	{
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
@@ -280,15 +280,15 @@ static int tolua_UncompressStringGZIP(lua_State * tolua_S)
 
 
 
-static int tolua_InflateString(lua_State * tolua_S)
+static int tolua_InflateString(lua_State * a_tolua_S)
 {
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		!S.CheckParamString(1) ||
 		!S.CheckParamEnd(2)
 	)
 	{
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
@@ -307,10 +307,10 @@ static int tolua_InflateString(lua_State * tolua_S)
 
 
 
-static int tolua_StringSplit(lua_State * tolua_S)
+static int tolua_StringSplit(lua_State * a_tolua_S)
 {
 	// Get the params:
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 	AString str, delim;
 	LuaState.GetStackValues(1, str, delim);
 
@@ -323,9 +323,9 @@ static int tolua_StringSplit(lua_State * tolua_S)
 
 
 
-static int tolua_StringSplitWithQuotes(lua_State * tolua_S)
+static int tolua_StringSplitWithQuotes(lua_State * a_tolua_S)
 {
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 
 	AString str;
 	AString delim;
@@ -341,10 +341,10 @@ static int tolua_StringSplitWithQuotes(lua_State * tolua_S)
 
 
 
-static int tolua_StringSplitAndTrim(lua_State * tolua_S)
+static int tolua_StringSplitAndTrim(lua_State * a_tolua_S)
 {
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamString(1, 2) ||
 		!L.CheckParamEnd(3)
@@ -367,17 +367,17 @@ static int tolua_StringSplitAndTrim(lua_State * tolua_S)
 /** Retrieves the log message from the first param on the Lua stack.
 Can take either a string or a cCompositeChat.
 */
-static AString GetLogMessage(lua_State * tolua_S)
+static AString GetLogMessage(lua_State * a_tolua_S)
 {
 	tolua_Error err;
-	if (tolua_isusertype(tolua_S, 1, "cCompositeChat", false, &err))
+	if (tolua_isusertype(a_tolua_S, 1, "cCompositeChat", false, &err))
 	{
-		return static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr))->ExtractText();
+		return static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr))->ExtractText();
 	}
 	else
 	{
 		size_t len = 0;
-		const char * str = lua_tolstring(tolua_S, 1, &len);
+		const char * str = lua_tolstring(a_tolua_S, 1, &len);
 		if (str != nullptr)
 		{
 			return AString(str, len);
@@ -390,26 +390,26 @@ static AString GetLogMessage(lua_State * tolua_S)
 
 
 
-static int tolua_LOG(lua_State * tolua_S)
+static int tolua_LOG(lua_State * a_tolua_S)
 {
 	// If there's no param, spit out an error message instead of crashing:
-	if (lua_isnil(tolua_S, 1))
+	if (lua_isnil(a_tolua_S, 1))
 	{
 		LOGWARNING("Attempting to LOG a nil value!");
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
 	// If the param is a cCompositeChat, read the log level from it:
 	cLogger::eLogLevel LogLevel = cLogger::llRegular;
 	tolua_Error err;
-	if (tolua_isusertype(tolua_S, 1, "cCompositeChat", false, &err))
+	if (tolua_isusertype(a_tolua_S, 1, "cCompositeChat", false, &err))
 	{
-		LogLevel = cCompositeChat::MessageTypeToLogLevel(static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr))->GetMessageType());
+		LogLevel = cCompositeChat::MessageTypeToLogLevel(static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr))->GetMessageType());
 	}
 
 	// Log the message:
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), LogLevel);
+	cLogger::GetInstance().LogSimple(GetLogMessage(a_tolua_S).c_str(), LogLevel);
 	return 0;
 }
 
@@ -417,17 +417,17 @@ static int tolua_LOG(lua_State * tolua_S)
 
 
 
-static int tolua_LOGINFO(lua_State * tolua_S)
+static int tolua_LOGINFO(lua_State * a_tolua_S)
 {
 	// If there's no param, spit out an error message instead of crashing:
-	if (lua_isnil(tolua_S, 1))
+	if (lua_isnil(a_tolua_S, 1))
 	{
 		LOGWARNING("Attempting to LOGINFO a nil value!");
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), cLogger::llInfo);
+	cLogger::GetInstance().LogSimple(GetLogMessage(a_tolua_S).c_str(), cLogger::llInfo);
 	return 0;
 }
 
@@ -435,17 +435,17 @@ static int tolua_LOGINFO(lua_State * tolua_S)
 
 
 
-static int tolua_LOGWARN(lua_State * tolua_S)
+static int tolua_LOGWARN(lua_State * a_tolua_S)
 {
 	// If there's no param, spit out an error message instead of crashing:
-	if (lua_isnil(tolua_S, 1))
+	if (lua_isnil(a_tolua_S, 1))
 	{
 		LOGWARNING("Attempting to LOGWARN a nil value!");
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), cLogger::llWarning);
+	cLogger::GetInstance().LogSimple(GetLogMessage(a_tolua_S).c_str(), cLogger::llWarning);
 	return 0;
 }
 
@@ -453,17 +453,17 @@ static int tolua_LOGWARN(lua_State * tolua_S)
 
 
 
-static int tolua_LOGERROR(lua_State * tolua_S)
+static int tolua_LOGERROR(lua_State * a_tolua_S)
 {
 	// If there's no param, spit out an error message instead of crashing:
-	if (lua_isnil(tolua_S, 1))
+	if (lua_isnil(a_tolua_S, 1))
 	{
 		LOGWARNING("Attempting to LOGERROR a nil value!");
-		cLuaState::LogStackTrace(tolua_S);
+		cLuaState::LogStackTrace(a_tolua_S);
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), cLogger::llError);
+	cLogger::GetInstance().LogSimple(GetLogMessage(a_tolua_S).c_str(), cLogger::llError);
 	return 0;
 }
 
@@ -471,9 +471,9 @@ static int tolua_LOGERROR(lua_State * tolua_S)
 
 
 
-static int tolua_Base64Encode(lua_State * tolua_S)
+static int tolua_Base64Encode(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamString(1) ||
 		!L.CheckParamEnd(2)
@@ -493,9 +493,9 @@ static int tolua_Base64Encode(lua_State * tolua_S)
 
 
 
-static int tolua_Base64Decode(lua_State * tolua_S)
+static int tolua_Base64Decode(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamString(1) ||
 		!L.CheckParamEnd(2)
@@ -515,18 +515,18 @@ static int tolua_Base64Decode(lua_State * tolua_S)
 
 
 
-cPluginLua * cManualBindings::GetLuaPlugin(lua_State * L)
+cPluginLua * cManualBindings::GetLuaPlugin(lua_State * a_L)
 {
 	// Get the plugin identification out of LuaState:
-	lua_getglobal(L, LUA_PLUGIN_INSTANCE_VAR_NAME);
-	if (!lua_islightuserdata(L, -1))
+	lua_getglobal(a_L, LUA_PLUGIN_INSTANCE_VAR_NAME);
+	if (!lua_islightuserdata(a_L, -1))
 	{
 		LOGWARNING("%s: cannot get plugin instance, what have you done to my Lua state?", __FUNCTION__);
-		lua_pop(L, 1);
+		lua_pop(a_L, 1);
 		return nullptr;
 	}
-	cPluginLua * Plugin = static_cast<cPluginLua *>(const_cast<void*>(lua_topointer(L, -1)));
-	lua_pop(L, 1);
+	cPluginLua * Plugin = static_cast<cPluginLua *>(const_cast<void*>(lua_topointer(a_L, -1)));
+	lua_pop(a_L, 1);
 
 	return Plugin;
 }
@@ -535,13 +535,13 @@ cPluginLua * cManualBindings::GetLuaPlugin(lua_State * L)
 
 
 
-static int tolua_cFile_ChangeFileExt(lua_State * tolua_S)
+static int tolua_cFile_ChangeFileExt(lua_State * a_tolua_S)
 {
 	// API signature:
 	// ChangeFileExt(string, string) -> string
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2, 3) ||
@@ -562,13 +562,13 @@ static int tolua_cFile_ChangeFileExt(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_Copy(lua_State * tolua_S)
+static int tolua_cFile_Copy(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:Copy(string, string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2, 3) ||
@@ -589,13 +589,13 @@ static int tolua_cFile_Copy(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_CreateFolder(lua_State * tolua_S)
+static int tolua_cFile_CreateFolder(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:CreateFolder(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -616,13 +616,13 @@ static int tolua_cFile_CreateFolder(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_CreateFolderRecursive(lua_State * tolua_S)
+static int tolua_cFile_CreateFolderRecursive(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:CreateFolderRecursive(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -643,13 +643,13 @@ static int tolua_cFile_CreateFolderRecursive(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_Delete(lua_State * tolua_S)
+static int tolua_cFile_Delete(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:Delete(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -670,13 +670,13 @@ static int tolua_cFile_Delete(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_DeleteFile(lua_State * tolua_S)
+static int tolua_cFile_DeleteFile(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:DeleteFile(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -697,13 +697,13 @@ static int tolua_cFile_DeleteFile(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_DeleteFolder(lua_State * tolua_S)
+static int tolua_cFile_DeleteFolder(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:DeleteFolder(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -724,13 +724,13 @@ static int tolua_cFile_DeleteFolder(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_DeleteFolderContents(lua_State * tolua_S)
+static int tolua_cFile_DeleteFolderContents(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:DeleteFolderContents(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -751,13 +751,13 @@ static int tolua_cFile_DeleteFolderContents(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_Exists(lua_State * tolua_S)
+static int tolua_cFile_Exists(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:Exists(string) -> bool
 
 	// Obsolete, use IsFile() or IsFolder() instead
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	LOGWARNING("cFile:Exists() is obsolete, use cFile:IsFolder() or cFile:IsFile() instead!");
 	L.LogStackTrace();
 
@@ -782,13 +782,13 @@ static int tolua_cFile_Exists(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_GetFolderContents(lua_State * tolua_S)
+static int tolua_cFile_GetFolderContents(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:GetFolderContents(string) -> {string, string, ...}
 
 	// Check params:
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 	if (
 		!LuaState.CheckParamUserTable(1, "cFile") ||
 		!LuaState.CheckParamString   (2) ||
@@ -811,13 +811,13 @@ static int tolua_cFile_GetFolderContents(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_GetLastModificationTime(lua_State * tolua_S)
+static int tolua_cFile_GetLastModificationTime(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:GetLastModificationTime(string) -> number
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -838,13 +838,13 @@ static int tolua_cFile_GetLastModificationTime(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_GetSize(lua_State * tolua_S)
+static int tolua_cFile_GetSize(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:GetSize(string) -> number
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -865,13 +865,13 @@ static int tolua_cFile_GetSize(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_IsFile(lua_State * tolua_S)
+static int tolua_cFile_IsFile(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:IsFile(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -892,13 +892,13 @@ static int tolua_cFile_IsFile(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_IsFolder(lua_State * tolua_S)
+static int tolua_cFile_IsFolder(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:IsFolder(string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2) ||
@@ -919,13 +919,13 @@ static int tolua_cFile_IsFolder(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_ReadWholeFile(lua_State * tolua_S)
+static int tolua_cFile_ReadWholeFile(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:ReadWholeFile(string) -> string
 
 	// Check params:
-	cLuaState LuaState(tolua_S);
+	cLuaState LuaState(a_tolua_S);
 	if (
 		!LuaState.CheckParamUserTable(1, "cFile") ||
 		!LuaState.CheckParamString   (2) ||
@@ -948,13 +948,13 @@ static int tolua_cFile_ReadWholeFile(lua_State * tolua_S)
 
 
 
-static int tolua_cFile_Rename(lua_State * tolua_S)
+static int tolua_cFile_Rename(lua_State * a_tolua_S)
 {
 	// API signature:
 	// cFile:Rename(string, string) -> bool
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cFile") ||
 		!L.CheckParamString(2, 3) ||
@@ -975,14 +975,14 @@ static int tolua_cFile_Rename(lua_State * tolua_S)
 
 
 
-static int tolua_cPluginManager_GetAllPlugins(lua_State * tolua_S)
+static int tolua_cPluginManager_GetAllPlugins(lua_State * a_tolua_S)
 {
 	// API function no longer available:
 	LOGWARNING("cPluginManager:GetAllPlugins() is no longer available, use cPluginManager:ForEachPlugin() instead");
-	cLuaState::LogStackTrace(tolua_S);
+	cLuaState::LogStackTrace(a_tolua_S);
 
 	// Return an empty table:
-	lua_newtable(tolua_S);
+	lua_newtable(a_tolua_S);
 	return 1;
 }
 
@@ -990,15 +990,15 @@ static int tolua_cPluginManager_GetAllPlugins(lua_State * tolua_S)
 
 
 
-static int tolua_cPluginManager_GetCurrentPlugin(lua_State * S)
+static int tolua_cPluginManager_GetCurrentPlugin(lua_State * a_S)
 {
-	cPluginLua * Plugin = cManualBindings::GetLuaPlugin(S);
+	cPluginLua * Plugin = cManualBindings::GetLuaPlugin(a_S);
 	if (Plugin == nullptr)
 	{
 		// An error message has already been printed in GetLuaPlugin()
 		return 0;
 	}
-	tolua_pushusertype(S, Plugin, "cPluginLua");
+	tolua_pushusertype(a_S, Plugin, "cPluginLua");
 	return 1;
 }
 
@@ -1006,11 +1006,11 @@ static int tolua_cPluginManager_GetCurrentPlugin(lua_State * S)
 
 
 
-static int tolua_cPluginManager_GetPlugin(lua_State * tolua_S)
+static int tolua_cPluginManager_GetPlugin(lua_State * a_tolua_S)
 {
 	// API function no longer available:
 	LOGWARNING("cPluginManager:GetPlugin() is no longer available. Use cPluginManager:DoWithPlugin() or cPluginManager:CallPlugin() instead.");
-	cLuaState::LogStackTrace(tolua_S);
+	cLuaState::LogStackTrace(a_tolua_S);
 	return 0;
 }
 
@@ -1018,9 +1018,9 @@ static int tolua_cPluginManager_GetPlugin(lua_State * tolua_S)
 
 
 
-static int tolua_cPluginManager_LogStackTrace(lua_State * S)
+static int tolua_cPluginManager_LogStackTrace(lua_State * a_S)
 {
-	cLuaState::LogStackTrace(S);
+	cLuaState::LogStackTrace(a_S);
 	return 0;
 }
 
@@ -1028,14 +1028,14 @@ static int tolua_cPluginManager_LogStackTrace(lua_State * S)
 
 
 
-static int tolua_cPluginManager_AddHook_FnRef(cPluginManager * a_PluginManager, cLuaState & S, int a_ParamIdx)
+static int tolua_cPluginManager_AddHook_FnRef(cPluginManager * a_PluginManager, cLuaState & a_S, int a_ParamIdx)
 {
 	// Helper function for cPluginmanager:AddHook() binding
 	// Takes care of the new case (#121): args are HOOK_TYPE and CallbackFunction
 	// The arg types have already been checked
 
 	// Retrieve the cPlugin from the LuaState:
-	cPluginLua * Plugin = cManualBindings::GetLuaPlugin(S);
+	cPluginLua * Plugin = cManualBindings::GetLuaPlugin(a_S);
 	if (Plugin == nullptr)
 	{
 		// An error message has been already printed in GetLuaPlugin()
@@ -1044,31 +1044,31 @@ static int tolua_cPluginManager_AddHook_FnRef(cPluginManager * a_PluginManager, 
 
 	// Retrieve and check the hook type
 	int HookType;
-	if (!S.GetStackValue(a_ParamIdx, HookType))
+	if (!a_S.GetStackValue(a_ParamIdx, HookType))
 	{
 		LOGWARNING("cPluginManager.AddHook(): Cannot read the hook type.");
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 	if (!a_PluginManager->IsValidHookType(HookType))
 	{
 		LOGWARNING("cPluginManager.AddHook(): Invalid HOOK_TYPE parameter: %d", HookType);
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 
 	// Add the hook to the plugin
 	cLuaState::cCallbackPtr callback;
-	if (!S.GetStackValue(a_ParamIdx + 1, callback))
+	if (!a_S.GetStackValue(a_ParamIdx + 1, callback))
 	{
 		LOGWARNING("cPluginManager.AddHook(): Cannot read the callback parameter");
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 	if (!Plugin->AddHookCallback(HookType, std::move(callback)))
 	{
 		LOGWARNING("cPluginManager.AddHook(): Cannot add hook %d, unknown error.", HookType);
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 	a_PluginManager->AddHook(Plugin, HookType);
@@ -1081,34 +1081,34 @@ static int tolua_cPluginManager_AddHook_FnRef(cPluginManager * a_PluginManager, 
 
 
 
-static int tolua_cPluginManager_AddHook_DefFn(cPluginManager * a_PluginManager, cLuaState & S, int a_ParamIdx)
+static int tolua_cPluginManager_AddHook_DefFn(cPluginManager * a_PluginManager, cLuaState & a_S, int a_ParamIdx)
 {
 	// Helper function for cPluginmanager:AddHook() binding
 	// Takes care of the old case (#121): args are cPluginLua and HOOK_TYPE
 	// The arg types have already been checked
 
 	// Retrieve and check the cPlugin parameter
-	cPluginLua * Plugin = static_cast<cPluginLua *>(tolua_tousertype(S, a_ParamIdx, nullptr));
+	cPluginLua * Plugin = static_cast<cPluginLua *>(tolua_tousertype(a_S, a_ParamIdx, nullptr));
 	if (Plugin == nullptr)
 	{
 		LOGWARNING("cPluginManager.AddHook(): Invalid Plugin parameter, expected a valid cPlugin object. Hook not added");
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
-	if (Plugin != cManualBindings::GetLuaPlugin(S))
+	if (Plugin != cManualBindings::GetLuaPlugin(a_S))
 	{
 		// The plugin parameter passed to us is not our stored plugin. Disallow this!
 		LOGWARNING("cPluginManager.AddHook(): Invalid Plugin parameter, cannot add hook to foreign plugins. Hook not added.");
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 
 	// Retrieve and check the hook type
-	int HookType = static_cast<int>(tolua_tonumber(S, a_ParamIdx + 1, -1));
+	int HookType = static_cast<int>(tolua_tonumber(a_S, a_ParamIdx + 1, -1));
 	if (!a_PluginManager->IsValidHookType(HookType))
 	{
 		LOGWARNING("cPluginManager.AddHook(): Invalid HOOK_TYPE parameter: %d", HookType);
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 
@@ -1117,19 +1117,19 @@ static int tolua_cPluginManager_AddHook_DefFn(cPluginManager * a_PluginManager, 
 	if (FnName == nullptr)
 	{
 		LOGWARNING("cPluginManager.AddHook(): Unknown hook type (%d). Hook not added.", HookType);
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 
 	// Retrieve the function to call and add it to the plugin:
 	cLuaState::cCallbackPtr callback;
-	lua_getglobal(S, FnName);
-	bool res = S.GetStackValue(-1, callback);
-	lua_pop(S, 1);
+	lua_getglobal(a_S, FnName);
+	bool res = a_S.GetStackValue(-1, callback);
+	lua_pop(a_S, 1);
 	if (!res || !callback->IsValid())
 	{
 		LOGWARNING("cPluginManager.AddHook(): Function %s not found. Hook not added.", FnName);
-		S.LogStackTrace();
+		a_S.LogStackTrace();
 		return 0;
 	}
 	a_PluginManager->AddHook(Plugin, HookType);
@@ -1142,7 +1142,7 @@ static int tolua_cPluginManager_AddHook_DefFn(cPluginManager * a_PluginManager, 
 
 
 
-static int tolua_cPluginManager_AddHook(lua_State * tolua_S)
+static int tolua_cPluginManager_AddHook(lua_State * a_tolua_S)
 {
 	/*
 	Function signatures:
@@ -1153,7 +1153,7 @@ static int tolua_cPluginManager_AddHook(lua_State * tolua_S)
 	cPluginManager.AddHook(Plugin, HOOK_TYPE)                  -- (5) old style (#121) mangled, accepted but complained about in the console
 	*/
 
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	cPluginManager * PlgMgr = cPluginManager::Get();
 
 	// If the first param is a cPluginManager instance, use it instead of the global one:
@@ -1201,7 +1201,7 @@ static int tolua_cPluginManager_AddHook(lua_State * tolua_S)
 
 
 
-static int tolua_cPluginManager_ForEachCommand(lua_State * tolua_S)
+static int tolua_cPluginManager_ForEachCommand(lua_State * a_tolua_S)
 {
 	/*
 	Function signature:
@@ -1209,7 +1209,7 @@ static int tolua_cPluginManager_ForEachCommand(lua_State * tolua_S)
 	*/
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cPluginManager") ||
 		!L.CheckParamFunction(2) ||
@@ -1259,7 +1259,7 @@ static int tolua_cPluginManager_ForEachCommand(lua_State * tolua_S)
 
 
 
-static int tolua_cPluginManager_ForEachConsoleCommand(lua_State * tolua_S)
+static int tolua_cPluginManager_ForEachConsoleCommand(lua_State * a_tolua_S)
 {
 	/*
 	Function signature:
@@ -1267,7 +1267,7 @@ static int tolua_cPluginManager_ForEachConsoleCommand(lua_State * tolua_S)
 	*/
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cPluginManager") ||
 		!L.CheckParamFunction(2) ||
@@ -1448,7 +1448,7 @@ static int tolua_cPluginManager_BindConsoleCommand(lua_State * a_LuaState)
 
 
 
-static int tolua_cPluginManager_CallPlugin(lua_State * tolua_S)
+static int tolua_cPluginManager_CallPlugin(lua_State * a_tolua_S)
 {
 	/*
 	Function signature:
@@ -1456,7 +1456,7 @@ static int tolua_cPluginManager_CallPlugin(lua_State * tolua_S)
 	*/
 
 	// Check the parameters:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cPluginManager") ||
 		!L.CheckParamString(2, 3))
@@ -1518,7 +1518,7 @@ static int tolua_cPluginManager_CallPlugin(lua_State * tolua_S)
 
 
 
-static int tolua_cPluginManager_ExecuteConsoleCommand(lua_State * tolua_S)
+static int tolua_cPluginManager_ExecuteConsoleCommand(lua_State * a_tolua_S)
 {
 	/*
 	Function signature:
@@ -1526,7 +1526,7 @@ static int tolua_cPluginManager_ExecuteConsoleCommand(lua_State * tolua_S)
 	*/
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cPluginManager") ||
 		!L.CheckParamString(2) ||
@@ -1552,11 +1552,11 @@ static int tolua_cPluginManager_ExecuteConsoleCommand(lua_State * tolua_S)
 
 
 
-static int tolua_cPluginManager_FindPlugins(lua_State * tolua_S)
+static int tolua_cPluginManager_FindPlugins(lua_State * a_tolua_S)
 {
 	// API function no longer exists:
 	LOGWARNING("cPluginManager:FindPlugins() is obsolete, use cPluginManager:RefreshPluginList() instead!");
-	cLuaState::LogStackTrace(tolua_S);
+	cLuaState::LogStackTrace(a_tolua_S);
 
 	// Still, do the actual work performed by the API function when it existed:
 	cPluginManager::Get()->RefreshPluginList();
@@ -1567,12 +1567,12 @@ static int tolua_cPluginManager_FindPlugins(lua_State * tolua_S)
 
 
 
-static int tolua_cPlayer_GetPermissions(lua_State * tolua_S)
+static int tolua_cPlayer_GetPermissions(lua_State * a_tolua_S)
 {
 	// Function signature: cPlayer:GetPermissions() -> {permissions-array}
 
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cPlayer") ||
 		!L.CheckParamEnd     (2)
@@ -1582,7 +1582,7 @@ static int tolua_cPlayer_GetPermissions(lua_State * tolua_S)
 	}
 
 	// Get the params:
-	cPlayer * self = static_cast<cPlayer *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cPlayer * self = static_cast<cPlayer *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
 		LOGWARNING("%s: invalid self (%p)", __FUNCTION__, static_cast<void *>(self));
@@ -1598,12 +1598,12 @@ static int tolua_cPlayer_GetPermissions(lua_State * tolua_S)
 
 
 
-static int tolua_cPlayer_GetRestrictions(lua_State * tolua_S)
+static int tolua_cPlayer_GetRestrictions(lua_State * a_tolua_S)
 {
 	// Function signature: cPlayer:GetRestrictions() -> {restrictions-array}
 
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cPlayer") ||
 		!L.CheckParamEnd     (2)
@@ -1613,7 +1613,7 @@ static int tolua_cPlayer_GetRestrictions(lua_State * tolua_S)
 	}
 
 	// Get the params:
-	cPlayer * self = static_cast<cPlayer *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cPlayer * self = static_cast<cPlayer *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
 		LOGWARNING("%s: invalid self (%p)", __FUNCTION__, static_cast<void *>(self));
@@ -1629,12 +1629,12 @@ static int tolua_cPlayer_GetRestrictions(lua_State * tolua_S)
 
 
 
-static int tolua_cPlayer_PermissionMatches(lua_State * tolua_S)
+static int tolua_cPlayer_PermissionMatches(lua_State * a_tolua_S)
 {
 	// Function signature: cPlayer:PermissionMatches(PermissionStr, TemplateStr) -> bool
 
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cPlayer") ||
 		!L.CheckParamString   (2, 3) ||
@@ -1657,10 +1657,10 @@ static int tolua_cPlayer_PermissionMatches(lua_State * tolua_S)
 
 
 
-static int tolua_cPlayer_GetUUID(lua_State * tolua_S)
+static int tolua_cPlayer_GetUUID(lua_State * a_tolua_S)
 {
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("cPlayer"))
 	{
 		return 0;
@@ -1683,12 +1683,12 @@ template <
 	class OBJTYPE,
 	void (OBJTYPE::*SetCallback)(cLuaState::cCallbackPtr && a_CallbackFn)
 >
-static int tolua_SetObjectCallback(lua_State * tolua_S)
+static int tolua_SetObjectCallback(lua_State * a_tolua_S)
 {
 	// Function signature: OBJTYPE:SetWhateverCallback(CallbackFunction)
 
 	// Get the parameters - self and the function reference:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	OBJTYPE * self;
 	cLuaState::cCallbackPtr callback;
 	if (!L.GetStackValues(1, self, callback))
@@ -1731,7 +1731,7 @@ public:
 
 
 
-static int tolua_cPluginLua_AddWebTab(lua_State * tolua_S)
+static int tolua_cPluginLua_AddWebTab(lua_State * a_tolua_S)
 {
 	// OBSOLETE, use cWebAdmin:AddWebTab() instead!
 	// Function signature:
@@ -1741,8 +1741,8 @@ static int tolua_cPluginLua_AddWebTab(lua_State * tolua_S)
 	// Only implement after merging the new API change and letting some time for changes in the plugins
 
 	// Check params:
-	cLuaState LuaState(tolua_S);
-	cPluginLua * self = cManualBindings::GetLuaPlugin(tolua_S);
+	cLuaState LuaState(a_tolua_S);
+	cPluginLua * self = cManualBindings::GetLuaPlugin(a_tolua_S);
 	if (self == nullptr)
 	{
 		return 0;
@@ -1779,16 +1779,16 @@ static int tolua_cPluginLua_AddWebTab(lua_State * tolua_S)
 
 
 
-static int tolua_cPlugin_GetDirectory(lua_State * tolua_S)
+static int tolua_cPlugin_GetDirectory(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 
 	// Log the obsoletion warning:
 	LOGWARNING("cPlugin:GetDirectory() is obsolete, use cPlugin:GetFolderName() instead.");
 	L.LogStackTrace();
 
 	// Retrieve the params:
-	cPlugin * Plugin = static_cast<cPluginLua *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cPlugin * Plugin = static_cast<cPluginLua *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 
 	// Get the folder name:
 	L.Push(Plugin->GetFolderName());
@@ -1799,16 +1799,16 @@ static int tolua_cPlugin_GetDirectory(lua_State * tolua_S)
 
 
 
-static int tolua_cPlugin_GetLocalDirectory(lua_State * tolua_S)
+static int tolua_cPlugin_GetLocalDirectory(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 
 	// Log the obsoletion warning:
 	LOGWARNING("cPlugin:GetLocalDirectory() is obsolete, use cPlugin:GetLocalFolder() instead.");
 	L.LogStackTrace();
 
 	// Retrieve the params:
-	cPlugin * Plugin = static_cast<cPluginLua *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cPlugin * Plugin = static_cast<cPluginLua *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 
 	// Get the folder:
 	L.Push(Plugin->GetLocalFolder());
@@ -1819,18 +1819,18 @@ static int tolua_cPlugin_GetLocalDirectory(lua_State * tolua_S)
 
 
 
-static int tolua_md5(lua_State * tolua_S)
+static int tolua_md5(lua_State * a_tolua_S)
 {
 	// Calculate the raw md5 checksum byte array:
 	unsigned char Output[16];
 	size_t len = 0;
-	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(tolua_S, 1, &len));
+	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(a_tolua_S, 1, &len));
 	if (SourceString == nullptr)
 	{
 		return 0;
 	}
 	mbedtls_md5(SourceString, len, Output);
-	lua_pushlstring(tolua_S, reinterpret_cast<const char *>(Output), ARRAYCOUNT(Output));
+	lua_pushlstring(a_tolua_S, reinterpret_cast<const char *>(Output), ARRAYCOUNT(Output));
 	return 1;
 }
 
@@ -1839,23 +1839,23 @@ static int tolua_md5(lua_State * tolua_S)
 
 
 /** Does the same as tolua_md5, but reports that the usage is obsolete and the plugin should use cCrypto.md5(). */
-static int tolua_md5_obsolete(lua_State * tolua_S)
+static int tolua_md5_obsolete(lua_State * a_tolua_S)
 {
 	LOGWARNING("Using md5() is obsolete, please change your plugin to use cCryptoHash.md5()");
-	cLuaState::LogStackTrace(tolua_S);
-	return tolua_md5(tolua_S);
+	cLuaState::LogStackTrace(a_tolua_S);
+	return tolua_md5(a_tolua_S);
 }
 
 
 
 
 
-static int tolua_md5HexString(lua_State * tolua_S)
+static int tolua_md5HexString(lua_State * a_tolua_S)
 {
 	// Calculate the raw md5 checksum byte array:
 	unsigned char md5Output[16];
 	size_t len = 0;
-	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(tolua_S, 1, &len));
+	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(a_tolua_S, 1, &len));
 	if (SourceString == nullptr)
 	{
 		return 0;
@@ -1869,7 +1869,7 @@ static int tolua_md5HexString(lua_State * tolua_S)
 	{
 		Output << std::setw(2) << static_cast<unsigned short>(md5Output[i]);  // Need to cast to a number, otherwise a char is output
 	}
-	lua_pushlstring(tolua_S, Output.str().c_str(), Output.str().size());
+	lua_pushlstring(a_tolua_S, Output.str().c_str(), Output.str().size());
 	return 1;
 }
 
@@ -1877,18 +1877,18 @@ static int tolua_md5HexString(lua_State * tolua_S)
 
 
 
-static int tolua_sha1(lua_State * tolua_S)
+static int tolua_sha1(lua_State * a_tolua_S)
 {
 	// Calculate the raw SHA1 checksum byte array from the input string:
 	unsigned char Output[20];
 	size_t len = 0;
-	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(tolua_S, 1, &len));
+	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(a_tolua_S, 1, &len));
 	if (SourceString == nullptr)
 	{
 		return 0;
 	}
 	mbedtls_sha1(SourceString, len, Output);
-	lua_pushlstring(tolua_S, reinterpret_cast<const char *>(Output), ARRAYCOUNT(Output));
+	lua_pushlstring(a_tolua_S, reinterpret_cast<const char *>(Output), ARRAYCOUNT(Output));
 	return 1;
 }
 
@@ -1896,12 +1896,12 @@ static int tolua_sha1(lua_State * tolua_S)
 
 
 
-static int tolua_sha1HexString(lua_State * tolua_S)
+static int tolua_sha1HexString(lua_State * a_tolua_S)
 {
 	// Calculate the raw SHA1 checksum byte array from the input string:
 	unsigned char sha1Output[20];
 	size_t len = 0;
-	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(tolua_S, 1, &len));
+	const unsigned char * SourceString = reinterpret_cast<const unsigned char *>(lua_tolstring(a_tolua_S, 1, &len));
 	if (SourceString == nullptr)
 	{
 		return 0;
@@ -1915,7 +1915,7 @@ static int tolua_sha1HexString(lua_State * tolua_S)
 	{
 		Output << std::setw(2) << static_cast<unsigned short>(sha1Output[i]);  // Need to cast to a number, otherwise a char is output
 	}
-	lua_pushlstring(tolua_S, Output.str().c_str(), Output.str().size());
+	lua_pushlstring(a_tolua_S, Output.str().c_str(), Output.str().size());
 	return 1;
 }
 
@@ -2125,10 +2125,10 @@ static int tolua_cUrlParser_ParseAuthorityPart(lua_State * a_LuaState)
 
 
 
-static int tolua_cUrlParser_UrlDecode(lua_State * tolua_S)
+static int tolua_cUrlParser_UrlDecode(lua_State * a_tolua_S)
 {
 	// Check the param types:
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		// Don't care about the first param
 		!S.CheckParamString(2) ||
@@ -2159,10 +2159,10 @@ static int tolua_cUrlParser_UrlDecode(lua_State * tolua_S)
 
 
 
-static int tolua_cUrlParser_UrlEncode(lua_State * tolua_S)
+static int tolua_cUrlParser_UrlEncode(lua_State * a_tolua_S)
 {
 	// Check the param types:
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		// Don't care about the first param
 		!S.CheckParamString(2) ||
@@ -2185,14 +2185,14 @@ static int tolua_cUrlParser_UrlEncode(lua_State * tolua_S)
 
 
 
-static int tolua_cWebAdmin_AddWebTab(lua_State * tolua_S)
+static int tolua_cWebAdmin_AddWebTab(lua_State * a_tolua_S)
 {
 	// Function signatures:
 	// cWebAdmin:AddWebTab(Title, UrlPath, CallbackFn)
 
 	// Check params:
-	cLuaState LuaState(tolua_S);
-	cPluginLua * self = cManualBindings::GetLuaPlugin(tolua_S);
+	cLuaState LuaState(a_tolua_S);
+	cPluginLua * self = cManualBindings::GetLuaPlugin(a_tolua_S);
 	if (self == nullptr)
 	{
 		return 0;
@@ -2225,7 +2225,7 @@ static int tolua_cWebAdmin_AddWebTab(lua_State * tolua_S)
 
 
 
-static int tolua_cWebAdmin_GetAllWebTabs(lua_State * tolua_S)
+static int tolua_cWebAdmin_GetAllWebTabs(lua_State * a_tolua_S)
 {
 	// Function signature:
 	// cWebAdmin:GetAllWebTabs() -> { {"PluginName", "UrlPath", "Title"}, {"PluginName", "UrlPath", "Title"}, ...}
@@ -2233,20 +2233,20 @@ static int tolua_cWebAdmin_GetAllWebTabs(lua_State * tolua_S)
 	// Don't care about params at all
 
 	auto webTabs = cRoot::Get()->GetWebAdmin()->GetAllWebTabs();
-	lua_createtable(tolua_S, static_cast<int>(webTabs.size()), 0);
-	int newTable = lua_gettop(tolua_S);
+	lua_createtable(a_tolua_S, static_cast<int>(webTabs.size()), 0);
+	int newTable = lua_gettop(a_tolua_S);
 	int index = 1;
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	for (const auto & wt: webTabs)
 	{
-		lua_createtable(tolua_S, 0, 3);
+		lua_createtable(a_tolua_S, 0, 3);
 		L.Push(wt->m_PluginName);
-		lua_setfield(tolua_S, -2, "PluginName");
+		lua_setfield(a_tolua_S, -2, "PluginName");
 		L.Push(wt->m_UrlPath);
-		lua_setfield(tolua_S, -2, "UrlPath");
+		lua_setfield(a_tolua_S, -2, "UrlPath");
 		L.Push(wt->m_Title);
-		lua_setfield(tolua_S, -2, "Title");
-		lua_rawseti(tolua_S, newTable, index);
+		lua_setfield(a_tolua_S, -2, "Title");
+		lua_rawseti(a_tolua_S, newTable, index);
 		++index;
 	}
 	return 1;
@@ -2257,7 +2257,7 @@ static int tolua_cWebAdmin_GetAllWebTabs(lua_State * tolua_S)
 
 
 /** Binding for cWebAdmin::GetPage. */
-static int tolua_cWebAdmin_GetPage(lua_State * tolua_S)
+static int tolua_cWebAdmin_GetPage(lua_State * a_tolua_S)
 {
 	/*
 	Function signature:
@@ -2273,7 +2273,7 @@ static int tolua_cWebAdmin_GetPage(lua_State * tolua_S)
 	*/
 
 	// Check the param types:
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	if (
 		// Don't care about first param, whether it's cWebAdmin instance or class
 		!S.CheckParamUserType(2, "HTTPRequest") ||
@@ -2314,23 +2314,23 @@ static int tolua_cWebAdmin_GetPage(lua_State * tolua_S)
 
 
 /** Binding for cWebAdmin::GetURLEncodedString. */
-static int tolua_cWebAdmin_GetURLEncodedString(lua_State * tolua_S)
+static int tolua_cWebAdmin_GetURLEncodedString(lua_State * a_tolua_S)
 {
 	// Emit the obsoletion warning:
-	cLuaState S(tolua_S);
+	cLuaState S(a_tolua_S);
 	LOGWARNING("cWebAdmin:GetURLEncodedString() is obsolete, use cUrlParser:UrlEncode() instead.");
 	S.LogStackTrace();
 
-	return tolua_cUrlParser_UrlEncode(tolua_S);
+	return tolua_cUrlParser_UrlEncode(a_tolua_S);
 }
 
 
 
 
 
-static int tolua_cClientHandle_SendPluginMessage(lua_State * L)
+static int tolua_cClientHandle_SendPluginMessage(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cClientHandle") ||
 		!S.CheckParamString(2, 3) ||
@@ -2339,7 +2339,7 @@ static int tolua_cClientHandle_SendPluginMessage(lua_State * L)
 	{
 		return 0;
 	}
-	cClientHandle * Client = static_cast<cClientHandle *>(tolua_tousertype(L, 1, nullptr));
+	cClientHandle * Client = static_cast<cClientHandle *>(tolua_tousertype(a_L, 1, nullptr));
 	if (Client == nullptr)
 	{
 		LOGWARNING("ClientHandle is nil in cClientHandle:SendPluginMessage()");
@@ -2347,8 +2347,8 @@ static int tolua_cClientHandle_SendPluginMessage(lua_State * L)
 		return 0;
 	}
 	AString Channel, Message;
-	Channel.assign(lua_tostring(L, 2), lua_strlen(L, 2));
-	Message.assign(lua_tostring(L, 3), lua_strlen(L, 3));
+	Channel.assign(lua_tostring(a_L, 2), lua_strlen(a_L, 2));
+	Message.assign(lua_tostring(a_L, 3), lua_strlen(a_L, 3));
 	Client->SendPluginMessage(Channel, Message);
 	return 0;
 }
@@ -2357,9 +2357,9 @@ static int tolua_cClientHandle_SendPluginMessage(lua_State * L)
 
 
 
-static int tolua_cClientHandle_GetForgeMods(lua_State * L)
+static int tolua_cClientHandle_GetForgeMods(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cClientHandle") ||
 		!S.CheckParamEnd(2)
@@ -2378,10 +2378,10 @@ static int tolua_cClientHandle_GetForgeMods(lua_State * L)
 
 
 
-static int tolua_cClientHandle_GetUUID(lua_State * tolua_S)
+static int tolua_cClientHandle_GetUUID(lua_State * a_tolua_S)
 {
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamSelf("cClientHandle") ||
 		!L.CheckParamEnd(2)
@@ -2403,10 +2403,10 @@ static int tolua_cClientHandle_GetUUID(lua_State * tolua_S)
 
 
 
-static int tolua_cClientHandle_GenerateOfflineUUID(lua_State * tolua_S)
+static int tolua_cClientHandle_GenerateOfflineUUID(lua_State * a_tolua_S)
 {
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamStaticSelf("cClientHandle") ||
 		!L.CheckParamString(2) ||
@@ -2429,10 +2429,10 @@ static int tolua_cClientHandle_GenerateOfflineUUID(lua_State * tolua_S)
 
 
 
-static int tolua_cClientHandle_IsUUIDOnline(lua_State * tolua_S)
+static int tolua_cClientHandle_IsUUIDOnline(lua_State * a_tolua_S)
 {
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamStaticSelf("cClientHandle") ||
 		!L.CheckParamUUID(2) ||
@@ -2454,10 +2454,10 @@ static int tolua_cClientHandle_IsUUIDOnline(lua_State * tolua_S)
 
 
 
-static int tolua_cMobHeadEntity_SetOwner(lua_State * tolua_S)
+static int tolua_cMobHeadEntity_SetOwner(lua_State * a_tolua_S)
 {
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamSelf("cMobHeadEntity") ||
 		!L.CheckParamUUID(2) ||
@@ -2484,10 +2484,10 @@ static int tolua_cMobHeadEntity_SetOwner(lua_State * tolua_S)
 
 
 
-static int tolua_cMobHeadEntity_GetOwnerUUID(lua_State * tolua_S)
+static int tolua_cMobHeadEntity_GetOwnerUUID(lua_State * a_tolua_S)
 {
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamSelf("cMobHeadEntity") ||
 		!L.CheckParamEnd(2)
@@ -2510,9 +2510,9 @@ static int tolua_cMobHeadEntity_GetOwnerUUID(lua_State * tolua_S)
 
 
 
-static int tolua_cMojangAPI_AddPlayerNameToUUIDMapping(lua_State * L)
+static int tolua_cMojangAPI_AddPlayerNameToUUIDMapping(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cMojangAPI") ||
 		!S.CheckParamString(2) ||
@@ -2537,9 +2537,9 @@ static int tolua_cMojangAPI_AddPlayerNameToUUIDMapping(lua_State * L)
 
 
 
-static int tolua_cMojangAPI_GetPlayerNameFromUUID(lua_State * L)
+static int tolua_cMojangAPI_GetPlayerNameFromUUID(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cMojangAPI") ||
 		!S.CheckParamUUID(2) ||
@@ -2554,10 +2554,10 @@ static int tolua_cMojangAPI_GetPlayerNameFromUUID(lua_State * L)
 
 	// If the UseOnlyCached param was given, read it; default to false
 	bool ShouldUseCacheOnly = false;
-	if (lua_gettop(L) == 3)
+	if (lua_gettop(a_L) == 3)
 	{
-		ShouldUseCacheOnly = (lua_toboolean(L, 3) != 0);
-		lua_pop(L, 1);
+		ShouldUseCacheOnly = (lua_toboolean(a_L, 3) != 0);
+		lua_pop(a_L, 1);
 	}
 
 	// Return the PlayerName:
@@ -2570,9 +2570,9 @@ static int tolua_cMojangAPI_GetPlayerNameFromUUID(lua_State * L)
 
 
 
-static int tolua_cMojangAPI_GetUUIDFromPlayerName(lua_State * L)
+static int tolua_cMojangAPI_GetUUIDFromPlayerName(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cMojangAPI") ||
 		!S.CheckParamString(2) ||
@@ -2587,10 +2587,10 @@ static int tolua_cMojangAPI_GetUUIDFromPlayerName(lua_State * L)
 
 	// If the UseOnlyCached param was given, read it; default to false
 	bool ShouldUseCacheOnly = false;
-	if (lua_gettop(L) == 3)
+	if (lua_gettop(a_L) == 3)
 	{
-		ShouldUseCacheOnly = (lua_toboolean(L, 3) != 0);
-		lua_pop(L, 1);
+		ShouldUseCacheOnly = (lua_toboolean(a_L, 3) != 0);
+		lua_pop(a_L, 1);
 	}
 
 	// Return the UUID as a string:
@@ -2603,9 +2603,9 @@ static int tolua_cMojangAPI_GetUUIDFromPlayerName(lua_State * L)
 
 
 
-static int tolua_cMojangAPI_GetUUIDsFromPlayerNames(lua_State * L)
+static int tolua_cMojangAPI_GetUUIDsFromPlayerNames(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cMojangAPI") ||
 		!S.CheckParamTable(2) ||
@@ -2617,30 +2617,30 @@ static int tolua_cMojangAPI_GetUUIDsFromPlayerNames(lua_State * L)
 
 	// Convert the input table into AStringVector:
 	AStringVector PlayerNames;
-	int NumNames = luaL_getn(L, 2);
+	int NumNames = luaL_getn(a_L, 2);
 	PlayerNames.reserve(static_cast<size_t>(NumNames));
 	for (int i = 1; i <= NumNames; i++)
 	{
-		lua_rawgeti(L, 2, i);
+		lua_rawgeti(a_L, 2, i);
 		AString Name;
 		S.GetStackValue(-1, Name);
 		if (!Name.empty())
 		{
 			PlayerNames.push_back(Name);
 		}
-		lua_pop(L, 1);
+		lua_pop(a_L, 1);
 	}
 
 	// If the UseOnlyCached param was given, read it; default to false
 	bool ShouldUseCacheOnly = false;
-	if (lua_gettop(L) == 3)
+	if (lua_gettop(a_L) == 3)
 	{
-		ShouldUseCacheOnly = (lua_toboolean(L, 3) != 0);
-		lua_pop(L, 1);
+		ShouldUseCacheOnly = (lua_toboolean(a_L, 3) != 0);
+		lua_pop(a_L, 1);
 	}
 
 	// Push the output table onto the stack:
-	lua_newtable(L);
+	lua_newtable(a_L);
 
 	// Get the UUIDs:
 	auto UUIDs = cRoot::Get()->GetMojangAPI().GetUUIDsFromPlayerNames(PlayerNames, ShouldUseCacheOnly);
@@ -2660,7 +2660,7 @@ static int tolua_cMojangAPI_GetUUIDsFromPlayerNames(lua_State * L)
 			continue;
 		}
 		S.Push(UUIDs[i].ToShortString());
-		lua_setfield(L, 3, PlayerNames[i].c_str());
+		lua_setfield(a_L, 3, PlayerNames[i].c_str());
 	}
 	return 1;
 }
@@ -2669,12 +2669,12 @@ static int tolua_cMojangAPI_GetUUIDsFromPlayerNames(lua_State * L)
 
 
 
-static int tolua_cMojangAPI_MakeUUIDDashed(lua_State * L)
+static int tolua_cMojangAPI_MakeUUIDDashed(lua_State * a_L)
 {
 	// Function now non-existant but kept for API compatibility
 
 	// Check params:
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cMojangAPI") ||
 		!S.CheckParamUUID(2) ||
@@ -2697,12 +2697,12 @@ static int tolua_cMojangAPI_MakeUUIDDashed(lua_State * L)
 
 
 
-static int tolua_cMojangAPI_MakeUUIDShort(lua_State * L)
+static int tolua_cMojangAPI_MakeUUIDShort(lua_State * a_L)
 {
 	// Function now non-existant but kept for API compatibility
 
 	// Check params:
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cMojangAPI") ||
 		!S.CheckParamUUID(2) ||
@@ -2725,10 +2725,10 @@ static int tolua_cMojangAPI_MakeUUIDShort(lua_State * L)
 
 
 
-static int tolua_get_cItem_m_LoreTable(lua_State * tolua_S)
+static int tolua_get_cItem_m_LoreTable(lua_State * a_tolua_S)
 {
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("const cItem"))
 	{
 		return 0;
@@ -2747,10 +2747,10 @@ static int tolua_get_cItem_m_LoreTable(lua_State * tolua_S)
 
 
 
-static int tolua_set_cItem_m_LoreTable(lua_State * tolua_S)
+static int tolua_set_cItem_m_LoreTable(lua_State * a_tolua_S)
 {
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamSelf("cItem") ||
 		!L.CheckParamTable(2)
@@ -2776,35 +2776,35 @@ static int tolua_set_cItem_m_LoreTable(lua_State * tolua_S)
 
 
 
-static int Lua_ItemGrid_GetSlotCoords(lua_State * L)
+static int Lua_ItemGrid_GetSlotCoords(lua_State * a_L)
 {
 	tolua_Error tolua_err;
 	if (
-		!tolua_isusertype(L, 1, "const cItemGrid", 0, &tolua_err) ||
-		!tolua_isnumber  (L, 2, 0, &tolua_err) ||
-		!tolua_isnoobj   (L, 3, &tolua_err)
+		!tolua_isusertype(a_L, 1, "const cItemGrid", 0, &tolua_err) ||
+		!tolua_isnumber  (a_L, 2, 0, &tolua_err) ||
+		!tolua_isnoobj   (a_L, 3, &tolua_err)
 	)
 	{
 		goto tolua_lerror;
 	}
 
 	{
-		const cItemGrid * self = static_cast<const cItemGrid *>(tolua_tousertype(L, 1, nullptr));
-		int SlotNum = static_cast<int>(tolua_tonumber(L, 2, 0));
+		const cItemGrid * self = static_cast<const cItemGrid *>(tolua_tousertype(a_L, 1, nullptr));
+		int SlotNum = static_cast<int>(tolua_tonumber(a_L, 2, 0));
 		if (self == nullptr)
 		{
-			tolua_error(L, "invalid 'self' in function 'cItemGrid:GetSlotCoords'", nullptr);
+			tolua_error(a_L, "invalid 'self' in function 'cItemGrid:GetSlotCoords'", nullptr);
 			return 0;
 		}
 		int X, Y;
 		self->GetSlotCoords(SlotNum, X, Y);
-		tolua_pushnumber(L, static_cast<lua_Number>(X));
-		tolua_pushnumber(L, static_cast<lua_Number>(Y));
+		tolua_pushnumber(a_L, static_cast<lua_Number>(X));
+		tolua_pushnumber(a_L, static_cast<lua_Number>(Y));
 		return 2;
 	}
 
 tolua_lerror:
-	tolua_error(L, "#ferror in function 'cItemGrid:GetSlotCoords'.", &tolua_err);
+	tolua_error(a_L, "#ferror in function 'cItemGrid:GetSlotCoords'.", &tolua_err);
 	return 0;
 }
 
@@ -2900,7 +2900,7 @@ protected:
 
 
 
-static int tolua_cLineBlockTracer_FirstSolidHitTrace(lua_State * tolua_S)
+static int tolua_cLineBlockTracer_FirstSolidHitTrace(lua_State * a_tolua_S)
 {
 	/* Supported function signatures:
 	cLineBlockTracer:FirstSolidHitTrace(World, StartX, StartY, StartZ, EndX, EndY, EndZ) -> bool, [Vector3d, Vector3i, eBlockFace]  // Canonical
@@ -2912,13 +2912,13 @@ static int tolua_cLineBlockTracer_FirstSolidHitTrace(lua_State * tolua_S)
 	// If the first param is the cLineBlockTracer class, shift param index by one:
 	int idx = 1;
 	tolua_Error err;
-	if (tolua_isusertable(tolua_S, 1, "cLineBlockTracer", 0, &err))
+	if (tolua_isusertable(a_tolua_S, 1, "cLineBlockTracer", 0, &err))
 	{
 		idx = 2;
 	}
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(idx, "cWorld")
 	)
@@ -3006,7 +3006,7 @@ static int tolua_cLineBlockTracer_FirstSolidHitTrace(lua_State * tolua_S)
 
 
 
-static int tolua_cLineBlockTracer_LineOfSightTrace(lua_State * tolua_S)
+static int tolua_cLineBlockTracer_LineOfSightTrace(lua_State * a_tolua_S)
 {
 	/* Supported function signatures:
 	cLineBlockTracer:LineOfSightTrace(World, StartX, StartY, StartZ, EndX, EndY, EndZ, Sight) -> bool  // Canonical
@@ -3018,13 +3018,13 @@ static int tolua_cLineBlockTracer_LineOfSightTrace(lua_State * tolua_S)
 	// If the first param is the cLineBlockTracer class, shift param index by one:
 	int idx = 1;
 	tolua_Error err;
-	if (tolua_isusertable(tolua_S, 1, "cLineBlockTracer", 0, &err))
+	if (tolua_isusertable(a_tolua_S, 1, "cLineBlockTracer", 0, &err))
 	{
 		idx = 2;
 	}
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(idx, "cWorld")
 	)
@@ -3096,7 +3096,7 @@ static int tolua_cLineBlockTracer_LineOfSightTrace(lua_State * tolua_S)
 
 
 
-static int tolua_cLineBlockTracer_Trace(lua_State * tolua_S)
+static int tolua_cLineBlockTracer_Trace(lua_State * a_tolua_S)
 {
 	/* Supported function signatures:
 	cLineBlockTracer:Trace(World, Callbacks, StartX, StartY, StartZ, EndX, EndY, EndZ)  // Canonical
@@ -3106,13 +3106,13 @@ static int tolua_cLineBlockTracer_Trace(lua_State * tolua_S)
 	// If the first param is the cLineBlockTracer class, shift param index by one:
 	int idx = 1;
 	tolua_Error err;
-	if (tolua_isusertable(tolua_S, 1, "cLineBlockTracer", 0, &err))
+	if (tolua_isusertable(a_tolua_S, 1, "cLineBlockTracer", 0, &err))
 	{
 		idx = 2;
 	}
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(idx, "cWorld") ||
 		!L.CheckParamTable   (idx + 1) ||
@@ -3147,13 +3147,13 @@ static int tolua_cLineBlockTracer_Trace(lua_State * tolua_S)
 
 
 
-static int tolua_cLuaWindow_new(lua_State * tolua_S)
+static int tolua_cLuaWindow_new(lua_State * a_tolua_S)
 {
 	// Function signature:
 	// cLuaWindow:new(type, slotsX, slotsY, title)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cLuaWindow") ||
 		!L.CheckParamNumber(2, 4) ||
@@ -3183,13 +3183,13 @@ static int tolua_cLuaWindow_new(lua_State * tolua_S)
 
 
 
-static int tolua_cLuaWindow_new_local(lua_State * tolua_S)
+static int tolua_cLuaWindow_new_local(lua_State * a_tolua_S)
 {
 	// Function signature:
 	// cLuaWindow:new(type, slotsX, slotsY, title)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cLuaWindow") ||
 		!L.CheckParamNumber(2, 4) ||
@@ -3212,7 +3212,7 @@ static int tolua_cLuaWindow_new_local(lua_State * tolua_S)
 
 	// Create the window, register it for GC and return it:
 	L.Push(new cLuaWindow(L, static_cast<cLuaWindow::WindowType>(windowType), slotsX, slotsY, title));
-	tolua_register_gc(tolua_S, lua_gettop(tolua_S));
+	tolua_register_gc(a_tolua_S, lua_gettop(a_tolua_S));
 	return 1;
 }
 
@@ -3220,10 +3220,10 @@ static int tolua_cLuaWindow_new_local(lua_State * tolua_S)
 
 
 
-static int tolua_cRoot_DoWithPlayerByUUID(lua_State * tolua_S)
+static int tolua_cRoot_DoWithPlayerByUUID(lua_State * a_tolua_S)
 {
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamSelf("cRoot") ||
 		!L.CheckParamUUID(2) ||
@@ -3267,9 +3267,9 @@ static int tolua_cRoot_DoWithPlayerByUUID(lua_State * tolua_S)
 
 
 
-static int tolua_cRoot_GetBuildCommitID(lua_State * tolua_S)
+static int tolua_cRoot_GetBuildCommitID(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	L.Push(BUILD_COMMIT_ID);
 	return 1;
 }
@@ -3278,9 +3278,9 @@ static int tolua_cRoot_GetBuildCommitID(lua_State * tolua_S)
 
 
 
-static int tolua_cRoot_GetBuildDateTime(lua_State * tolua_S)
+static int tolua_cRoot_GetBuildDateTime(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	L.Push(BUILD_DATETIME);
 	return 1;
 }
@@ -3289,9 +3289,9 @@ static int tolua_cRoot_GetBuildDateTime(lua_State * tolua_S)
 
 
 
-static int tolua_cRoot_GetBuildID(lua_State * tolua_S)
+static int tolua_cRoot_GetBuildID(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	L.Push(BUILD_ID);
 	return 1;
 }
@@ -3300,9 +3300,9 @@ static int tolua_cRoot_GetBuildID(lua_State * tolua_S)
 
 
 
-static int tolua_cRoot_GetBuildSeriesName(lua_State * tolua_S)
+static int tolua_cRoot_GetBuildSeriesName(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	L.Push(BUILD_SERIES_NAME);
 	return 1;
 }
@@ -3311,9 +3311,9 @@ static int tolua_cRoot_GetBuildSeriesName(lua_State * tolua_S)
 
 
 
-static int tolua_cRoot_GetBrewingRecipe(lua_State * tolua_S)
+static int tolua_cRoot_GetBrewingRecipe(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cRoot") ||
 		!L.CheckParamUserType (2, "const cItem") ||
@@ -3360,9 +3360,9 @@ static int tolua_cRoot_GetBrewingRecipe(lua_State * tolua_S)
 
 
 
-static int tolua_cRoot_GetFurnaceRecipe(lua_State * tolua_S)
+static int tolua_cRoot_GetFurnaceRecipe(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserTable(1, "cRoot") ||
 		!L.CheckParamUserType (2, "const cItem") ||
@@ -3430,9 +3430,9 @@ static int tolua_cServer_RegisterForgeMod(lua_State * a_LuaState)
 
 
 
-static int tolua_cScoreboard_GetTeamNames(lua_State * L)
+static int tolua_cScoreboard_GetTeamNames(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserType(1, "cScoreboard") ||
 		!S.CheckParamEnd(2)
@@ -3442,7 +3442,7 @@ static int tolua_cScoreboard_GetTeamNames(lua_State * L)
 	}
 
 	// Get the groups:
-	cScoreboard * Scoreboard = static_cast<cScoreboard *>(tolua_tousertype(L, 1, nullptr));
+	cScoreboard * Scoreboard = static_cast<cScoreboard *>(tolua_tousertype(a_L, 1, nullptr));
 	AStringVector Teams = Scoreboard->GetTeamNames();
 
 	// Push the results:
@@ -3454,12 +3454,12 @@ static int tolua_cScoreboard_GetTeamNames(lua_State * L)
 
 
 
-static int tolua_cHopperEntity_GetOutputBlockPos(lua_State * tolua_S)
+static int tolua_cHopperEntity_GetOutputBlockPos(lua_State * a_tolua_S)
 {
 	// function cHopperEntity::GetOutputBlockPos()
 	// Exported manually because tolua would require meaningless params
 
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cHopperEntity") ||
 		!L.CheckParamNumber  (2) ||
@@ -3468,22 +3468,22 @@ static int tolua_cHopperEntity_GetOutputBlockPos(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cHopperEntity * self = static_cast<cHopperEntity *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cHopperEntity * self = static_cast<cHopperEntity *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cHopperEntity::GetOutputBlockPos()'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cHopperEntity::GetOutputBlockPos()'", nullptr);
 		return 0;
 	}
 
-	NIBBLETYPE a_BlockMeta = static_cast<NIBBLETYPE>(tolua_tonumber(tolua_S, 2, 0));
+	NIBBLETYPE a_BlockMeta = static_cast<NIBBLETYPE>(tolua_tonumber(a_tolua_S, 2, 0));
 	int a_OutputX, a_OutputY, a_OutputZ;
 	bool res = self->GetOutputBlockPos(a_BlockMeta, a_OutputX, a_OutputY, a_OutputZ);
-	tolua_pushboolean(tolua_S, res);
+	tolua_pushboolean(a_tolua_S, res);
 	if (res)
 	{
-		tolua_pushnumber(tolua_S, static_cast<lua_Number>(a_OutputX));
-		tolua_pushnumber(tolua_S, static_cast<lua_Number>(a_OutputY));
-		tolua_pushnumber(tolua_S, static_cast<lua_Number>(a_OutputZ));
+		tolua_pushnumber(a_tolua_S, static_cast<lua_Number>(a_OutputX));
+		tolua_pushnumber(a_tolua_S, static_cast<lua_Number>(a_OutputY));
+		tolua_pushnumber(a_tolua_S, static_cast<lua_Number>(a_OutputZ));
 		return 4;
 	}
 	return 1;
@@ -3593,9 +3593,9 @@ static int tolua_cChunkDesc_GetBlockTypeMeta(lua_State * a_LuaState)
 
 
 
-static int tolua_cColor_GetColor(lua_State * tolua_S)
+static int tolua_cColor_GetColor(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 
 	cColor * self;
 	if (!L.CheckParamSelf("cColor") || !L.GetStackValue(1, self))
@@ -3674,13 +3674,13 @@ static int tolua_cCompositeChat_new_local(lua_State * a_LuaState)
 
 
 
-static int tolua_cCompositeChat_AddRunCommandPart(lua_State * tolua_S)
+static int tolua_cCompositeChat_AddRunCommandPart(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:AddRunCommandPart(Message, Command, [Style])
 	// Exported manually to support call-chaining (return *this)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cCompositeChat") ||
 		!L.CheckParamString(2, 3)
@@ -3688,10 +3688,10 @@ static int tolua_cCompositeChat_AddRunCommandPart(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:AddRunCommandPart'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:AddRunCommandPart'", nullptr);
 		return 0;
 	}
 
@@ -3711,13 +3711,13 @@ static int tolua_cCompositeChat_AddRunCommandPart(lua_State * tolua_S)
 
 
 
-static int tolua_cCompositeChat_AddSuggestCommandPart(lua_State * tolua_S)
+static int tolua_cCompositeChat_AddSuggestCommandPart(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:AddSuggestCommandPart(Message, Command, [Style])
 	// Exported manually to support call-chaining (return *this)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cCompositeChat") ||
 		!L.CheckParamString(2, 3)
@@ -3725,10 +3725,10 @@ static int tolua_cCompositeChat_AddSuggestCommandPart(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:AddSuggestCommandPart'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:AddSuggestCommandPart'", nullptr);
 		return 0;
 	}
 
@@ -3748,13 +3748,13 @@ static int tolua_cCompositeChat_AddSuggestCommandPart(lua_State * tolua_S)
 
 
 
-static int tolua_cCompositeChat_AddTextPart(lua_State * tolua_S)
+static int tolua_cCompositeChat_AddTextPart(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:AddTextPart(Message, [Style])
 	// Exported manually to support call-chaining (return *this)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cCompositeChat") ||
 		!L.CheckParamString(2)
@@ -3762,10 +3762,10 @@ static int tolua_cCompositeChat_AddTextPart(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:AddTextPart'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:AddTextPart'", nullptr);
 		return 0;
 	}
 
@@ -3784,13 +3784,13 @@ static int tolua_cCompositeChat_AddTextPart(lua_State * tolua_S)
 
 
 
-static int tolua_cCompositeChat_AddUrlPart(lua_State * tolua_S)
+static int tolua_cCompositeChat_AddUrlPart(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:AddTextPart(Message, Url, [Style])
 	// Exported manually to support call-chaining (return *this)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cCompositeChat") ||
 		!L.CheckParamString(2, 3)
@@ -3798,10 +3798,10 @@ static int tolua_cCompositeChat_AddUrlPart(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:AddUrlPart'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:AddUrlPart'", nullptr);
 		return 0;
 	}
 
@@ -3821,13 +3821,13 @@ static int tolua_cCompositeChat_AddUrlPart(lua_State * tolua_S)
 
 
 
-static int tolua_cCompositeChat_Clear(lua_State * tolua_S)
+static int tolua_cCompositeChat_Clear(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:Clear()
 	// Exported manually to support call-chaining (return *this)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cCompositeChat") ||
 		!L.CheckParamEnd(2)
@@ -3835,10 +3835,10 @@ static int tolua_cCompositeChat_Clear(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:ParseText'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:ParseText'", nullptr);
 		return 0;
 	}
 
@@ -3854,13 +3854,13 @@ static int tolua_cCompositeChat_Clear(lua_State * tolua_S)
 
 
 
-static int tolua_cCompositeChat_ParseText(lua_State * tolua_S)
+static int tolua_cCompositeChat_ParseText(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:ParseText(TextMessage)
 	// Exported manually to support call-chaining (return *this)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cCompositeChat") ||
 		!L.CheckParamString(2)
@@ -3868,10 +3868,10 @@ static int tolua_cCompositeChat_ParseText(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:ParseText'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:ParseText'", nullptr);
 		return 0;
 	}
 
@@ -3889,13 +3889,13 @@ static int tolua_cCompositeChat_ParseText(lua_State * tolua_S)
 
 
 
-static int tolua_cCompositeChat_SetMessageType(lua_State * tolua_S)
+static int tolua_cCompositeChat_SetMessageType(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:SetMessageType(MessageType)
 	// Exported manually to support call-chaining (return *this)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cCompositeChat") ||
 		!L.CheckParamNumber(2)
@@ -3903,10 +3903,10 @@ static int tolua_cCompositeChat_SetMessageType(lua_State * tolua_S)
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:SetMessageType'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:SetMessageType'", nullptr);
 		return 0;
 	}
 
@@ -3924,21 +3924,21 @@ static int tolua_cCompositeChat_SetMessageType(lua_State * tolua_S)
 
 
 
-static int tolua_cCompositeChat_UnderlineUrls(lua_State * tolua_S)
+static int tolua_cCompositeChat_UnderlineUrls(lua_State * a_tolua_S)
 {
 	// function cCompositeChat:UnderlineUrls()
 	// Exported manually to support call-chaining (return self)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamUserType(1, "cCompositeChat"))
 	{
 		return 0;
 	}
-	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cCompositeChat * self = static_cast<cCompositeChat *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "invalid 'self' in function 'cCompositeChat:UnderlineUrls'", nullptr);
+		tolua_error(a_tolua_S, "invalid 'self' in function 'cCompositeChat:UnderlineUrls'", nullptr);
 		return 0;
 	}
 
@@ -3954,10 +3954,10 @@ static int tolua_cCompositeChat_UnderlineUrls(lua_State * tolua_S)
 
 
 
-static int tolua_cEntity_IsSubmerged(lua_State * tolua_S)
+static int tolua_cEntity_IsSubmerged(lua_State * a_tolua_S)
 {
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("cEntity"))
 	{
 		return 0;
@@ -3969,7 +3969,7 @@ static int tolua_cEntity_IsSubmerged(lua_State * tolua_S)
 
 	// API function deprecated:
 	LOGWARNING("cEntity:IsSubmerged() is deprecated. Use cEntity:IsHeadInWater() instead.");
-	cLuaState::LogStackTrace(tolua_S);
+	cLuaState::LogStackTrace(a_tolua_S);
 
 	L.Push(self->IsHeadInWater());
 	return 1;
@@ -3979,10 +3979,10 @@ static int tolua_cEntity_IsSubmerged(lua_State * tolua_S)
 
 
 
-static int tolua_cEntity_IsSwimming(lua_State * tolua_S)
+static int tolua_cEntity_IsSwimming(lua_State * a_tolua_S)
 {
 	// Check the params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (!L.CheckParamSelf("cEntity"))
 	{
 		return 0;
@@ -3994,7 +3994,7 @@ static int tolua_cEntity_IsSwimming(lua_State * tolua_S)
 
 	// API function deprecated
 	LOGWARNING("cEntity:IsSwimming() is deprecated. Use cEntity:IsInWater() instead.");
-	cLuaState::LogStackTrace(tolua_S);
+	cLuaState::LogStackTrace(a_tolua_S);
 
 	L.Push(self->IsInWater());
 	return 1;
@@ -4004,12 +4004,12 @@ static int tolua_cEntity_IsSwimming(lua_State * tolua_S)
 
 
 
-static int tolua_cEntity_GetPosition(lua_State * tolua_S)
+static int tolua_cEntity_GetPosition(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 
 	// Get the params:
-	cEntity * self = static_cast<cEntity *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cEntity * self = static_cast<cEntity *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
 		LOGWARNING("%s: invalid self (%p)", __FUNCTION__, static_cast<void *>(self));
@@ -4026,12 +4026,12 @@ static int tolua_cEntity_GetPosition(lua_State * tolua_S)
 
 
 
-static int tolua_cEntity_GetSpeed(lua_State * tolua_S)
+static int tolua_cEntity_GetSpeed(lua_State * a_tolua_S)
 {
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 
 	// Get the params:
-	cEntity * self = static_cast<cEntity *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cEntity * self = static_cast<cEntity *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (self == nullptr)
 	{
 		LOGWARNING("%s: invalid self (%p)", __FUNCTION__, static_cast<void *>(self));
@@ -4048,245 +4048,245 @@ static int tolua_cEntity_GetSpeed(lua_State * tolua_S)
 
 
 
-void cManualBindings::Bind(lua_State * tolua_S)
+void cManualBindings::Bind(lua_State * a_tolua_S)
 {
-	tolua_beginmodule(tolua_S, nullptr);
+	tolua_beginmodule(a_tolua_S, nullptr);
 
 		// Create the new classes:
-		tolua_usertype(tolua_S, "cCryptoHash");
-		tolua_usertype(tolua_S, "cLineBlockTracer");
-		tolua_usertype(tolua_S, "cStringCompression");
-		tolua_usertype(tolua_S, "cUrlParser");
-		tolua_cclass(tolua_S, "cCryptoHash",        "cCryptoHash",        "", nullptr);
-		tolua_cclass(tolua_S, "cLineBlockTracer",   "cLineBlockTracer",   "", nullptr);
-		tolua_cclass(tolua_S, "cStringCompression", "cStringCompression", "", nullptr);
-		tolua_cclass(tolua_S, "cUrlParser",         "cUrlParser",         "", nullptr);
+		tolua_usertype(a_tolua_S, "cCryptoHash");
+		tolua_usertype(a_tolua_S, "cLineBlockTracer");
+		tolua_usertype(a_tolua_S, "cStringCompression");
+		tolua_usertype(a_tolua_S, "cUrlParser");
+		tolua_cclass(a_tolua_S, "cCryptoHash",        "cCryptoHash",        "", nullptr);
+		tolua_cclass(a_tolua_S, "cLineBlockTracer",   "cLineBlockTracer",   "", nullptr);
+		tolua_cclass(a_tolua_S, "cStringCompression", "cStringCompression", "", nullptr);
+		tolua_cclass(a_tolua_S, "cUrlParser",         "cUrlParser",         "", nullptr);
 
 		// Globals:
-		tolua_function(tolua_S, "Clamp",                 tolua_Clamp);
-		tolua_function(tolua_S, "StringSplit",           tolua_StringSplit);
-		tolua_function(tolua_S, "StringSplitWithQuotes", tolua_StringSplitWithQuotes);
-		tolua_function(tolua_S, "StringSplitAndTrim",    tolua_StringSplitAndTrim);
-		tolua_function(tolua_S, "LOG",                   tolua_LOG);
-		tolua_function(tolua_S, "LOGINFO",               tolua_LOGINFO);
-		tolua_function(tolua_S, "LOGWARN",               tolua_LOGWARN);
-		tolua_function(tolua_S, "LOGWARNING",            tolua_LOGWARN);
-		tolua_function(tolua_S, "LOGERROR",              tolua_LOGERROR);
-		tolua_function(tolua_S, "Base64Encode",          tolua_Base64Encode);
-		tolua_function(tolua_S, "Base64Decode",          tolua_Base64Decode);
-		tolua_function(tolua_S, "md5",                   tolua_md5_obsolete);  // OBSOLETE, use cCryptoHash.md5() instead
+		tolua_function(a_tolua_S, "Clamp",                 tolua_Clamp);
+		tolua_function(a_tolua_S, "StringSplit",           tolua_StringSplit);
+		tolua_function(a_tolua_S, "StringSplitWithQuotes", tolua_StringSplitWithQuotes);
+		tolua_function(a_tolua_S, "StringSplitAndTrim",    tolua_StringSplitAndTrim);
+		tolua_function(a_tolua_S, "LOG",                   tolua_LOG);
+		tolua_function(a_tolua_S, "LOGINFO",               tolua_LOGINFO);
+		tolua_function(a_tolua_S, "LOGWARN",               tolua_LOGWARN);
+		tolua_function(a_tolua_S, "LOGWARNING",            tolua_LOGWARN);
+		tolua_function(a_tolua_S, "LOGERROR",              tolua_LOGERROR);
+		tolua_function(a_tolua_S, "Base64Encode",          tolua_Base64Encode);
+		tolua_function(a_tolua_S, "Base64Decode",          tolua_Base64Decode);
+		tolua_function(a_tolua_S, "md5",                   tolua_md5_obsolete);  // OBSOLETE, use cCryptoHash.md5() instead
 
-		tolua_beginmodule(tolua_S, "cBoundingBox");
-			tolua_function(tolua_S, "CalcLineIntersection", tolua_cBoundingBox_CalcLineIntersection);
-			tolua_function(tolua_S, "Intersect",            tolua_cBoundingBox_Intersect);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cBoundingBox");
+			tolua_function(a_tolua_S, "CalcLineIntersection", tolua_cBoundingBox_CalcLineIntersection);
+			tolua_function(a_tolua_S, "Intersect",            tolua_cBoundingBox_Intersect);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cChunkDesc");
-			tolua_function(tolua_S, "GetBlockTypeMeta", tolua_cChunkDesc_GetBlockTypeMeta);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cChunkDesc");
+			tolua_function(a_tolua_S, "GetBlockTypeMeta", tolua_cChunkDesc_GetBlockTypeMeta);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cClientHandle");
-			tolua_constant(tolua_S, "MAX_VIEW_DISTANCE",   cClientHandle::MAX_VIEW_DISTANCE);
-			tolua_constant(tolua_S, "MIN_VIEW_DISTANCE",   cClientHandle::MIN_VIEW_DISTANCE);
+		tolua_beginmodule(a_tolua_S, "cClientHandle");
+			tolua_constant(a_tolua_S, "MAX_VIEW_DISTANCE",   cClientHandle::MAX_VIEW_DISTANCE);
+			tolua_constant(a_tolua_S, "MIN_VIEW_DISTANCE",   cClientHandle::MIN_VIEW_DISTANCE);
 
-			tolua_function(tolua_S, "GetForgeMods", tolua_cClientHandle_GetForgeMods);
-			tolua_function(tolua_S, "SendPluginMessage",   tolua_cClientHandle_SendPluginMessage);
-			tolua_function(tolua_S, "GetUUID",             tolua_cClientHandle_GetUUID);
-			tolua_function(tolua_S, "GenerateOfflineUUID", tolua_cClientHandle_GenerateOfflineUUID);
-			tolua_function(tolua_S, "IsUUIDOnline",        tolua_cClientHandle_IsUUIDOnline);
-		tolua_endmodule(tolua_S);
+			tolua_function(a_tolua_S, "GetForgeMods", tolua_cClientHandle_GetForgeMods);
+			tolua_function(a_tolua_S, "SendPluginMessage",   tolua_cClientHandle_SendPluginMessage);
+			tolua_function(a_tolua_S, "GetUUID",             tolua_cClientHandle_GetUUID);
+			tolua_function(a_tolua_S, "GenerateOfflineUUID", tolua_cClientHandle_GenerateOfflineUUID);
+			tolua_function(a_tolua_S, "IsUUIDOnline",        tolua_cClientHandle_IsUUIDOnline);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cColor");
-			tolua_function(tolua_S, "GetColor", tolua_cColor_GetColor);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cColor");
+			tolua_function(a_tolua_S, "GetColor", tolua_cColor_GetColor);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cCompositeChat");
-			tolua_function(tolua_S, "new",                   tolua_cCompositeChat_new);
-			tolua_function(tolua_S, "new_local",             tolua_cCompositeChat_new_local);
-			tolua_function(tolua_S, ".call",                 tolua_cCompositeChat_new_local);
-			tolua_function(tolua_S, "AddRunCommandPart",     tolua_cCompositeChat_AddRunCommandPart);
-			tolua_function(tolua_S, "AddSuggestCommandPart", tolua_cCompositeChat_AddSuggestCommandPart);
-			tolua_function(tolua_S, "AddTextPart",           tolua_cCompositeChat_AddTextPart);
-			tolua_function(tolua_S, "AddUrlPart",            tolua_cCompositeChat_AddUrlPart);
-			tolua_function(tolua_S, "Clear",                 tolua_cCompositeChat_Clear);
-			tolua_function(tolua_S, "ParseText",             tolua_cCompositeChat_ParseText);
-			tolua_function(tolua_S, "SetMessageType",        tolua_cCompositeChat_SetMessageType);
-			tolua_function(tolua_S, "UnderlineUrls",         tolua_cCompositeChat_UnderlineUrls);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cCompositeChat");
+			tolua_function(a_tolua_S, "new",                   tolua_cCompositeChat_new);
+			tolua_function(a_tolua_S, "new_local",             tolua_cCompositeChat_new_local);
+			tolua_function(a_tolua_S, ".call",                 tolua_cCompositeChat_new_local);
+			tolua_function(a_tolua_S, "AddRunCommandPart",     tolua_cCompositeChat_AddRunCommandPart);
+			tolua_function(a_tolua_S, "AddSuggestCommandPart", tolua_cCompositeChat_AddSuggestCommandPart);
+			tolua_function(a_tolua_S, "AddTextPart",           tolua_cCompositeChat_AddTextPart);
+			tolua_function(a_tolua_S, "AddUrlPart",            tolua_cCompositeChat_AddUrlPart);
+			tolua_function(a_tolua_S, "Clear",                 tolua_cCompositeChat_Clear);
+			tolua_function(a_tolua_S, "ParseText",             tolua_cCompositeChat_ParseText);
+			tolua_function(a_tolua_S, "SetMessageType",        tolua_cCompositeChat_SetMessageType);
+			tolua_function(a_tolua_S, "UnderlineUrls",         tolua_cCompositeChat_UnderlineUrls);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cCryptoHash");
-			tolua_function(tolua_S, "md5", tolua_md5);
-			tolua_function(tolua_S, "md5HexString", tolua_md5HexString);
-			tolua_function(tolua_S, "sha1", tolua_sha1);
-			tolua_function(tolua_S, "sha1HexString", tolua_sha1HexString);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cCryptoHash");
+			tolua_function(a_tolua_S, "md5", tolua_md5);
+			tolua_function(a_tolua_S, "md5HexString", tolua_md5HexString);
+			tolua_function(a_tolua_S, "sha1", tolua_sha1);
+			tolua_function(a_tolua_S, "sha1HexString", tolua_sha1HexString);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cEntity");
-			tolua_constant(tolua_S, "INVALID_ID", cEntity::INVALID_ID);
-			tolua_function(tolua_S, "IsSubmerged", tolua_cEntity_IsSubmerged);
-			tolua_function(tolua_S, "IsSwimming", tolua_cEntity_IsSwimming);
-			tolua_function(tolua_S, "GetPosition", tolua_cEntity_GetPosition);
-			tolua_function(tolua_S, "GetSpeed", tolua_cEntity_GetSpeed);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cEntity");
+			tolua_constant(a_tolua_S, "INVALID_ID", cEntity::INVALID_ID);
+			tolua_function(a_tolua_S, "IsSubmerged", tolua_cEntity_IsSubmerged);
+			tolua_function(a_tolua_S, "IsSwimming", tolua_cEntity_IsSwimming);
+			tolua_function(a_tolua_S, "GetPosition", tolua_cEntity_GetPosition);
+			tolua_function(a_tolua_S, "GetSpeed", tolua_cEntity_GetSpeed);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cFile");
-			tolua_function(tolua_S, "ChangeFileExt",           tolua_cFile_ChangeFileExt);
-			tolua_function(tolua_S, "Copy",                    tolua_cFile_Copy);
-			tolua_function(tolua_S, "CreateFolder",            tolua_cFile_CreateFolder);
-			tolua_function(tolua_S, "CreateFolderRecursive",   tolua_cFile_CreateFolderRecursive);
-			tolua_function(tolua_S, "Delete",                  tolua_cFile_Delete);
-			tolua_function(tolua_S, "DeleteFile",              tolua_cFile_DeleteFile);
-			tolua_function(tolua_S, "DeleteFolder",            tolua_cFile_DeleteFolder);
-			tolua_function(tolua_S, "DeleteFolderContents",    tolua_cFile_DeleteFolderContents);
-			tolua_function(tolua_S, "Exists",                  tolua_cFile_Exists);
-			tolua_function(tolua_S, "GetFolderContents",       tolua_cFile_GetFolderContents);
-			tolua_function(tolua_S, "GetLastModificationTime", tolua_cFile_GetLastModificationTime);
-			tolua_function(tolua_S, "GetSize",                 tolua_cFile_GetSize);
-			tolua_function(tolua_S, "IsFile",                  tolua_cFile_IsFile);
-			tolua_function(tolua_S, "IsFolder",                tolua_cFile_IsFolder);
-			tolua_function(tolua_S, "ReadWholeFile",           tolua_cFile_ReadWholeFile);
-			tolua_function(tolua_S, "Rename",                  tolua_cFile_Rename);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cFile");
+			tolua_function(a_tolua_S, "ChangeFileExt",           tolua_cFile_ChangeFileExt);
+			tolua_function(a_tolua_S, "Copy",                    tolua_cFile_Copy);
+			tolua_function(a_tolua_S, "CreateFolder",            tolua_cFile_CreateFolder);
+			tolua_function(a_tolua_S, "CreateFolderRecursive",   tolua_cFile_CreateFolderRecursive);
+			tolua_function(a_tolua_S, "Delete",                  tolua_cFile_Delete);
+			tolua_function(a_tolua_S, "DeleteFile",              tolua_cFile_DeleteFile);
+			tolua_function(a_tolua_S, "DeleteFolder",            tolua_cFile_DeleteFolder);
+			tolua_function(a_tolua_S, "DeleteFolderContents",    tolua_cFile_DeleteFolderContents);
+			tolua_function(a_tolua_S, "Exists",                  tolua_cFile_Exists);
+			tolua_function(a_tolua_S, "GetFolderContents",       tolua_cFile_GetFolderContents);
+			tolua_function(a_tolua_S, "GetLastModificationTime", tolua_cFile_GetLastModificationTime);
+			tolua_function(a_tolua_S, "GetSize",                 tolua_cFile_GetSize);
+			tolua_function(a_tolua_S, "IsFile",                  tolua_cFile_IsFile);
+			tolua_function(a_tolua_S, "IsFolder",                tolua_cFile_IsFolder);
+			tolua_function(a_tolua_S, "ReadWholeFile",           tolua_cFile_ReadWholeFile);
+			tolua_function(a_tolua_S, "Rename",                  tolua_cFile_Rename);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cHopperEntity");
-			tolua_function(tolua_S, "GetOutputBlockPos", tolua_cHopperEntity_GetOutputBlockPos);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cHopperEntity");
+			tolua_function(a_tolua_S, "GetOutputBlockPos", tolua_cHopperEntity_GetOutputBlockPos);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cItem");
-			tolua_variable(tolua_S, "m_LoreTable", tolua_get_cItem_m_LoreTable, tolua_set_cItem_m_LoreTable);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cItem");
+			tolua_variable(a_tolua_S, "m_LoreTable", tolua_get_cItem_m_LoreTable, tolua_set_cItem_m_LoreTable);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cItemGrid");
-			tolua_function(tolua_S, "GetSlotCoords", Lua_ItemGrid_GetSlotCoords);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cItemGrid");
+			tolua_function(a_tolua_S, "GetSlotCoords", Lua_ItemGrid_GetSlotCoords);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cLineBlockTracer");
-			tolua_function(tolua_S, "FirstSolidHitTrace", tolua_cLineBlockTracer_FirstSolidHitTrace);
-			tolua_function(tolua_S, "LineOfSightTrace",   tolua_cLineBlockTracer_LineOfSightTrace);
-			tolua_function(tolua_S, "Trace",              tolua_cLineBlockTracer_Trace);
+		tolua_beginmodule(a_tolua_S, "cLineBlockTracer");
+			tolua_function(a_tolua_S, "FirstSolidHitTrace", tolua_cLineBlockTracer_FirstSolidHitTrace);
+			tolua_function(a_tolua_S, "LineOfSightTrace",   tolua_cLineBlockTracer_LineOfSightTrace);
+			tolua_function(a_tolua_S, "Trace",              tolua_cLineBlockTracer_Trace);
 
-			tolua_constant(tolua_S, "losAir",   cLineBlockTracer::losAir);
-			tolua_constant(tolua_S, "losWater", cLineBlockTracer::losWater);
-			tolua_constant(tolua_S, "losLava",  cLineBlockTracer::losLava);
-		tolua_endmodule(tolua_S);
+			tolua_constant(a_tolua_S, "losAir",   cLineBlockTracer::losAir);
+			tolua_constant(a_tolua_S, "losWater", cLineBlockTracer::losWater);
+			tolua_constant(a_tolua_S, "losLava",  cLineBlockTracer::losLava);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cLuaWindow");
-			tolua_function(tolua_S, "new",              tolua_cLuaWindow_new);
-			tolua_function(tolua_S, "new_local",        tolua_cLuaWindow_new_local);
-			tolua_function(tolua_S, ".call",            tolua_cLuaWindow_new_local);
-			tolua_function(tolua_S, "SetOnClicked",     tolua_SetObjectCallback<cLuaWindow, &cLuaWindow::SetOnClicked>);
-			tolua_function(tolua_S, "SetOnClosing",     tolua_SetObjectCallback<cLuaWindow, &cLuaWindow::SetOnClosing>);
-			tolua_function(tolua_S, "SetOnSlotChanged", tolua_SetObjectCallback<cLuaWindow, &cLuaWindow::SetOnSlotChanged>);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cLuaWindow");
+			tolua_function(a_tolua_S, "new",              tolua_cLuaWindow_new);
+			tolua_function(a_tolua_S, "new_local",        tolua_cLuaWindow_new_local);
+			tolua_function(a_tolua_S, ".call",            tolua_cLuaWindow_new_local);
+			tolua_function(a_tolua_S, "SetOnClicked",     tolua_SetObjectCallback<cLuaWindow, &cLuaWindow::SetOnClicked>);
+			tolua_function(a_tolua_S, "SetOnClosing",     tolua_SetObjectCallback<cLuaWindow, &cLuaWindow::SetOnClosing>);
+			tolua_function(a_tolua_S, "SetOnSlotChanged", tolua_SetObjectCallback<cLuaWindow, &cLuaWindow::SetOnSlotChanged>);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cMapManager");
-			tolua_function(tolua_S, "DoWithMap", DoWithID<cMapManager, cMap, &cMapManager::DoWithMap>);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cMapManager");
+			tolua_function(a_tolua_S, "DoWithMap", DoWithID<cMapManager, cMap, &cMapManager::DoWithMap>);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cMobHeadEntity");
-			tolua_function(tolua_S, "SetOwner",     tolua_cMobHeadEntity_SetOwner);
-			tolua_function(tolua_S, "GetOwnerUUID", tolua_cMobHeadEntity_GetOwnerUUID);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cMobHeadEntity");
+			tolua_function(a_tolua_S, "SetOwner",     tolua_cMobHeadEntity_SetOwner);
+			tolua_function(a_tolua_S, "GetOwnerUUID", tolua_cMobHeadEntity_GetOwnerUUID);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cMojangAPI");
-			tolua_function(tolua_S, "AddPlayerNameToUUIDMapping", tolua_cMojangAPI_AddPlayerNameToUUIDMapping);
-			tolua_function(tolua_S, "GetPlayerNameFromUUID",      tolua_cMojangAPI_GetPlayerNameFromUUID);
-			tolua_function(tolua_S, "GetUUIDFromPlayerName",      tolua_cMojangAPI_GetUUIDFromPlayerName);
-			tolua_function(tolua_S, "GetUUIDsFromPlayerNames",    tolua_cMojangAPI_GetUUIDsFromPlayerNames);
-			tolua_function(tolua_S, "MakeUUIDDashed",             tolua_cMojangAPI_MakeUUIDDashed);
-			tolua_function(tolua_S, "MakeUUIDShort",              tolua_cMojangAPI_MakeUUIDShort);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cMojangAPI");
+			tolua_function(a_tolua_S, "AddPlayerNameToUUIDMapping", tolua_cMojangAPI_AddPlayerNameToUUIDMapping);
+			tolua_function(a_tolua_S, "GetPlayerNameFromUUID",      tolua_cMojangAPI_GetPlayerNameFromUUID);
+			tolua_function(a_tolua_S, "GetUUIDFromPlayerName",      tolua_cMojangAPI_GetUUIDFromPlayerName);
+			tolua_function(a_tolua_S, "GetUUIDsFromPlayerNames",    tolua_cMojangAPI_GetUUIDsFromPlayerNames);
+			tolua_function(a_tolua_S, "MakeUUIDDashed",             tolua_cMojangAPI_MakeUUIDDashed);
+			tolua_function(a_tolua_S, "MakeUUIDShort",              tolua_cMojangAPI_MakeUUIDShort);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cPlayer");
-			tolua_function(tolua_S, "GetPermissions",    tolua_cPlayer_GetPermissions);
-			tolua_function(tolua_S, "GetRestrictions",   tolua_cPlayer_GetRestrictions);
-			tolua_function(tolua_S, "PermissionMatches", tolua_cPlayer_PermissionMatches);
-			tolua_function(tolua_S, "GetUUID",           tolua_cPlayer_GetUUID);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cPlayer");
+			tolua_function(a_tolua_S, "GetPermissions",    tolua_cPlayer_GetPermissions);
+			tolua_function(a_tolua_S, "GetRestrictions",   tolua_cPlayer_GetRestrictions);
+			tolua_function(a_tolua_S, "PermissionMatches", tolua_cPlayer_PermissionMatches);
+			tolua_function(a_tolua_S, "GetUUID",           tolua_cPlayer_GetUUID);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cPlugin");
-			tolua_function(tolua_S, "GetDirectory",      tolua_cPlugin_GetDirectory);
-			tolua_function(tolua_S, "GetLocalDirectory", tolua_cPlugin_GetLocalDirectory);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cPlugin");
+			tolua_function(a_tolua_S, "GetDirectory",      tolua_cPlugin_GetDirectory);
+			tolua_function(a_tolua_S, "GetLocalDirectory", tolua_cPlugin_GetLocalDirectory);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cPluginLua");
-			tolua_function(tolua_S, "AddWebTab", tolua_cPluginLua_AddWebTab);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cPluginLua");
+			tolua_function(a_tolua_S, "AddWebTab", tolua_cPluginLua_AddWebTab);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cPluginManager");
-			tolua_function(tolua_S, "AddHook",               tolua_cPluginManager_AddHook);
-			tolua_function(tolua_S, "BindCommand",           tolua_cPluginManager_BindCommand);
-			tolua_function(tolua_S, "BindConsoleCommand",    tolua_cPluginManager_BindConsoleCommand);
-			tolua_function(tolua_S, "CallPlugin",            tolua_cPluginManager_CallPlugin);
-			tolua_function(tolua_S, "DoWithPlugin",          StaticDoWith<cPluginManager, cPlugin, &cPluginManager::DoWithPlugin>);
-			tolua_function(tolua_S, "ExecuteConsoleCommand", tolua_cPluginManager_ExecuteConsoleCommand);
-			tolua_function(tolua_S, "FindPlugins",           tolua_cPluginManager_FindPlugins);
-			tolua_function(tolua_S, "ForEachCommand",        tolua_cPluginManager_ForEachCommand);
-			tolua_function(tolua_S, "ForEachConsoleCommand", tolua_cPluginManager_ForEachConsoleCommand);
-			tolua_function(tolua_S, "ForEachPlugin",         StaticForEach<cPluginManager, cPlugin, &cPluginManager::ForEachPlugin>);
-			tolua_function(tolua_S, "GetAllPlugins",         tolua_cPluginManager_GetAllPlugins);
-			tolua_function(tolua_S, "GetCurrentPlugin",      tolua_cPluginManager_GetCurrentPlugin);
-			tolua_function(tolua_S, "GetPlugin",             tolua_cPluginManager_GetPlugin);
-			tolua_function(tolua_S, "LogStackTrace",         tolua_cPluginManager_LogStackTrace);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cPluginManager");
+			tolua_function(a_tolua_S, "AddHook",               tolua_cPluginManager_AddHook);
+			tolua_function(a_tolua_S, "BindCommand",           tolua_cPluginManager_BindCommand);
+			tolua_function(a_tolua_S, "BindConsoleCommand",    tolua_cPluginManager_BindConsoleCommand);
+			tolua_function(a_tolua_S, "CallPlugin",            tolua_cPluginManager_CallPlugin);
+			tolua_function(a_tolua_S, "DoWithPlugin",          StaticDoWith<cPluginManager, cPlugin, &cPluginManager::DoWithPlugin>);
+			tolua_function(a_tolua_S, "ExecuteConsoleCommand", tolua_cPluginManager_ExecuteConsoleCommand);
+			tolua_function(a_tolua_S, "FindPlugins",           tolua_cPluginManager_FindPlugins);
+			tolua_function(a_tolua_S, "ForEachCommand",        tolua_cPluginManager_ForEachCommand);
+			tolua_function(a_tolua_S, "ForEachConsoleCommand", tolua_cPluginManager_ForEachConsoleCommand);
+			tolua_function(a_tolua_S, "ForEachPlugin",         StaticForEach<cPluginManager, cPlugin, &cPluginManager::ForEachPlugin>);
+			tolua_function(a_tolua_S, "GetAllPlugins",         tolua_cPluginManager_GetAllPlugins);
+			tolua_function(a_tolua_S, "GetCurrentPlugin",      tolua_cPluginManager_GetCurrentPlugin);
+			tolua_function(a_tolua_S, "GetPlugin",             tolua_cPluginManager_GetPlugin);
+			tolua_function(a_tolua_S, "LogStackTrace",         tolua_cPluginManager_LogStackTrace);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cRoot");
-			tolua_function(tolua_S, "DoWithPlayerByUUID",  tolua_cRoot_DoWithPlayerByUUID);
-			tolua_function(tolua_S, "FindAndDoWithPlayer", DoWith <cRoot, cPlayer, &cRoot::FindAndDoWithPlayer>);
-			tolua_function(tolua_S, "ForEachPlayer",       ForEach<cRoot, cPlayer, &cRoot::ForEachPlayer>);
-			tolua_function(tolua_S, "ForEachWorld",        ForEach<cRoot, cWorld,  &cRoot::ForEachWorld>);
-			tolua_function(tolua_S, "GetBrewingRecipe",    tolua_cRoot_GetBrewingRecipe);
-			tolua_function(tolua_S, "GetBuildCommitID",    tolua_cRoot_GetBuildCommitID);
-			tolua_function(tolua_S, "GetBuildDateTime",    tolua_cRoot_GetBuildDateTime);
-			tolua_function(tolua_S, "GetBuildID",          tolua_cRoot_GetBuildID);
-			tolua_function(tolua_S, "GetBuildSeriesName",  tolua_cRoot_GetBuildSeriesName);
-			tolua_function(tolua_S, "GetFurnaceRecipe",    tolua_cRoot_GetFurnaceRecipe);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cRoot");
+			tolua_function(a_tolua_S, "DoWithPlayerByUUID",  tolua_cRoot_DoWithPlayerByUUID);
+			tolua_function(a_tolua_S, "FindAndDoWithPlayer", DoWith <cRoot, cPlayer, &cRoot::FindAndDoWithPlayer>);
+			tolua_function(a_tolua_S, "ForEachPlayer",       ForEach<cRoot, cPlayer, &cRoot::ForEachPlayer>);
+			tolua_function(a_tolua_S, "ForEachWorld",        ForEach<cRoot, cWorld,  &cRoot::ForEachWorld>);
+			tolua_function(a_tolua_S, "GetBrewingRecipe",    tolua_cRoot_GetBrewingRecipe);
+			tolua_function(a_tolua_S, "GetBuildCommitID",    tolua_cRoot_GetBuildCommitID);
+			tolua_function(a_tolua_S, "GetBuildDateTime",    tolua_cRoot_GetBuildDateTime);
+			tolua_function(a_tolua_S, "GetBuildID",          tolua_cRoot_GetBuildID);
+			tolua_function(a_tolua_S, "GetBuildSeriesName",  tolua_cRoot_GetBuildSeriesName);
+			tolua_function(a_tolua_S, "GetFurnaceRecipe",    tolua_cRoot_GetFurnaceRecipe);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cScoreboard");
-			tolua_function(tolua_S, "ForEachObjective", ForEach<cScoreboard, cObjective, &cScoreboard::ForEachObjective>);
-			tolua_function(tolua_S, "ForEachTeam",      ForEach<cScoreboard, cTeam,      &cScoreboard::ForEachTeam>);
-			tolua_function(tolua_S, "GetTeamNames",     tolua_cScoreboard_GetTeamNames);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cScoreboard");
+			tolua_function(a_tolua_S, "ForEachObjective", ForEach<cScoreboard, cObjective, &cScoreboard::ForEachObjective>);
+			tolua_function(a_tolua_S, "ForEachTeam",      ForEach<cScoreboard, cTeam,      &cScoreboard::ForEachTeam>);
+			tolua_function(a_tolua_S, "GetTeamNames",     tolua_cScoreboard_GetTeamNames);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cServer");
-			tolua_function(tolua_S, "RegisterForgeMod",            tolua_cServer_RegisterForgeMod);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cServer");
+			tolua_function(a_tolua_S, "RegisterForgeMod",            tolua_cServer_RegisterForgeMod);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cStringCompression");
-			tolua_function(tolua_S, "CompressStringZLIB",     tolua_CompressStringZLIB);
-			tolua_function(tolua_S, "UncompressStringZLIB",   tolua_UncompressStringZLIB);
-			tolua_function(tolua_S, "CompressStringGZIP",     tolua_CompressStringGZIP);
-			tolua_function(tolua_S, "UncompressStringGZIP",   tolua_UncompressStringGZIP);
-			tolua_function(tolua_S, "InflateString",          tolua_InflateString);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cStringCompression");
+			tolua_function(a_tolua_S, "CompressStringZLIB",     tolua_CompressStringZLIB);
+			tolua_function(a_tolua_S, "UncompressStringZLIB",   tolua_UncompressStringZLIB);
+			tolua_function(a_tolua_S, "CompressStringGZIP",     tolua_CompressStringGZIP);
+			tolua_function(a_tolua_S, "UncompressStringGZIP",   tolua_UncompressStringGZIP);
+			tolua_function(a_tolua_S, "InflateString",          tolua_InflateString);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cUrlParser");
-			tolua_function(tolua_S, "GetDefaultPort",     tolua_cUrlParser_GetDefaultPort);
-			tolua_function(tolua_S, "IsKnownScheme",      tolua_cUrlParser_IsKnownScheme);
-			tolua_function(tolua_S, "Parse",              tolua_cUrlParser_Parse);
-			tolua_function(tolua_S, "ParseAuthorityPart", tolua_cUrlParser_ParseAuthorityPart);
-			tolua_function(tolua_S, "UrlDecode",          tolua_cUrlParser_UrlDecode);
-			tolua_function(tolua_S, "UrlEncode",          tolua_cUrlParser_UrlEncode);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cUrlParser");
+			tolua_function(a_tolua_S, "GetDefaultPort",     tolua_cUrlParser_GetDefaultPort);
+			tolua_function(a_tolua_S, "IsKnownScheme",      tolua_cUrlParser_IsKnownScheme);
+			tolua_function(a_tolua_S, "Parse",              tolua_cUrlParser_Parse);
+			tolua_function(a_tolua_S, "ParseAuthorityPart", tolua_cUrlParser_ParseAuthorityPart);
+			tolua_function(a_tolua_S, "UrlDecode",          tolua_cUrlParser_UrlDecode);
+			tolua_function(a_tolua_S, "UrlEncode",          tolua_cUrlParser_UrlEncode);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "cWebAdmin");
-			tolua_function(tolua_S, "AddWebTab",                 tolua_cWebAdmin_AddWebTab);
-			tolua_function(tolua_S, "GetAllWebTabs",             tolua_cWebAdmin_GetAllWebTabs);
-			tolua_function(tolua_S, "GetPage",                   tolua_cWebAdmin_GetPage);
-			tolua_function(tolua_S, "GetURLEncodedString",       tolua_cWebAdmin_GetURLEncodedString);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "cWebAdmin");
+			tolua_function(a_tolua_S, "AddWebTab",                 tolua_cWebAdmin_AddWebTab);
+			tolua_function(a_tolua_S, "GetAllWebTabs",             tolua_cWebAdmin_GetAllWebTabs);
+			tolua_function(a_tolua_S, "GetPage",                   tolua_cWebAdmin_GetPage);
+			tolua_function(a_tolua_S, "GetURLEncodedString",       tolua_cWebAdmin_GetURLEncodedString);
+		tolua_endmodule(a_tolua_S);
 
-		tolua_beginmodule(tolua_S, "HTTPRequest");
-			tolua_variable(tolua_S, "FormData",   tolua_get_HTTPRequest_FormData,   nullptr);
-			tolua_variable(tolua_S, "Params",     tolua_get_HTTPRequest_Params,     nullptr);
-			tolua_variable(tolua_S, "PostParams", tolua_get_HTTPRequest_PostParams, nullptr);
-		tolua_endmodule(tolua_S);
+		tolua_beginmodule(a_tolua_S, "HTTPRequest");
+			tolua_variable(a_tolua_S, "FormData",   tolua_get_HTTPRequest_FormData,   nullptr);
+			tolua_variable(a_tolua_S, "Params",     tolua_get_HTTPRequest_Params,     nullptr);
+			tolua_variable(a_tolua_S, "PostParams", tolua_get_HTTPRequest_PostParams, nullptr);
+		tolua_endmodule(a_tolua_S);
 
-		BindNetwork(tolua_S);
-		BindRankManager(tolua_S);
-		BindWorld(tolua_S);
-		BindBlockArea(tolua_S);
+		BindNetwork(a_tolua_S);
+		BindRankManager(a_tolua_S);
+		BindWorld(a_tolua_S);
+		BindBlockArea(a_tolua_S);
 
-	tolua_endmodule(tolua_S);
+	tolua_endmodule(a_tolua_S);
 }

--- a/src/Bindings/ManualBindings.h
+++ b/src/Bindings/ManualBindings.h
@@ -26,31 +26,31 @@ class cManualBindings
 {
 public:
 	/** Binds all the manually implemented functions to tolua_S. */
-	static void Bind(lua_State * tolua_S);
+	static void Bind(lua_State * a_tolua_S);
 
 protected:
 	/** Binds the manually implemented cNetwork-related API to tolua_S.
 	Implemented in ManualBindings_Network.cpp. */
-	static void BindNetwork(lua_State * tolua_S);
+	static void BindNetwork(lua_State * a_tolua_S);
 
 	/** Binds the manually implemented cRankManager glue code to tolua_S.
 	Implemented in ManualBindings_RankManager.cpp. */
-	static void BindRankManager(lua_State * tolua_S);
+	static void BindRankManager(lua_State * a_tolua_S);
 
 	/** Binds the manually implemented cWorld API functions to tolua_S.
 	Implemented in ManualBindings_World.cpp. */
-	static void BindWorld(lua_State * tolua_S);
+	static void BindWorld(lua_State * a_tolua_S);
 
 	/** Binds the manually implemented cBlockArea API functions to tlua_S.
 	Implemented in ManualBindings_BlockArea.cpp. */
-	static void BindBlockArea(lua_State * tolua_S);
+	static void BindBlockArea(lua_State * a_tolua_S);
 
 
 public:
 	// Helper functions:
-	static cPluginLua * GetLuaPlugin(lua_State * L);
-	static int tolua_do_error(lua_State * L, const char * a_pMsg, tolua_Error * a_pToLuaError);
-	static int lua_do_error(lua_State * L, const char * a_pFormat, fmt::ArgList a_ArgList);
+	static cPluginLua * GetLuaPlugin(lua_State * a_L);
+	static int tolua_do_error(lua_State * a_L, const char * a_pMsg, tolua_Error * a_pToLuaError);
+	static int lua_do_error(lua_State * a_L, const char * a_pFormat, fmt::ArgList a_ArgList);
 	FMT_VARIADIC(static int, lua_do_error, lua_State *, const char *)
 
 
@@ -60,10 +60,10 @@ public:
 		class Ty2,
 		bool (Ty1::*DoWithFn)(const AString &, cFunctionRef<bool(Ty2 &)>)
 	>
-	static int DoWith(lua_State * tolua_S)
+	static int DoWith(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamString(2) ||
 			!L.CheckParamFunction(3)
@@ -79,15 +79,15 @@ public:
 		L.GetStackValues(1, Self, ItemName, FnRef);
 		if (Self == nullptr)
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 		}
 		if (ItemName.empty() || (ItemName[0] == 0))
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a non-empty string for parameter #1");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a non-empty string for parameter #1");
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
 		}
 
 		// Call the DoWith function:
@@ -114,10 +114,10 @@ public:
 		class Ty2,
 		bool (Ty1::*DoWithFn)(const AString &, cFunctionRef<bool(Ty2 &)>)
 	>
-	static int StaticDoWith(lua_State * tolua_S)
+	static int StaticDoWith(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamString(2) ||
 			!L.CheckParamFunction(3)
@@ -132,11 +132,11 @@ public:
 		L.GetStackValues(2, ItemName, FnRef);
 		if (ItemName.empty() || (ItemName[0] == 0))
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a non-empty string for parameter #1");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a non-empty string for parameter #1");
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
 		}
 
 		// Call the DoWith function:
@@ -162,10 +162,10 @@ public:
 		class Ty2,
 		bool (Ty1::*DoWithFn)(UInt32, cFunctionRef<bool(Ty2 &)>)
 	>
-	static int DoWithID(lua_State * tolua_S)
+	static int DoWithID(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamNumber(2) ||
 			!L.CheckParamFunction(3)
@@ -181,11 +181,11 @@ public:
 		L.GetStackValues(1, Self, ItemID, FnRef);
 		if (Self == nullptr)
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
 		}
 
 		// Call the DoWith function:
@@ -212,10 +212,10 @@ public:
 		class ITEM,
 		bool (SELF::*DoWithFn)(int, int, int, cFunctionRef<bool(ITEM &)>)
 	>
-	static int DoWithXYZ(lua_State * tolua_S)
+	static int DoWithXYZ(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamNumber(2, 4) ||
 			!L.CheckParamFunction(5) ||
@@ -234,11 +234,11 @@ public:
 		L.GetStackValues(1, Self, BlockX, BlockY, BlockZ, FnRef);
 		if (Self == nullptr)
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #5");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #5");
 		}
 
 		// Call the DoWith function:
@@ -266,10 +266,10 @@ public:
 		bool (SELF::*DoWithFn)(int, int, int, cFunctionRef<bool(ITEM &)>),
 		bool (SELF::*CoordCheckFn)(int, int, int) const
 	>
-	static int DoWithXYZ(lua_State * tolua_S)
+	static int DoWithXYZ(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamNumber(2, 4) ||
 			!L.CheckParamFunction(5) ||
@@ -288,15 +288,15 @@ public:
 		L.GetStackValues(1, Self, BlockX, BlockY, BlockZ, FnRef);
 		if (Self == nullptr)
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #5");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #5");
 		}
 		if (!(Self->*CoordCheckFn)(BlockX, BlockY, BlockZ))
 		{
-			return lua_do_error(tolua_S, Printf("Error in function call '#funcname#': The provided coordinates ({%d, %d, %d}) are not valid",
+			return lua_do_error(a_tolua_S, Printf("Error in function call '#funcname#': The provided coordinates ({%d, %d, %d}) are not valid",
 				BlockX, BlockY, BlockZ
 			).c_str());
 		}
@@ -324,10 +324,10 @@ public:
 		class Ty2,
 		bool (Ty1::*ForEachFn)(int, int, cFunctionRef<bool(Ty2 &)>)
 	>
-	static int ForEachInChunk(lua_State * tolua_S)
+	static int ForEachInChunk(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamNumber(2, 3) ||
 			!L.CheckParamFunction(4) ||
@@ -345,11 +345,11 @@ public:
 		L.GetStackValues(1, Self, ChunkX, ChunkZ, FnRef);
 		if (Self == nullptr)
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #4");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #4");
 		}
 
 		// Call the DoWith function:
@@ -375,10 +375,10 @@ public:
 		class Ty2,
 		bool (Ty1::*ForEachFn)(const cBoundingBox &, cFunctionRef<bool(Ty2 &)>)
 	>
-	static int ForEachInBox(lua_State * tolua_S)
+	static int ForEachInBox(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamUserType(1, "cWorld") ||
 			!L.CheckParamUserType(2, "cBoundingBox") ||
@@ -402,7 +402,7 @@ public:
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #2");
 		}
 
 		bool res = (Self->*ForEachFn)(*Box, [&](Ty2 & a_Item)
@@ -433,10 +433,10 @@ public:
 		class Ty2,
 		bool (Ty1::*ForEachFn)(cFunctionRef<bool(Ty2 &)>)
 	>
-	static int ForEach(lua_State * tolua_S)
+	static int ForEach(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamFunction(2) ||
 			!L.CheckParamEnd(3)
@@ -451,11 +451,11 @@ public:
 		L.GetStackValues(1, Self, FnRef);
 		if (Self == nullptr)
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'.");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'.");
 		}
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #1");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #1");
 		}
 
 		// Call the enumeration:
@@ -482,10 +482,10 @@ public:
 		class Ty2,
 		bool (Ty1::*ForEachFn)(cFunctionRef<bool(Ty2 &)>)
 	>
-	static int StaticForEach(lua_State * tolua_S)
+	static int StaticForEach(lua_State * a_tolua_S)
 	{
 		// Check params:
-		cLuaState L(tolua_S);
+		cLuaState L(a_tolua_S);
 		if (
 			!L.CheckParamFunction(2) ||
 			!L.CheckParamEnd(3)
@@ -498,7 +498,7 @@ public:
 		cLuaState::cRef FnRef(L, 2);
 		if (!FnRef.IsValid())
 		{
-			return lua_do_error(tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #1");
+			return lua_do_error(a_tolua_S, "Error in function call '#funcname#': Expected a valid callback function for parameter #1");
 		}
 
 		// Call the enumeration:

--- a/src/Bindings/ManualBindings_Network.cpp
+++ b/src/Bindings/ManualBindings_Network.cpp
@@ -22,12 +22,12 @@
 // cNetwork API functions:
 
 /** Binds cNetwork::Connect */
-static int tolua_cNetwork_Connect(lua_State * L)
+static int tolua_cNetwork_Connect(lua_State * a_L)
 {
 	// Function signature:
 	// cNetwork:Connect(Host, Port, Callbacks) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamString(2) ||
@@ -70,12 +70,12 @@ static int tolua_cNetwork_Connect(lua_State * L)
 
 
 /** Binds cNetwork::CreateUDPEndpoint */
-static int tolua_cNetwork_CreateUDPEndpoint(lua_State * L)
+static int tolua_cNetwork_CreateUDPEndpoint(lua_State * a_L)
 {
 	// Function signature:
 	// cNetwork:CreateUDPEndpoint(Port, Callbacks) -> cUDPEndpoint
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamNumber(2) ||
@@ -106,8 +106,8 @@ static int tolua_cNetwork_CreateUDPEndpoint(lua_State * L)
 	endpoint->Open(static_cast<UInt16>(port), endpoint);
 
 	// Register the endpoint to be garbage-collected by Lua:
-	tolua_pushusertype(L, endpoint.get(), "cUDPEndpoint");
-	tolua_register_gc(L, lua_gettop(L));
+	tolua_pushusertype(a_L, endpoint.get(), "cUDPEndpoint");
+	tolua_register_gc(a_L, lua_gettop(a_L));
 
 	// Return the endpoint object:
 	S.Push(endpoint.get());
@@ -119,12 +119,12 @@ static int tolua_cNetwork_CreateUDPEndpoint(lua_State * L)
 
 
 /** Binds cNetwork::EnumLocalIPAddresses */
-static int tolua_cNetwork_EnumLocalIPAddresses(lua_State * L)
+static int tolua_cNetwork_EnumLocalIPAddresses(lua_State * a_L)
 {
 	// Function signature:
 	// cNetwork:EnumLocalIPAddresses() -> {string, ...}
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamEnd(2)
@@ -143,12 +143,12 @@ static int tolua_cNetwork_EnumLocalIPAddresses(lua_State * L)
 
 
 /** Binds cNetwork::HostnameToIP */
-static int tolua_cNetwork_HostnameToIP(lua_State * L)
+static int tolua_cNetwork_HostnameToIP(lua_State * a_L)
 {
 	// Function signature:
 	// cNetwork:HostnameToIP(Host, Callbacks) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamString(2) ||
@@ -179,12 +179,12 @@ static int tolua_cNetwork_HostnameToIP(lua_State * L)
 
 
 /** Binds cNetwork::IPToHostname */
-static int tolua_cNetwork_IPToHostname(lua_State * L)
+static int tolua_cNetwork_IPToHostname(lua_State * a_L)
 {
 	// Function signature:
 	// cNetwork:IPToHostname(IP, Callbacks) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamString(2) ||
@@ -215,12 +215,12 @@ static int tolua_cNetwork_IPToHostname(lua_State * L)
 
 
 /** Binds cNetwork::Listen */
-static int tolua_cNetwork_Listen(lua_State * L)
+static int tolua_cNetwork_Listen(lua_State * a_L)
 {
 	// Function signature:
 	// cNetwork:Listen(Port, Callbacks) -> cServerHandle
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cNetwork") ||
 		!S.CheckParamNumber(2) ||
@@ -253,8 +253,8 @@ static int tolua_cNetwork_Listen(lua_State * L)
 	srv->SetServerHandle(cNetwork::Listen(port16, srv), srv);
 
 	// Register the server to be garbage-collected by Lua:
-	tolua_pushusertype(L, srv.get(), "cServerHandle");
-	tolua_register_gc(L, lua_gettop(L));
+	tolua_pushusertype(a_L, srv.get(), "cServerHandle");
+	tolua_register_gc(a_L, lua_gettop(a_L));
 
 	// Return the server handle wrapper:
 	S.Push(srv.get());
@@ -270,9 +270,9 @@ static int tolua_cNetwork_Listen(lua_State * L)
 
 /** Called when Lua destroys the object instance.
 Close the server and let it deallocate on its own (it's in a SharedPtr). */
-static int tolua_collect_cServerHandle(lua_State * L)
+static int tolua_collect_cServerHandle(lua_State * a_L)
 {
-	auto Srv = static_cast<cLuaServerHandle *>(tolua_tousertype(L, 1, nullptr));
+	auto Srv = static_cast<cLuaServerHandle *>(tolua_tousertype(a_L, 1, nullptr));
 	ASSERT(Srv != nullptr);
 	Srv->Release();
 	return 0;
@@ -283,12 +283,12 @@ static int tolua_collect_cServerHandle(lua_State * L)
 
 
 /** Binds cLuaServerHandle::Close */
-static int tolua_cServerHandle_Close(lua_State * L)
+static int tolua_cServerHandle_Close(lua_State * a_L)
 {
 	// Function signature:
 	// ServerInstance:Close()
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cServerHandle") ||
 		!S.CheckParamEnd(2)
@@ -298,7 +298,7 @@ static int tolua_cServerHandle_Close(lua_State * L)
 	}
 
 	// Get the server handle:
-	auto Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(L, 1));
+	auto Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(a_L, 1));
 	ASSERT(Srv != nullptr);  // Checked by CheckParamSelf()
 
 	// Close it:
@@ -311,12 +311,12 @@ static int tolua_cServerHandle_Close(lua_State * L)
 
 
 /** Binds cLuaServerHandle::IsListening */
-static int tolua_cServerHandle_IsListening(lua_State * L)
+static int tolua_cServerHandle_IsListening(lua_State * a_L)
 {
 	// Function signature:
 	// ServerInstance:IsListening() -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cServerHandle") ||
 		!S.CheckParamEnd(2)
@@ -326,7 +326,7 @@ static int tolua_cServerHandle_IsListening(lua_State * L)
 	}
 
 	// Get the server handle:
-	auto Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(L, 1));
+	auto Srv = *static_cast<cLuaServerHandle **>(lua_touserdata(a_L, 1));
 	ASSERT(Srv != nullptr);  // Checked by CheckParamSelf()
 
 	// Query it:
@@ -342,12 +342,12 @@ static int tolua_cServerHandle_IsListening(lua_State * L)
 // cTCPLink bindings (routed through cLuaTCPLink):
 
 /** Binds cLuaTCPLink::Close */
-static int tolua_cTCPLink_Close(lua_State * L)
+static int tolua_cTCPLink_Close(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:Close()
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
@@ -357,7 +357,7 @@ static int tolua_cTCPLink_Close(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Close the link:
@@ -370,12 +370,12 @@ static int tolua_cTCPLink_Close(lua_State * L)
 
 
 /** Binds cLuaTCPLink::GetLocalIP */
-static int tolua_cTCPLink_GetLocalIP(lua_State * L)
+static int tolua_cTCPLink_GetLocalIP(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:GetLocalIP() -> string
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
@@ -385,7 +385,7 @@ static int tolua_cTCPLink_GetLocalIP(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the IP:
@@ -398,12 +398,12 @@ static int tolua_cTCPLink_GetLocalIP(lua_State * L)
 
 
 /** Binds cLuaTCPLink::GetLocalPort */
-static int tolua_cTCPLink_GetLocalPort(lua_State * L)
+static int tolua_cTCPLink_GetLocalPort(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:GetLocalPort() -> number
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
@@ -413,7 +413,7 @@ static int tolua_cTCPLink_GetLocalPort(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the Port:
@@ -426,12 +426,12 @@ static int tolua_cTCPLink_GetLocalPort(lua_State * L)
 
 
 /** Binds cLuaTCPLink::GetRemoteIP */
-static int tolua_cTCPLink_GetRemoteIP(lua_State * L)
+static int tolua_cTCPLink_GetRemoteIP(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:GetRemoteIP() -> string
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
@@ -441,7 +441,7 @@ static int tolua_cTCPLink_GetRemoteIP(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the IP:
@@ -454,12 +454,12 @@ static int tolua_cTCPLink_GetRemoteIP(lua_State * L)
 
 
 /** Binds cLuaTCPLink::GetRemotePort */
-static int tolua_cTCPLink_GetRemotePort(lua_State * L)
+static int tolua_cTCPLink_GetRemotePort(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:GetRemotePort() -> number
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
@@ -469,7 +469,7 @@ static int tolua_cTCPLink_GetRemotePort(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the Port:
@@ -482,12 +482,12 @@ static int tolua_cTCPLink_GetRemotePort(lua_State * L)
 
 
 /** Binds cLuaTCPLink::Send */
-static int tolua_cTCPLink_Send(lua_State * L)
+static int tolua_cTCPLink_Send(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:Send(DataString)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamString(2) ||
@@ -498,7 +498,7 @@ static int tolua_cTCPLink_Send(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Get the data to send:
@@ -515,12 +515,12 @@ static int tolua_cTCPLink_Send(lua_State * L)
 
 
 /** Binds cLuaTCPLink::Shutdown */
-static int tolua_cTCPLink_Shutdown(lua_State * L)
+static int tolua_cTCPLink_Shutdown(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:Shutdown()
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamEnd(2)
@@ -530,7 +530,7 @@ static int tolua_cTCPLink_Shutdown(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Shutdown the link:
@@ -543,18 +543,18 @@ static int tolua_cTCPLink_Shutdown(lua_State * L)
 
 
 /** Binds cLuaTCPLink::StartTLSClient */
-static int tolua_cTCPLink_StartTLSClient(lua_State * L)
+static int tolua_cTCPLink_StartTLSClient(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:StartTLSClient(OwnCert, OwnPrivKey, OwnPrivKeyPassword) -> [true] or [nil, ErrMsg]
 
 	// Get the link:
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (!S.CheckParamSelf("cTCPLink"))
 	{
 		return 0;
 	}
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Read the (optional) params:
@@ -576,12 +576,12 @@ static int tolua_cTCPLink_StartTLSClient(lua_State * L)
 
 
 /** Binds cLuaTCPLink::StartTLSServer */
-static int tolua_cTCPLink_StartTLSServer(lua_State * L)
+static int tolua_cTCPLink_StartTLSServer(lua_State * a_L)
 {
 	// Function signature:
 	// LinkInstance:StartTLSServer(OwnCert, OwnPrivKey, OwnPrivKeyPassword, StartTLSData) -> [true] or [nil, ErrMsg]
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cTCPLink") ||
 		!S.CheckParamString(2, 4) ||
@@ -593,7 +593,7 @@ static int tolua_cTCPLink_StartTLSServer(lua_State * L)
 	}
 
 	// Get the link:
-	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(L, 1));
+	auto Link = *static_cast<cLuaTCPLink **>(lua_touserdata(a_L, 1));
 	ASSERT(Link != nullptr);  // Checked by CheckParamSelf()
 
 	// Read the params:
@@ -620,9 +620,9 @@ static int tolua_cTCPLink_StartTLSServer(lua_State * L)
 
 /** Called when Lua destroys the object instance.
 Close the endpoint and let it deallocate on its own (it's in a SharedPtr). */
-static int tolua_collect_cUDPEndpoint(lua_State * L)
+static int tolua_collect_cUDPEndpoint(lua_State * a_L)
 {
-	auto endpoint = static_cast<cLuaUDPEndpoint *>(tolua_tousertype(L, 1, nullptr));
+	auto endpoint = static_cast<cLuaUDPEndpoint *>(tolua_tousertype(a_L, 1, nullptr));
 	ASSERT(endpoint != nullptr);
 	endpoint->Release();
 	return 0;
@@ -633,12 +633,12 @@ static int tolua_collect_cUDPEndpoint(lua_State * L)
 
 
 /** Binds cLuaUDPEndpoint::Close */
-static int tolua_cUDPEndpoint_Close(lua_State * L)
+static int tolua_cUDPEndpoint_Close(lua_State * a_L)
 {
 	// Function signature:
 	// EndpointInstance:Close()
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
@@ -648,7 +648,7 @@ static int tolua_cUDPEndpoint_Close(lua_State * L)
 	}
 
 	// Get the endpoint:
-	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(a_L, 1));
 	ASSERT(endpoint != nullptr);
 
 	// Close it:
@@ -661,12 +661,12 @@ static int tolua_cUDPEndpoint_Close(lua_State * L)
 
 
 /** Binds cLuaUDPEndpoint::EnableBroadcasts */
-static int tolua_cUDPEndpoint_EnableBroadcasts(lua_State * L)
+static int tolua_cUDPEndpoint_EnableBroadcasts(lua_State * a_L)
 {
 	// Function signature:
 	// EndpointInstance:EnableBroadcasts()
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
@@ -676,7 +676,7 @@ static int tolua_cUDPEndpoint_EnableBroadcasts(lua_State * L)
 	}
 
 	// Get the endpoint:
-	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(a_L, 1));
 	ASSERT(endpoint != nullptr);
 
 	// Enable the broadcasts:
@@ -689,12 +689,12 @@ static int tolua_cUDPEndpoint_EnableBroadcasts(lua_State * L)
 
 
 /** Binds cLuaUDPEndpoint::GetPort */
-static int tolua_cUDPEndpoint_GetPort(lua_State * L)
+static int tolua_cUDPEndpoint_GetPort(lua_State * a_L)
 {
 	// Function signature:
 	// Endpoint:GetPort() -> number
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
@@ -704,7 +704,7 @@ static int tolua_cUDPEndpoint_GetPort(lua_State * L)
 	}
 
 	// Get the endpoint:
-	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(a_L, 1));
 	ASSERT(endpoint != nullptr);
 
 	// Get the Port:
@@ -717,12 +717,12 @@ static int tolua_cUDPEndpoint_GetPort(lua_State * L)
 
 
 /** Binds cLuaUDPEndpoint::IsOpen */
-static int tolua_cUDPEndpoint_IsOpen(lua_State * L)
+static int tolua_cUDPEndpoint_IsOpen(lua_State * a_L)
 {
 	// Function signature:
 	// Endpoint:IsOpen() -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamEnd(2)
@@ -732,7 +732,7 @@ static int tolua_cUDPEndpoint_IsOpen(lua_State * L)
 	}
 
 	// Get the endpoint:
-	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(a_L, 1));
 	ASSERT(endpoint != nullptr);
 
 	// Close it:
@@ -745,12 +745,12 @@ static int tolua_cUDPEndpoint_IsOpen(lua_State * L)
 
 
 /** Binds cLuaUDPEndpoint::Send */
-static int tolua_cUDPEndpoint_Send(lua_State * L)
+static int tolua_cUDPEndpoint_Send(lua_State * a_L)
 {
 	// Function signature:
 	// Endpoint:Send(DataString)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamSelf("cUDPEndpoint") ||
 		!S.CheckParamString(2, 3) ||
@@ -762,7 +762,7 @@ static int tolua_cUDPEndpoint_Send(lua_State * L)
 	}
 
 	// Get the link:
-	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(L, 1));
+	auto endpoint = *static_cast<cLuaUDPEndpoint **>(lua_touserdata(a_L, 1));
 	ASSERT(endpoint != nullptr);
 
 	// Get the data to send:
@@ -1095,62 +1095,62 @@ static int tolua_cUrlClient_Request(lua_State * a_LuaState)
 ////////////////////////////////////////////////////////////////////////////////
 // Register the bindings:
 
-void cManualBindings::BindNetwork(lua_State * tolua_S)
+void cManualBindings::BindNetwork(lua_State * a_tolua_S)
 {
 	// Create the cNetwork API classes:
-	tolua_usertype(tolua_S, "cNetwork");
-	tolua_usertype(tolua_S, "cServerHandle");
-	tolua_usertype(tolua_S, "cTCPLink");
-	tolua_usertype(tolua_S, "cUDPEndpoint");
-	tolua_usertype(tolua_S, "cUrlClient");
-	tolua_cclass(tolua_S, "cNetwork",      "cNetwork",      "", nullptr);
-	tolua_cclass(tolua_S, "cServerHandle", "cServerHandle", "", tolua_collect_cServerHandle);
-	tolua_cclass(tolua_S, "cTCPLink",      "cTCPLink",      "", nullptr);
-	tolua_cclass(tolua_S, "cUDPEndpoint",  "cUDPEndpoint",  "", tolua_collect_cUDPEndpoint);
-	tolua_cclass(tolua_S, "cUrlClient",    "cUrlClient",    "", nullptr);
+	tolua_usertype(a_tolua_S, "cNetwork");
+	tolua_usertype(a_tolua_S, "cServerHandle");
+	tolua_usertype(a_tolua_S, "cTCPLink");
+	tolua_usertype(a_tolua_S, "cUDPEndpoint");
+	tolua_usertype(a_tolua_S, "cUrlClient");
+	tolua_cclass(a_tolua_S, "cNetwork",      "cNetwork",      "", nullptr);
+	tolua_cclass(a_tolua_S, "cServerHandle", "cServerHandle", "", tolua_collect_cServerHandle);
+	tolua_cclass(a_tolua_S, "cTCPLink",      "cTCPLink",      "", nullptr);
+	tolua_cclass(a_tolua_S, "cUDPEndpoint",  "cUDPEndpoint",  "", tolua_collect_cUDPEndpoint);
+	tolua_cclass(a_tolua_S, "cUrlClient",    "cUrlClient",    "", nullptr);
 
 	// Fill in the functions (alpha-sorted):
-	tolua_beginmodule(tolua_S, "cNetwork");
-		tolua_function(tolua_S, "Connect",              tolua_cNetwork_Connect);
-		tolua_function(tolua_S, "CreateUDPEndpoint",    tolua_cNetwork_CreateUDPEndpoint);
-		tolua_function(tolua_S, "EnumLocalIPAddresses", tolua_cNetwork_EnumLocalIPAddresses);
-		tolua_function(tolua_S, "HostnameToIP",         tolua_cNetwork_HostnameToIP);
-		tolua_function(tolua_S, "IPToHostname",         tolua_cNetwork_IPToHostname);
-		tolua_function(tolua_S, "Listen",               tolua_cNetwork_Listen);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cNetwork");
+		tolua_function(a_tolua_S, "Connect",              tolua_cNetwork_Connect);
+		tolua_function(a_tolua_S, "CreateUDPEndpoint",    tolua_cNetwork_CreateUDPEndpoint);
+		tolua_function(a_tolua_S, "EnumLocalIPAddresses", tolua_cNetwork_EnumLocalIPAddresses);
+		tolua_function(a_tolua_S, "HostnameToIP",         tolua_cNetwork_HostnameToIP);
+		tolua_function(a_tolua_S, "IPToHostname",         tolua_cNetwork_IPToHostname);
+		tolua_function(a_tolua_S, "Listen",               tolua_cNetwork_Listen);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "cServerHandle");
-		tolua_function(tolua_S, "Close",       tolua_cServerHandle_Close);
-		tolua_function(tolua_S, "IsListening", tolua_cServerHandle_IsListening);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cServerHandle");
+		tolua_function(a_tolua_S, "Close",       tolua_cServerHandle_Close);
+		tolua_function(a_tolua_S, "IsListening", tolua_cServerHandle_IsListening);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "cTCPLink");
-		tolua_function(tolua_S, "Close",          tolua_cTCPLink_Close);
-		tolua_function(tolua_S, "GetLocalIP",     tolua_cTCPLink_GetLocalIP);
-		tolua_function(tolua_S, "GetLocalPort",   tolua_cTCPLink_GetLocalPort);
-		tolua_function(tolua_S, "GetRemoteIP",    tolua_cTCPLink_GetRemoteIP);
-		tolua_function(tolua_S, "GetRemotePort",  tolua_cTCPLink_GetRemotePort);
-		tolua_function(tolua_S, "Send",           tolua_cTCPLink_Send);
-		tolua_function(tolua_S, "Shutdown",       tolua_cTCPLink_Shutdown);
-		tolua_function(tolua_S, "StartTLSClient", tolua_cTCPLink_StartTLSClient);
-		tolua_function(tolua_S, "StartTLSServer", tolua_cTCPLink_StartTLSServer);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cTCPLink");
+		tolua_function(a_tolua_S, "Close",          tolua_cTCPLink_Close);
+		tolua_function(a_tolua_S, "GetLocalIP",     tolua_cTCPLink_GetLocalIP);
+		tolua_function(a_tolua_S, "GetLocalPort",   tolua_cTCPLink_GetLocalPort);
+		tolua_function(a_tolua_S, "GetRemoteIP",    tolua_cTCPLink_GetRemoteIP);
+		tolua_function(a_tolua_S, "GetRemotePort",  tolua_cTCPLink_GetRemotePort);
+		tolua_function(a_tolua_S, "Send",           tolua_cTCPLink_Send);
+		tolua_function(a_tolua_S, "Shutdown",       tolua_cTCPLink_Shutdown);
+		tolua_function(a_tolua_S, "StartTLSClient", tolua_cTCPLink_StartTLSClient);
+		tolua_function(a_tolua_S, "StartTLSServer", tolua_cTCPLink_StartTLSServer);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "cUDPEndpoint");
-		tolua_function(tolua_S, "Close",            tolua_cUDPEndpoint_Close);
-		tolua_function(tolua_S, "EnableBroadcasts", tolua_cUDPEndpoint_EnableBroadcasts);
-		tolua_function(tolua_S, "GetPort",          tolua_cUDPEndpoint_GetPort);
-		tolua_function(tolua_S, "IsOpen",           tolua_cUDPEndpoint_IsOpen);
-		tolua_function(tolua_S, "Send",             tolua_cUDPEndpoint_Send);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cUDPEndpoint");
+		tolua_function(a_tolua_S, "Close",            tolua_cUDPEndpoint_Close);
+		tolua_function(a_tolua_S, "EnableBroadcasts", tolua_cUDPEndpoint_EnableBroadcasts);
+		tolua_function(a_tolua_S, "GetPort",          tolua_cUDPEndpoint_GetPort);
+		tolua_function(a_tolua_S, "IsOpen",           tolua_cUDPEndpoint_IsOpen);
+		tolua_function(a_tolua_S, "Send",             tolua_cUDPEndpoint_Send);
+	tolua_endmodule(a_tolua_S);
 
-	tolua_beginmodule(tolua_S, "cUrlClient");
-		tolua_function(tolua_S, "Delete",  tolua_cUrlClient_Delete);
-		tolua_function(tolua_S, "Get",     tolua_cUrlClient_Get);
-		tolua_function(tolua_S, "Post",    tolua_cUrlClient_Post);
-		tolua_function(tolua_S, "Put",     tolua_cUrlClient_Put);
-		tolua_function(tolua_S, "Request", tolua_cUrlClient_Request);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cUrlClient");
+		tolua_function(a_tolua_S, "Delete",  tolua_cUrlClient_Delete);
+		tolua_function(a_tolua_S, "Get",     tolua_cUrlClient_Get);
+		tolua_function(a_tolua_S, "Post",    tolua_cUrlClient_Post);
+		tolua_function(a_tolua_S, "Put",     tolua_cUrlClient_Put);
+		tolua_function(a_tolua_S, "Request", tolua_cUrlClient_Request);
+	tolua_endmodule(a_tolua_S);
 }
 
 

--- a/src/Bindings/ManualBindings_RankManager.cpp
+++ b/src/Bindings/ManualBindings_RankManager.cpp
@@ -15,12 +15,12 @@
 
 
 /** Binds cRankManager::AddGroup */
-static int tolua_cRankManager_AddGroup(lua_State * L)
+static int tolua_cRankManager_AddGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:AddGroup(GroupName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -44,12 +44,12 @@ static int tolua_cRankManager_AddGroup(lua_State * L)
 
 
 /** Binds cRankManager::AddGroupToRank */
-static int tolua_cRankManager_AddGroupToRank(lua_State * L)
+static int tolua_cRankManager_AddGroupToRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:AddGroupToRank(GroupName, RankName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -73,12 +73,12 @@ static int tolua_cRankManager_AddGroupToRank(lua_State * L)
 
 
 /** Binds cRankManager::AddPermissionToGroup */
-static int tolua_cRankManager_AddPermissionToGroup(lua_State * L)
+static int tolua_cRankManager_AddPermissionToGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:AddPermissionToGroup(Permission, GroupName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -102,12 +102,12 @@ static int tolua_cRankManager_AddPermissionToGroup(lua_State * L)
 
 
 /** Binds cRankManager::AddRank */
-static int tolua_cRankManager_AddRank(lua_State * L)
+static int tolua_cRankManager_AddRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:AddRank(RankName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 5) ||
@@ -131,12 +131,12 @@ static int tolua_cRankManager_AddRank(lua_State * L)
 
 
 /** Binds cRankManager::AddRestrictionToGroup */
-static int tolua_cRankManager_AddRestrictionToGroup(lua_State * L)
+static int tolua_cRankManager_AddRestrictionToGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:AddRestrictionToGroup(Restriction, GroupName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -160,9 +160,9 @@ static int tolua_cRankManager_AddRestrictionToGroup(lua_State * L)
 
 
 /** Binds cRankManager::ClearPlayerRanks */
-static int tolua_cRankManager_ClearPlayerRanks(lua_State * L)
+static int tolua_cRankManager_ClearPlayerRanks(lua_State * a_L)
 {
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -181,12 +181,12 @@ static int tolua_cRankManager_ClearPlayerRanks(lua_State * L)
 
 
 /** Binds cRankManager::GetAllGroups */
-static int tolua_cRankManager_GetAllGroups(lua_State * L)
+static int tolua_cRankManager_GetAllGroups(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetAllGroups() -> arraytable of GroupNames
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -208,12 +208,12 @@ static int tolua_cRankManager_GetAllGroups(lua_State * L)
 
 
 /** Binds cRankManager::GetAllPermissions */
-static int tolua_cRankManager_GetAllPermissions(lua_State * L)
+static int tolua_cRankManager_GetAllPermissions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetAllPermissions() -> arraytable of Permissions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -235,12 +235,12 @@ static int tolua_cRankManager_GetAllPermissions(lua_State * L)
 
 
 /** Binds cRankManager::GetAllPermissionsRestrictions */
-static int tolua_cRankManager_GetAllPermissionsRestrictions(lua_State * L)
+static int tolua_cRankManager_GetAllPermissionsRestrictions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetAllPermissionsRestrictions() -> arraytable of Permissions and Restrictions together
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -260,12 +260,12 @@ static int tolua_cRankManager_GetAllPermissionsRestrictions(lua_State * L)
 
 
 /** Binds cRankManager::GetAllPlayerUUIDs */
-static int tolua_cRankManager_GetAllPlayerUUIDs(lua_State * L)
+static int tolua_cRankManager_GetAllPlayerUUIDs(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetAllPlayerUUIDs() -> arraytable of Player UUID's
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -295,12 +295,12 @@ static int tolua_cRankManager_GetAllPlayerUUIDs(lua_State * L)
 
 
 /** Binds cRankManager::GetAllRanks */
-static int tolua_cRankManager_GetAllRanks(lua_State * L)
+static int tolua_cRankManager_GetAllRanks(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetAllRanks() -> arraytable of RankNames
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -319,12 +319,12 @@ static int tolua_cRankManager_GetAllRanks(lua_State * L)
 
 
 /** Binds cRankManager::GetAllRestrictions */
-static int tolua_cRankManager_GetAllRestrictions(lua_State * L)
+static int tolua_cRankManager_GetAllRestrictions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetAllRestrictions() -> arraytable of Restrictions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -344,12 +344,12 @@ static int tolua_cRankManager_GetAllRestrictions(lua_State * L)
 
 
 /** Binds cRankManager::GetDefaultRank */
-static int tolua_cRankManager_GetDefaultRank(lua_State * L)
+static int tolua_cRankManager_GetDefaultRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetDefaultRank() -> string
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamEnd(2)
@@ -368,12 +368,12 @@ static int tolua_cRankManager_GetDefaultRank(lua_State * L)
 
 
 /** Binds cRankManager::GetGroupPermissions */
-static int tolua_cRankManager_GetGroupPermissions(lua_State * L)
+static int tolua_cRankManager_GetGroupPermissions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetGroupPermissions(GroupName) -> arraytable of permissions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -400,12 +400,12 @@ static int tolua_cRankManager_GetGroupPermissions(lua_State * L)
 
 
 /** Binds cRankManager::GetGroupRestrictions */
-static int tolua_cRankManager_GetGroupRestrictions(lua_State * L)
+static int tolua_cRankManager_GetGroupRestrictions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetGroupRestrictions(GroupName) -> arraytable of restrictions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -432,12 +432,12 @@ static int tolua_cRankManager_GetGroupRestrictions(lua_State * L)
 
 
 /** Binds cRankManager::GetPlayerGroups */
-static int tolua_cRankManager_GetPlayerGroups(lua_State * L)
+static int tolua_cRankManager_GetPlayerGroups(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetPlayerGroups(PlayerUUID) -> arraytable of GroupNames
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -464,12 +464,12 @@ static int tolua_cRankManager_GetPlayerGroups(lua_State * L)
 
 
 /** Binds cRankManager::GetPlayerMsgVisuals */
-static int tolua_cRankManager_GetPlayerMsgVisuals(lua_State * L)
+static int tolua_cRankManager_GetPlayerMsgVisuals(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetPlayerMsgVisuals(PlayerUUID) -> string, string, string
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -500,12 +500,12 @@ static int tolua_cRankManager_GetPlayerMsgVisuals(lua_State * L)
 
 
 /** Binds cRankManager::GetPlayerPermissions */
-static int tolua_cRankManager_GetPlayerPermissions(lua_State * L)
+static int tolua_cRankManager_GetPlayerPermissions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetPlayerPermissions(PlayerUUID) -> arraytable of permissions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -532,12 +532,12 @@ static int tolua_cRankManager_GetPlayerPermissions(lua_State * L)
 
 
 /** Binds cRankManager::GetPlayerRestrictions */
-static int tolua_cRankManager_GetPlayerRestrictions(lua_State * L)
+static int tolua_cRankManager_GetPlayerRestrictions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetPlayerRestrictions(PlayerUUID) -> arraytable of restrictions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -564,12 +564,12 @@ static int tolua_cRankManager_GetPlayerRestrictions(lua_State * L)
 
 
 /** Binds cRankManager::GetPlayerRankName */
-static int tolua_cRankManager_GetPlayerRankName(lua_State * L)
+static int tolua_cRankManager_GetPlayerRankName(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetPlayerRankName(PlayerUUID) -> string
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -596,12 +596,12 @@ static int tolua_cRankManager_GetPlayerRankName(lua_State * L)
 
 
 /** Binds cRankManager::GetPlayerName */
-static int tolua_cRankManager_GetPlayerName(lua_State * L)
+static int tolua_cRankManager_GetPlayerName(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetPlayerName(PlayerUUID) -> string
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -628,12 +628,12 @@ static int tolua_cRankManager_GetPlayerName(lua_State * L)
 
 
 /** Binds cRankManager::GetRankGroups */
-static int tolua_cRankManager_GetRankGroups(lua_State * L)
+static int tolua_cRankManager_GetRankGroups(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetRankGroups(RankName) -> arraytable of groupnames
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -660,12 +660,12 @@ static int tolua_cRankManager_GetRankGroups(lua_State * L)
 
 
 /** Binds cRankManager::GetRankPermissions */
-static int tolua_cRankManager_GetRankPermissions(lua_State * L)
+static int tolua_cRankManager_GetRankPermissions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetRankPermissions(RankName) -> arraytable of permissions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -692,12 +692,12 @@ static int tolua_cRankManager_GetRankPermissions(lua_State * L)
 
 
 /** Binds cRankManager::GetRankRestrictions */
-static int tolua_cRankManager_GetRankRestrictions(lua_State * L)
+static int tolua_cRankManager_GetRankRestrictions(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetRankRestrictions(RankName) -> arraytable of restrictions
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -724,12 +724,12 @@ static int tolua_cRankManager_GetRankRestrictions(lua_State * L)
 
 
 /** Binds cRankManager::GetRankVisuals */
-static int tolua_cRankManager_GetRankVisuals(lua_State * L)
+static int tolua_cRankManager_GetRankVisuals(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GetRankVisuals(RankName) -> MsgPrefix, MsgSuffix, MsgNameColorCode
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -761,12 +761,12 @@ static int tolua_cRankManager_GetRankVisuals(lua_State * L)
 
 
 /** Binds cRankManager::GroupExists */
-static int tolua_cRankManager_GroupExists(lua_State * L)
+static int tolua_cRankManager_GroupExists(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:GroupExists(GroupName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -793,12 +793,12 @@ static int tolua_cRankManager_GroupExists(lua_State * L)
 
 
 /** Binds cRankManager::IsGroupInRank */
-static int tolua_cRankManager_IsGroupInRank(lua_State * L)
+static int tolua_cRankManager_IsGroupInRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:IsGroupInRank(GroupName, RankName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -825,12 +825,12 @@ static int tolua_cRankManager_IsGroupInRank(lua_State * L)
 
 
 /** Binds cRankManager::IsPermissionInGroup */
-static int tolua_cRankManager_IsPermissionInGroup(lua_State * L)
+static int tolua_cRankManager_IsPermissionInGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:IsPermissionInGroup(Permission, GroupName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -857,12 +857,12 @@ static int tolua_cRankManager_IsPermissionInGroup(lua_State * L)
 
 
 /** Binds cRankManager::IsRestrictionInGroup */
-static int tolua_cRankManager_IsRestrictionInGroup(lua_State * L)
+static int tolua_cRankManager_IsRestrictionInGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:IsRestrictionInGroup(Restriction, GroupName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -889,12 +889,12 @@ static int tolua_cRankManager_IsRestrictionInGroup(lua_State * L)
 
 
 /** Binds cRankManager::IsPlayerRankSet */
-static int tolua_cRankManager_IsPlayerRankSet(lua_State * L)
+static int tolua_cRankManager_IsPlayerRankSet(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:IsPlayerRankSet(PlayerUUID) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -921,12 +921,12 @@ static int tolua_cRankManager_IsPlayerRankSet(lua_State * L)
 
 
 /** Binds cRankManager::RankExists */
-static int tolua_cRankManager_RankExists(lua_State * L)
+static int tolua_cRankManager_RankExists(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RankExists(RankName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -953,12 +953,12 @@ static int tolua_cRankManager_RankExists(lua_State * L)
 
 
 /** Binds cRankManager::RemoveGroup */
-static int tolua_cRankManager_RemoveGroup(lua_State * L)
+static int tolua_cRankManager_RemoveGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RemoveGroup(GroupName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -982,12 +982,12 @@ static int tolua_cRankManager_RemoveGroup(lua_State * L)
 
 
 /** Binds cRankManager::RemoveGroupFromRank */
-static int tolua_cRankManager_RemoveGroupFromRank(lua_State * L)
+static int tolua_cRankManager_RemoveGroupFromRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RemoveGroupFromRank(GroupName, RankName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -1011,12 +1011,12 @@ static int tolua_cRankManager_RemoveGroupFromRank(lua_State * L)
 
 
 /** Binds cRankManager::RemovePermissionFromGroup */
-static int tolua_cRankManager_RemovePermissionFromGroup(lua_State * L)
+static int tolua_cRankManager_RemovePermissionFromGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RemovePermissionFromGroup(Permission, GroupName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -1040,12 +1040,12 @@ static int tolua_cRankManager_RemovePermissionFromGroup(lua_State * L)
 
 
 /** Binds cRankManager::RemoveRestrictionFromGroup */
-static int tolua_cRankManager_RemoveRestrictionFromGroup(lua_State * L)
+static int tolua_cRankManager_RemoveRestrictionFromGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RemoveRestrictionFromGroup(Restriction, GroupName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -1069,12 +1069,12 @@ static int tolua_cRankManager_RemoveRestrictionFromGroup(lua_State * L)
 
 
 /** Binds cRankManager::RemovePlayerRank */
-static int tolua_cRankManager_RemovePlayerRank(lua_State * L)
+static int tolua_cRankManager_RemovePlayerRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RemovePlayerRank(PlayerUUID)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -1098,12 +1098,12 @@ static int tolua_cRankManager_RemovePlayerRank(lua_State * L)
 
 
 /** Binds cRankManager::RemoveRank */
-static int tolua_cRankManager_RemoveRank(lua_State * L)
+static int tolua_cRankManager_RemoveRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RemoveRank(RankName, [ReplacementRankName])
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -1128,12 +1128,12 @@ static int tolua_cRankManager_RemoveRank(lua_State * L)
 
 
 /** Binds cRankManager::RenameGroup */
-static int tolua_cRankManager_RenameGroup(lua_State * L)
+static int tolua_cRankManager_RenameGroup(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RenameGroup(OldName, NewName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -1160,12 +1160,12 @@ static int tolua_cRankManager_RenameGroup(lua_State * L)
 
 
 /** Binds cRankManager::RenameRank */
-static int tolua_cRankManager_RenameRank(lua_State * L)
+static int tolua_cRankManager_RenameRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:RenameRank(OldName, NewName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 3) ||
@@ -1192,12 +1192,12 @@ static int tolua_cRankManager_RenameRank(lua_State * L)
 
 
 /** Binds cRankManager::SetDefaultRank */
-static int tolua_cRankManager_SetDefaultRank(lua_State * L)
+static int tolua_cRankManager_SetDefaultRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:SetDefaultRank(RankName) -> bool
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2) ||
@@ -1221,12 +1221,12 @@ static int tolua_cRankManager_SetDefaultRank(lua_State * L)
 
 
 /** Binds cRankManager::SetPlayerRank */
-static int tolua_cRankManager_SetPlayerRank(lua_State * L)
+static int tolua_cRankManager_SetPlayerRank(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:SetPlayerRank(PlayerUUID, PlayerName, RankName)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamStaticSelf("cRankManager") ||
 		!S.CheckParamUUID(2) ||
@@ -1252,12 +1252,12 @@ static int tolua_cRankManager_SetPlayerRank(lua_State * L)
 
 
 /** Binds cRankManager::SetRankVisuals */
-static int tolua_cRankManager_SetRankVisuals(lua_State * L)
+static int tolua_cRankManager_SetRankVisuals(lua_State * a_L)
 {
 	// Function signature:
 	// cRankManager:SetRankVisuals(RankName, MsgPrefix, MsgSuffix, MsgNameColorCode)
 
-	cLuaState S(L);
+	cLuaState S(a_L);
 	if (
 		!S.CheckParamUserTable(1, "cRankManager") ||
 		!S.CheckParamString(2, 5) ||
@@ -1280,57 +1280,57 @@ static int tolua_cRankManager_SetRankVisuals(lua_State * L)
 
 
 
-void cManualBindings::BindRankManager(lua_State * tolua_S)
+void cManualBindings::BindRankManager(lua_State * a_tolua_S)
 {
 	// Create the cRankManager class in the API:
-	tolua_usertype(tolua_S, "cRankManager");
-	tolua_cclass(tolua_S, "cRankManager", "cRankManager", "", nullptr);
+	tolua_usertype(a_tolua_S, "cRankManager");
+	tolua_cclass(a_tolua_S, "cRankManager", "cRankManager", "", nullptr);
 
 	// Fill in the functions (alpha-sorted):
-	tolua_beginmodule(tolua_S, "cRankManager");
-		tolua_function(tolua_S, "AddGroup",                      tolua_cRankManager_AddGroup);
-		tolua_function(tolua_S, "AddGroupToRank",                tolua_cRankManager_AddGroupToRank);
-		tolua_function(tolua_S, "AddPermissionToGroup",          tolua_cRankManager_AddPermissionToGroup);
-		tolua_function(tolua_S, "AddRestrictionToGroup",         tolua_cRankManager_AddRestrictionToGroup);
-		tolua_function(tolua_S, "AddRank",                       tolua_cRankManager_AddRank);
-		tolua_function(tolua_S, "ClearPlayerRanks",              tolua_cRankManager_ClearPlayerRanks);
-		tolua_function(tolua_S, "GetAllGroups",                  tolua_cRankManager_GetAllGroups);
-		tolua_function(tolua_S, "GetAllPermissions",             tolua_cRankManager_GetAllPermissions);
-		tolua_function(tolua_S, "GetAllRestrictions",            tolua_cRankManager_GetAllRestrictions);
-		tolua_function(tolua_S, "GetAllPermissionsRestrictions", tolua_cRankManager_GetAllPermissionsRestrictions);
-		tolua_function(tolua_S, "GetAllPlayerUUIDs",             tolua_cRankManager_GetAllPlayerUUIDs);
-		tolua_function(tolua_S, "GetAllRanks",                   tolua_cRankManager_GetAllRanks);
-		tolua_function(tolua_S, "GetDefaultRank",                tolua_cRankManager_GetDefaultRank);
-		tolua_function(tolua_S, "GetGroupPermissions",           tolua_cRankManager_GetGroupPermissions);
-		tolua_function(tolua_S, "GetGroupRestrictions",          tolua_cRankManager_GetGroupRestrictions);
-		tolua_function(tolua_S, "GetPlayerGroups",               tolua_cRankManager_GetPlayerGroups);
-		tolua_function(tolua_S, "GetPlayerMsgVisuals",           tolua_cRankManager_GetPlayerMsgVisuals);
-		tolua_function(tolua_S, "GetPlayerPermissions",          tolua_cRankManager_GetPlayerPermissions);
-		tolua_function(tolua_S, "GetPlayerPermissions",          tolua_cRankManager_GetPlayerRestrictions);
-		tolua_function(tolua_S, "GetPlayerRankName",             tolua_cRankManager_GetPlayerRankName);
-		tolua_function(tolua_S, "GetPlayerName",                 tolua_cRankManager_GetPlayerName);
-		tolua_function(tolua_S, "GetRankGroups",                 tolua_cRankManager_GetRankGroups);
-		tolua_function(tolua_S, "GetRankPermissions",            tolua_cRankManager_GetRankPermissions);
-		tolua_function(tolua_S, "GetRankRestrictions",           tolua_cRankManager_GetRankRestrictions);
-		tolua_function(tolua_S, "GetRankVisuals",                tolua_cRankManager_GetRankVisuals);
-		tolua_function(tolua_S, "GroupExists",                   tolua_cRankManager_GroupExists);
-		tolua_function(tolua_S, "IsGroupInRank",                 tolua_cRankManager_IsGroupInRank);
-		tolua_function(tolua_S, "IsPermissionInGroup",           tolua_cRankManager_IsPermissionInGroup);
-		tolua_function(tolua_S, "IsRestrictionInGroup",          tolua_cRankManager_IsRestrictionInGroup);
-		tolua_function(tolua_S, "IsPlayerRankSet",               tolua_cRankManager_IsPlayerRankSet);
-		tolua_function(tolua_S, "RankExists",                    tolua_cRankManager_RankExists);
-		tolua_function(tolua_S, "RemoveGroup",                   tolua_cRankManager_RemoveGroup);
-		tolua_function(tolua_S, "RemoveGroupFromRank",           tolua_cRankManager_RemoveGroupFromRank);
-		tolua_function(tolua_S, "RemovePermissionFromGroup",     tolua_cRankManager_RemovePermissionFromGroup);
-		tolua_function(tolua_S, "RemoveRestrictionFromGroup",    tolua_cRankManager_RemoveRestrictionFromGroup);
-		tolua_function(tolua_S, "RemovePlayerRank",              tolua_cRankManager_RemovePlayerRank);
-		tolua_function(tolua_S, "RemoveRank",                    tolua_cRankManager_RemoveRank);
-		tolua_function(tolua_S, "RenameGroup",                   tolua_cRankManager_RenameGroup);
-		tolua_function(tolua_S, "RenameRank",                    tolua_cRankManager_RenameRank);
-		tolua_function(tolua_S, "SetDefaultRank",                tolua_cRankManager_SetDefaultRank);
-		tolua_function(tolua_S, "SetPlayerRank",                 tolua_cRankManager_SetPlayerRank);
-		tolua_function(tolua_S, "SetRankVisuals",                tolua_cRankManager_SetRankVisuals);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, "cRankManager");
+		tolua_function(a_tolua_S, "AddGroup",                      tolua_cRankManager_AddGroup);
+		tolua_function(a_tolua_S, "AddGroupToRank",                tolua_cRankManager_AddGroupToRank);
+		tolua_function(a_tolua_S, "AddPermissionToGroup",          tolua_cRankManager_AddPermissionToGroup);
+		tolua_function(a_tolua_S, "AddRestrictionToGroup",         tolua_cRankManager_AddRestrictionToGroup);
+		tolua_function(a_tolua_S, "AddRank",                       tolua_cRankManager_AddRank);
+		tolua_function(a_tolua_S, "ClearPlayerRanks",              tolua_cRankManager_ClearPlayerRanks);
+		tolua_function(a_tolua_S, "GetAllGroups",                  tolua_cRankManager_GetAllGroups);
+		tolua_function(a_tolua_S, "GetAllPermissions",             tolua_cRankManager_GetAllPermissions);
+		tolua_function(a_tolua_S, "GetAllRestrictions",            tolua_cRankManager_GetAllRestrictions);
+		tolua_function(a_tolua_S, "GetAllPermissionsRestrictions", tolua_cRankManager_GetAllPermissionsRestrictions);
+		tolua_function(a_tolua_S, "GetAllPlayerUUIDs",             tolua_cRankManager_GetAllPlayerUUIDs);
+		tolua_function(a_tolua_S, "GetAllRanks",                   tolua_cRankManager_GetAllRanks);
+		tolua_function(a_tolua_S, "GetDefaultRank",                tolua_cRankManager_GetDefaultRank);
+		tolua_function(a_tolua_S, "GetGroupPermissions",           tolua_cRankManager_GetGroupPermissions);
+		tolua_function(a_tolua_S, "GetGroupRestrictions",          tolua_cRankManager_GetGroupRestrictions);
+		tolua_function(a_tolua_S, "GetPlayerGroups",               tolua_cRankManager_GetPlayerGroups);
+		tolua_function(a_tolua_S, "GetPlayerMsgVisuals",           tolua_cRankManager_GetPlayerMsgVisuals);
+		tolua_function(a_tolua_S, "GetPlayerPermissions",          tolua_cRankManager_GetPlayerPermissions);
+		tolua_function(a_tolua_S, "GetPlayerPermissions",          tolua_cRankManager_GetPlayerRestrictions);
+		tolua_function(a_tolua_S, "GetPlayerRankName",             tolua_cRankManager_GetPlayerRankName);
+		tolua_function(a_tolua_S, "GetPlayerName",                 tolua_cRankManager_GetPlayerName);
+		tolua_function(a_tolua_S, "GetRankGroups",                 tolua_cRankManager_GetRankGroups);
+		tolua_function(a_tolua_S, "GetRankPermissions",            tolua_cRankManager_GetRankPermissions);
+		tolua_function(a_tolua_S, "GetRankRestrictions",           tolua_cRankManager_GetRankRestrictions);
+		tolua_function(a_tolua_S, "GetRankVisuals",                tolua_cRankManager_GetRankVisuals);
+		tolua_function(a_tolua_S, "GroupExists",                   tolua_cRankManager_GroupExists);
+		tolua_function(a_tolua_S, "IsGroupInRank",                 tolua_cRankManager_IsGroupInRank);
+		tolua_function(a_tolua_S, "IsPermissionInGroup",           tolua_cRankManager_IsPermissionInGroup);
+		tolua_function(a_tolua_S, "IsRestrictionInGroup",          tolua_cRankManager_IsRestrictionInGroup);
+		tolua_function(a_tolua_S, "IsPlayerRankSet",               tolua_cRankManager_IsPlayerRankSet);
+		tolua_function(a_tolua_S, "RankExists",                    tolua_cRankManager_RankExists);
+		tolua_function(a_tolua_S, "RemoveGroup",                   tolua_cRankManager_RemoveGroup);
+		tolua_function(a_tolua_S, "RemoveGroupFromRank",           tolua_cRankManager_RemoveGroupFromRank);
+		tolua_function(a_tolua_S, "RemovePermissionFromGroup",     tolua_cRankManager_RemovePermissionFromGroup);
+		tolua_function(a_tolua_S, "RemoveRestrictionFromGroup",    tolua_cRankManager_RemoveRestrictionFromGroup);
+		tolua_function(a_tolua_S, "RemovePlayerRank",              tolua_cRankManager_RemovePlayerRank);
+		tolua_function(a_tolua_S, "RemoveRank",                    tolua_cRankManager_RemoveRank);
+		tolua_function(a_tolua_S, "RenameGroup",                   tolua_cRankManager_RenameGroup);
+		tolua_function(a_tolua_S, "RenameRank",                    tolua_cRankManager_RenameRank);
+		tolua_function(a_tolua_S, "SetDefaultRank",                tolua_cRankManager_SetDefaultRank);
+		tolua_function(a_tolua_S, "SetPlayerRank",                 tolua_cRankManager_SetPlayerRank);
+		tolua_function(a_tolua_S, "SetRankVisuals",                tolua_cRankManager_SetRankVisuals);
+	tolua_endmodule(a_tolua_S);
 }
 
 

--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -17,12 +17,12 @@
 
 
 
-static int tolua_cWorld_BroadcastParticleEffect(lua_State * tolua_S)
+static int tolua_cWorld_BroadcastParticleEffect(lua_State * a_tolua_S)
 {
 	/* Function signature:
 	World:BroadcastParticleEffect("Name", PosX, PosY, PosZ, OffX, OffY, OffZ, ParticleData, ParticleAmount, [ExcludeClient], [OptionalParam1], [OptionalParam2]
 	*/
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamString  (2) ||
@@ -63,14 +63,14 @@ static int tolua_cWorld_BroadcastParticleEffect(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_ChunkStay(lua_State * tolua_S)
+static int tolua_cWorld_ChunkStay(lua_State * a_tolua_S)
 {
 	/* Function signature:
 	World:ChunkStay(ChunkCoordTable, OnChunkAvailable, OnAllChunksAvailable)
 	ChunkCoordTable == { {Chunk1x, Chunk1z}, {Chunk2x, Chunk2z}, ... }
 	*/
 
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType     (1, "cWorld") ||
 		!L.CheckParamTable        (2) ||
@@ -115,13 +115,13 @@ static int tolua_cWorld_ChunkStay(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_DoExplosionAt(lua_State * tolua_S)
+static int tolua_cWorld_DoExplosionAt(lua_State * a_tolua_S)
 {
 	/* Function signature:
 	World:DoExplosionAt(ExplosionSize, BlockX, BlockY, BlockZ, CanCauseFire, SourceType, [SourceData])
 	*/
 
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType     (1, "cWorld") ||
 		!L.CheckParamNumber       (2, 5) ||
@@ -207,10 +207,10 @@ static int tolua_cWorld_DoExplosionAt(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_DoWithPlayerByUUID(lua_State * tolua_S)
+static int tolua_cWorld_DoWithPlayerByUUID(lua_State * a_tolua_S)
 {
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamSelf("cWorld") ||
 		!L.CheckParamUUID(2) ||
@@ -254,12 +254,12 @@ static int tolua_cWorld_DoWithPlayerByUUID(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_ForEachLoadedChunk(lua_State * tolua_S)
+static int tolua_cWorld_ForEachLoadedChunk(lua_State * a_tolua_S)
 {
 	// Exported manually, because tolua doesn't support converting functions to functor types.
 	// Function signature: ForEachLoadedChunk(callback) -> bool
 
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamFunction(2)
@@ -268,14 +268,14 @@ static int tolua_cWorld_ForEachLoadedChunk(lua_State * tolua_S)
 		return 0;
 	}
 
-	cPluginLua * Plugin = cManualBindings::GetLuaPlugin(tolua_S);
+	cPluginLua * Plugin = cManualBindings::GetLuaPlugin(a_tolua_S);
 	if (Plugin == nullptr)
 	{
 		return 0;
 	}
 
 	// Read the params:
-	cWorld * World = static_cast<cWorld *>(tolua_tousertype(tolua_S, 1, nullptr));
+	cWorld * World = static_cast<cWorld *>(tolua_tousertype(a_tolua_S, 1, nullptr));
 	if (World == nullptr)
 	{
 		LOGWARNING("World:ForEachLoadedChunk(): invalid world parameter");
@@ -286,7 +286,7 @@ static int tolua_cWorld_ForEachLoadedChunk(lua_State * tolua_S)
 	L.GetStackValues(2, FnRef);
 	if (!FnRef.IsValid())
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Could not get function reference of parameter #2");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Could not get function reference of parameter #2");
 	}
 
 	// Call the enumeration:
@@ -308,13 +308,13 @@ static int tolua_cWorld_ForEachLoadedChunk(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_GetBlockInfo(lua_State * tolua_S)
+static int tolua_cWorld_GetBlockInfo(lua_State * a_tolua_S)
 {
 	// Exported manually, because tolua would generate useless additional parameters (a_BlockType .. a_BlockSkyLight)
 	// Function signature: GetBlockInfo(BlockX, BlockY, BlockZ) -> BlockValid, [BlockType, BlockMeta, BlockSkyLight, BlockBlockLight]
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamNumber(2, 4) ||
@@ -332,7 +332,7 @@ static int tolua_cWorld_GetBlockInfo(lua_State * tolua_S)
 	L.GetStackValues(1, Self, BlockX, BlockY, BlockZ);
 	if (Self == nullptr)
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 	}
 
 	// Call the function:
@@ -354,13 +354,13 @@ static int tolua_cWorld_GetBlockInfo(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_GetBlockTypeMeta(lua_State * tolua_S)
+static int tolua_cWorld_GetBlockTypeMeta(lua_State * a_tolua_S)
 {
 	// Exported manually, because tolua would generate useless additional parameters (a_BlockType, a_BlockMeta)
 	// Function signature: GetBlockTypeMeta(BlockX, BlockY, BlockZ) -> BlockValid, [BlockType, BlockMeta]
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamNumber(2, 4) ||
@@ -378,7 +378,7 @@ static int tolua_cWorld_GetBlockTypeMeta(lua_State * tolua_S)
 	L.GetStackValues(1, Self, BlockX, BlockY, BlockZ);
 	if (Self == nullptr)
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 	}
 
 	// Call the function:
@@ -400,12 +400,12 @@ static int tolua_cWorld_GetBlockTypeMeta(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_GetSignLines(lua_State * tolua_S)
+static int tolua_cWorld_GetSignLines(lua_State * a_tolua_S)
 {
 	// Exported manually, because tolua would generate useless additional parameters (a_Line1 .. a_Line4)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamNumber(2, 4) ||
@@ -423,7 +423,7 @@ static int tolua_cWorld_GetSignLines(lua_State * tolua_S)
 	L.GetStackValues(1, Self, BlockX, BlockY, BlockZ);
 	if (Self == nullptr)
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 	}
 
 	// Call the function:
@@ -444,14 +444,14 @@ static int tolua_cWorld_GetSignLines(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_PrepareChunk(lua_State * tolua_S)
+static int tolua_cWorld_PrepareChunk(lua_State * a_tolua_S)
 {
 	/* Function signature:
 	World:PrepareChunk(ChunkX, ChunkZ, Callback)
 	*/
 
 	// Check the param types:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType     (1, "cWorld") ||
 		!L.CheckParamNumber       (2, 3) ||
@@ -497,13 +497,13 @@ static int tolua_cWorld_PrepareChunk(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_QueueTask(lua_State * tolua_S)
+static int tolua_cWorld_QueueTask(lua_State * a_tolua_S)
 {
 	// Function signature:
 	// World:QueueTask(Callback)
 
 	// Retrieve the args:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamFunction(2)
@@ -515,15 +515,15 @@ static int tolua_cWorld_QueueTask(lua_State * tolua_S)
 	cLuaState::cCallbackSharedPtr Task;
 	if (!L.GetStackValues(1, World, Task))
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Cannot read parameters");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Cannot read parameters");
 	}
 	if (World == nullptr)
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Not called on an object instance");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Not called on an object instance");
 	}
 	if (!Task->IsValid())
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Could not store the callback parameter");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Could not store the callback parameter");
 	}
 
 	World->QueueTask([Task](cWorld & a_World)
@@ -538,12 +538,12 @@ static int tolua_cWorld_QueueTask(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_SetSignLines(lua_State * tolua_S)
+static int tolua_cWorld_SetSignLines(lua_State * a_tolua_S)
 {
 	// Exported manually, because tolua would generate useless additional return values (a_Line1 .. a_Line4)
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamNumber(2, 4) ||
@@ -563,7 +563,7 @@ static int tolua_cWorld_SetSignLines(lua_State * tolua_S)
 	L.GetStackValues(1, Self, BlockX, BlockY, BlockZ, Line1, Line2, Line3, Line4);
 	if (Self == nullptr)
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Invalid 'self'");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Invalid 'self'");
 	}
 
 	// Call the function:
@@ -578,13 +578,13 @@ static int tolua_cWorld_SetSignLines(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_ScheduleTask(lua_State * tolua_S)
+static int tolua_cWorld_ScheduleTask(lua_State * a_tolua_S)
 {
 	// Function signature:
 	// World:ScheduleTask(NumTicks, Callback)
 
 	// Retrieve the args:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamNumber  (2) ||
@@ -598,15 +598,15 @@ static int tolua_cWorld_ScheduleTask(lua_State * tolua_S)
 	auto Task = std::make_shared<cLuaState::cCallback>();
 	if (!L.GetStackValues(1, World, NumTicks, Task))
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Cannot read parameters");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Cannot read parameters");
 	}
 	if (World == nullptr)
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Not called on an object instance");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Not called on an object instance");
 	}
 	if (!Task->IsValid())
 	{
-		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Could not store the callback parameter");
+		return cManualBindings::lua_do_error(a_tolua_S, "Error in function call '#funcname#': Could not store the callback parameter");
 	}
 
 	World->ScheduleTask(NumTicks, [Task](cWorld & a_World)
@@ -622,14 +622,14 @@ static int tolua_cWorld_ScheduleTask(lua_State * tolua_S)
 
 
 
-static int tolua_cWorld_TryGetHeight(lua_State * tolua_S)
+static int tolua_cWorld_TryGetHeight(lua_State * a_tolua_S)
 {
 	/* Exported manually, because tolua would require the out-only param a_Height to be used when calling
 	Function signature: world:TryGetHeight(a_World, a_BlockX, a_BlockZ) -> IsValid, Height
 	*/
 
 	// Check params:
-	cLuaState L(tolua_S);
+	cLuaState L(a_tolua_S);
 	if (
 		!L.CheckParamUserType(1, "cWorld") ||
 		!L.CheckParamNumber(2, 3) ||
@@ -646,7 +646,7 @@ static int tolua_cWorld_TryGetHeight(lua_State * tolua_S)
 	L.GetStackValues(1, self, BlockX, BlockZ);
 	if (self == nullptr)
 	{
-		tolua_error(tolua_S, "Invalid 'self' in function 'TryGetHeight'", nullptr);
+		tolua_error(a_tolua_S, "Invalid 'self' in function 'TryGetHeight'", nullptr);
 		return 0;
 	}
 
@@ -666,49 +666,49 @@ static int tolua_cWorld_TryGetHeight(lua_State * tolua_S)
 
 
 
-void cManualBindings::BindWorld(lua_State * tolua_S)
+void cManualBindings::BindWorld(lua_State * a_tolua_S)
 {
-	tolua_beginmodule(tolua_S, nullptr);
-		tolua_beginmodule(tolua_S, "cWorld");
-			tolua_function(tolua_S, "BroadcastParticleEffect",    tolua_cWorld_BroadcastParticleEffect);
-			tolua_function(tolua_S, "ChunkStay",                  tolua_cWorld_ChunkStay);
-			tolua_function(tolua_S, "DoExplosionAt",              tolua_cWorld_DoExplosionAt);
-			tolua_function(tolua_S, "DoWithBeaconAt",             DoWithXYZ<cWorld, cBeaconEntity,       &cWorld::DoWithBeaconAt>);
-			tolua_function(tolua_S, "DoWithBedAt",                DoWithXYZ<cWorld, cBedEntity,          &cWorld::DoWithBedAt>);
-			tolua_function(tolua_S, "DoWithBlockEntityAt",        DoWithXYZ<cWorld, cBlockEntity,        &cWorld::DoWithBlockEntityAt>);
-			tolua_function(tolua_S, "DoWithBrewingstandAt",       DoWithXYZ<cWorld, cBrewingstandEntity, &cWorld::DoWithBrewingstandAt>);
-			tolua_function(tolua_S, "DoWithChestAt",              DoWithXYZ<cWorld, cChestEntity,        &cWorld::DoWithChestAt>);
-			tolua_function(tolua_S, "DoWithCommandBlockAt",       DoWithXYZ<cWorld, cCommandBlockEntity, &cWorld::DoWithCommandBlockAt>);
-			tolua_function(tolua_S, "DoWithDispenserAt",          DoWithXYZ<cWorld, cDispenserEntity,    &cWorld::DoWithDispenserAt>);
-			tolua_function(tolua_S, "DoWithDropSpenserAt",        DoWithXYZ<cWorld, cDropSpenserEntity,  &cWorld::DoWithDropSpenserAt>);
-			tolua_function(tolua_S, "DoWithDropperAt",            DoWithXYZ<cWorld, cDropperEntity,      &cWorld::DoWithDropperAt>);
-			tolua_function(tolua_S, "DoWithEntityByID",           DoWithID< cWorld, cEntity,             &cWorld::DoWithEntityByID>);
-			tolua_function(tolua_S, "DoWithFlowerPotAt",          DoWithXYZ<cWorld, cFlowerPotEntity,    &cWorld::DoWithFlowerPotAt>);
-			tolua_function(tolua_S, "DoWithFurnaceAt",            DoWithXYZ<cWorld, cFurnaceEntity,      &cWorld::DoWithFurnaceAt>);
-			tolua_function(tolua_S, "DoWithMobHeadAt",            DoWithXYZ<cWorld, cMobHeadEntity,      &cWorld::DoWithMobHeadAt>);
-			tolua_function(tolua_S, "DoWithNoteBlockAt",          DoWithXYZ<cWorld, cNoteEntity,         &cWorld::DoWithNoteBlockAt>);
-			tolua_function(tolua_S, "DoWithPlayer",               DoWith<   cWorld, cPlayer,             &cWorld::DoWithPlayer>);
-			tolua_function(tolua_S, "DoWithPlayerByUUID",         tolua_cWorld_DoWithPlayerByUUID);
-			tolua_function(tolua_S, "FindAndDoWithPlayer",        DoWith<   cWorld, cPlayer,             &cWorld::FindAndDoWithPlayer>);
-			tolua_function(tolua_S, "ForEachBlockEntityInChunk",  ForEachInChunk<cWorld, cBlockEntity,   &cWorld::ForEachBlockEntityInChunk>);
-			tolua_function(tolua_S, "ForEachBrewingstandInChunk", ForEachInChunk<cWorld, cBrewingstandEntity, &cWorld::ForEachBrewingstandInChunk>);
-			tolua_function(tolua_S, "ForEachChestInChunk",        ForEachInChunk<cWorld, cChestEntity,   &cWorld::ForEachChestInChunk>);
-			tolua_function(tolua_S, "ForEachEntity",              ForEach<       cWorld, cEntity,        &cWorld::ForEachEntity>);
-			tolua_function(tolua_S, "ForEachEntityInBox",         ForEachInBox<  cWorld, cEntity,        &cWorld::ForEachEntityInBox>);
-			tolua_function(tolua_S, "ForEachEntityInChunk",       ForEachInChunk<cWorld, cEntity,        &cWorld::ForEachEntityInChunk>);
-			tolua_function(tolua_S, "ForEachFurnaceInChunk",      ForEachInChunk<cWorld, cFurnaceEntity, &cWorld::ForEachFurnaceInChunk>);
-			tolua_function(tolua_S, "ForEachLoadedChunk",         tolua_cWorld_ForEachLoadedChunk);
-			tolua_function(tolua_S, "ForEachPlayer",              ForEach<       cWorld, cPlayer,        &cWorld::ForEachPlayer>);
-			tolua_function(tolua_S, "GetBlockInfo",               tolua_cWorld_GetBlockInfo);
-			tolua_function(tolua_S, "GetBlockTypeMeta",           tolua_cWorld_GetBlockTypeMeta);
-			tolua_function(tolua_S, "GetSignLines",               tolua_cWorld_GetSignLines);
-			tolua_function(tolua_S, "PrepareChunk",               tolua_cWorld_PrepareChunk);
-			tolua_function(tolua_S, "QueueTask",                  tolua_cWorld_QueueTask);
-			tolua_function(tolua_S, "ScheduleTask",               tolua_cWorld_ScheduleTask);
-			tolua_function(tolua_S, "SetSignLines",               tolua_cWorld_SetSignLines);
-			tolua_function(tolua_S, "TryGetHeight",               tolua_cWorld_TryGetHeight);
-		tolua_endmodule(tolua_S);
-	tolua_endmodule(tolua_S);
+	tolua_beginmodule(a_tolua_S, nullptr);
+		tolua_beginmodule(a_tolua_S, "cWorld");
+			tolua_function(a_tolua_S, "BroadcastParticleEffect",    tolua_cWorld_BroadcastParticleEffect);
+			tolua_function(a_tolua_S, "ChunkStay",                  tolua_cWorld_ChunkStay);
+			tolua_function(a_tolua_S, "DoExplosionAt",              tolua_cWorld_DoExplosionAt);
+			tolua_function(a_tolua_S, "DoWithBeaconAt",             DoWithXYZ<cWorld, cBeaconEntity,       &cWorld::DoWithBeaconAt>);
+			tolua_function(a_tolua_S, "DoWithBedAt",                DoWithXYZ<cWorld, cBedEntity,          &cWorld::DoWithBedAt>);
+			tolua_function(a_tolua_S, "DoWithBlockEntityAt",        DoWithXYZ<cWorld, cBlockEntity,        &cWorld::DoWithBlockEntityAt>);
+			tolua_function(a_tolua_S, "DoWithBrewingstandAt",       DoWithXYZ<cWorld, cBrewingstandEntity, &cWorld::DoWithBrewingstandAt>);
+			tolua_function(a_tolua_S, "DoWithChestAt",              DoWithXYZ<cWorld, cChestEntity,        &cWorld::DoWithChestAt>);
+			tolua_function(a_tolua_S, "DoWithCommandBlockAt",       DoWithXYZ<cWorld, cCommandBlockEntity, &cWorld::DoWithCommandBlockAt>);
+			tolua_function(a_tolua_S, "DoWithDispenserAt",          DoWithXYZ<cWorld, cDispenserEntity,    &cWorld::DoWithDispenserAt>);
+			tolua_function(a_tolua_S, "DoWithDropSpenserAt",        DoWithXYZ<cWorld, cDropSpenserEntity,  &cWorld::DoWithDropSpenserAt>);
+			tolua_function(a_tolua_S, "DoWithDropperAt",            DoWithXYZ<cWorld, cDropperEntity,      &cWorld::DoWithDropperAt>);
+			tolua_function(a_tolua_S, "DoWithEntityByID",           DoWithID< cWorld, cEntity,             &cWorld::DoWithEntityByID>);
+			tolua_function(a_tolua_S, "DoWithFlowerPotAt",          DoWithXYZ<cWorld, cFlowerPotEntity,    &cWorld::DoWithFlowerPotAt>);
+			tolua_function(a_tolua_S, "DoWithFurnaceAt",            DoWithXYZ<cWorld, cFurnaceEntity,      &cWorld::DoWithFurnaceAt>);
+			tolua_function(a_tolua_S, "DoWithMobHeadAt",            DoWithXYZ<cWorld, cMobHeadEntity,      &cWorld::DoWithMobHeadAt>);
+			tolua_function(a_tolua_S, "DoWithNoteBlockAt",          DoWithXYZ<cWorld, cNoteEntity,         &cWorld::DoWithNoteBlockAt>);
+			tolua_function(a_tolua_S, "DoWithPlayer",               DoWith<   cWorld, cPlayer,             &cWorld::DoWithPlayer>);
+			tolua_function(a_tolua_S, "DoWithPlayerByUUID",         tolua_cWorld_DoWithPlayerByUUID);
+			tolua_function(a_tolua_S, "FindAndDoWithPlayer",        DoWith<   cWorld, cPlayer,             &cWorld::FindAndDoWithPlayer>);
+			tolua_function(a_tolua_S, "ForEachBlockEntityInChunk",  ForEachInChunk<cWorld, cBlockEntity,   &cWorld::ForEachBlockEntityInChunk>);
+			tolua_function(a_tolua_S, "ForEachBrewingstandInChunk", ForEachInChunk<cWorld, cBrewingstandEntity, &cWorld::ForEachBrewingstandInChunk>);
+			tolua_function(a_tolua_S, "ForEachChestInChunk",        ForEachInChunk<cWorld, cChestEntity,   &cWorld::ForEachChestInChunk>);
+			tolua_function(a_tolua_S, "ForEachEntity",              ForEach<       cWorld, cEntity,        &cWorld::ForEachEntity>);
+			tolua_function(a_tolua_S, "ForEachEntityInBox",         ForEachInBox<  cWorld, cEntity,        &cWorld::ForEachEntityInBox>);
+			tolua_function(a_tolua_S, "ForEachEntityInChunk",       ForEachInChunk<cWorld, cEntity,        &cWorld::ForEachEntityInChunk>);
+			tolua_function(a_tolua_S, "ForEachFurnaceInChunk",      ForEachInChunk<cWorld, cFurnaceEntity, &cWorld::ForEachFurnaceInChunk>);
+			tolua_function(a_tolua_S, "ForEachLoadedChunk",         tolua_cWorld_ForEachLoadedChunk);
+			tolua_function(a_tolua_S, "ForEachPlayer",              ForEach<       cWorld, cPlayer,        &cWorld::ForEachPlayer>);
+			tolua_function(a_tolua_S, "GetBlockInfo",               tolua_cWorld_GetBlockInfo);
+			tolua_function(a_tolua_S, "GetBlockTypeMeta",           tolua_cWorld_GetBlockTypeMeta);
+			tolua_function(a_tolua_S, "GetSignLines",               tolua_cWorld_GetSignLines);
+			tolua_function(a_tolua_S, "PrepareChunk",               tolua_cWorld_PrepareChunk);
+			tolua_function(a_tolua_S, "QueueTask",                  tolua_cWorld_QueueTask);
+			tolua_function(a_tolua_S, "ScheduleTask",               tolua_cWorld_ScheduleTask);
+			tolua_function(a_tolua_S, "SetSignLines",               tolua_cWorld_SetSignLines);
+			tolua_function(a_tolua_S, "TryGetHeight",               tolua_cWorld_TryGetHeight);
+		tolua_endmodule(a_tolua_S);
+	tolua_endmodule(a_tolua_S);
 }
 
 

--- a/src/BlockArea.h
+++ b/src/BlockArea.h
@@ -479,7 +479,7 @@ protected:
 	);
 
 	template <bool MetasValid>
-	void MergeByStrategy(const cBlockArea & a_Src, int a_RelX, int a_RelY, int a_RelZ, eMergeStrategy a_Strategy, const NIBBLETYPE * SrcMetas, NIBBLETYPE * DstMetas);
+	void MergeByStrategy(const cBlockArea & a_Src, int a_RelX, int a_RelY, int a_RelZ, eMergeStrategy a_Strategy, const NIBBLETYPE * a_SrcMetas, NIBBLETYPE * a_DstMetas);
 
 	/** Clears the block entities from the specified container, freeing each blockentity. */
 	static void ClearBlockEntities(cBlockEntities & a_BlockEntities);

--- a/src/BlockEntities/CommandBlockEntity.cpp
+++ b/src/BlockEntities/CommandBlockEntity.cpp
@@ -175,7 +175,7 @@ void cCommandBlockEntity::Execute()
 		virtual void Out(const AString & a_Text)
 		{
 			// Overwrite field
-			m_CmdBlock->SetLastOutput(cClientHandle::FormatChatPrefix(m_CmdBlock->GetWorld()->ShouldUseChatPrefixes(), "SUCCESS", cChatColor::Green, cChatColor::White) + a_Text);
+			m_CmdBlock->SetLastOutput(cClientHandle::FormatChatPrefix(m_CmdBlock->GetWorld()->ShouldUseChatPrefixes(), "SUCCESS", cChatColor::m_Green, cChatColor::m_White) + a_Text);
 		}
 	} CmdBlockOutCb(this);
 
@@ -194,7 +194,7 @@ void cCommandBlockEntity::Execute()
 	}
 	else
 	{
-		SetLastOutput(cClientHandle::FormatChatPrefix(GetWorld()->ShouldUseChatPrefixes(), "FAILURE", cChatColor::Rose, cChatColor::White) + "Adminstration commands can not be executed");
+		SetLastOutput(cClientHandle::FormatChatPrefix(GetWorld()->ShouldUseChatPrefixes(), "FAILURE", cChatColor::m_Rose, cChatColor::m_White) + "Adminstration commands can not be executed");
 		LOGD("cCommandBlockEntity: Prevented execution of administration command %s", m_Command.c_str());
 	}
 

--- a/src/BlockEntities/FlowerPotEntity.cpp
+++ b/src/BlockEntities/FlowerPotEntity.cpp
@@ -85,9 +85,9 @@ void cFlowerPotEntity::SendTo(cClientHandle & a_Client)
 
 
 
-bool cFlowerPotEntity::IsFlower(short m_ItemType, short m_ItemData)
+bool cFlowerPotEntity::IsFlower(short a_m_ItemType, short a_m_ItemData)
 {
-	switch (m_ItemType)
+	switch (a_m_ItemType)
 	{
 		case E_BLOCK_DANDELION:
 		case E_BLOCK_FLOWER:
@@ -101,7 +101,7 @@ bool cFlowerPotEntity::IsFlower(short m_ItemType, short m_ItemData)
 		}
 		case E_BLOCK_TALL_GRASS:
 		{
-			return (m_ItemData == static_cast<short>(2));
+			return (a_m_ItemData == static_cast<short>(2));
 		}
 		default:
 		{

--- a/src/BlockEntities/FlowerPotEntity.cpp
+++ b/src/BlockEntities/FlowerPotEntity.cpp
@@ -85,9 +85,9 @@ void cFlowerPotEntity::SendTo(cClientHandle & a_Client)
 
 
 
-bool cFlowerPotEntity::IsFlower(short a_m_ItemType, short a_m_ItemData)
+bool cFlowerPotEntity::IsFlower(short a_ItemType, short a_ItemData)
 {
-	switch (a_m_ItemType)
+	switch (a_ItemType)
 	{
 		case E_BLOCK_DANDELION:
 		case E_BLOCK_FLOWER:
@@ -101,7 +101,7 @@ bool cFlowerPotEntity::IsFlower(short a_m_ItemType, short a_m_ItemData)
 		}
 		case E_BLOCK_TALL_GRASS:
 		{
-			return (a_m_ItemData == static_cast<short>(2));
+			return (a_ItemData == static_cast<short>(2));
 		}
 		default:
 		{

--- a/src/BlockEntities/FlowerPotEntity.h
+++ b/src/BlockEntities/FlowerPotEntity.h
@@ -51,7 +51,7 @@ public:
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 
-	static bool IsFlower(short m_ItemType, short m_ItemData);
+	static bool IsFlower(short a_m_ItemType, short a_m_ItemData);
 
 private:
 

--- a/src/BlockEntities/FlowerPotEntity.h
+++ b/src/BlockEntities/FlowerPotEntity.h
@@ -51,7 +51,7 @@ public:
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 
-	static bool IsFlower(short a_m_ItemType, short a_m_ItemData);
+	static bool IsFlower(short a_ItemType, short a_ItemData);
 
 private:
 

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -372,7 +372,7 @@ bool cHopperEntity::MoveItemsFromChest(cChunk & a_Chunk)
 	// Check if the chest is a double-chest (chest directly above was empty), if so, try to move from there:
 	static const struct
 	{
-		int x, z;
+		int m_x, m_z;
 	}
 	Coords [] =
 	{
@@ -539,7 +539,7 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, int a_BlockX, int a_Block
 	// Check if the chest is a double-chest (chest block directly connected was full), if so, try to move into the other half:
 	static const struct
 	{
-		int x, z;
+		int m_x, m_z;
 	}
 	Coords [] =
 	{

--- a/src/BlockID.cpp
+++ b/src/BlockID.cpp
@@ -190,7 +190,7 @@ protected:
 
 
 bool cBlockIDMap::m_bHasRunInit = false;
-static cBlockIDMap gsBlockIDMap;
+static cBlockIDMap g_gsBlockIDMap;
 
 
 
@@ -224,11 +224,11 @@ int BlockStringToType(const AString & a_BlockTypeString)
 		return res;
 	}
 
-	if (!gsBlockIDMap.m_bHasRunInit)
+	if (!g_gsBlockIDMap.m_bHasRunInit)
 	{
-		gsBlockIDMap.init();
+		g_gsBlockIDMap.init();
 	}
-	return gsBlockIDMap.Resolve(TrimString(a_BlockTypeString));
+	return g_gsBlockIDMap.Resolve(TrimString(a_BlockTypeString));
 }
 
 
@@ -242,11 +242,11 @@ bool StringToItem(const AString & a_ItemTypeString, cItem & a_Item)
 		ItemName = ItemName.substr(10);
 	}
 
-	if (!gsBlockIDMap.m_bHasRunInit)
+	if (!g_gsBlockIDMap.m_bHasRunInit)
 	{
-		gsBlockIDMap.init();
+		g_gsBlockIDMap.init();
 	}
-	return gsBlockIDMap.ResolveItem(ItemName, a_Item);
+	return g_gsBlockIDMap.ResolveItem(ItemName, a_Item);
 }
 
 
@@ -255,11 +255,11 @@ bool StringToItem(const AString & a_ItemTypeString, cItem & a_Item)
 
 AString ItemToString(const cItem & a_Item)
 {
-	if (!gsBlockIDMap.m_bHasRunInit)
+	if (!g_gsBlockIDMap.m_bHasRunInit)
 	{
-		gsBlockIDMap.init();
+		g_gsBlockIDMap.init();
 	}
-	return gsBlockIDMap.Desolve(a_Item.m_ItemType, a_Item.m_ItemDamage);
+	return g_gsBlockIDMap.Desolve(a_Item.m_ItemType, a_Item.m_ItemDamage);
 }
 
 
@@ -268,11 +268,11 @@ AString ItemToString(const cItem & a_Item)
 
 AString ItemTypeToString(short a_ItemType)
 {
-	if (!gsBlockIDMap.m_bHasRunInit)
+	if (!g_gsBlockIDMap.m_bHasRunInit)
 	{
-		gsBlockIDMap.init();
+		g_gsBlockIDMap.init();
 	}
-	return gsBlockIDMap.Desolve(a_ItemType, -1);
+	return g_gsBlockIDMap.Desolve(a_ItemType, -1);
 }
 
 

--- a/src/Blocks/BlockBed.h
+++ b/src/Blocks/BlockBed.h
@@ -33,7 +33,7 @@ public:
 		return true;
 	}
 
-	virtual void ConvertToPickups(cItems & Pickups, NIBBLETYPE Meta) override {}
+	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_Meta) override {}
 
 	virtual void ConvertToPickups(cWorldInterface & a_WorldInterface, cItems & a_Pickups, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ) override;
 

--- a/src/Blocks/BlockCactus.h
+++ b/src/Blocks/BlockCactus.h
@@ -39,7 +39,7 @@ public:
 		// Check surroundings. Cacti may ONLY be surrounded by non-solid blocks
 		static const struct
 		{
-			int x, z;
+			int m_x, m_z;
 		} Coords[] =
 		{
 			{-1,  0},
@@ -67,7 +67,7 @@ public:
 		return true;
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		if (CanGrow(a_Chunk, a_RelX, a_RelY, a_RelZ) == paGrowth)
 		{

--- a/src/Blocks/BlockCocoaPod.h
+++ b/src/Blocks/BlockCocoaPod.h
@@ -28,7 +28,7 @@ public:
 		return ((BlockType == E_BLOCK_LOG) && ((BlockMeta & 0x3) == E_META_LOG_JUNGLE));
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		if (GetRandomProvider().RandBool(0.20))
 		{

--- a/src/Blocks/BlockCrops.h
+++ b/src/Blocks/BlockCrops.h
@@ -88,7 +88,7 @@ public:
 
 
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		NIBBLETYPE Meta = a_Chunk.GetMeta(a_RelX, a_RelY, a_RelZ);
 

--- a/src/Blocks/BlockDirt.h
+++ b/src/Blocks/BlockDirt.h
@@ -33,7 +33,7 @@ public:
 		}
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		if (m_BlockType != E_BLOCK_GRASS)
 		{

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -26,7 +26,7 @@ public:
 	{
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		NIBBLETYPE BlockMeta = a_Chunk.GetMeta(a_RelX, a_RelY, a_RelZ);
 

--- a/src/Blocks/BlockFence.h
+++ b/src/Blocks/BlockFence.h
@@ -17,8 +17,8 @@ public:
 	// These are the min and max coordinates (X and Z) for a straight fence.
 	// 0.4 and 0.6 are really just guesses, but they seem pretty good.
 	// (0.4 to 0.6 is a fence that's 0.2 wide, down the center of the block)
-	const double MIN_COORD = 0.4;
-	const double MAX_COORD = 0.6;
+	const double m_MIN_COORD = 0.4;
+	const double m_MAX_COORD = 0.6;
 
 	cBlockFenceHandler(BLOCKTYPE a_BlockType)
 		: cBlockHandler(a_BlockType)

--- a/src/Blocks/BlockFire.h
+++ b/src/Blocks/BlockFire.h
@@ -13,14 +13,14 @@ class cBlockFireHandler :
 public:
 	cBlockFireHandler(BLOCKTYPE a_BlockType)
 		: cBlockHandler(a_BlockType),
-		XZP(0), XZM(0), Dir(0)
+		m_XZP(0), m_XZM(0), m_Dir(0)
 	{
 	}
 
 	/** Portal boundary and direction variables */
 	// 2014_03_30 _X: What are these used for? Why do we need extra variables?
-	int XZP, XZM;
-	NIBBLETYPE Dir;
+	int m_XZP, m_XZM;
+	NIBBLETYPE m_Dir;
 
 	virtual void OnPlaced(cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface, int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) override
 	{
@@ -53,16 +53,16 @@ public:
 
 	/** Traces along YP until it finds an obsidian block, returns Y difference or 0 if no portal, and -1 for border
 	Takes the X, Y, and Z of the base block; with an optional MaxY for portal border finding */
-	int FindObsidianCeiling(int X, int Y, int Z, cChunkInterface & a_ChunkInterface, int MaxY = 0)
+	int FindObsidianCeiling(int a_X, int a_Y, int a_Z, cChunkInterface & a_ChunkInterface, int a_MaxY = 0)
 	{
-		if (a_ChunkInterface.GetBlock({X, Y, Z}) != E_BLOCK_OBSIDIAN)
+		if (a_ChunkInterface.GetBlock({a_X, a_Y, a_Z}) != E_BLOCK_OBSIDIAN)
 		{
 			return 0;
 		}
 
-		for (int newY = Y + 1; newY < cChunkDef::Height; newY++)
+		for (int newY = a_Y + 1; newY < cChunkDef::Height; newY++)
 		{
-			BLOCKTYPE Block = a_ChunkInterface.GetBlock({X, newY, Z});
+			BLOCKTYPE Block = a_ChunkInterface.GetBlock({a_X, newY, a_Z});
 			if ((Block == E_BLOCK_AIR) || (Block == E_BLOCK_FIRE))
 			{
 				continue;
@@ -72,9 +72,9 @@ public:
 				// We found an obsidian ceiling
 				// Make sure MaxY has a value and newY ('ceiling' location) is at one above the base block
 				// This is because the frame is a solid obsidian pillar
-				if ((MaxY != 0) && (newY == Y + 1))
+				if ((a_MaxY != 0) && (newY == a_Y + 1))
 				{
-					return EvaluatePortalBorder(X, newY, Z, MaxY, a_ChunkInterface) ? -1 /* -1 = found a frame */ : 0;
+					return EvaluatePortalBorder(a_X, newY, a_Z, a_MaxY, a_ChunkInterface) ? -1 /* -1 = found a frame */ : 0;
 				}
 				else
 				{
@@ -88,11 +88,11 @@ public:
 	}
 
 	/** Evaluates if coords have a valid border on top, based on MaxY */
-	bool EvaluatePortalBorder(int X, int FoundObsidianY, int Z, int MaxY, cChunkInterface & a_ChunkInterface)
+	bool EvaluatePortalBorder(int a_X, int a_FoundObsidianY, int a_Z, int a_MaxY, cChunkInterface & a_ChunkInterface)
 	{
-		for (int checkBorder = FoundObsidianY + 1; checkBorder <= MaxY - 1; checkBorder++)  // FoundObsidianY + 1: FoundObsidianY has already been checked in FindObsidianCeiling; MaxY - 1: portal doesn't need corners
+		for (int checkBorder = a_FoundObsidianY + 1; checkBorder <= a_MaxY - 1; checkBorder++)  // FoundObsidianY + 1: FoundObsidianY has already been checked in FindObsidianCeiling; MaxY - 1: portal doesn't need corners
 		{
-			if (a_ChunkInterface.GetBlock({X, checkBorder, Z}) != E_BLOCK_OBSIDIAN)
+			if (a_ChunkInterface.GetBlock({a_X, checkBorder, a_Z}) != E_BLOCK_OBSIDIAN)
 			{
 				// Base obsidian, base + 1 obsidian, base + x NOT obsidian -> not complete portal
 				return false;
@@ -103,25 +103,25 @@ public:
 	}
 
 	/** Finds entire frame in any direction with the coordinates of a base block and fills hole with nether portal (START HERE) */
-	void FindAndSetPortalFrame(int X, int Y, int Z, cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface)
+	void FindAndSetPortalFrame(int a_X, int a_Y, int a_Z, cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface)
 	{
-		int MaxY = FindObsidianCeiling(X, Y, Z, a_ChunkInterface);  // Get topmost obsidian block as reference for all other checks
-		int X1 = X + 1, Z1 = Z + 1, X2 = X - 1, Z2 = Z - 1;  // Duplicate XZ values, add / subtract one as we've checked the original already the line above
+		int MaxY = FindObsidianCeiling(a_X, a_Y, a_Z, a_ChunkInterface);  // Get topmost obsidian block as reference for all other checks
+		int X1 = a_X + 1, Z1 = a_Z + 1, X2 = a_X - 1, Z2 = a_Z - 1;  // Duplicate XZ values, add / subtract one as we've checked the original already the line above
 
 		if (MaxY == 0)  // Oh noes! Not a portal coordinate :(
 		{
 			return;
 		}
 
-		if (!FindPortalSliceX(X1, X2, Y, Z, MaxY, a_ChunkInterface))
+		if (!FindPortalSliceX(X1, X2, a_Y, a_Z, MaxY, a_ChunkInterface))
 		{
-			if (!FindPortalSliceZ(X, Y, Z1, Z2, MaxY, a_ChunkInterface))
+			if (!FindPortalSliceZ(a_X, a_Y, Z1, Z2, MaxY, a_ChunkInterface))
 			{
 				return;  // No eligible portal construct, abort abort abort!!
 			}
 		}
 
-		int PortalHeight = MaxY - Y - 1;
+		int PortalHeight = MaxY - a_Y - 1;
 		int PortalWidth = XZP - XZM + 1;
 		if ((PortalHeight < a_WorldInterface.GetMinNetherPortalHeight()) || (PortalHeight > a_WorldInterface.GetMaxNetherPortalHeight()))
 		{
@@ -135,17 +135,17 @@ public:
 			return;
 		}
 
-		for (int Height = Y + 1; Height <= MaxY - 1; Height++)  // Loop through boundary to set portal blocks
+		for (int Height = a_Y + 1; Height <= MaxY - 1; Height++)  // Loop through boundary to set portal blocks
 		{
 			for (int Width = XZM; Width <= XZP; Width++)
 			{
 				if (Dir == 1)
 				{
-					a_ChunkInterface.SetBlock(Width, Height, Z, E_BLOCK_NETHER_PORTAL, Dir);
+					a_ChunkInterface.SetBlock(Width, Height, a_Z, E_BLOCK_NETHER_PORTAL, Dir);
 				}
 				else
 				{
-					a_ChunkInterface.SetBlock(X, Height, Width, E_BLOCK_NETHER_PORTAL, Dir);
+					a_ChunkInterface.SetBlock(a_X, Height, Width, E_BLOCK_NETHER_PORTAL, Dir);
 				}
 			}
 		}
@@ -155,79 +155,79 @@ public:
 
 	/** Evaluates if coordinates are a portal going XP / XM; returns true if so, and writes boundaries to variable
 	Takes coordinates of base block and Y coord of target obsidian ceiling */
-	bool FindPortalSliceX(int X1, int X2, int Y, int Z, int MaxY, cChunkInterface & a_ChunkInterface)
+	bool FindPortalSliceX(int a_X1, int a_X2, int a_Y, int a_Z, int a_MaxY, cChunkInterface & a_ChunkInterface)
 	{
 		Dir = 1;  // Set assumed direction (will change if portal turns out to be facing the other direction)
 		bool FoundFrameXP = false, FoundFrameXM = false;
-		for (; ((a_ChunkInterface.GetBlock({X1, Y, Z}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({X1, Y + 1, Z}) == E_BLOCK_OBSIDIAN)); X1++)  // Check XP for obsidian blocks, exempting corners
+		for (; ((a_ChunkInterface.GetBlock({a_X1, a_Y, a_Z}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({a_X1, a_Y + 1, a_Z}) == E_BLOCK_OBSIDIAN)); a_X1++)  // Check XP for obsidian blocks, exempting corners
 		{
-			int Value = FindObsidianCeiling(X1, Y, Z, a_ChunkInterface, MaxY);
-			int ValueTwo = FindObsidianCeiling(X1, Y + 1, Z, a_ChunkInterface, MaxY);  // For corners without obsidian
+			int Value = FindObsidianCeiling(a_X1, a_Y, a_Z, a_ChunkInterface, a_MaxY);
+			int ValueTwo = FindObsidianCeiling(a_X1, a_Y + 1, a_Z, a_ChunkInterface, a_MaxY);  // For corners without obsidian
 			if ((Value == -1) || (ValueTwo == -1))  // FindObsidianCeiling returns -1 upon frame-find
 			{
 				FoundFrameXP = true;  // Found a frame border in this direction, proceed in other direction (don't go further)
 				break;
 			}
-			else if ((Value != MaxY) && (ValueTwo != MaxY))  // Make sure that there is a valid portal 'slice'
+			else if ((Value != a_MaxY) && (ValueTwo != a_MaxY))  // Make sure that there is a valid portal 'slice'
 			{
 				return false;  // Not valid slice, no portal can be formed
 			}
 		}
-		XZP = X1 - 1;  // Set boundary of frame interior
-		for (; ((a_ChunkInterface.GetBlock({X2, Y, Z}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({X2, Y + 1, Z}) == E_BLOCK_OBSIDIAN)); X2--)  // Go the other direction (XM)
+		XZP = a_X1 - 1;  // Set boundary of frame interior
+		for (; ((a_ChunkInterface.GetBlock({a_X2, a_Y, a_Z}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({a_X2, a_Y + 1, a_Z}) == E_BLOCK_OBSIDIAN)); a_X2--)  // Go the other direction (XM)
 		{
-			int Value = FindObsidianCeiling(X2, Y, Z, a_ChunkInterface, MaxY);
-			int ValueTwo = FindObsidianCeiling(X2, Y + 1, Z, a_ChunkInterface, MaxY);
+			int Value = FindObsidianCeiling(a_X2, a_Y, a_Z, a_ChunkInterface, a_MaxY);
+			int ValueTwo = FindObsidianCeiling(a_X2, a_Y + 1, a_Z, a_ChunkInterface, a_MaxY);
 			if ((Value == -1) || (ValueTwo == -1))
 			{
 				FoundFrameXM = true;
 				break;
 			}
-			else if ((Value != MaxY) && (ValueTwo != MaxY))
+			else if ((Value != a_MaxY) && (ValueTwo != a_MaxY))
 			{
 				return false;
 			}
 		}
-		XZM = X2 + 1;  // Set boundary, see previous
+		XZM = a_X2 + 1;  // Set boundary, see previous
 
 		return (FoundFrameXP && FoundFrameXM);
 	}
 
 	/** Evaluates if coords are a portal going ZP / ZM; returns true if so, and writes boundaries to variable */
-	bool FindPortalSliceZ(int X, int Y, int Z1, int Z2, int MaxY, cChunkInterface & a_ChunkInterface)
+	bool FindPortalSliceZ(int a_X, int a_Y, int a_Z1, int a_Z2, int a_MaxY, cChunkInterface & a_ChunkInterface)
 	{
 		Dir = 2;
 		bool FoundFrameZP = false, FoundFrameZM = false;
-		for (; ((a_ChunkInterface.GetBlock({X, Y, Z1}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({X, Y + 1, Z1}) == E_BLOCK_OBSIDIAN)); Z1++)
+		for (; ((a_ChunkInterface.GetBlock({a_X, a_Y, a_Z1}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({a_X, a_Y + 1, a_Z1}) == E_BLOCK_OBSIDIAN)); a_Z1++)
 		{
-			int Value = FindObsidianCeiling(X, Y, Z1, a_ChunkInterface, MaxY);
-			int ValueTwo = FindObsidianCeiling(X, Y + 1, Z1, a_ChunkInterface, MaxY);
+			int Value = FindObsidianCeiling(a_X, a_Y, a_Z1, a_ChunkInterface, a_MaxY);
+			int ValueTwo = FindObsidianCeiling(a_X, a_Y + 1, a_Z1, a_ChunkInterface, a_MaxY);
 			if ((Value == -1) || (ValueTwo == -1))
 			{
 				FoundFrameZP = true;
 				break;
 			}
-			else if ((Value != MaxY) && (ValueTwo != MaxY))
+			else if ((Value != a_MaxY) && (ValueTwo != a_MaxY))
 			{
 				return false;
 			}
 		}
-		XZP = Z1 - 1;
-		for (; ((a_ChunkInterface.GetBlock({X, Y, Z2}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({X, Y + 1, Z2}) == E_BLOCK_OBSIDIAN)); Z2--)
+		XZP = a_Z1 - 1;
+		for (; ((a_ChunkInterface.GetBlock({a_X, a_Y, a_Z2}) == E_BLOCK_OBSIDIAN) || (a_ChunkInterface.GetBlock({a_X, a_Y + 1, a_Z2}) == E_BLOCK_OBSIDIAN)); a_Z2--)
 		{
-			int Value = FindObsidianCeiling(X, Y, Z2, a_ChunkInterface, MaxY);
-			int ValueTwo = FindObsidianCeiling(X, Y + 1, Z2, a_ChunkInterface, MaxY);
+			int Value = FindObsidianCeiling(a_X, a_Y, a_Z2, a_ChunkInterface, a_MaxY);
+			int ValueTwo = FindObsidianCeiling(a_X, a_Y + 1, a_Z2, a_ChunkInterface, a_MaxY);
 			if ((Value == -1) || (ValueTwo == -1))
 			{
 				FoundFrameZM = true;
 				break;
 			}
-			else if ((Value != MaxY) && (ValueTwo != MaxY))
+			else if ((Value != a_MaxY) && (ValueTwo != a_MaxY))
 			{
 				return false;
 			}
 		}
-		XZM = Z2 + 1;
+		XZM = a_Z2 + 1;
 
 		return (FoundFrameZP && FoundFrameZM);
 	}

--- a/src/Blocks/BlockFluid.h
+++ b/src/Blocks/BlockFluid.h
@@ -87,7 +87,7 @@ public:
 	}
 
 	/** Called to tick the block */
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		if (a_Chunk.GetWorld()->ShouldLavaSpawnFire())
 		{
@@ -122,7 +122,7 @@ public:
 		// Try to set it on fire:
 		static struct
 		{
-			int x, y, z;
+			int m_x, m_y, m_z;
 		} CrossCoords[] =
 		{
 			{-1,  0,  0},

--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -384,7 +384,7 @@ bool cBlockHandler::GetPlacementBlockTypeMeta(
 
 
 
-void cBlockHandler::OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_BlockX, int a_BlockY, int a_BlockZ)
+void cBlockHandler::OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 }
 

--- a/src/Blocks/BlockHandler.h
+++ b/src/Blocks/BlockHandler.h
@@ -30,7 +30,7 @@ public:
 
 	/** Called when the block gets ticked either by a random tick or by a queued tick.
 	Note that the coords are chunk-relative! */
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_BlockPluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ);
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_BlockPluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ);
 
 	/** Returns the relative bounding box that must be entity-free in
 	order for the block to be placed. a_XM, a_XP, etc. stand for the
@@ -75,7 +75,7 @@ public:
 	static void NeighborChanged(cChunkInterface & a_ChunkInterface, int a_NeighborX, int a_NeighborY, int a_NeighborZ, eBlockFace a_WhichNeighbor);
 
 	/** Called when the player starts digging the block. */
-	virtual void OnDigging(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cPlayer & a_Player, int a_BlockX, int a_BlockY, int a_BlockZ) {}
+	virtual void OnDigging(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cPlayer & a_Player, int a_BlockX, int a_BlockY, int a_BlockZ) {}
 
 	/** Called if the user right clicks the block and the block is useable
 	returns true if the use was successful, return false to use the block as a "normal" block */
@@ -126,7 +126,7 @@ public:
 	@param a_Player Player trying to build on the block
 	@param a_Meta Meta value of the block currently at a_Pos
 	*/
-	virtual bool DoesIgnoreBuildCollision(cChunkInterface & ChunkInterface, Vector3i a_Pos, cPlayer & a_Player, NIBBLETYPE a_Meta);
+	virtual bool DoesIgnoreBuildCollision(cChunkInterface & a_ChunkInterface, Vector3i a_Pos, cPlayer & a_Player, NIBBLETYPE a_Meta);
 
 	/** Returns if this block drops if it gets destroyed by an unsuitable situation.
 	Default: true */
@@ -139,7 +139,7 @@ public:
 	/** Called when one of the neighbors gets set; equivalent to MC block update.
 	By default drops if position no more suitable (CanBeAt(), DoesDropOnUnsuitable(), Drop()),
 	and wakes up all simulators on the block. */
-	virtual void Check(cChunkInterface & ChunkInterface, cBlockPluginInterface & a_PluginInterface, int a_RelX, int a_RelY, int a_RelZ, cChunk & a_Chunk);
+	virtual void Check(cChunkInterface & a_ChunkInterface, cBlockPluginInterface & a_PluginInterface, int a_RelX, int a_RelY, int a_RelZ, cChunk & a_Chunk);
 
 	/** Returns the base colour ID of the block, as will be represented on a map, as per documentation: https://minecraft.gamepedia.com/Map_item_format */
 	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta);

--- a/src/Blocks/BlockNetherWart.h
+++ b/src/Blocks/BlockNetherWart.h
@@ -33,7 +33,7 @@ public:
 		}
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		NIBBLETYPE Meta = a_Chunk.GetMeta(a_RelX, a_RelY, a_RelZ);
 		if ((Meta < 3) && (CanGrow(a_Chunk, a_RelX, a_RelY, a_RelZ) == paGrowth))

--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -104,9 +104,9 @@ void cBlockPistonHandler::PushBlocks(
 	// Sort blocks to move the blocks first, which are farest away from the piston
 	// This prevents the overwriting of existing blocks
 	std::vector<Vector3i> sortedBlocks(a_BlocksToPush.begin(), a_BlocksToPush.end());
-	std::sort(sortedBlocks.begin(), sortedBlocks.end(), [a_PushDir](const Vector3i & a, const Vector3i & b)
+	std::sort(sortedBlocks.begin(), sortedBlocks.end(), [a_PushDir](const Vector3i & a_a, const Vector3i & a_b)
 	{
-		return a.Dot(a_PushDir) > b.Dot(a_PushDir);
+		return a_a.Dot(a_PushDir) > a_b.Dot(a_PushDir);
 	});
 
 	// Move every block

--- a/src/Blocks/BlockPortal.h
+++ b/src/Blocks/BlockPortal.h
@@ -37,7 +37,7 @@ public:
 		// No pickups
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		if (GetRandomProvider().RandBool(0.9995))
 		{

--- a/src/Blocks/BlockRail.h
+++ b/src/Blocks/BlockRail.h
@@ -115,7 +115,7 @@ public:
 				Meta -= E_META_RAIL_ASCEND_XP;  // Base index at zero
 				static const struct
 				{
-					int x, z;
+					int m_x, m_z;
 				} Coords[] =
 				{
 					{ 1,  0},  // east,  XP

--- a/src/Blocks/BlockSapling.h
+++ b/src/Blocks/BlockSapling.h
@@ -28,7 +28,7 @@ public:
 		return (a_RelY > 0) && IsBlockTypeOfDirt(a_Chunk.GetBlock(a_RelX, a_RelY - 1, a_RelZ));
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		NIBBLETYPE Meta = a_Chunk.GetMeta(a_RelX, a_RelY, a_RelZ);
 		NIBBLETYPE Light = std::max(a_Chunk.GetBlockLight(a_RelX, a_RelY, a_RelZ), a_Chunk.GetTimeAlteredLight(a_Chunk.GetSkyLight(a_RelX, a_RelY, a_RelZ)));

--- a/src/Blocks/BlockStems.h
+++ b/src/Blocks/BlockStems.h
@@ -23,7 +23,7 @@ public:
 		a_Pickups.push_back(cItem(ItemType, 1, 0));
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		auto Action = CanGrow(a_Chunk, a_RelX, a_RelY, a_RelZ);
 		if (Action == paGrowth)

--- a/src/Blocks/BlockSugarcane.h
+++ b/src/Blocks/BlockSugarcane.h
@@ -38,7 +38,7 @@ public:
 			{
 				static const struct
 				{
-					int x, z;
+					int m_x, m_z;
 				} Coords[] =
 				{
 					{-1,  0},
@@ -72,7 +72,7 @@ public:
 		return false;
 	}
 
-	virtual void OnUpdate(cChunkInterface & cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
+	virtual void OnUpdate(cChunkInterface & a_cChunkInterface, cWorldInterface & a_WorldInterface, cBlockPluginInterface & a_PluginInterface, cChunk & a_Chunk, int a_RelX, int a_RelY, int a_RelZ) override
 	{
 		if (CanGrow(a_Chunk, a_RelX, a_RelY, a_RelZ) == paGrowth)
 		{

--- a/src/Blocks/BlockVine.h
+++ b/src/Blocks/BlockVine.h
@@ -99,8 +99,8 @@ public:
 	{
 		static const struct
 		{
-			int x, z;
-			NIBBLETYPE Bit;
+			int m_x, m_z;
+			NIBBLETYPE m_Bit;
 		} Coords[] =
 		{
 			{ 0,  1, 1},  // south, ZP

--- a/src/Blocks/WorldInterface.h
+++ b/src/Blocks/WorldInterface.h
@@ -37,10 +37,10 @@ public:
 	virtual bool DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBlockEntityCallback a_Callback) = 0;
 
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities: */
-	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool IsPlayerCreated = false) = 0;
+	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool a_IsPlayerCreated = false) = 0;
 
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
-	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) = 0;
+	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool a_IsPlayerCreated = false) = 0;
 
 	virtual UInt32 SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) = 0;
 

--- a/src/BrewingRecipes.h
+++ b/src/BrewingRecipes.h
@@ -27,9 +27,9 @@ public:
 			Output.m_ItemType = E_ITEM_POTION;
 		}
 
-		cItem Input;
-		cItem Output;
-		cItem Ingredient;
+		cItem m_Input;
+		cItem m_Output;
+		cItem m_Ingredient;
 	};
 
 	/** Returns a recipe for the specified input, nullptr if no recipe found */

--- a/src/ChatColor.cpp
+++ b/src/ChatColor.cpp
@@ -2,31 +2,31 @@
 
 #include "ChatColor.h"
 
-const char * cChatColor::Color         = "\xc2\xa7";  // or in other words: "§" in UTF-8
-const char * cChatColor::Delimiter     = "\xc2\xa7";  // or in other words: "§" in UTF-8
-const char * cChatColor::Black         = "\xc2\xa7""0";
-const char * cChatColor::Navy          = "\xc2\xa7""1";
-const char * cChatColor::Green         = "\xc2\xa7""2";
-const char * cChatColor::Blue          = "\xc2\xa7""3";
-const char * cChatColor::Red           = "\xc2\xa7""4";
-const char * cChatColor::Purple        = "\xc2\xa7""5";
-const char * cChatColor::Gold          = "\xc2\xa7""6";
-const char * cChatColor::LightGray     = "\xc2\xa7""7";
-const char * cChatColor::Gray          = "\xc2\xa7""8";
-const char * cChatColor::DarkPurple    = "\xc2\xa7""9";
-const char * cChatColor::LightGreen    = "\xc2\xa7""a";
-const char * cChatColor::LightBlue     = "\xc2\xa7""b";
-const char * cChatColor::Rose          = "\xc2\xa7""c";
-const char * cChatColor::LightPurple   = "\xc2\xa7""d";
-const char * cChatColor::Yellow        = "\xc2\xa7""e";
-const char * cChatColor::White         = "\xc2\xa7""f";
+const char * cChatColor::m_Color         = "\xc2\xa7";  // or in other words: "§" in UTF-8
+const char * cChatColor::m_Delimiter     = "\xc2\xa7";  // or in other words: "§" in UTF-8
+const char * cChatColor::m_Black         = "\xc2\xa7""0";
+const char * cChatColor::m_Navy          = "\xc2\xa7""1";
+const char * cChatColor::m_Green         = "\xc2\xa7""2";
+const char * cChatColor::m_Blue          = "\xc2\xa7""3";
+const char * cChatColor::m_Red           = "\xc2\xa7""4";
+const char * cChatColor::m_Purple        = "\xc2\xa7""5";
+const char * cChatColor::m_Gold          = "\xc2\xa7""6";
+const char * cChatColor::m_LightGray     = "\xc2\xa7""7";
+const char * cChatColor::m_Gray          = "\xc2\xa7""8";
+const char * cChatColor::m_DarkPurple    = "\xc2\xa7""9";
+const char * cChatColor::m_LightGreen    = "\xc2\xa7""a";
+const char * cChatColor::m_LightBlue     = "\xc2\xa7""b";
+const char * cChatColor::m_Rose          = "\xc2\xa7""c";
+const char * cChatColor::m_LightPurple   = "\xc2\xa7""d";
+const char * cChatColor::m_Yellow        = "\xc2\xa7""e";
+const char * cChatColor::m_White         = "\xc2\xa7""f";
 
-const char * cChatColor::Random        = "\xc2\xa7""k";
-const char * cChatColor::Bold          = "\xc2\xa7""l";
-const char * cChatColor::Strikethrough = "\xc2\xa7""m";
-const char * cChatColor::Underlined    = "\xc2\xa7""n";
-const char * cChatColor::Italic        = "\xc2\xa7""o";
-const char * cChatColor::Plain         = "\xc2\xa7""r";
+const char * cChatColor::m_Random        = "\xc2\xa7""k";
+const char * cChatColor::m_Bold          = "\xc2\xa7""l";
+const char * cChatColor::m_Strikethrough = "\xc2\xa7""m";
+const char * cChatColor::m_Underlined    = "\xc2\xa7""n";
+const char * cChatColor::m_Italic        = "\xc2\xa7""o";
+const char * cChatColor::m_Plain         = "\xc2\xa7""r";
 
 
 

--- a/src/ChatColor.h
+++ b/src/ChatColor.h
@@ -9,36 +9,36 @@
 class cChatColor
 {
 public:
-	static const char * Delimiter;
+	static const char * m_Delimiter;
 
 	/** @deprecated use ChatColor::Delimiter instead */
-	static const char * Color;
+	static const char * m_Color;
 
-	static const char * Black;
-	static const char * Navy;
-	static const char * Green;
-	static const char * Blue;
-	static const char * Red;
-	static const char * Purple;
-	static const char * Gold;
-	static const char * LightGray;
-	static const char * Gray;
-	static const char * DarkPurple;
-	static const char * LightGreen;
-	static const char * LightBlue;
-	static const char * Rose;
-	static const char * LightPurple;
-	static const char * Yellow;
-	static const char * White;
+	static const char * m_Black;
+	static const char * m_Navy;
+	static const char * m_Green;
+	static const char * m_Blue;
+	static const char * m_Red;
+	static const char * m_Purple;
+	static const char * m_Gold;
+	static const char * m_LightGray;
+	static const char * m_Gray;
+	static const char * m_DarkPurple;
+	static const char * m_LightGreen;
+	static const char * m_LightBlue;
+	static const char * m_Rose;
+	static const char * m_LightPurple;
+	static const char * m_Yellow;
+	static const char * m_White;
 
 	// Styles
 	// source: http://wiki.vg/Chat
-	static const char * Random;
-	static const char * Bold;
-	static const char * Strikethrough;
-	static const char * Underlined;
-	static const char * Italic;
-	static const char * Plain;
+	static const char * m_Random;
+	static const char * m_Bold;
+	static const char * m_Strikethrough;
+	static const char * m_Underlined;
+	static const char * m_Italic;
+	static const char * m_Plain;
 };
 
 // tolua_end

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -522,9 +522,9 @@ void cChunk::Stay(bool a_Stay)
 
 
 
-void cChunk::CollectMobCensus(cMobCensus & toFill)
+void cChunk::CollectMobCensus(cMobCensus & a_toFill)
 {
-	toFill.CollectSpawnableChunk(*this);
+	a_toFill.CollectSpawnableChunk(*this);
 	std::vector<Vector3d> PlayerPositions;
 	PlayerPositions.reserve(m_LoadedByClient.size());
 	for (auto ClientHandle : m_LoadedByClient)
@@ -543,7 +543,7 @@ void cChunk::CollectMobCensus(cMobCensus & toFill)
 			currentPosition = Monster.GetPosition();
 			for (const auto & PlayerPos : PlayerPositions)
 			{
-				toFill.CollectMob(Monster, *this, (currentPosition - PlayerPos).SqrLength());
+				a_toFill.CollectMob(Monster, *this, (currentPosition - PlayerPos).SqrLength());
 			}
 		}
 	}  // for itr - m_Entitites[]
@@ -1160,7 +1160,7 @@ int cChunk::GrowCactus(int a_RelX, int a_RelY, int a_RelZ, int a_NumBlocks)
 			// Check surroundings. Cacti may ONLY be surrounded by non-solid blocks
 			static const struct
 			{
-				int x, z;
+				int m_x, m_z;
 			} Coords[] =
 			{
 				{-1,  0},
@@ -1631,7 +1631,7 @@ void cChunk::QueueTickBlockNeighbors(int a_RelX, int a_RelY, int a_RelZ)
 {
 	struct
 	{
-		int x, y, z;
+		int m_x, m_y, m_z;
 	}
 	Coords[] =
 	{

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -65,7 +65,7 @@ public:
 		cChunk * a_NeighborXM, cChunk * a_NeighborXP, cChunk * a_NeighborZM, cChunk * a_NeighborZP,  // Neighbor chunks
 		cAllocationPool<cChunkData::sChunkSection> & a_Pool
 	);
-	cChunk(cChunk & other) = delete;
+	cChunk(cChunk & a_other) = delete;
 	~cChunk();
 
 	/** Returns true iff the chunk block data is valid (loaded / generated) */
@@ -137,7 +137,7 @@ public:
 	void Stay(bool a_Stay = true);
 
 	/** Recence all mobs proximities to players in order to know what to do with them */
-	void CollectMobCensus(cMobCensus & toFill);
+	void CollectMobCensus(cMobCensus & a_toFill);
 
 	/** Try to Spawn Monsters inside chunk */
 	void SpawnMobs(cMobSpawner & a_MobSpawner);

--- a/src/ChunkData.cpp
+++ b/src/ChunkData.cpp
@@ -32,8 +32,8 @@ namespace
 
 	struct sSectionIndices
 	{
-		int Section = 0;  // Index into m_Sections
-		int Index = 0;    // Index into a single sChunkSection
+		int m_Section = 0;  // Index into m_Sections
+		int m_Index = 0;    // Index into a single sChunkSection
 	};
 
 	sSectionIndices IndicesFromRelPos(Vector3i a_RelPos)

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -180,40 +180,40 @@ public:
 	}
 
 
-	inline static int MakeIndex(int x, int y, int z)
+	inline static int MakeIndex(int a_x, int a_y, int a_z)
 	{
 		if (
-			(x < Width)  && (x > -1) &&
-			(y < Height) && (y > -1) &&
-			(z < Width)  && (z > -1)
+			(a_x < Width)  && (a_x > -1) &&
+			(a_y < Height) && (a_y > -1) &&
+			(a_z < Width)  && (a_z > -1)
 		)
 		{
-			return MakeIndexNoCheck(x, y, z);
+			return MakeIndexNoCheck(a_x, a_y, a_z);
 		}
-		LOGERROR("cChunkDef::MakeIndex(): coords out of range: {%d, %d, %d}; returning fake index 0", x, y, z);
+		LOGERROR("cChunkDef::MakeIndex(): coords out of range: {%d, %d, %d}; returning fake index 0", a_x, a_y, a_z);
 		ASSERT(!"cChunkDef::MakeIndex(): coords out of chunk range!");
 		return 0;
 	}
 
 
-	inline static int MakeIndexNoCheck(int x, int y, int z)
+	inline static int MakeIndexNoCheck(int a_x, int a_y, int a_z)
 	{
 		#if AXIS_ORDER == AXIS_ORDER_XZY
 			// For some reason, NOT using the Horner schema is faster. Weird.
-			return x + (z * cChunkDef::Width) + (y * cChunkDef::Width * cChunkDef::Width);   // 1.2 uses XZY
+			return a_x + (a_z * cChunkDef::Width) + (a_y * cChunkDef::Width * cChunkDef::Width);   // 1.2 uses XZY
 		#elif AXIS_ORDER == AXIS_ORDER_YZX
 			return y + (z * cChunkDef::Width) + (x * cChunkDef::Height * cChunkDef::Width);  // 1.1 uses YZX
 		#endif
 	}
 
 
-	inline static Vector3i IndexToCoordinate( unsigned int index)
+	inline static Vector3i IndexToCoordinate( unsigned int a_index)
 	{
 		#if AXIS_ORDER == AXIS_ORDER_XZY
 			return Vector3i(  // 1.2
-				index % cChunkDef::Width,                       // X
-				index / (cChunkDef::Width * cChunkDef::Width),  // Y
-				(index / cChunkDef::Width) % cChunkDef::Width   // Z
+				a_index % cChunkDef::Width,                       // X
+				a_index / (cChunkDef::Width * cChunkDef::Width),  // Y
+				(a_index / cChunkDef::Width) % cChunkDef::Width   // Z
 			);
 		#elif AXIS_ORDER == AXIS_ORDER_YZX
 			return Vector3i(  // 1.1
@@ -304,11 +304,11 @@ public:
 	}
 
 
-	static NIBBLETYPE GetNibble(const COMPRESSED_NIBBLETYPE & a_Buffer, int x, int y, int z, bool a_IsSkyLightNibble = false)
+	static NIBBLETYPE GetNibble(const COMPRESSED_NIBBLETYPE & a_Buffer, int a_x, int a_y, int a_z, bool a_IsSkyLightNibble = false)
 	{
-		if ((x < Width) && (x > -1) && (y < Height) && (y > -1) && (z < Width) && (z > -1))
+		if ((a_x < Width) && (a_x > -1) && (a_y < Height) && (a_y > -1) && (a_z < Width) && (a_z > -1))
 		{
-			size_t Index = static_cast<size_t>(MakeIndexNoCheck(x, y, z));
+			size_t Index = static_cast<size_t>(MakeIndexNoCheck(a_x, a_y, a_z));
 			if ((Index / 2) >= a_Buffer.size())
 			{
 				return (a_IsSkyLightNibble ? 0xff : 0);
@@ -320,11 +320,11 @@ public:
 	}
 
 
-	static NIBBLETYPE GetNibble(const NIBBLETYPE * a_Buffer, int x, int y, int z)
+	static NIBBLETYPE GetNibble(const NIBBLETYPE * a_Buffer, int a_x, int a_y, int a_z)
 	{
-		if ((x < Width) && (x > -1) && (y < Height) && (y > -1) && (z < Width) && (z > -1))
+		if ((a_x < Width) && (a_x > -1) && (a_y < Height) && (a_y > -1) && (a_z < Width) && (a_z > -1))
 		{
-			int Index = MakeIndexNoCheck(x, y, z);
+			int Index = MakeIndexNoCheck(a_x, a_y, a_z);
 			return (a_Buffer[static_cast<size_t>(Index / 2)] >> ((Index & 1) * 4)) & 0x0f;
 		}
 		ASSERT(!"cChunkDef::GetNibble(): coords out of chunk range!");
@@ -347,19 +347,19 @@ public:
 	}
 
 
-	static void SetNibble(COMPRESSED_NIBBLETYPE & a_Buffer, int x, int y, int z, NIBBLETYPE a_Nibble)
+	static void SetNibble(COMPRESSED_NIBBLETYPE & a_Buffer, int a_x, int a_y, int a_z, NIBBLETYPE a_Nibble)
 	{
 		if (
-			(x >= Width)  || (x < 0) ||
-			(y >= Height) || (y < 0) ||
-			(z >= Width)  || (z < 0)
+			(a_x >= Width)  || (a_x < 0) ||
+			(a_y >= Height) || (a_y < 0) ||
+			(a_z >= Width)  || (a_z < 0)
 		)
 		{
 			ASSERT(!"cChunkDef::SetNibble(): index out of range!");
 			return;
 		}
 
-		size_t Index = static_cast<size_t>(MakeIndexNoCheck(x, y, z));
+		size_t Index = static_cast<size_t>(MakeIndexNoCheck(a_x, a_y, a_z));
 		if ((Index / 2) >= a_Buffer.size())
 		{
 			a_Buffer.resize(((Index / 2) + 1));
@@ -530,18 +530,18 @@ public:
 template <typename X> class cCoordWithData
 {
 public:
-	int x;
-	int y;
-	int z;
-	X   Data;
+	int m_x;
+	int m_y;
+	int m_z;
+	X   m_Data;
 
 	cCoordWithData(int a_X, int a_Y, int a_Z) :
-		x(a_X), y(a_Y), z(a_Z), Data()
+		m_x(a_X), m_y(a_Y), m_z(a_Z), m_Data()
 	{
 	}
 
 	cCoordWithData(int a_X, int a_Y, int a_Z, const X & a_Data) :
-		x(a_X), y(a_Y), z(a_Z), Data(a_Data)
+		m_x(a_X), m_y(a_Y), m_z(a_Z), m_Data(a_Data)
 	{
 	}
 } ;

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -462,8 +462,8 @@ private:
 			}
 		};
 
-		int ChunkX;
-		int ChunkZ;
+		int m_ChunkX;
+		int m_ChunkZ;
 	};
 
 	typedef std::list<cChunkStay *> cChunkStays;

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -45,17 +45,17 @@
 
 /** The interval for sending pings to clients.
 Vanilla sends one ping every 1 second. */
-static const std::chrono::milliseconds PING_TIME_MS = std::chrono::milliseconds(1000);
+static const std::chrono::milliseconds g_PING_TIME_MS = std::chrono::milliseconds(1000);
 
 
 
 
 
 
-int cClientHandle::s_ClientCount = 0;
+int cClientHandle::m_s_ClientCount = 0;
 
 
-float cClientHandle::FASTBREAK_PERCENTAGE;
+float cClientHandle::m_FASTBREAK_PERCENTAGE;
 
 
 
@@ -97,8 +97,8 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 {
 	m_Protocol = cpp14::make_unique<cProtocolRecognizer>(this);
 
-	s_ClientCount++;  // Not protected by CS because clients are always constructed from the same thread
-	m_UniqueID = s_ClientCount;
+	m_s_ClientCount++;  // Not protected by CS because clients are always constructed from the same thread
+	m_UniqueID = m_s_ClientCount;
 	m_PingStartTime = std::chrono::steady_clock::now();
 
 	LOGD("New ClientHandle created at %p", static_cast<void *>(this));
@@ -219,15 +219,15 @@ void cClientHandle::GenerateOfflineUUID(void)
 
 
 
-AString cClientHandle::FormatChatPrefix(bool ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString m_Color1, AString m_Color2)
+AString cClientHandle::FormatChatPrefix(bool a_ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString a_m_Color1, AString a_m_Color2)
 {
-	if (ShouldAppendChatPrefixes)
+	if (a_ShouldAppendChatPrefixes)
 	{
-		return Printf("%s[%s] %s", m_Color1.c_str(), a_ChatPrefixS.c_str(), m_Color2.c_str());
+		return Printf("%s[%s] %s", a_m_Color1.c_str(), a_ChatPrefixS.c_str(), a_m_Color2.c_str());
 	}
 	else
 	{
-		return Printf("%s", m_Color1.c_str());
+		return Printf("%s", a_m_Color1.c_str());
 	}
 }
 
@@ -235,28 +235,28 @@ AString cClientHandle::FormatChatPrefix(bool ShouldAppendChatPrefixes, AString a
 
 
 
-AString cClientHandle::FormatMessageType(bool ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData)
+AString cClientHandle::FormatMessageType(bool a_ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData)
 {
 	switch (a_ChatPrefix)
 	{
 		case mtCustom:      return "";
-		case mtFailure:     return FormatChatPrefix(ShouldAppendChatPrefixes, "INFO",  cChatColor::Rose,   cChatColor::White);
-		case mtInformation: return FormatChatPrefix(ShouldAppendChatPrefixes, "INFO",  cChatColor::Yellow, cChatColor::White);
-		case mtSuccess:     return FormatChatPrefix(ShouldAppendChatPrefixes, "INFO",  cChatColor::Green,  cChatColor::White);
-		case mtWarning:     return FormatChatPrefix(ShouldAppendChatPrefixes, "WARN",  cChatColor::Rose,   cChatColor::White);
-		case mtFatal:       return FormatChatPrefix(ShouldAppendChatPrefixes, "FATAL", cChatColor::Red,    cChatColor::White);
-		case mtDeath:       return FormatChatPrefix(ShouldAppendChatPrefixes, "DEATH", cChatColor::Gray,   cChatColor::White);
-		case mtJoin:        return FormatChatPrefix(ShouldAppendChatPrefixes, "JOIN",  cChatColor::Yellow, cChatColor::White);
-		case mtLeave:       return FormatChatPrefix(ShouldAppendChatPrefixes, "LEAVE", cChatColor::Yellow, cChatColor::White);
+		case mtFailure:     return FormatChatPrefix(a_ShouldAppendChatPrefixes, "INFO",  cChatColor::m_Rose,   cChatColor::m_White);
+		case mtInformation: return FormatChatPrefix(a_ShouldAppendChatPrefixes, "INFO",  cChatColor::m_Yellow, cChatColor::m_White);
+		case mtSuccess:     return FormatChatPrefix(a_ShouldAppendChatPrefixes, "INFO",  cChatColor::m_Green,  cChatColor::m_White);
+		case mtWarning:     return FormatChatPrefix(a_ShouldAppendChatPrefixes, "WARN",  cChatColor::m_Rose,   cChatColor::m_White);
+		case mtFatal:       return FormatChatPrefix(a_ShouldAppendChatPrefixes, "FATAL", cChatColor::m_Red,    cChatColor::m_White);
+		case mtDeath:       return FormatChatPrefix(a_ShouldAppendChatPrefixes, "DEATH", cChatColor::m_Gray,   cChatColor::m_White);
+		case mtJoin:        return FormatChatPrefix(a_ShouldAppendChatPrefixes, "JOIN",  cChatColor::m_Yellow, cChatColor::m_White);
+		case mtLeave:       return FormatChatPrefix(a_ShouldAppendChatPrefixes, "LEAVE", cChatColor::m_Yellow, cChatColor::m_White);
 		case mtPrivateMessage:
 		{
-			if (ShouldAppendChatPrefixes)
+			if (a_ShouldAppendChatPrefixes)
 			{
-				return Printf("%s[MSG: %s] %s%s", cChatColor::LightBlue, a_AdditionalData.c_str(), cChatColor::White, cChatColor::Italic);
+				return Printf("%s[MSG: %s] %s%s", cChatColor::m_LightBlue, a_AdditionalData.c_str(), cChatColor::m_White, cChatColor::m_Italic);
 			}
 			else
 			{
-				return Printf("%s: %s", a_AdditionalData.c_str(), cChatColor::LightBlue);
+				return Printf("%s: %s", a_AdditionalData.c_str(), cChatColor::m_LightBlue);
 			}
 		}
 		case mtMaxPlusOne: break;
@@ -694,9 +694,9 @@ void cClientHandle::HandlePing(void)
 
 	Printf(Reply, "%s%s%zu%s%zu",
 		Server.GetDescription().c_str(),
-		cChatColor::Delimiter,
+		cChatColor::m_Delimiter,
 		Server.GetNumPlayers(),
-		cChatColor::Delimiter,
+		cChatColor::m_Delimiter,
 		Server.GetMaxPlayers()
 	);
 	Kick(Reply);
@@ -805,10 +805,10 @@ void cClientHandle::HandleEnchantItem(UInt8 a_WindowID, UInt8 a_Enchantment)
 
 
 
-void cClientHandle::HandlePlayerAbilities(bool a_CanFly, bool a_IsFlying, float FlyingSpeed, float WalkingSpeed)
+void cClientHandle::HandlePlayerAbilities(bool a_CanFly, bool a_IsFlying, float a_FlyingSpeed, float a_WalkingSpeed)
 {
-	UNUSED(FlyingSpeed);  // Ignore the client values for these
-	UNUSED(WalkingSpeed);
+	UNUSED(a_FlyingSpeed);  // Ignore the client values for these
+	UNUSED(a_WalkingSpeed);
 
 	m_Player->SetCanFly(a_CanFly);
 	m_Player->SetFlying(a_IsFlying);
@@ -1314,7 +1314,7 @@ void cClientHandle::HandleBlockDigFinished(int a_BlockX, int a_BlockY, int a_Blo
 	{
 		// Fix for very fast tools.
 		m_BreakProgress += m_Player->GetPlayerRelativeBlockHardness(a_OldBlock);
-		if (m_BreakProgress < FASTBREAK_PERCENTAGE)
+		if (m_BreakProgress < m_FASTBREAK_PERCENTAGE)
 		{
 			LOGD("Break progress of player %s was less than expected: %f < %f\n", m_Player->GetName().c_str(), m_BreakProgress * 100, FASTBREAK_PERCENTAGE * 100);
 			// AntiFastBreak doesn't agree with the breaking. Bail out. Send the block back to the client, so that it knows:
@@ -2113,7 +2113,7 @@ void cClientHandle::Tick(float a_Dt)
 	// Send a ping packet:
 	if (m_State == csPlaying)
 	{
-		if ((m_PingStartTime + PING_TIME_MS <= std::chrono::steady_clock::now()))
+		if ((m_PingStartTime + g_PING_TIME_MS <= std::chrono::steady_clock::now()))
 		{
 			m_PingID++;
 			m_PingStartTime = std::chrono::steady_clock::now();

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -219,15 +219,15 @@ void cClientHandle::GenerateOfflineUUID(void)
 
 
 
-AString cClientHandle::FormatChatPrefix(bool a_ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString a_m_Color1, AString a_m_Color2)
+AString cClientHandle::FormatChatPrefix(bool a_ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString a_Color1, AString a_Color2)
 {
 	if (a_ShouldAppendChatPrefixes)
 	{
-		return Printf("%s[%s] %s", a_m_Color1.c_str(), a_ChatPrefixS.c_str(), a_m_Color2.c_str());
+		return Printf("%s[%s] %s", a_Color1.c_str(), a_ChatPrefixS.c_str(), a_Color2.c_str());
 	}
 	else
 	{
-		return Printf("%s", a_m_Color1.c_str());
+		return Printf("%s", a_Color1.c_str());
 	}
 }
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -107,7 +107,7 @@ public:  // tolua_export
 	/** Formats the type of message with the proper color and prefix for sending to the client. */
 	static AString FormatMessageType(bool a_ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData);
 
-	static AString FormatChatPrefix(bool a_ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString a_m_Color1, AString a_m_Color2);
+	static AString FormatChatPrefix(bool a_ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString a_Color1, AString a_Color2);
 
 	void Kick(const AString & a_Reason);  // tolua_export
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -59,7 +59,7 @@ public:  // tolua_export
 	/** The percentage how much a block has to be broken.
 	Should be a value between 0.7 (70% broken) and 1 (100% broken) depending on lag.
 	Can be set in settings.ini [AntiCheat] FastBreakPercentage=(from 0 to 100) */
-	static float FASTBREAK_PERCENTAGE;
+	static float m_FASTBREAK_PERCENTAGE;
 
 	/** Creates a new client with the specified IP address in its description and the specified initial view distance. */
 	cClientHandle(const AString & a_IPString, int a_ViewDistance);
@@ -105,9 +105,9 @@ public:  // tolua_export
 	static bool IsUUIDOnline(const cUUID & a_UUID);  // Exported in ManualBindings.cpp
 
 	/** Formats the type of message with the proper color and prefix for sending to the client. */
-	static AString FormatMessageType(bool ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData);
+	static AString FormatMessageType(bool a_ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData);
 
-	static AString FormatChatPrefix(bool ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString m_Color1, AString m_Color2);
+	static AString FormatChatPrefix(bool a_ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString a_m_Color1, AString a_m_Color2);
 
 	void Kick(const AString & a_Reason);  // tolua_export
 
@@ -343,7 +343,7 @@ public:  // tolua_export
 	void HandleOpenHorseInventory(UInt32 a_EntityID);
 
 	void HandlePing             (void);
-	void HandlePlayerAbilities  (bool a_CanFly, bool a_IsFlying, float FlyingSpeed, float WalkingSpeed);
+	void HandlePlayerAbilities  (bool a_CanFly, bool a_IsFlying, float a_FlyingSpeed, float a_WalkingSpeed);
 	void HandlePlayerLook       (float a_Rotation, float a_Pitch, bool a_IsOnGround);
 	void HandlePlayerMoveLook   (double a_PosX, double a_PosY, double a_PosZ, double a_Stance, float a_Rotation, float a_Pitch, bool a_IsOnGround);  // While m_bPositionConfirmed (normal gameplay)
 
@@ -359,7 +359,7 @@ public:  // tolua_export
 	void HandleRightClick       (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, int a_CursorX, int a_CursorY, int a_CursorZ, eHand a_Hand);
 	void HandleSlotSelected     (Int16 a_SlotNum);
 	void HandleSpectate         (const cUUID & a_PlayerUUID);
-	void HandleSteerVehicle     (float Forward, float Sideways);
+	void HandleSteerVehicle     (float a_Forward, float a_Sideways);
 	void HandleTabCompletion    (const AString & a_Text);
 	void HandleUpdateSign       (
 		int a_BlockX, int a_BlockY, int a_BlockZ,
@@ -522,7 +522,7 @@ private:
 	/** Number of place or break interactions this tick */
 	int m_NumBlockChangeInteractionsThisTick;
 
-	static int s_ClientCount;
+	static int m_s_ClientCount;
 
 	/** ID used for identification during authenticating. Assigned sequentially for each new instance. */
 	int m_UniqueID;

--- a/src/CommandOutput.cpp
+++ b/src/CommandOutput.cpp
@@ -13,9 +13,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 // cCommandOutputCallback:
 
-void cCommandOutputCallback::Out(const char * a_Fmt, fmt::ArgList args)
+void cCommandOutputCallback::Out(const char * a_Fmt, fmt::ArgList a_args)
 {
-	AString Output = Printf(a_Fmt, args);
+	AString Output = Printf(a_Fmt, a_args);
 	Output.append("\n");
 	Out(Output);
 }

--- a/src/CraftingRecipes.cpp
+++ b/src/CraftingRecipes.cpp
@@ -66,53 +66,53 @@ cCraftingGrid::~cCraftingGrid()
 
 
 
-cItem & cCraftingGrid::GetItem(int x, int y) const
+cItem & cCraftingGrid::GetItem(int a_x, int a_y) const
 {
 	// Accessible through scripting, must verify parameters:
-	if ((x < 0) || (x >= m_Width) || (y < 0) || (y >= m_Height))
+	if ((a_x < 0) || (a_x >= m_Width) || (a_y < 0) || (a_y >= m_Height))
 	{
 		LOGERROR("Attempted to get an invalid item from a crafting grid: (%d, %d), grid dimensions: (%d, %d).",
-			x, y, m_Width, m_Height
+			a_x, a_y, m_Width, m_Height
 		);
 		return m_Items[0];
 	}
-	return m_Items[x + m_Width * y];
+	return m_Items[a_x + m_Width * a_y];
 }
 
 
 
 
 
-void cCraftingGrid::SetItem(int x, int y, ENUM_ITEM_ID a_ItemType, char a_ItemCount, short a_ItemHealth)
+void cCraftingGrid::SetItem(int a_x, int a_y, ENUM_ITEM_ID a_ItemType, char a_ItemCount, short a_ItemHealth)
 {
 	// Accessible through scripting, must verify parameters:
-	if ((x < 0) || (x >= m_Width) || (y < 0) || (y >= m_Height))
+	if ((a_x < 0) || (a_x >= m_Width) || (a_y < 0) || (a_y >= m_Height))
 	{
 		LOGERROR("Attempted to set an invalid item in a crafting grid: (%d, %d), grid dimensions: (%d, %d).",
-			x, y, m_Width, m_Height
+			a_x, a_y, m_Width, m_Height
 		);
 		return;
 	}
 
-	m_Items[x + m_Width * y] = cItem(a_ItemType, a_ItemCount, a_ItemHealth);
+	m_Items[a_x + m_Width * a_y] = cItem(a_ItemType, a_ItemCount, a_ItemHealth);
 }
 
 
 
 
 
-void cCraftingGrid::SetItem(int x, int y, const cItem & a_Item)
+void cCraftingGrid::SetItem(int a_x, int a_y, const cItem & a_Item)
 {
 	// Accessible through scripting, must verify parameters:
-	if ((x < 0) || (x >= m_Width) || (y < 0) || (y >= m_Height))
+	if ((a_x < 0) || (a_x >= m_Width) || (a_y < 0) || (a_y >= m_Height))
 	{
 		LOGERROR("Attempted to set an invalid item in a crafting grid: (%d, %d), grid dimensions: (%d, %d).",
-			x, y, m_Width, m_Height
+			a_x, a_y, m_Width, m_Height
 		);
 		return;
 	}
 
-	m_Items[x + m_Width * y] = a_Item;
+	m_Items[a_x + m_Width * a_y] = a_Item;
 }
 
 

--- a/src/CraftingRecipes.h
+++ b/src/CraftingRecipes.h
@@ -32,9 +32,9 @@ public:
 	// tolua_begin
 	int     GetWidth (void) const {return m_Width; }
 	int     GetHeight(void) const {return m_Height; }
-	cItem & GetItem  (int x, int y) const;
-	void    SetItem  (int x, int y, ENUM_ITEM_ID a_ItemType, char a_ItemCount, short a_ItemHealth);
-	void    SetItem  (int x, int y, const cItem & a_Item);
+	cItem & GetItem  (int a_x, int a_y) const;
+	void    SetItem  (int a_x, int a_y, ENUM_ITEM_ID a_ItemType, char a_ItemCount, short a_ItemHealth);
+	void    SetItem  (int a_x, int a_y, const cItem & a_Item);
 	void    Clear    (void);
 
 	/** Removes items in a_Grid from m_Items[] (used by cCraftingRecipe::ConsumeIngredients()) */
@@ -70,7 +70,7 @@ public:
 	void          Clear               (void);
 	int           GetIngredientsWidth (void) const {return m_Ingredients.GetWidth(); }
 	int           GetIngredientsHeight(void) const {return m_Ingredients.GetHeight(); }
-	cItem &       GetIngredient       (int x, int y) const {return m_Ingredients.GetItem(x, y); }
+	cItem &       GetIngredient       (int a_x, int a_y) const {return m_Ingredients.GetItem(a_x, a_y); }
 	const cItem & GetResult           (void) const {return m_Result; }
 	void          SetResult           (ENUM_ITEM_ID a_ItemType, char a_ItemCount, short a_ItemHealth);
 	void          SetResult           (const cItem & a_Item)
@@ -78,14 +78,14 @@ public:
 		m_Result = a_Item;
 	}
 
-	void          SetIngredient       (int x, int y, ENUM_ITEM_ID a_ItemType, char a_ItemCount, short a_ItemHealth)
+	void          SetIngredient       (int a_x, int a_y, ENUM_ITEM_ID a_ItemType, char a_ItemCount, short a_ItemHealth)
 	{
-		m_Ingredients.SetItem(x, y, a_ItemType, a_ItemCount, a_ItemHealth);
+		m_Ingredients.SetItem(a_x, a_y, a_ItemType, a_ItemCount, a_ItemHealth);
 	}
 
-	void          SetIngredient       (int x, int y, const cItem & a_Item)
+	void          SetIngredient       (int a_x, int a_y, const cItem & a_Item)
 	{
-		m_Ingredients.SetItem(x, y, a_Item);
+		m_Ingredients.SetItem(a_x, a_y, a_Item);
 	}
 
 	/** Consumes ingredients from the crafting grid specified */
@@ -122,7 +122,7 @@ protected:
 	struct cRecipeSlot
 	{
 		cItem m_Item;
-		int x, y;  // 1..3, or -1 for "any"
+		int m_x, m_y;  // 1..3, or -1 for "any"
 	} ;
 	typedef std::vector<cRecipeSlot> cRecipeSlots;
 

--- a/src/Cuboid.h
+++ b/src/Cuboid.h
@@ -10,18 +10,18 @@ class cCuboid
 {
 public:
 	// p1 is expected to have the smaller of the coords; Sort() swaps coords to match this
-	Vector3i p1, p2;
+	Vector3i m_p1, m_p2;
 
 	cCuboid(void) {}
-	cCuboid(const Vector3i & a_p1, const Vector3i & a_p2) : p1(a_p1), p2(a_p2) {}
-	cCuboid(int a_X1, int a_Y1, int a_Z1) : p1(a_X1, a_Y1, a_Z1), p2(a_X1, a_Y1, a_Z1) {}
+	cCuboid(const Vector3i & a_p1, const Vector3i & a_p2) : m_p1(a_p1), m_p2(a_p2) {}
+	cCuboid(int a_X1, int a_Y1, int a_Z1) : m_p1(a_X1, a_Y1, a_Z1), m_p2(a_X1, a_Y1, a_Z1) {}
 
 	#ifdef TOLUA_EXPOSITION  // tolua isn't aware of implicitly generated copy constructors
 		cCuboid(const cCuboid & a_Cuboid);
 	#endif
 
 	// DEPRECATED, use cCuboid(Vector3i, Vector3i) instead
-	cCuboid(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2) : p1(a_X1, a_Y1, a_Z1), p2(a_X2, a_Y2, a_Z2)
+	cCuboid(int a_X1, int a_Y1, int a_Z1, int a_X2, int a_Y2, int a_Z2) : m_p1(a_X1, a_Y1, a_Z1), m_p2(a_X2, a_Y2, a_Z2)
 	{
 		LOGWARNING("cCuboid(int, int, int, int, int, int) constructor is deprecated, use cCuboid(Vector3i, Vector3i) constructor instead.");
 	}
@@ -55,12 +55,12 @@ public:
 		);
 	}
 
-	bool IsInside(Vector3i v) const
+	bool IsInside(Vector3i a_v) const
 	{
 		return (
-			(v.x >= p1.x) && (v.x <= p2.x) &&
-			(v.y >= p1.y) && (v.y <= p2.y) &&
-			(v.z >= p1.z) && (v.z <= p2.z)
+			(a_v.x >= p1.x) && (a_v.x <= p2.x) &&
+			(a_v.y >= p1.y) && (a_v.y <= p2.y) &&
+			(a_v.z >= p1.z) && (a_v.z <= p2.z)
 		);
 	}
 
@@ -73,12 +73,12 @@ public:
 		);
 	}
 
-	bool IsInside(Vector3d v) const
+	bool IsInside(Vector3d a_v) const
 	{
 		return (
-			(v.x >= p1.x) && (v.x <= p2.x) &&
-			(v.y >= p1.y) && (v.y <= p2.y) &&
-			(v.z >= p1.z) && (v.z <= p2.z)
+			(a_v.x >= p1.x) && (a_v.x <= p2.x) &&
+			(a_v.y >= p1.y) && (a_v.y <= p2.y) &&
+			(a_v.z >= p1.z) && (a_v.z <= p2.z)
 		);
 	}
 

--- a/src/DeadlockDetect.cpp
+++ b/src/DeadlockDetect.cpp
@@ -14,7 +14,7 @@
 
 
 /** Number of milliseconds per cycle */
-const int CYCLE_MILLISECONDS = 100;
+const int g_CYCLE_MILLISECONDS = 100;
 
 
 
@@ -109,7 +109,7 @@ void cDeadlockDetect::Execute(void)
 			}
 		);
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(CYCLE_MILLISECONDS));
+		std::this_thread::sleep_for(std::chrono::milliseconds(g_CYCLE_MILLISECONDS));
 	}  // while (should run)
 }
 
@@ -141,7 +141,7 @@ void cDeadlockDetect::CheckWorldAge(const AString & a_WorldName, Int64 a_Age)
 	if (WorldAge.m_Age == a_Age)
 	{
 		WorldAge.m_NumCyclesSame += 1;
-		if (WorldAge.m_NumCyclesSame > (m_IntervalSec * 1000) / CYCLE_MILLISECONDS)
+		if (WorldAge.m_NumCyclesSame > (m_IntervalSec * 1000) / g_CYCLE_MILLISECONDS)
 		{
 			DeadlockDetected(a_WorldName, a_Age);
 		}

--- a/src/Enchantments.cpp
+++ b/src/Enchantments.cpp
@@ -205,9 +205,9 @@ unsigned int cEnchantments::GetLevelCap(int a_EnchantmentID)
 
 
 
-int cEnchantments::GetXPCostMultiplier(int a_EnchantmentID, bool FromBook)
+int cEnchantments::GetXPCostMultiplier(int a_EnchantmentID, bool a_FromBook)
 {
-	if (FromBook)
+	if (a_FromBook)
 	{
 		switch (a_EnchantmentID)
 		{

--- a/src/Enchantments.h
+++ b/src/Enchantments.h
@@ -119,7 +119,7 @@ public:
 	If FromBook is true, then this function returns the XP multiplier if
 	the enchantment is coming from a book, otherwise it returns the normal
 	item multiplier. */
-	static int GetXPCostMultiplier(int a_EnchantmentID, bool FromBook);
+	static int GetXPCostMultiplier(int a_EnchantmentID, bool a_FromBook);
 
 	/** Get the maximum level the enchantment can have */
 	static unsigned int GetLevelCap(int a_EnchantmentID);

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -38,10 +38,10 @@ void cBoat::SpawnOn(cClientHandle & a_ClientHandle)
 
 
 
-bool cBoat::DoTakeDamage(TakeDamageInfo & TDI)
+bool cBoat::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
 	m_LastDamage = 10;
-	if (!super::DoTakeDamage(TDI))
+	if (!super::DoTakeDamage(a_TDI))
 	{
 		return false;
 	}
@@ -50,9 +50,9 @@ bool cBoat::DoTakeDamage(TakeDamageInfo & TDI)
 
 	if (GetHealth() <= 0)
 	{
-		if (TDI.Attacker != nullptr)
+		if (a_TDI.Attacker != nullptr)
 		{
-			if (TDI.Attacker->IsPlayer())
+			if (a_TDI.Attacker->IsPlayer())
 			{
 				cItems Pickups;
 				Pickups.Add(MaterialToItem(m_Material));
@@ -153,9 +153,9 @@ void cBoat::HandleSpeedFromAttachee(float a_Forward, float a_Sideways)
 
 
 
-void cBoat::SetLastDamage(int TimeSinceLastHit)
+void cBoat::SetLastDamage(int a_TimeSinceLastHit)
 {
-	m_LastDamage = TimeSinceLastHit;
+	m_LastDamage = a_TimeSinceLastHit;
 }
 
 

--- a/src/Entities/Boat.h
+++ b/src/Entities/Boat.h
@@ -38,7 +38,7 @@ public:
 	// cEntity overrides:
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 	virtual void OnRightClicked(cPlayer & a_Player) override;
-	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
+	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways) override;
 
@@ -74,9 +74,9 @@ public:
 	bool IsRightPaddleUsed(void) const { return m_RightPaddleUsed; }
 	bool IsLeftPaddleUsed(void) const { return m_LeftPaddleUsed; }
 
-	void SetLastDamage(int TimeSinceLastHit);
+	void SetLastDamage(int a_TimeSinceLastHit);
 
-	void UpdatePaddles(bool rightPaddleUsed, bool leftPaddleUsed);
+	void UpdatePaddles(bool a_rightPaddleUsed, bool a_leftPaddleUsed);
 private:
 	int m_LastDamage;
 	int m_ForwardDirection;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -599,7 +599,7 @@ int cEntity::GetRawDamageAgainst(const cEntity & a_Receiver)
 
 
 
-void cEntity::ApplyArmorDamage(int DamageBlocked)
+void cEntity::ApplyArmorDamage(int a_DamageBlocked)
 {
 	// cEntities don't necessarily have armor to damage.
 	return;
@@ -938,7 +938,7 @@ void cEntity::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 		static const struct
 		{
-			int x, y, z;
+			int m_x, m_y, m_z;
 		} gCrossCoords[] =
 		{
 			{ 1, 0,  0},

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -54,11 +54,11 @@ class cMonster;
 // tolua_begin
 struct TakeDamageInfo
 {
-	eDamageType DamageType;   // Where does the damage come from? Being hit / on fire / contact with cactus / ...
-	cEntity *   Attacker;     // The attacking entity; valid only for dtAttack
-	int         RawDamage;    // What damage would the receiver get without any armor. Usually: attacker mob type + weapons
-	int         FinalDamage;  // What actual damage will be received. Usually: m_RawDamage minus armor
-	Vector3d    Knockback;    // The amount and direction of knockback received from the damage
+	eDamageType m_DamageType;   // Where does the damage come from? Being hit / on fire / contact with cactus / ...
+	cEntity *   m_Attacker;     // The attacking entity; valid only for dtAttack
+	int         m_RawDamage;    // What damage would the receiver get without any armor. Usually: attacker mob type + weapons
+	int         m_FinalDamage;  // What actual damage will be received. Usually: m_RawDamage minus armor
+	Vector3d    m_Knockback;    // The amount and direction of knockback received from the damage
 	// TODO: Effects - list of effects that the hit is causing. Unknown representation yet
 } ;
 // tolua_end
@@ -352,7 +352,7 @@ public:
 	virtual cItem GetEquippedBoots(void) const { return cItem(); }
 
 	/** Applies damage to the armor after the armor blocked the given amount */
-	virtual void ApplyArmorDamage(int DamageBlocked);
+	virtual void ApplyArmorDamage(int a_DamageBlocked);
 
 	// tolua_end
 

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1030,18 +1030,18 @@ bool cMinecart::TestEntityCollision(NIBBLETYPE a_RailMeta)
 
 
 
-bool cMinecart::DoTakeDamage(TakeDamageInfo & TDI)
+bool cMinecart::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
-	if ((TDI.Attacker != nullptr) && TDI.Attacker->IsPlayer() && static_cast<cPlayer *>(TDI.Attacker)->IsGameModeCreative())
+	if ((a_TDI.Attacker != nullptr) && a_TDI.Attacker->IsPlayer() && static_cast<cPlayer *>(a_TDI.Attacker)->IsGameModeCreative())
 	{
 		Destroy();
-		TDI.FinalDamage = static_cast<int>(GetMaxHealth());  // Instant hit for creative
+		a_TDI.FinalDamage = static_cast<int>(GetMaxHealth());  // Instant hit for creative
 		SetInvulnerableTicks(0);
-		return super::DoTakeDamage(TDI);  // No drops for creative
+		return super::DoTakeDamage(a_TDI);  // No drops for creative
 	}
 
-	m_LastDamage = TDI.FinalDamage;
-	if (!super::DoTakeDamage(TDI))
+	m_LastDamage = a_TDI.FinalDamage;
+	if (!super::DoTakeDamage(a_TDI))
 	{
 		return false;
 	}
@@ -1266,9 +1266,9 @@ void cMinecartWithChest::Destroyed()
 	auto posX = GetPosX();
 	auto posY = GetPosY() + 1;
 	auto posZ = GetPosZ();
-	GetWorld()->ScheduleTask(1, [Pickups, posX, posY, posZ](cWorld & World)
+	GetWorld()->ScheduleTask(1, [Pickups, posX, posY, posZ](cWorld & a_World)
 	{
-		World.SpawnItemPickups(Pickups, posX, posY, posZ, 4);
+		a_World.SpawnItemPickups(Pickups, posX, posY, posZ, 4);
 	});
 }
 

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -39,7 +39,7 @@ public:
 	// cEntity overrides:
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 	virtual void HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
-	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
+	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
 	virtual void Destroyed() override;
 
 	int LastDamage(void) const { return m_LastDamage; }

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -317,7 +317,7 @@ void cPawn::HandleFalling(void)
 	/* The "cross" we sample around to account for the player width/girth */
 	static const struct
 	{
-		int x, z;
+		int m_x, m_z;
 	} CrossSampleCoords[] =
 	{
 		{ 0, 0 },
@@ -332,7 +332,7 @@ void cPawn::HandleFalling(void)
 	in memory but have a hitbox larger than 1 (like fences) */
 	static const struct
 	{
-		int x, y, z;
+		int m_x, m_y, m_z;
 	} BlockSampleOffsets[] =
 	{
 		{ 0, 0, 0 },  // TODO: something went wrong here (offset 0?)

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -95,12 +95,12 @@ protected:
 
 
 
-cPickup::cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX, float a_SpeedY, float a_SpeedZ, int a_LifetimeTicks, bool a_CanCombine)
+cPickup::cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool a_IsPlayerCreated, float a_SpeedX, float a_SpeedY, float a_SpeedZ, int a_LifetimeTicks, bool a_CanCombine)
 	: cEntity(etPickup, a_PosX, a_PosY, a_PosZ, 0.2, 0.2)
 	, m_Timer(0)
 	, m_Item(a_Item)
 	, m_bCollected(false)
-	, m_bIsPlayerCreated(IsPlayerCreated)
+	, m_bIsPlayerCreated(a_IsPlayerCreated)
 	, m_bCanCombine(a_CanCombine)
 	, m_Lifetime(cTickTime(a_LifetimeTicks))
 {

--- a/src/Entities/Pickup.h
+++ b/src/Entities/Pickup.h
@@ -25,7 +25,7 @@ public:
 
 	CLASS_PROTODEF(cPickup)
 
-	cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true);
+	cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool a_IsPlayerCreated, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true);
 
 	cItem &       GetItem(void)       {return m_Item; }  // tolua_export
 	const cItem & GetItem(void) const {return m_Item; }

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -934,9 +934,9 @@ void cPlayer::SetFlying(bool a_IsFlying)
 
 
 
-void cPlayer::ApplyArmorDamage(int DamageBlocked)
+void cPlayer::ApplyArmorDamage(int a_DamageBlocked)
 {
-	short ArmorDamage = static_cast<short>(DamageBlocked / 4);
+	short ArmorDamage = static_cast<short>(a_DamageBlocked / 4);
 	if (ArmorDamage == 0)
 	{
 		ArmorDamage = 1;
@@ -1818,7 +1818,7 @@ AString cPlayer::GetColor(void) const
 	}
 
 	// Return the color, including the delimiter:
-	return cChatColor::Delimiter + m_MsgNameColorCode;
+	return cChatColor::m_Delimiter + m_MsgNameColorCode;
 }
 
 

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -71,7 +71,7 @@ public:
 	/** Returns the currently equipped boots; empty item if none */
 	virtual cItem GetEquippedBoots(void) const override { return m_Inventory.GetEquippedBoots(); }
 
-	virtual void ApplyArmorDamage(int DamageBlocked) override;
+	virtual void ApplyArmorDamage(int a_DamageBlocked) override;
 
 	// tolua_begin
 
@@ -737,7 +737,7 @@ protected:
 	virtual void Destroyed(void) override;
 
 	/** Filters out damage for creative mode / friendly fire */
-	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
+	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
 
 	/** Called in each tick to handle food-related processing */
 	void HandleFood(void);

--- a/src/FastRandom.h
+++ b/src/FastRandom.h
@@ -185,13 +185,13 @@ struct cRandomDeviceSeeder
 	using result_type = std::random_device::result_type;
 
 	template <class Itr>
-	void generate(Itr first, Itr last)
+	void generate(Itr a_first, Itr a_last)
 	{
 		std::random_device rd;
 		std::uniform_int_distribution<result_type> dist;
-		for (; first != last; ++first)
+		for (; a_first != a_last; ++a_first)
 		{
-			*first = dist(rd);
+			*a_first = dist(rd);
 		}
 	}
 };

--- a/src/FurnaceRecipe.cpp
+++ b/src/FurnaceRecipe.cpp
@@ -21,8 +21,8 @@ typedef std::list<cFurnaceRecipe::cFuel> FuelList;
 
 struct cFurnaceRecipe::sFurnaceRecipeState
 {
-	RecipeList Recipes;
-	FuelList Fuel;
+	RecipeList m_Recipes;
+	FuelList m_Fuel;
 };
 
 

--- a/src/FurnaceRecipe.h
+++ b/src/FurnaceRecipe.h
@@ -21,16 +21,16 @@ public:
 
 	struct cFuel
 	{
-		cItem * In;
-		int BurnTime;  ///< How long this fuel burns, in ticks
+		cItem * m_In;
+		int m_BurnTime;  ///< How long this fuel burns, in ticks
 	};
 
 	struct cRecipe
 	{
-		cItem * In;
-		cItem * Out;
-		int CookTime;  ///< How long this recipe takes to smelt, in ticks
-		float Reward;  ///< Experience reward for creating 1 of this item
+		cItem * m_In;
+		cItem * m_Out;
+		int m_CookTime;  ///< How long this recipe takes to smelt, in ticks
+		float m_Reward;  ///< Experience reward for creating 1 of this item
 	};
 
 	/** Returns a recipe for the specified input, nullptr if no recipe found */

--- a/src/Generating/BioGen.cpp
+++ b/src/Generating/BioGen.cpp
@@ -800,8 +800,8 @@ EMCSBiome cBioGenTwoLevel::SelectBiome(int a_BiomeGroup, size_t a_BiomeIdx, int 
 	// TODO: Move this into settings
 	struct BiomeLevels
 	{
-		EMCSBiome InnerBiome;
-		EMCSBiome OuterBiome;
+		EMCSBiome m_InnerBiome;
+		EMCSBiome m_OuterBiome;
 	} ;
 
 	static BiomeLevels bgOcean[] =
@@ -882,8 +882,8 @@ EMCSBiome cBioGenTwoLevel::SelectBiome(int a_BiomeGroup, size_t a_BiomeIdx, int 
 	} ;
 	static struct
 	{
-		BiomeLevels * Biomes;
-		size_t        Count;
+		BiomeLevels * m_Biomes;
+		size_t        m_Count;
 	} BiomeGroups[] =
 	{
 		{ bgOcean,      ARRAYCOUNT(bgOcean), },
@@ -995,10 +995,10 @@ public:
 			std::make_shared<cIntGenBiomeGroupEdges<6>> (
 			std::make_shared<cIntGenAddIslands     <8>> (a_Seed + 2000, 200,
 			std::make_shared<cIntGenZoom           <8>> (a_Seed + 7,
-			std::make_shared<cIntGenSetRandomly    <6>> (a_Seed + 8, 50, bgOcean,
-			std::make_shared<cIntGenReplaceRandomly<6>> (a_Seed + 101, bgIce, bgTemperate, 150,
+			std::make_shared<cIntGenSetRandomly    <6>> (a_Seed + 8, 50, g_bgOcean,
+			std::make_shared<cIntGenReplaceRandomly<6>> (a_Seed + 101, g_bgIce, g_bgTemperate, 150,
 			std::make_shared<cIntGenAddIslands     <6>> (a_Seed + 2000, 200,
-			std::make_shared<cIntGenSetRandomly    <6>> (a_Seed + 9, 50, bgOcean,
+			std::make_shared<cIntGenSetRandomly    <6>> (a_Seed + 9, 50, g_bgOcean,
 			std::make_shared<cIntGenLandOcean      <5>> (a_Seed + 100, 30)
 			| MakeIntGen<cIntGenZoom           <6>> (a_Seed + 10)
 		)))))))))))))))))))))))))))));
@@ -1099,10 +1099,10 @@ public:
 			std::make_shared<cProtIntGenBiomeGroupEdges>(
 			std::make_shared<cProtIntGenAddIslands     >(a_Seed + 2000, 200,
 			std::make_shared<cProtIntGenZoom           >(a_Seed + 7,
-			std::make_shared<cProtIntGenSetRandomly    >(a_Seed + 8, 50, bgOcean,
-			std::make_shared<cProtIntGenReplaceRandomly>(a_Seed + 101, bgIce, bgTemperate, 150,
+			std::make_shared<cProtIntGenSetRandomly    >(a_Seed + 8, 50, g_bgOcean,
+			std::make_shared<cProtIntGenReplaceRandomly>(a_Seed + 101, g_bgIce, g_bgTemperate, 150,
 			std::make_shared<cProtIntGenAddIslands     >(a_Seed + 2000, 200,
-			std::make_shared<cProtIntGenSetRandomly    >(a_Seed + 9, 50, bgOcean,
+			std::make_shared<cProtIntGenSetRandomly    >(a_Seed + 9, 50, g_bgOcean,
 			std::make_shared<cProtIntGenZoom           >(a_Seed + 10,
 			std::make_shared<cProtIntGenLandOcean      >(a_Seed + 100, 30
 		)))))))))))))))))))))))))))))));

--- a/src/Generating/Caves.cpp
+++ b/src/Generating/Caves.cpp
@@ -35,8 +35,8 @@ reduced in complexity in order for this generator to be useful, so the caves' sh
 
 
 
-const int MIN_RADIUS = 3;
-const int MAX_RADIUS = 8;
+const int g_MIN_RADIUS = 3;
+const int g_MAX_RADIUS = 8;
 
 
 
@@ -207,7 +207,7 @@ void cCaveTunnel::Randomize(cNoise & a_Noise)
 			len += (PrevY - itr->m_BlockY) * (PrevY - itr->m_BlockY);
 			len += (PrevZ - itr->m_BlockZ) * (PrevZ - itr->m_BlockZ);
 			len = 3 * static_cast<int>(sqrt(static_cast<double>(len))) / 4;
-			int Rad = std::min(MAX_RADIUS, std::max(MIN_RADIUS, (PrevR + itr->m_Radius) / 2 + (Random % 3) - 1));
+			int Rad = std::min(g_MAX_RADIUS, std::max(g_MIN_RADIUS, (PrevR + itr->m_Radius) / 2 + (Random % 3) - 1));
 			Random /= 4;
 			int x = (itr->m_BlockX + PrevX) / 2 + (Random % (len + 1) - len / 2);
 			Random /= 256;
@@ -681,7 +681,7 @@ int cStructGenWormNestCaves::cCaveSystem::GetRadius(cNoise & a_Noise, int a_Orig
 	*/
 
 	// Algorithm of choice: random value in the range of zero to random value - heavily towards zero
-	int res = MIN_RADIUS + (rnd >> 8) % ((rnd % (MAX_RADIUS - MIN_RADIUS)) + 1);
+	int res = g_MIN_RADIUS + (rnd >> 8) % ((rnd % (g_MAX_RADIUS - g_MIN_RADIUS)) + 1);
 	return res;
 }
 
@@ -705,10 +705,10 @@ cGridStructGen::cStructurePtr cStructGenWormNestCaves::CreateStructure(int a_Gri
 ////////////////////////////////////////////////////////////////////////////////
 // cStructGenMarbleCaves:
 
-static float GetMarbleNoise( float x, float y, float z, cNoise & a_Noise)
+static float GetMarbleNoise( float a_x, float a_y, float a_z, cNoise & a_Noise)
 {
 	static const float PI_2 = 1.57079633f;
-	float oct1 = (a_Noise.CubicNoise3D(x * 0.1f, y * 0.1f, z * 0.1f)) * 4;
+	float oct1 = (a_Noise.CubicNoise3D(a_x * 0.1f, a_y * 0.1f, a_z * 0.1f)) * 4;
 
 	oct1 = oct1 * oct1 * oct1;
 	if (oct1 < 0.f)

--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -13,10 +13,10 @@
 
 
 /** If the generation queue size exceeds this number, a warning will be output */
-const unsigned int QUEUE_WARNING_LIMIT = 1000;
+const unsigned int g_QUEUE_WARNING_LIMIT = 1000;
 
 /** If the generation queue size exceeds this number, chunks with no clients will be skipped */
-const unsigned int QUEUE_SKIP_LIMIT = 500;
+const unsigned int g_QUEUE_SKIP_LIMIT = 500;
 
 
 
@@ -116,7 +116,7 @@ void cChunkGenerator::QueueGenerateChunk(int a_ChunkX, int a_ChunkZ, bool a_Forc
 		cCSLock Lock(m_CS);
 
 		// Add to queue, issue a warning if too many:
-		if (m_Queue.size() >= QUEUE_WARNING_LIMIT)
+		if (m_Queue.size() >= g_QUEUE_WARNING_LIMIT)
 		{
 			LOGWARN("WARNING: Adding chunk [%i, %i] to generation queue; Queue is too big! (%zu)", a_ChunkX, a_ChunkZ, m_Queue.size());
 		}
@@ -231,7 +231,7 @@ void cChunkGenerator::Execute(void)
 		}
 
 		cQueueItem item = m_Queue.front();  // Get next chunk from the queue
-		bool SkipEnabled = (m_Queue.size() > QUEUE_SKIP_LIMIT);
+		bool SkipEnabled = (m_Queue.size() > g_QUEUE_SKIP_LIMIT);
 		m_Queue.erase(m_Queue.begin());  // Remove the item from the queue
 		Lock.Unlock();  // Unlock ASAP
 		m_evtRemoved.Set();

--- a/src/Generating/CompoGenBiomal.cpp
+++ b/src/Generating/CompoGenBiomal.cpp
@@ -60,7 +60,7 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 // The arrays to use for the top block pattern definitions:
 
-static cPattern::BlockInfo tbGrass[] =
+static cPattern::BlockInfo g_tbGrass[] =
 {
 	{E_BLOCK_GRASS, 0},
 	{E_BLOCK_DIRT,  E_META_DIRT_NORMAL},
@@ -68,7 +68,7 @@ static cPattern::BlockInfo tbGrass[] =
 	{E_BLOCK_DIRT,  E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbSand[] =
+static cPattern::BlockInfo g_tbSand[] =
 {
 	{ E_BLOCK_SAND, 0},
 	{ E_BLOCK_SAND, 0},
@@ -76,7 +76,7 @@ static cPattern::BlockInfo tbSand[] =
 	{ E_BLOCK_SANDSTONE, 0},
 } ;
 
-static cPattern::BlockInfo tbDirt[] =
+static cPattern::BlockInfo g_tbDirt[] =
 {
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
@@ -84,7 +84,7 @@ static cPattern::BlockInfo tbDirt[] =
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbPodzol[] =
+static cPattern::BlockInfo g_tbPodzol[] =
 {
 	{E_BLOCK_DIRT, E_META_DIRT_PODZOL},
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
@@ -92,7 +92,7 @@ static cPattern::BlockInfo tbPodzol[] =
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbGrassLess[] =
+static cPattern::BlockInfo g_tbGrassLess[] =
 {
 	{E_BLOCK_DIRT, E_META_DIRT_GRASSLESS},
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
@@ -100,7 +100,7 @@ static cPattern::BlockInfo tbGrassLess[] =
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbMycelium[] =
+static cPattern::BlockInfo g_tbMycelium[] =
 {
 	{E_BLOCK_MYCELIUM, 0},
 	{E_BLOCK_DIRT,     0},
@@ -108,7 +108,7 @@ static cPattern::BlockInfo tbMycelium[] =
 	{E_BLOCK_DIRT,     0},
 } ;
 
-static cPattern::BlockInfo tbGravel[] =
+static cPattern::BlockInfo g_tbGravel[] =
 {
 	{E_BLOCK_GRAVEL, 0},
 	{E_BLOCK_GRAVEL, 0},
@@ -116,7 +116,7 @@ static cPattern::BlockInfo tbGravel[] =
 	{E_BLOCK_STONE,  0},
 } ;
 
-static cPattern::BlockInfo tbStone[] =
+static cPattern::BlockInfo g_tbStone[] =
 {
 	{E_BLOCK_STONE,   0},
 	{E_BLOCK_STONE,   0},
@@ -129,7 +129,7 @@ static cPattern::BlockInfo tbStone[] =
 ////////////////////////////////////////////////////////////////////////////////
 // Ocean floor pattern top-block definitions:
 
-static cPattern::BlockInfo tbOFSand[] =
+static cPattern::BlockInfo g_tbOFSand[] =
 {
 	{E_BLOCK_SAND, 0},
 	{E_BLOCK_SAND, 0},
@@ -137,7 +137,7 @@ static cPattern::BlockInfo tbOFSand[] =
 	{E_BLOCK_SANDSTONE, 0}
 } ;
 
-static cPattern::BlockInfo tbOFClay[] =
+static cPattern::BlockInfo g_tbOFClay[] =
 {
 	{ E_BLOCK_CLAY, 0},
 	{ E_BLOCK_CLAY, 0},
@@ -145,7 +145,7 @@ static cPattern::BlockInfo tbOFClay[] =
 	{ E_BLOCK_SAND, 0},
 } ;
 
-static cPattern::BlockInfo tbOFOrangeClay[] =
+static cPattern::BlockInfo g_tbOFOrangeClay[] =
 {
 	{ E_BLOCK_STAINED_CLAY, E_META_STAINED_GLASS_ORANGE},
 	{ E_BLOCK_STAINED_CLAY, E_META_STAINED_GLASS_ORANGE},
@@ -160,18 +160,18 @@ static cPattern::BlockInfo tbOFOrangeClay[] =
 ////////////////////////////////////////////////////////////////////////////////
 // Individual patterns to use:
 
-static cPattern patGrass    (tbGrass,     ARRAYCOUNT(tbGrass));
-static cPattern patSand     (tbSand,      ARRAYCOUNT(tbSand));
-static cPattern patDirt     (tbDirt,      ARRAYCOUNT(tbDirt));
-static cPattern patPodzol   (tbPodzol,    ARRAYCOUNT(tbPodzol));
-static cPattern patGrassLess(tbGrassLess, ARRAYCOUNT(tbGrassLess));
-static cPattern patMycelium (tbMycelium,  ARRAYCOUNT(tbMycelium));
-static cPattern patGravel   (tbGravel,    ARRAYCOUNT(tbGravel));
-static cPattern patStone    (tbStone,     ARRAYCOUNT(tbStone));
+static cPattern g_patGrass    (g_tbGrass,     ARRAYCOUNT(g_tbGrass));
+static cPattern g_patSand     (g_tbSand,      ARRAYCOUNT(g_tbSand));
+static cPattern g_patDirt     (g_tbDirt,      ARRAYCOUNT(g_tbDirt));
+static cPattern g_patPodzol   (g_tbPodzol,    ARRAYCOUNT(g_tbPodzol));
+static cPattern g_patGrassLess(g_tbGrassLess, ARRAYCOUNT(g_tbGrassLess));
+static cPattern g_patMycelium (g_tbMycelium,  ARRAYCOUNT(g_tbMycelium));
+static cPattern g_patGravel   (g_tbGravel,    ARRAYCOUNT(g_tbGravel));
+static cPattern g_patStone    (g_tbStone,     ARRAYCOUNT(g_tbStone));
 
-static cPattern patOFSand      (tbOFSand,       ARRAYCOUNT(tbOFSand));
-static cPattern patOFClay      (tbOFClay,       ARRAYCOUNT(tbOFClay));
-static cPattern patOFOrangeClay(tbOFOrangeClay, ARRAYCOUNT(tbOFOrangeClay));
+static cPattern g_patOFSand      (g_tbOFSand,       ARRAYCOUNT(g_tbOFSand));
+static cPattern g_patOFClay      (g_tbOFClay,       ARRAYCOUNT(g_tbOFClay));
+static cPattern g_patOFOrangeClay(g_tbOFOrangeClay, ARRAYCOUNT(g_tbOFOrangeClay));
 
 
 
@@ -354,7 +354,7 @@ protected:
 			case biSavannaM:
 			case biSavannaPlateauM:
 			{
-				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, patGrass.Get(), a_ShapeColumn);
+				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, g_patGrass.Get(), a_ShapeColumn);
 				return;
 			}
 
@@ -367,7 +367,7 @@ protected:
 				NOISE_DATATYPE NoiseX = (static_cast<NOISE_DATATYPE>(a_ChunkDesc.GetChunkX() * cChunkDef::Width + a_RelX)) / FrequencyX;
 				NOISE_DATATYPE NoiseY = (static_cast<NOISE_DATATYPE>(a_ChunkDesc.GetChunkZ() * cChunkDef::Width + a_RelZ)) / FrequencyZ;
 				NOISE_DATATYPE Val = m_OceanFloorSelect.CubicNoise2D(NoiseX, NoiseY);
-				const cPattern::BlockInfo * Pattern = (Val < -0.9) ? patGrassLess.Get() : ((Val > 0) ? patPodzol.Get() : patGrass.Get());
+				const cPattern::BlockInfo * Pattern = (Val < -0.9) ? g_patGrassLess.Get() : ((Val > 0) ? g_patPodzol.Get() : g_patGrass.Get());
 				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, Pattern, a_ShapeColumn);
 				return;
 			}
@@ -377,14 +377,14 @@ protected:
 			case biDesertM:
 			case biBeach:
 			{
-				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, patSand.Get(), a_ShapeColumn);
+				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, g_patSand.Get(), a_ShapeColumn);
 				return;
 			}
 
 			case biMushroomIsland:
 			case biMushroomShore:
 			{
-				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, patMycelium.Get(), a_ShapeColumn);
+				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, g_patMycelium.Get(), a_ShapeColumn);
 				return;
 			}
 
@@ -409,7 +409,7 @@ protected:
 				NOISE_DATATYPE NoiseX = (static_cast<NOISE_DATATYPE>(a_ChunkDesc.GetChunkX() * cChunkDef::Width + a_RelX)) / FrequencyX;
 				NOISE_DATATYPE NoiseY = (static_cast<NOISE_DATATYPE>(a_ChunkDesc.GetChunkZ() * cChunkDef::Width + a_RelZ)) / FrequencyZ;
 				NOISE_DATATYPE Val = m_OceanFloorSelect.CubicNoise2D(NoiseX, NoiseY);
-				const cPattern::BlockInfo * Pattern = (Val < 0.0) ? patStone.Get() : patGrass.Get();
+				const cPattern::BlockInfo * Pattern = (Val < 0.0) ? g_patStone.Get() : g_patGrass.Get();
 				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, Pattern, a_ShapeColumn);
 				return;
 			}
@@ -469,7 +469,7 @@ protected:
 			// Select the ocean-floor pattern to use:
 			if (a_ChunkDesc.GetBiome(a_RelX, a_RelZ) == biDeepOcean)
 			{
-				a_Pattern = patGravel.Get();
+				a_Pattern = g_patGravel.Get();
 			}
 			else
 			{
@@ -493,7 +493,7 @@ protected:
 		if (Top < m_SeaLevel)
 		{
 			// The terrain is below sealevel, handle as regular ocean with red sand floor:
-			FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, patOFOrangeClay.Get(), a_ShapeColumn);
+			FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, g_patOFOrangeClay.Get(), a_ShapeColumn);
 			return;
 		}
 
@@ -586,15 +586,15 @@ protected:
 		NOISE_DATATYPE Val = m_OceanFloorSelect.CubicNoise2D(NoiseX, NoiseY);
 		if (Val < -0.95)
 		{
-			return patOFClay.Get();
+			return g_patOFClay.Get();
 		}
 		else if (Val < 0)
 		{
-			return patOFSand.Get();
+			return g_patOFSand.Get();
 		}
 		else
 		{
-			return patDirt.Get();
+			return g_patDirt.Get();
 		}
 	}
 } ;

--- a/src/Generating/DungeonRoomsFinisher.cpp
+++ b/src/Generating/DungeonRoomsFinisher.cpp
@@ -14,7 +14,7 @@
 
 
 /** Height, in blocks, of the internal dungeon room open space. This many air blocks Y-wise. */
-static const int ROOM_HEIGHT = 4;
+static const int g_ROOM_HEIGHT = 4;
 
 
 
@@ -249,7 +249,7 @@ protected:
 		}
 
 		int b = m_FloorHeight + 1;  // Bottom
-		int t = m_FloorHeight + 1 + ROOM_HEIGHT;  // Top
+		int t = m_FloorHeight + 1 + g_ROOM_HEIGHT;  // Top
 		ReplaceCuboidRandom(a_ChunkDesc, m_StartX, m_FloorHeight, m_StartZ, m_EndX + 1, b, m_EndZ + 1, E_BLOCK_MOSSY_COBBLESTONE, E_BLOCK_COBBLESTONE);  // Floor
 		ReplaceCuboid(a_ChunkDesc, m_StartX + 1, b, m_StartZ + 1, m_EndX, t, m_EndZ, E_BLOCK_AIR);  // Insides
 

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -1220,7 +1220,7 @@ void cFinishGenPreSimulator::StationarizeFluid(
 				}
 				static const struct
 				{
-					int x, y, z;
+					int m_x, m_y, m_z;
 				} Coords[] =
 				{
 					{1, 0, 0},
@@ -1375,18 +1375,18 @@ void cFinishGenFluidSprings::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int y, int z)
+bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int a_x, int a_y, int a_z)
 {
 	// In order to place a spring, it needs exactly one of the XZ neighbors or a below neighbor to be air
 	// Also, its neighbor on top of it must be non-air
-	if (a_ChunkDesc.GetBlockType(x, y + 1, z) == E_BLOCK_AIR)
+	if (a_ChunkDesc.GetBlockType(a_x, a_y + 1, a_z) == E_BLOCK_AIR)
 	{
 		return false;
 	}
 
 	static const struct
 	{
-		int x, y, z;
+		int m_x, m_y, m_z;
 	} Coords[] =
 	{
 		{-1,  0,  0},
@@ -1398,7 +1398,7 @@ bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int
 	int NumAirNeighbors = 0;
 	for (size_t i = 0; i < ARRAYCOUNT(Coords); i++)
 	{
-		switch (a_ChunkDesc.GetBlockType(x + Coords[i].x, y + Coords[i].y, z + Coords[i].z))
+		switch (a_ChunkDesc.GetBlockType(a_x + Coords[i].x, a_y + Coords[i].y, a_z + Coords[i].z))
 		{
 			case E_BLOCK_AIR:
 			{
@@ -1416,7 +1416,7 @@ bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int
 	}
 
 	// Has exactly one air neighbor, place a spring:
-	a_ChunkDesc.SetBlockTypeMeta(x, y, z, m_Fluid, 0);
+	a_ChunkDesc.SetBlockTypeMeta(a_x, a_y, a_z, m_Fluid, 0);
 	return true;
 }
 
@@ -1504,7 +1504,7 @@ void cFinishGenPassiveMobs::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, eMonsterType AnimalToSpawn)
+bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, eMonsterType a_AnimalToSpawn)
 {
 	if ((a_RelY >= cChunkDef::Height - 1) || (a_RelY <= 0))
 	{
@@ -1516,12 +1516,12 @@ bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX
 	BLOCKTYPE BlockUnderFeet = a_ChunkDesc.GetBlockType(a_RelX, a_RelY - 1, a_RelZ);
 
 	// Check block below (opaque, grass, water), and above (air)
-	if ((AnimalToSpawn == mtSquid) && (BlockAtFeet != E_BLOCK_WATER))
+	if ((a_AnimalToSpawn == mtSquid) && (BlockAtFeet != E_BLOCK_WATER))
 	{
 		return false;
 	}
 	if (
-		(AnimalToSpawn != mtSquid) &&
+		(a_AnimalToSpawn != mtSquid) &&
 		(BlockAtHead != E_BLOCK_AIR) &&
 		(BlockAtFeet != E_BLOCK_AIR) &&
 		(!cBlockInfo::IsTransparent(BlockUnderFeet))
@@ -1531,12 +1531,12 @@ bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX
 	}
 	if (
 		(BlockUnderFeet != E_BLOCK_GRASS) &&
-		((AnimalToSpawn == mtWolf) || (AnimalToSpawn == mtRabbit) || (AnimalToSpawn == mtCow) || (AnimalToSpawn == mtSheep) || (AnimalToSpawn == mtChicken) || (AnimalToSpawn == mtPig))
+		((a_AnimalToSpawn == mtWolf) || (a_AnimalToSpawn == mtRabbit) || (a_AnimalToSpawn == mtCow) || (a_AnimalToSpawn == mtSheep) || (a_AnimalToSpawn == mtChicken) || (a_AnimalToSpawn == mtPig))
 	)
 	{
 		return false;
 	}
-	if ((AnimalToSpawn == mtMooshroom) && (BlockUnderFeet != E_BLOCK_MYCELIUM))
+	if ((a_AnimalToSpawn == mtMooshroom) && (BlockUnderFeet != E_BLOCK_MYCELIUM))
 	{
 		return false;
 	}
@@ -1545,7 +1545,7 @@ bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX
 	double AnimalY = a_RelY;
 	double AnimalZ = static_cast<double>(a_ChunkDesc.GetChunkZ() * cChunkDef::Width + a_RelZ + 0.5);
 
-	auto NewMob = cMonster::NewMonsterFromType(AnimalToSpawn);
+	auto NewMob = cMonster::NewMonsterFromType(a_AnimalToSpawn);
 	NewMob->SetHealth(NewMob->GetMaxHealth());
 	NewMob->SetPosition(AnimalX, AnimalY, AnimalZ);
 	LOGD("Spawning %s #%i at {%.02f, %.02f, %.02f}", NewMob->GetClass(), NewMob->GetUniqueID(), AnimalX, AnimalY, AnimalZ);

--- a/src/Generating/FinishGen.h
+++ b/src/Generating/FinishGen.h
@@ -128,13 +128,13 @@ protected:
 	std::vector<BiomeInfo> m_FlowersPerBiome;
 
 	/** The maximum number of foliage per clump */
-	const int MAX_NUM_FOLIAGE = 8;
+	const int m_MAX_NUM_FOLIAGE = 8;
 
 	/** The mininum number of foliage per clump */
-	const int MIN_NUM_FOLIAGE = 4;
+	const int m_MIN_NUM_FOLIAGE = 4;
 
 	/** The maximum range a foliage can be placed from the center of the clump */
-	const int RANGE_FROM_CENTER = 5;
+	const int m_RANGE_FROM_CENTER = 5;
 
 	void TryPlaceFoliageClump(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_IsDoubleTall);
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
@@ -440,7 +440,7 @@ protected:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 
 	/** Tries to place a spring at the specified coords, checks neighbors. Returns true if successful. */
-	bool TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int y, int z);
+	bool TryPlaceSpring(cChunkDesc & a_ChunkDesc, int a_x, int a_y, int a_z);
 } ;
 
 
@@ -469,7 +469,7 @@ protected:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 
 	/** Returns false if an animal cannot spawn at given coords, else adds it to the chunk's entity list and returns true */
-	bool TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int x, int y, int z, eMonsterType AnimalToSpawn);
+	bool TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_x, int a_y, int a_z, eMonsterType a_AnimalToSpawn);
 
 	/** Picks a random animal from biome-dependant list for a random position in the chunk.
 	Returns the chosen mob type, or mtInvalid if no mob chosen. */

--- a/src/Generating/HeiGen.cpp
+++ b/src/Generating/HeiGen.cpp
@@ -315,15 +315,15 @@ cHeiGenClassic::cHeiGenClassic(int a_Seed) :
 
 
 
-float cHeiGenClassic::GetNoise(float x, float y)
+float cHeiGenClassic::GetNoise(float a_x, float a_y)
 {
-	float oct1 = m_Noise.CubicNoise2D(x * m_HeightFreq1, y * m_HeightFreq1) * m_HeightAmp1;
-	float oct2 = m_Noise.CubicNoise2D(x * m_HeightFreq2, y * m_HeightFreq2) * m_HeightAmp2;
-	float oct3 = m_Noise.CubicNoise2D(x * m_HeightFreq3, y * m_HeightFreq3) * m_HeightAmp3;
+	float oct1 = m_Noise.CubicNoise2D(a_x * m_HeightFreq1, a_y * m_HeightFreq1) * m_HeightAmp1;
+	float oct2 = m_Noise.CubicNoise2D(a_x * m_HeightFreq2, a_y * m_HeightFreq2) * m_HeightAmp2;
+	float oct3 = m_Noise.CubicNoise2D(a_x * m_HeightFreq3, a_y * m_HeightFreq3) * m_HeightAmp3;
 
-	float height = m_Noise.CubicNoise2D(x * 0.1f, y * 0.1f) * 2;
+	float height = m_Noise.CubicNoise2D(a_x * 0.1f, a_y * 0.1f) * 2;
 
-	float flatness = ((m_Noise.CubicNoise2D(x * 0.5f, y * 0.5f) + 1.f) * 0.5f) * 1.1f;  // 0 ... 1.5
+	float flatness = ((m_Noise.CubicNoise2D(a_x * 0.5f, a_y * 0.5f) + 1.f) * 0.5f) * 1.1f;  // 0 ... 1.5
 	flatness *= flatness * flatness;
 
 	return (oct1 + oct2 + oct3) * flatness + height;

--- a/src/Generating/HeiGen.h
+++ b/src/Generating/HeiGen.h
@@ -130,7 +130,7 @@ protected:
 	float m_HeightFreq2, m_HeightAmp2;
 	float m_HeightFreq3, m_HeightAmp3;
 
-	float GetNoise(float x, float y);
+	float GetNoise(float a_x, float a_y);
 
 	// cTerrainHeightGen overrides:
 	virtual void GenHeightMap(int a_ChunkX, int a_ChunkZ, cChunkDef::HeightMap & a_HeightMap) override;

--- a/src/Generating/IntGen.h
+++ b/src/Generating/IntGen.h
@@ -37,13 +37,13 @@ by using templates.
 
 
 /** Constants representing the biome group designators. */
-const int bgOcean        = 0;
-const int bgDesert       = 1;
-const int bgTemperate    = 2;
-const int bgMountains    = 3;
-const int bgIce          = 4;
-const int bgLandOceanMax = 4;  // Maximum biome group value generated in the landOcean generator
-const int bgfRare        = 1024;  // Flag added to values to generate rare biomes for the group
+const int g_bgOcean        = 0;
+const int g_bgDesert       = 1;
+const int g_bgTemperate    = 2;
+const int g_bgMountains    = 3;
+const int g_bgIce          = 4;
+const int g_bgLandOceanMax = 4;  // Maximum biome group value generated in the landOcean generator
+const int g_bgfRare        = 1024;  // Flag added to values to generate rare biomes for the group
 
 
 
@@ -232,14 +232,14 @@ public:
 			for (int x = 0; x < SizeX; x++)
 			{
 				int rnd = (super::m_Noise.IntNoise2DInt(a_MinX + x, BaseZ) / 7);
-				a_Values[x + SizeX * z] = ((rnd % 100) < m_Threshold) ? ((rnd / 101) % bgLandOceanMax + 1) : 0;
+				a_Values[x + SizeX * z] = ((rnd % 100) < m_Threshold) ? ((rnd / 101) % g_bgLandOceanMax + 1) : 0;
 			}
 		}
 
 		// If the centerpoint of the world is within the area, set it to bgTemperate, always:
 		if ((a_MinX <= 0) && (a_MinZ <= 0) && (a_MinX + SizeX > 0) && (a_MinZ + SizeZ > 0))
 		{
-			a_Values[-a_MinX - a_MinZ * SizeX] = bgTemperate;
+			a_Values[-a_MinX - a_MinZ * SizeX] = g_bgTemperate;
 		}
 	}
 
@@ -529,12 +529,12 @@ public:
 		{
 			for (int x = 0; x < SizeX; x++)
 			{
-				if (a_Values[x + z * SizeX] == bgOcean)
+				if (a_Values[x + z * SizeX] == g_bgOcean)
 				{
 					int rnd = super::m_Noise.IntNoise2DInt(a_MinX + x, a_MinZ + z) / 7;
 					if (rnd % 1000 < m_Chance)
 					{
-						a_Values[x + z * SizeX] = (rnd / 1003) % bgLandOceanMax;
+						a_Values[x + z * SizeX] = (rnd / 1003) % g_bgLandOceanMax;
 					}
 				}
 			}  // for x
@@ -591,7 +591,7 @@ public:
 				switch (val)
 				{
 					// Desert should neighbor only oceans, desert and temperates; change to temperate when another:
-					case bgDesert:
+					case g_bgDesert:
 					{
 						if (
 							!isDesertCompatible(above) ||
@@ -600,22 +600,22 @@ public:
 							!isDesertCompatible(right)
 						)
 						{
-							val = bgTemperate;
+							val = g_bgTemperate;
 						}
 						break;
 					}  // case bgDesert
 
 					// Ice should not neighbor deserts; change to temperate:
-					case bgIce:
+					case g_bgIce:
 					{
 						if (
-							(above == bgDesert) ||
-							(below == bgDesert) ||
-							(left  == bgDesert) ||
-							(right == bgDesert)
+							(above == g_bgDesert) ||
+							(below == g_bgDesert) ||
+							(left  == g_bgDesert) ||
+							(right == g_bgDesert)
 						)
 						{
-							val = bgTemperate;
+							val = g_bgTemperate;
 						}
 						break;
 					}  // case bgIce
@@ -633,9 +633,9 @@ protected:
 	{
 		switch (a_BiomeGroup)
 		{
-			case bgOcean:
-			case bgDesert:
-			case bgTemperate:
+			case g_bgOcean:
+			case g_bgDesert:
+			case g_bgTemperate:
 			{
 				return true;
 			}
@@ -754,8 +754,8 @@ public:
 			for (int x = 0; x < SizeX; x++)
 			{
 				size_t val = static_cast<size_t>(a_Values[x + IdxZ]);
-				const cBiomesInGroups & Biomes = (val > bgfRare) ?
-					rareBiomesInGroups[(val & (bgfRare - 1)) % ARRAYCOUNT(rareBiomesInGroups)] :
+				const cBiomesInGroups & Biomes = (val > g_bgfRare) ?
+					rareBiomesInGroups[(val & (g_bgfRare - 1)) % ARRAYCOUNT(rareBiomesInGroups)] :
 					biomesInGroups[val % ARRAYCOUNT(biomesInGroups)];
 				int rnd = (super::m_Noise.IntNoise2DInt(x + a_MinX, z + a_MinZ) / 7);
 				a_Values[x + IdxZ] = Biomes.Biomes[rnd % Biomes.Count];
@@ -767,8 +767,8 @@ protected:
 
 	struct cBiomesInGroups
 	{
-		const int Count;
-		const int * Biomes;
+		const int m_Count;
+		const int * m_Biomes;
 	};
 
 
@@ -1151,7 +1151,7 @@ public:
 				if (rnd % 1000 < m_Chance)
 				{
 					int idx = x + SizeX * z;
-					a_Values[idx] = a_Values[idx] | bgfRare;
+					a_Values[idx] = a_Values[idx] | g_bgfRare;
 				}
 			}
 		}

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -1024,8 +1024,8 @@ void cMineShaftCrossing::AppendBranches(int a_RecursionLevel, cNoise & a_Noise)
 {
 	struct
 	{
-		int x, y, z;
-		eDirection dir;
+		int m_x, m_y, m_z;
+		eDirection m_dir;
 	} Exits[] =
 	{
 		// Bottom level:

--- a/src/Generating/ProtIntGen.h
+++ b/src/Generating/ProtIntGen.h
@@ -166,14 +166,14 @@ public:
 			for (size_t x = 0; x < a_SizeX; x++)
 			{
 				int rnd = (super::m_Noise.IntNoise2DInt(a_MinX + static_cast<int>(x), BaseZ) / 7);
-				a_Values[x + a_SizeX * z] = ((rnd % 100) < m_Threshold) ? ((rnd / 101) % bgLandOceanMax + 1) : 0;
+				a_Values[x + a_SizeX * z] = ((rnd % 100) < m_Threshold) ? ((rnd / 101) % g_bgLandOceanMax + 1) : 0;
 			}
 		}
 
 		// If the centerpoint of the world is within the area, set it to bgTemperate, always:
 		if ((a_MinX <= 0) && (a_MinZ <= 0) && (a_MinX + static_cast<int>(a_SizeX) > 0) && (a_MinZ + static_cast<int>(a_SizeZ) > 0))
 		{
-			a_Values[static_cast<size_t>(-a_MinX) - static_cast<size_t>(a_MinZ) * a_SizeX] = bgTemperate;
+			a_Values[static_cast<size_t>(-a_MinX) - static_cast<size_t>(a_MinZ) * a_SizeX] = g_bgTemperate;
 		}
 	}
 
@@ -798,12 +798,12 @@ public:
 		{
 			for (size_t x = 0; x < a_SizeX; x++)
 			{
-				if (a_Values[x + z * a_SizeX] == bgOcean)
+				if (a_Values[x + z * a_SizeX] == g_bgOcean)
 				{
 					int rnd = super::m_Noise.IntNoise2DInt(a_MinX + static_cast<int>(x), a_MinZ + static_cast<int>(z)) / 7;
 					if (rnd % 1000 < m_Chance)
 					{
-						a_Values[x + z * a_SizeX] = (rnd / 1003) % bgLandOceanMax;
+						a_Values[x + z * a_SizeX] = (rnd / 1003) % g_bgLandOceanMax;
 					}
 				}
 			}
@@ -856,7 +856,7 @@ public:
 				switch (val)
 				{
 					// Desert should neighbor only oceans, desert and temperates; change to temperate when another:
-					case bgDesert:
+					case g_bgDesert:
 					{
 						if (
 							!isDesertCompatible(Above) ||
@@ -865,22 +865,22 @@ public:
 							!isDesertCompatible(Right)
 						)
 						{
-							val = bgTemperate;
+							val = g_bgTemperate;
 						}
 						break;
 					}  // case bgDesert
 
 					// Ice should not neighbor deserts; change to temperate:
-					case bgIce:
+					case g_bgIce:
 					{
 						if (
-							(Above == bgDesert) ||
-							(Below == bgDesert) ||
-							(Left  == bgDesert) ||
-							(Right == bgDesert)
+							(Above == g_bgDesert) ||
+							(Below == g_bgDesert) ||
+							(Left  == g_bgDesert) ||
+							(Right == g_bgDesert)
 						)
 						{
-							val = bgTemperate;
+							val = g_bgTemperate;
 						}
 						break;
 					}  // case bgIce
@@ -898,9 +898,9 @@ protected:
 	{
 		switch (a_BiomeGroup)
 		{
-			case bgOcean:
-			case bgDesert:
-			case bgTemperate:
+			case g_bgOcean:
+			case g_bgDesert:
+			case g_bgTemperate:
 			{
 				return true;
 			}
@@ -1016,8 +1016,8 @@ public:
 			for (size_t x = 0; x < a_SizeX; x++)
 			{
 				int val = a_Values[x + IdxZ];
-				const cBiomesInGroups & Biomes = (val > bgfRare) ?
-					rareBiomesInGroups[(val & (bgfRare - 1)) % ARRAYCOUNT(rareBiomesInGroups)] :
+				const cBiomesInGroups & Biomes = (val > g_bgfRare) ?
+					rareBiomesInGroups[(val & (g_bgfRare - 1)) % ARRAYCOUNT(rareBiomesInGroups)] :
 					biomesInGroups[static_cast<size_t>(val) % ARRAYCOUNT(biomesInGroups)];
 				int rnd = (super::m_Noise.IntNoise2DInt(static_cast<int>(x) + a_MinX, static_cast<int>(z) + a_MinZ) / 7);
 				a_Values[x + IdxZ] = Biomes.Biomes[rnd % Biomes.Count];
@@ -1029,8 +1029,8 @@ protected:
 
 	struct cBiomesInGroups
 	{
-		const int Count;
-		const int * Biomes;
+		const int m_Count;
+		const int * m_Biomes;
 	};
 
 
@@ -1396,7 +1396,7 @@ public:
 				if (rnd % 1000 < m_Chance)
 				{
 					size_t idx = x + a_SizeX * z;
-					a_Values[idx] = a_Values[idx] | bgfRare;
+					a_Values[idx] = a_Values[idx] | g_bgfRare;
 				}
 			}
 		}

--- a/src/Generating/Ravines.cpp
+++ b/src/Generating/Ravines.cpp
@@ -9,7 +9,7 @@
 
 
 
-static const int NUM_RAVINE_POINTS = 4;
+static const int g_NUM_RAVINE_POINTS = 4;
 
 
 
@@ -145,16 +145,16 @@ void cStructGenRavines::cRavine::GenerateBaseDefPoints(int a_BlockX, int a_Block
 	int DefinitionPointX = CenterX - static_cast<int>(xc * a_Size / 2);
 	int DefinitionPointZ = CenterZ - static_cast<int>(zc * a_Size / 2);
 	m_Points.push_back(cRavDefPoint(DefinitionPointX, DefinitionPointZ, 0, (Mid + Top) / 2, (Mid + Bottom) / 2));
-	for (int i = 1; i < NUM_RAVINE_POINTS - 1; i++)
+	for (int i = 1; i < g_NUM_RAVINE_POINTS - 1; i++)
 	{
-		int LineX = CenterX + static_cast<int>(xc * a_Size * (i - NUM_RAVINE_POINTS / 2) / NUM_RAVINE_POINTS);
-		int LineZ = CenterZ + static_cast<int>(zc * a_Size * (i - NUM_RAVINE_POINTS / 2) / NUM_RAVINE_POINTS);
+		int LineX = CenterX + static_cast<int>(xc * a_Size * (i - g_NUM_RAVINE_POINTS / 2) / g_NUM_RAVINE_POINTS);
+		int LineZ = CenterZ + static_cast<int>(zc * a_Size * (i - g_NUM_RAVINE_POINTS / 2) / g_NUM_RAVINE_POINTS);
 		// Amplitude is the amount of blocks that this point is away from the ravine "axis"
 		int Amplitude = (a_Noise.IntNoise3DInt(70 * a_BlockX, 20 * a_BlockZ + 31 * i, 10000 * i) / 9) % a_Size;
 		Amplitude = Amplitude / 4 - a_Size / 8;  // Amplitude is in interval [-a_Size / 4, a_Size / 4]
 		int PointX = LineX + static_cast<int>(zc * Amplitude);
 		int PointZ = LineZ - static_cast<int>(xc * Amplitude);
-		int Radius = MaxRadius - abs(i - NUM_RAVINE_POINTS / 2);  // TODO: better radius function
+		int Radius = MaxRadius - abs(i - g_NUM_RAVINE_POINTS / 2);  // TODO: better radius function
 		int ThisTop    = Top    + ((a_Noise.IntNoise3DInt(7 *  a_BlockX, 19 * a_BlockZ, i * 31) / 13) % 8) - 4;
 		int ThisBottom = Bottom + ((a_Noise.IntNoise3DInt(19 * a_BlockX, 7 *  a_BlockZ, i * 31) / 13) % 8) - 4;
 		m_Points.push_back(cRavDefPoint(PointX, PointZ, Radius, ThisTop, ThisBottom));

--- a/src/Generating/Trees.cpp
+++ b/src/Generating/Trees.cpp
@@ -13,16 +13,16 @@
 
 typedef struct
 {
-	int x, z;
+	int m_x, m_z;
 } sCoords;
 
 typedef struct
 {
-	int x, z;
-	NIBBLETYPE Meta;
+	int m_x, m_z;
+	NIBBLETYPE m_Meta;
 } sMetaCoords;
 
-static const sCoords Corners[] =
+static const sCoords g_Corners[] =
 {
 	{-1, -1},
 	{-1, 1},
@@ -32,14 +32,14 @@ static const sCoords Corners[] =
 
 // BigO = a big ring of blocks, used for generating horz slices of treetops, the number indicates the radius
 
-static const sCoords BigO1[] =
+static const sCoords g_BigO1[] =
 {
 	/* -1 */           {0, -1},
 	/*  0 */ {-1,  0},          {1,  0},
 	/*  1 */           {0,  1},
 } ;
 
-static const sCoords BigO2[] =
+static const sCoords g_BigO2[] =
 {
 	/* -2 */           {-1, -2}, {0, -2}, {1, -2},
 	/* -1 */ {-2, -1}, {-1, -1}, {0, -1}, {1, -1}, {2, -1},
@@ -48,7 +48,7 @@ static const sCoords BigO2[] =
 	/*  2 */           {-1,  2}, {0,  2}, {1,  2},
 } ;
 
-static const sCoords BigO3[] =
+static const sCoords g_BigO3[] =
 {
 	/* -3 */           {-2, -3}, {-1, -3}, {0, -3}, {1, -3}, {2, -3},
 	/* -2 */ {-3, -2}, {-2, -2}, {-1, -2}, {0, -2}, {1, -2}, {2, -2}, {3, -2},
@@ -59,7 +59,7 @@ static const sCoords BigO3[] =
 	/*  3 */           {-2,  3}, {-1,  3}, {0,  3}, {1,  3}, {2,  3},
 } ;
 
-static const sCoords BigO4[] =  // Part of Big Jungle tree
+static const sCoords g_BigO4[] =  // Part of Big Jungle tree
 {
 	/* -4 */                     {-2, -4}, {-1, -4}, {0, -4}, {1, -4}, {2, -4},
 	/* -3 */           {-3, -3}, {-2, -3}, {-1, -3}, {0, -3}, {1, -3}, {2, -3}, {3, -3},
@@ -78,16 +78,16 @@ static const sCoords BigO4[] =  // Part of Big Jungle tree
 
 typedef struct
 {
-	const sCoords * Coords;
-	size_t          Count;
+	const sCoords * m_Coords;
+	size_t          m_Count;
 } sCoordsArr;
 
-static const sCoordsArr BigOs[] =
+static const sCoordsArr g_BigOs[] =
 {
-	{BigO1, ARRAYCOUNT(BigO1)},
-	{BigO2, ARRAYCOUNT(BigO2)},
-	{BigO3, ARRAYCOUNT(BigO3)},
-	{BigO4, ARRAYCOUNT(BigO4)},
+	{g_BigO1, ARRAYCOUNT(g_BigO1)},
+	{g_BigO2, ARRAYCOUNT(g_BigO2)},
+	{g_BigO3, ARRAYCOUNT(g_BigO3)},
+	{g_BigO4, ARRAYCOUNT(g_BigO4)},
 } ;
 
 
@@ -109,10 +109,10 @@ inline void PushCoordBlocks(int a_BlockX, int a_Height, int a_BlockZ, sSetBlockV
 
 inline void PushCornerBlocks(int a_BlockX, int a_Height, int a_BlockZ, int a_Seq, cNoise & a_Noise, int a_Chance, sSetBlockVector & a_Blocks, int a_CornersDist, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta)
 {
-	for (size_t i = 0; i < ARRAYCOUNT(Corners); i++)
+	for (size_t i = 0; i < ARRAYCOUNT(g_Corners); i++)
 	{
-		int x = a_BlockX + Corners[i].x;
-		int z = a_BlockZ + Corners[i].z;
+		int x = a_BlockX + g_Corners[i].x;
+		int z = a_BlockZ + g_Corners[i].z;
 		if (a_Noise.IntNoise3DInt(x + 64 * a_Seq, a_Height, z + 64 * a_Seq) <= a_Chance)
 		{
 			a_Blocks.push_back(sSetBlock(x, a_Height, z, a_BlockType, a_Meta));
@@ -328,7 +328,7 @@ void GetSmallAppleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a
 
 	// Pre-alloc so that we don't realloc too often later:
 	a_LogBlocks.reserve(static_cast<size_t>(Height + 5));
-	a_OtherBlocks.reserve(ARRAYCOUNT(BigO2) * 2 + ARRAYCOUNT(BigO1) + ARRAYCOUNT(Corners) * 3 + 3 + 5);
+	a_OtherBlocks.reserve(ARRAYCOUNT(g_BigO2) * 2 + ARRAYCOUNT(g_BigO1) + ARRAYCOUNT(g_Corners) * 3 + 3 + 5);
 
 	// Trunk:
 	for (int i = 0; i < Height; i++)
@@ -340,7 +340,7 @@ void GetSmallAppleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a
 	// 2 BigO2 + corners layers:
 	for (int i = 0; i < 2; i++)
 	{
-		PushCoordBlocks (a_BlockX, Hei, a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+		PushCoordBlocks (a_BlockX, Hei, a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		PushCornerBlocks(a_BlockX, Hei, a_BlockZ, a_Seq, a_Noise, 0x5000000 - i * 0x10000000, a_OtherBlocks, 2, E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		a_LogBlocks.push_back(sSetBlock(a_BlockX, Hei, a_BlockZ, E_BLOCK_LOG, E_META_LOG_APPLE));
 		Hei++;
@@ -349,14 +349,14 @@ void GetSmallAppleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a
 	// Optional BigO1 + corners layer:
 	if ((Random & 1) == 0)
 	{
-		PushCoordBlocks (a_BlockX, Hei, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+		PushCoordBlocks (a_BlockX, Hei, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		PushCornerBlocks(a_BlockX, Hei, a_BlockZ, a_Seq, a_Noise, 0x6000000, a_OtherBlocks, 1, E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		a_LogBlocks.push_back(sSetBlock(a_BlockX, Hei, a_BlockZ, E_BLOCK_LOG, E_META_LOG_APPLE));
 		Hei++;
 	}
 
 	// Top plus:
-	PushCoordBlocks(a_BlockX, Hei, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+	PushCoordBlocks(a_BlockX, Hei, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, Hei, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_APPLE));
 }
 
@@ -412,12 +412,12 @@ void GetLargeAppleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a
 		int Z = itr.GetZ();
 
 		a_OtherBlocks.push_back(sSetBlock(X, itr.m_RelY - 2, Z, E_BLOCK_LEAVES, E_META_LEAVES_APPLE));
-		PushCoordBlocks(X, itr.m_RelY - 2, Z, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+		PushCoordBlocks(X, itr.m_RelY - 2, Z, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		for (int y = -1; y <= 1; y++)
 		{
-			PushCoordBlocks (X, itr.m_RelY + y, Z, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+			PushCoordBlocks (X, itr.m_RelY + y, Z, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		}
-		PushCoordBlocks(X, itr.m_RelY + 2, Z, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+		PushCoordBlocks(X, itr.m_RelY + 2, Z, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		a_OtherBlocks.push_back(sSetBlock(X, itr.m_RelY + 2, Z, E_BLOCK_LEAVES, E_META_LEAVES_APPLE));
 	}
 
@@ -491,19 +491,19 @@ void GetBirchTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Nois
 	int h = a_BlockY + Height;
 
 	// Top layer - just the Plus:
-	PushCoordBlocks(a_BlockX, h, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
+	PushCoordBlocks(a_BlockX, h, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, h, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_BIRCH));  // There's no log at this layer
 	h--;
 
 	// Second layer - log, Plus and maybe Corners:
-	PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
+	PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 	PushCornerBlocks(a_BlockX, h, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 1, E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 	h--;
 
 	// Third and fourth layers - BigO2 and maybe 2 * Corners:
 	for (int Row = 0; Row < 2; Row++)
 	{
-		PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
+		PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 		PushCornerBlocks(a_BlockX, h, a_BlockZ, a_Seq, a_Noise, 0x3fffffff + Row * 0x10000000, a_OtherBlocks, 2, E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 		h--;
 	}  // for Row - 2*
@@ -550,8 +550,8 @@ void GetAcaciaTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 	}
 
 	// Add the leaves to the top of the branch
-	PushCoordBlocks(BranchPos.x, BranchPos.y, BranchPos.z, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
-	PushCoordBlocks(BranchPos.x, BranchPos.y + 1, BranchPos.z, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
+	PushCoordBlocks(BranchPos.x, BranchPos.y, BranchPos.z, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
+	PushCoordBlocks(BranchPos.x, BranchPos.y + 1, BranchPos.z, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
 	a_OtherBlocks.push_back(sSetBlock(BranchPos.x, BranchPos.y + 1, BranchPos.z, E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA));
 
 	// Choose if we have to add another branch
@@ -578,8 +578,8 @@ void GetAcaciaTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 	}
 
 	// And add the leaves ontop of the second branch
-	PushCoordBlocks(BranchPos.x, BranchPos.y, BranchPos.z, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
-	PushCoordBlocks(BranchPos.x, BranchPos.y + 1, BranchPos.z, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
+	PushCoordBlocks(BranchPos.x, BranchPos.y, BranchPos.z, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
+	PushCoordBlocks(BranchPos.x, BranchPos.y + 1, BranchPos.z, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA);
 	a_OtherBlocks.push_back(sSetBlock(BranchPos.x, BranchPos.y + 1, BranchPos.z, E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA));
 }
 
@@ -643,13 +643,13 @@ void GetDarkoakTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_No
 	// The lower two leaves layers are BigO4 with log in the middle and possibly corners:
 	for (int i = 0; i < 2; i++)
 	{
-		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO4, ARRAYCOUNT(BigO4), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_DARK_OAK);
+		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO4, ARRAYCOUNT(g_BigO4), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_DARK_OAK);
 		PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 3, E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_DARK_OAK);
 		hei++;
 	}  // for i < 2
 
 	// The top leaves layer is a BigO3 with leaves in the middle and possibly corners:
-	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO3, ARRAYCOUNT(BigO3), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_DARK_OAK);
+	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO3, ARRAYCOUNT(g_BigO3), E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_DARK_OAK);
 	PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 3, E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_DARK_OAK);
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_DARK_OAK));
 }
@@ -674,19 +674,19 @@ void GetTallBirchTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_
 	int h = a_BlockY + Height;
 
 	// Top layer - just the Plus:
-	PushCoordBlocks(a_BlockX, h, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
+	PushCoordBlocks(a_BlockX, h, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, h, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_BIRCH));  // There's no log at this layer
 	h--;
 
 	// Second layer - log, Plus and maybe Corners:
-	PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
+	PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 	PushCornerBlocks(a_BlockX, h, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 1, E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 	h--;
 
 	// Third and fourth layers - BigO2 and maybe 2 * Corners:
 	for (int Row = 0; Row < 2; Row++)
 	{
-		PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
+		PushCoordBlocks (a_BlockX, h, a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 		PushCornerBlocks(a_BlockX, h, a_BlockZ, a_Seq, a_Noise, 0x3fffffff + Row * 0x10000000, a_OtherBlocks, 2, E_BLOCK_LEAVES, E_META_LEAVES_BIRCH);
 		h--;
 	}  // for Row - 2*
@@ -741,7 +741,7 @@ void GetSpruceTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 	// Optional size-1 bottom leaves layer:
 	if ((MyRandom & 1) == 0)
 	{
-		PushCoordBlocks(a_BlockX, Height, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+		PushCoordBlocks(a_BlockX, Height, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
 		a_OtherBlocks.push_back(sSetBlock(a_BlockX, Height, a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
 		Height++;
 	}
@@ -758,8 +758,8 @@ void GetSpruceTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 			case 0:
 			case 1:
 			{
-				PushCoordBlocks(a_BlockX, Height,     a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
-				PushCoordBlocks(a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+				PushCoordBlocks(a_BlockX, Height,     a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+				PushCoordBlocks(a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
 				a_LogBlocks.push_back(sSetBlock(a_BlockX, Height,     a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
 				a_LogBlocks.push_back(sSetBlock(a_BlockX, Height + 1, a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
 				Height += 2;
@@ -767,8 +767,8 @@ void GetSpruceTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 			}
 			case 2:
 			{
-				PushCoordBlocks(a_BlockX, Height,     a_BlockZ, a_OtherBlocks, BigO3, ARRAYCOUNT(BigO3), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
-				PushCoordBlocks(a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+				PushCoordBlocks(a_BlockX, Height,     a_BlockZ, a_OtherBlocks, g_BigO3, ARRAYCOUNT(g_BigO3), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+				PushCoordBlocks(a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
 				a_LogBlocks.push_back(sSetBlock(a_BlockX, Height,     a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
 				a_LogBlocks.push_back(sSetBlock(a_BlockX, Height + 1, a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
 				Height += 2;
@@ -776,9 +776,9 @@ void GetSpruceTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 			}
 			case 3:
 			{
-				PushCoordBlocks(a_BlockX, Height,     a_BlockZ, a_OtherBlocks, BigO3, ARRAYCOUNT(BigO3), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
-				PushCoordBlocks(a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
-				PushCoordBlocks(a_BlockX, Height + 2, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+				PushCoordBlocks(a_BlockX, Height,     a_BlockZ, a_OtherBlocks, g_BigO3, ARRAYCOUNT(g_BigO3), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+				PushCoordBlocks(a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+				PushCoordBlocks(a_BlockX, Height + 2, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
 				a_LogBlocks.push_back(sSetBlock(a_BlockX, Height,     a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
 				a_LogBlocks.push_back(sSetBlock(a_BlockX, Height + 1, a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
 				a_LogBlocks.push_back(sSetBlock(a_BlockX, Height + 2, a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
@@ -793,7 +793,7 @@ void GetSpruceTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 	{
 		// (0, 1, 0) top:
 		a_LogBlocks.push_back  (sSetBlock(a_BlockX, Height,     a_BlockZ, E_BLOCK_LOG, E_META_LOG_CONIFER));
-		PushCoordBlocks                  (a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+		PushCoordBlocks                  (a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
 		a_OtherBlocks.push_back(sSetBlock(a_BlockX, Height + 1, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_CONIFER));
 		a_OtherBlocks.push_back(sSetBlock(a_BlockX, Height + 2, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_CONIFER));
 	}
@@ -801,7 +801,7 @@ void GetSpruceTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noi
 	{
 		// (1, 0) top:
 		a_OtherBlocks.push_back(sSetBlock(a_BlockX, Height,     a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_CONIFER));
-		PushCoordBlocks                  (a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+		PushCoordBlocks                  (a_BlockX, Height + 1, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
 		a_OtherBlocks.push_back(sSetBlock(a_BlockX, Height + 1, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_CONIFER));
 	}
 }
@@ -854,7 +854,7 @@ void GetPineTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noise
 			break;
 		}
 		ASSERT(static_cast<size_t>(LayerSize) < ARRAYCOUNT(BigOs));
-		PushCoordBlocks(a_BlockX, h, a_BlockZ, a_OtherBlocks, BigOs[LayerSize].Coords, BigOs[LayerSize].Count, E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
+		PushCoordBlocks(a_BlockX, h, a_BlockZ, a_OtherBlocks, g_BigOs[LayerSize].Coords, g_BigOs[LayerSize].Count, E_BLOCK_LEAVES, E_META_LEAVES_CONIFER);
 		h--;
 	}
 }
@@ -877,7 +877,7 @@ void GetSwampTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Nois
 	int Height = 3 + (a_Noise.IntNoise3DInt(a_BlockX + 32 * a_Seq, a_BlockY, a_BlockZ + 32 * a_Seq) / 8) % 3;
 
 	a_LogBlocks.reserve(static_cast<size_t>(Height));
-	a_OtherBlocks.reserve(2 * ARRAYCOUNT(BigO2) + 2 * ARRAYCOUNT(BigO3) + static_cast<size_t>(Height) * ARRAYCOUNT(Vines) + 20);
+	a_OtherBlocks.reserve(2 * ARRAYCOUNT(g_BigO2) + 2 * ARRAYCOUNT(g_BigO3) + static_cast<size_t>(Height) * ARRAYCOUNT(Vines) + 20);
 
 	for (int i = 0; i < Height; i++)
 	{
@@ -891,7 +891,7 @@ void GetSwampTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Nois
 	// The lower two leaves layers are BigO3 with log in the middle and possibly corners:
 	for (int i = 0; i < 2; i++)
 	{
-		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO3, ARRAYCOUNT(BigO3), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO3, ARRAYCOUNT(g_BigO3), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 3, E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		hei++;
 	}  // for i - 2*
@@ -899,7 +899,7 @@ void GetSwampTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Nois
 	// The upper two leaves layers are BigO2 with leaves in the middle and possibly corners:
 	for (int i = 0; i < 2; i++)
 	{
-		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 3, E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 		a_OtherBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_APPLE));
 		hei++;
@@ -912,15 +912,15 @@ void GetSwampTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Nois
 
 void GetAppleBushImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
-	a_OtherBlocks.reserve(3 + ARRAYCOUNT(BigO2) + ARRAYCOUNT(BigO1));
+	a_OtherBlocks.reserve(3 + ARRAYCOUNT(g_BigO2) + ARRAYCOUNT(g_BigO1));
 
 	int hei = a_BlockY;
 	a_LogBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_LOG, E_META_LOG_JUNGLE));
-	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 	hei++;
 
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_APPLE));
-	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
+	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_APPLE);
 	hei++;
 
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_APPLE));
@@ -963,7 +963,7 @@ void GetLargeJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & 
 	int Height = 24 + (a_Noise.IntNoise3DInt(a_BlockX + 32 * a_Seq, a_BlockY, a_BlockZ + 32 * a_Seq) / 11) % 24;
 
 	a_LogBlocks.reserve(static_cast<size_t>(Height) * 4);
-	a_OtherBlocks.reserve(2 * ARRAYCOUNT(BigO4) + ARRAYCOUNT(BigO3) + static_cast<size_t>(Height) * ARRAYCOUNT(Vines) + 50);
+	a_OtherBlocks.reserve(2 * ARRAYCOUNT(g_BigO4) + ARRAYCOUNT(g_BigO3) + static_cast<size_t>(Height) * ARRAYCOUNT(Vines) + 50);
 
 	for (int i = 0; i < Height; i++)
 	{
@@ -989,13 +989,13 @@ void GetLargeJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & 
 	// The lower two leaves layers are BigO4 with log in the middle and possibly corners:
 	for (int i = 0; i < 2; i++)
 	{
-		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO4, ARRAYCOUNT(BigO4), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
+		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO4, ARRAYCOUNT(g_BigO4), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 		PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 3, E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 		hei++;
 	}  // for i - 2*
 
 	// The top leaves layer is a BigO3 with leaves in the middle and possibly corners:
-	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO3, ARRAYCOUNT(BigO3), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
+	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO3, ARRAYCOUNT(g_BigO3), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 	PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 3, E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE));
 }
@@ -1020,9 +1020,9 @@ void GetSmallJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & 
 
 	a_LogBlocks.reserve(static_cast<size_t>(Height));
 	a_OtherBlocks.reserve(
-		2 * ARRAYCOUNT(BigO3) +       // O3 layer, 2x
-		2 * ARRAYCOUNT(BigO2) +       // O2 layer, 2x
-		ARRAYCOUNT(BigO1) + 1 +       // Plus on the top
+		2 * ARRAYCOUNT(g_BigO3) +       // O3 layer, 2x
+		2 * ARRAYCOUNT(g_BigO2) +       // O2 layer, 2x
+		ARRAYCOUNT(g_BigO1) + 1 +       // Plus on the top
 		static_cast<size_t>(Height) * ARRAYCOUNT(Vines) +  // Vines
 		50  // some safety
 	);
@@ -1039,7 +1039,7 @@ void GetSmallJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & 
 	// The lower two leaves layers are BigO3 with log in the middle and possibly corners:
 	for (int i = 0; i < 2; i++)
 	{
-		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO3, ARRAYCOUNT(BigO3), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
+		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO3, ARRAYCOUNT(g_BigO3), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 		PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 3, E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 		hei++;
 	}  // for i - 2*
@@ -1047,13 +1047,13 @@ void GetSmallJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & 
 	// Two layers of BigO2 leaves, possibly with corners:
 	for (int i = 0; i < 1; i++)
 	{
-		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO2, ARRAYCOUNT(BigO2), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
+		PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO2, ARRAYCOUNT(g_BigO2), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 		PushCornerBlocks(a_BlockX, hei, a_BlockZ, a_Seq, a_Noise, 0x5fffffff, a_OtherBlocks, 2, E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 		hei++;
 	}  // for i - 2*
 
 	// Top plus, all leaves:
-	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
+	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, g_BigO1, ARRAYCOUNT(g_BigO1), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE));
 }
 

--- a/src/Generating/VerticalStrategy.cpp
+++ b/src/Generating/VerticalStrategy.cpp
@@ -12,7 +12,7 @@
 
 
 // Constant that is added to random seed
-static const int SEED_OFFSET = 135;
+static const int g_SEED_OFFSET = 135;
 
 
 
@@ -159,7 +159,7 @@ public:
 
 	virtual void AssignGens(int a_Seed, cBiomeGenPtr & a_BiomeGen, cTerrainHeightGenPtr & a_TerrainHeightGen, int a_SeaLevel) override
 	{
-		m_Seed = a_Seed + SEED_OFFSET;
+		m_Seed = a_Seed + g_SEED_OFFSET;
 	}
 
 protected:
@@ -206,7 +206,7 @@ public:
 
 	virtual void AssignGens(int a_Seed, cBiomeGenPtr & a_BiomeGen, cTerrainHeightGenPtr & a_HeightGen, int a_SeaLevel) override
 	{
-		m_Seed = a_Seed + SEED_OFFSET;
+		m_Seed = a_Seed + g_SEED_OFFSET;
 		m_HeightGen = a_HeightGen;
 	}
 
@@ -262,7 +262,7 @@ public:
 
 	virtual void AssignGens(int a_Seed, cBiomeGenPtr & a_BiomeGen, cTerrainHeightGenPtr & a_HeightGen, int a_SeaLevel) override
 	{
-		m_Seed = a_Seed + SEED_OFFSET;
+		m_Seed = a_Seed + g_SEED_OFFSET;
 		m_HeightGen = a_HeightGen;
 		m_SeaLevel = a_SeaLevel;
 	}

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -390,9 +390,9 @@ typename std::enable_if<std::is_arithmetic<T>::value, C>::type CeilC(T a_Value)
 namespace cpp14
 {
 	template <class T, class... Args>
-	std::unique_ptr<T> make_unique(Args&&... args)
+	std::unique_ptr<T> make_unique(Args&&... a_args)
 	{
-		return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+		return std::unique_ptr<T>(new T(std::forward<Args>(a_args)...));
 	}
 }
 

--- a/src/IniFile.cpp
+++ b/src/IniFile.cpp
@@ -253,17 +253,17 @@ int cIniFile::FindKey(const AString & a_KeyName) const
 
 
 
-int cIniFile::FindValue(const int keyID, const AString & a_ValueName) const
+int cIniFile::FindValue(const int a_keyID, const AString & a_ValueName) const
 {
-	if (!m_Keys.size() || (keyID >= static_cast<int>(m_Keys.size())))
+	if (!m_Keys.size() || (a_keyID >= static_cast<int>(m_Keys.size())))
 	{
 		return noID;
 	}
 
 	AString CaseValueName = CheckCase(a_ValueName);
-	for (size_t valueID = 0; valueID < m_Keys[static_cast<size_t>(keyID)].m_Names.size(); ++valueID)
+	for (size_t valueID = 0; valueID < m_Keys[static_cast<size_t>(a_keyID)].m_Names.size(); ++valueID)
 	{
-		if (CheckCase(m_Keys[static_cast<size_t>(keyID)].m_Names[valueID]) == CaseValueName)
+		if (CheckCase(m_Keys[static_cast<size_t>(a_keyID)].m_Names[valueID]) == CaseValueName)
 		{
 			return int(valueID);
 		}
@@ -275,9 +275,9 @@ int cIniFile::FindValue(const int keyID, const AString & a_ValueName) const
 
 
 
-int cIniFile::AddKeyName(const AString & keyname)
+int cIniFile::AddKeyName(const AString & a_keyname)
 {
-	m_Names.resize(m_Names.size() + 1, keyname);
+	m_Names.resize(m_Names.size() + 1, a_keyname);
 	m_Keys.resize(m_Keys.size() + 1);
 	return static_cast<int>(m_Names.size()) - 1;
 }
@@ -286,11 +286,11 @@ int cIniFile::AddKeyName(const AString & keyname)
 
 
 
-AString cIniFile::GetKeyName(const int keyID) const
+AString cIniFile::GetKeyName(const int a_keyID) const
 {
-	if (keyID < static_cast<int>(m_Names.size()))
+	if (a_keyID < static_cast<int>(m_Names.size()))
 	{
-		return m_Names[static_cast<size_t>(keyID)];
+		return m_Names[static_cast<size_t>(a_keyID)];
 	}
 	else
 	{
@@ -302,11 +302,11 @@ AString cIniFile::GetKeyName(const int keyID) const
 
 
 
-int cIniFile::GetNumValues(const int keyID) const
+int cIniFile::GetNumValues(const int a_keyID) const
 {
-	if (keyID < static_cast<int>(m_Keys.size()))
+	if (a_keyID < static_cast<int>(m_Keys.size()))
 	{
-		return static_cast<int>(m_Keys[static_cast<size_t>(keyID)].m_Names.size());
+		return static_cast<int>(m_Keys[static_cast<size_t>(a_keyID)].m_Names.size());
 	}
 	return 0;
 }
@@ -315,9 +315,9 @@ int cIniFile::GetNumValues(const int keyID) const
 
 
 
-int cIniFile::GetNumValues(const AString & keyname) const
+int cIniFile::GetNumValues(const AString & a_keyname) const
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return 0;
@@ -329,11 +329,11 @@ int cIniFile::GetNumValues(const AString & keyname) const
 
 
 
-AString cIniFile::GetValueName(const int keyID, const int valueID) const
+AString cIniFile::GetValueName(const int a_keyID, const int a_valueID) const
 {
-	if ((keyID < static_cast<int>(m_Keys.size())) && (valueID < static_cast<int>(m_Keys[static_cast<size_t>(keyID)].m_Names.size())))
+	if ((a_keyID < static_cast<int>(m_Keys.size())) && (a_valueID < static_cast<int>(m_Keys[static_cast<size_t>(a_keyID)].m_Names.size())))
 	{
-		return m_Keys[static_cast<size_t>(keyID)].m_Names[static_cast<size_t>(valueID)];
+		return m_Keys[static_cast<size_t>(a_keyID)].m_Names[static_cast<size_t>(a_valueID)];
 	}
 	return "";
 }
@@ -342,14 +342,14 @@ AString cIniFile::GetValueName(const int keyID, const int valueID) const
 
 
 
-AString cIniFile::GetValueName(const AString & keyname, const int valueID) const
+AString cIniFile::GetValueName(const AString & a_keyname, const int a_valueID) const
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return "";
 	}
-	return GetValueName(keyID, valueID);
+	return GetValueName(keyID, a_valueID);
 }
 
 
@@ -390,13 +390,13 @@ void cIniFile::AddValueF(const AString & a_KeyName, const AString & a_ValueName,
 
 
 
-bool cIniFile::SetValue(const int keyID, const int valueID, const AString & value)
+bool cIniFile::SetValue(const int a_keyID, const int a_valueID, const AString & a_value)
 {
-	if ((static_cast<size_t>(keyID) >= m_Keys.size()) || (static_cast<size_t>(valueID) >= m_Keys[static_cast<size_t>(keyID)].m_Names.size()))
+	if ((static_cast<size_t>(a_keyID) >= m_Keys.size()) || (static_cast<size_t>(a_valueID) >= m_Keys[static_cast<size_t>(a_keyID)].m_Names.size()))
 	{
 		return false;
 	}
-	m_Keys[static_cast<size_t>(keyID)].m_Values[static_cast<size_t>(valueID)] = value;
+	m_Keys[static_cast<size_t>(a_keyID)].m_Values[static_cast<size_t>(a_valueID)] = a_value;
 	return true;
 }
 
@@ -465,31 +465,31 @@ bool cIniFile::SetValueF(const AString & a_KeyName, const AString & a_ValueName,
 
 
 
-AString cIniFile::GetValue(const int keyID, const int valueID, const AString & defValue) const
+AString cIniFile::GetValue(const int a_keyID, const int a_valueID, const AString & a_defValue) const
 {
-	if ((keyID < static_cast<int>(m_Keys.size())) && (valueID < static_cast<int>(m_Keys[static_cast<size_t>(keyID)].m_Names.size())))
+	if ((a_keyID < static_cast<int>(m_Keys.size())) && (a_valueID < static_cast<int>(m_Keys[static_cast<size_t>(a_keyID)].m_Names.size())))
 	{
-		return m_Keys[static_cast<size_t>(keyID)].m_Values[static_cast<size_t>(valueID)];
+		return m_Keys[static_cast<size_t>(a_keyID)].m_Values[static_cast<size_t>(a_valueID)];
 	}
-	return defValue;
+	return a_defValue;
 }
 
 
 
 
 
-AString cIniFile::GetValue(const AString & keyname, const AString & valuename, const AString & defValue) const
+AString cIniFile::GetValue(const AString & a_keyname, const AString & a_valuename, const AString & a_defValue) const
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
-		return defValue;
+		return a_defValue;
 	}
 
-	int valueID = FindValue(int(keyID), valuename);
+	int valueID = FindValue(int(keyID), a_valuename);
 	if (valueID == noID)
 	{
-		return defValue;
+		return a_defValue;
 	}
 
 	return m_Keys[static_cast<size_t>(keyID)].m_Values[static_cast<size_t>(valueID)];
@@ -499,42 +499,42 @@ AString cIniFile::GetValue(const AString & keyname, const AString & valuename, c
 
 
 
-int cIniFile::GetValueI(const AString & keyname, const AString & valuename, const int defValue) const
+int cIniFile::GetValueI(const AString & a_keyname, const AString & a_valuename, const int a_defValue) const
 {
 	AString Data;
-	Printf(Data, "%d", defValue);
-	return atoi(GetValue(keyname, valuename, Data).c_str());
+	Printf(Data, "%d", a_defValue);
+	return atoi(GetValue(a_keyname, a_valuename, Data).c_str());
 }
 
 
 
 
 
-double cIniFile::GetValueF(const AString & keyname, const AString & valuename, double const defValue) const
+double cIniFile::GetValueF(const AString & a_keyname, const AString & a_valuename, double const a_defValue) const
 {
 	AString Data;
-	Printf(Data, "%f", defValue);
-	return atof(GetValue(keyname, valuename, Data).c_str());
+	Printf(Data, "%f", a_defValue);
+	return atof(GetValue(a_keyname, a_valuename, Data).c_str());
 }
 
 
 
 
 
-AString cIniFile::GetValueSet(const AString & keyname, const AString & valuename, const AString & defValue)
+AString cIniFile::GetValueSet(const AString & a_keyname, const AString & a_valuename, const AString & a_defValue)
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
-		SetValue(keyname, valuename, defValue);
-		return defValue;
+		SetValue(a_keyname, a_valuename, a_defValue);
+		return a_defValue;
 	}
 
-	int valueID = FindValue(int(keyID), valuename);
+	int valueID = FindValue(int(keyID), a_valuename);
 	if (valueID == noID)
 	{
-		SetValue(keyname, valuename, defValue);
-		return defValue;
+		SetValue(a_keyname, a_valuename, a_defValue);
+		return a_defValue;
 	}
 
 	return m_Keys[static_cast<size_t>(keyID)].m_Values[static_cast<size_t>(valueID)];
@@ -544,34 +544,34 @@ AString cIniFile::GetValueSet(const AString & keyname, const AString & valuename
 
 
 
-double cIniFile::GetValueSetF(const AString & keyname, const AString & valuename, const double defValue)
+double cIniFile::GetValueSetF(const AString & a_keyname, const AString & a_valuename, const double a_defValue)
 {
 	AString Data;
-	Printf(Data, "%f", defValue);
-	return atof(GetValueSet(keyname, valuename, Data).c_str());
+	Printf(Data, "%f", a_defValue);
+	return atof(GetValueSet(a_keyname, a_valuename, Data).c_str());
 }
 
 
 
 
 
-int cIniFile::GetValueSetI(const AString & keyname, const AString & valuename, const int defValue)
+int cIniFile::GetValueSetI(const AString & a_keyname, const AString & a_valuename, const int a_defValue)
 {
 	AString Data;
-	Printf(Data, "%d", defValue);
-	return atoi(GetValueSet(keyname, valuename, Data).c_str());
+	Printf(Data, "%d", a_defValue);
+	return atoi(GetValueSet(a_keyname, a_valuename, Data).c_str());
 }
 
 
 
 
 
-Int64 cIniFile::GetValueSetI(const AString & keyname, const AString & valuename, const Int64 defValue)
+Int64 cIniFile::GetValueSetI(const AString & a_keyname, const AString & a_valuename, const Int64 a_defValue)
 {
 	AString Data;
-	Printf(Data, "%lld", defValue);
-	AString resultstring = GetValueSet(keyname, valuename, Data);
-	Int64 result = defValue;
+	Printf(Data, "%lld", a_defValue);
+	AString resultstring = GetValueSet(a_keyname, a_valuename, Data);
+	Int64 result = a_defValue;
 #ifdef _WIN32
 	sscanf_s(resultstring.c_str(), "%lld", &result);
 #else
@@ -584,15 +584,15 @@ Int64 cIniFile::GetValueSetI(const AString & keyname, const AString & valuename,
 
 
 
-bool cIniFile::DeleteValueByID(const int keyID, const int valueID)
+bool cIniFile::DeleteValueByID(const int a_keyID, const int a_valueID)
 {
-	if ((keyID < static_cast<int>(m_Keys.size())) && (valueID < static_cast<int>(m_Keys[static_cast<size_t>(keyID)].m_Names.size())))
+	if ((a_keyID < static_cast<int>(m_Keys.size())) && (a_valueID < static_cast<int>(m_Keys[static_cast<size_t>(a_keyID)].m_Names.size())))
 	{
 		// This looks strange, but is neccessary.
-		vector<AString>::iterator npos = m_Keys[static_cast<size_t>(keyID)].m_Names.begin() + valueID;
-		vector<AString>::iterator vpos = m_Keys[static_cast<size_t>(keyID)].m_Values.begin() + valueID;
-		m_Keys[static_cast<size_t>(keyID)].m_Names.erase(npos, npos + 1);
-		m_Keys[static_cast<size_t>(keyID)].m_Values.erase(vpos, vpos + 1);
+		vector<AString>::iterator npos = m_Keys[static_cast<size_t>(a_keyID)].m_Names.begin() + a_valueID;
+		vector<AString>::iterator vpos = m_Keys[static_cast<size_t>(a_keyID)].m_Values.begin() + a_valueID;
+		m_Keys[static_cast<size_t>(a_keyID)].m_Names.erase(npos, npos + 1);
+		m_Keys[static_cast<size_t>(a_keyID)].m_Values.erase(vpos, vpos + 1);
 		return true;
 	}
 	return false;
@@ -602,15 +602,15 @@ bool cIniFile::DeleteValueByID(const int keyID, const int valueID)
 
 
 
-bool cIniFile::DeleteValue(const AString & keyname, const AString & valuename)
+bool cIniFile::DeleteValue(const AString & a_keyname, const AString & a_valuename)
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return false;
 	}
 
-	int valueID = FindValue(int(keyID), valuename);
+	int valueID = FindValue(int(keyID), a_valuename);
 	if (valueID == noID)
 	{
 		return false;
@@ -623,9 +623,9 @@ bool cIniFile::DeleteValue(const AString & keyname, const AString & valuename)
 
 
 
-bool cIniFile::DeleteKey(const AString & keyname)
+bool cIniFile::DeleteKey(const AString & a_keyname)
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return false;
@@ -672,9 +672,9 @@ bool cIniFile::HasValue(const AString & a_KeyName, const AString & a_ValueName) 
 
 
 
-void cIniFile::AddHeaderComment(const AString & comment)
+void cIniFile::AddHeaderComment(const AString & a_comment)
 {
-	m_Comments.push_back(comment);
+	m_Comments.push_back(a_comment);
 	// comments.resize(comments.size() + 1, comment);
 }
 
@@ -682,11 +682,11 @@ void cIniFile::AddHeaderComment(const AString & comment)
 
 
 
-AString cIniFile::GetHeaderComment(const int commentID) const
+AString cIniFile::GetHeaderComment(const int a_commentID) const
 {
-	if (commentID < static_cast<int>(m_Comments.size()))
+	if (a_commentID < static_cast<int>(m_Comments.size()))
 	{
-		return m_Comments[static_cast<size_t>(commentID)];
+		return m_Comments[static_cast<size_t>(a_commentID)];
 	}
 	return "";
 }
@@ -695,11 +695,11 @@ AString cIniFile::GetHeaderComment(const int commentID) const
 
 
 
-bool cIniFile::DeleteHeaderComment(int commentID)
+bool cIniFile::DeleteHeaderComment(int a_commentID)
 {
-	if (commentID < static_cast<int>(m_Comments.size()))
+	if (a_commentID < static_cast<int>(m_Comments.size()))
 	{
-		vector<AString>::iterator cpos = m_Comments.begin() + commentID;
+		vector<AString>::iterator cpos = m_Comments.begin() + a_commentID;
 		m_Comments.erase(cpos, cpos + 1);
 		return true;
 	}
@@ -710,11 +710,11 @@ bool cIniFile::DeleteHeaderComment(int commentID)
 
 
 
-int cIniFile::GetNumKeyComments(const int keyID) const
+int cIniFile::GetNumKeyComments(const int a_keyID) const
 {
-	if (keyID < static_cast<int>(m_Keys.size()))
+	if (a_keyID < static_cast<int>(m_Keys.size()))
 	{
-		return static_cast<int>(m_Keys[static_cast<size_t>(keyID)].m_Comments.size());
+		return static_cast<int>(m_Keys[static_cast<size_t>(a_keyID)].m_Comments.size());
 	}
 	return 0;
 }
@@ -723,9 +723,9 @@ int cIniFile::GetNumKeyComments(const int keyID) const
 
 
 
-int cIniFile::GetNumKeyComments(const AString & keyname) const
+int cIniFile::GetNumKeyComments(const AString & a_keyname) const
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return 0;
@@ -737,11 +737,11 @@ int cIniFile::GetNumKeyComments(const AString & keyname) const
 
 
 
-bool cIniFile::AddKeyComment(const int keyID, const AString & comment)
+bool cIniFile::AddKeyComment(const int a_keyID, const AString & a_comment)
 {
-	if (keyID < static_cast<int>(m_Keys.size()))
+	if (a_keyID < static_cast<int>(m_Keys.size()))
 	{
-		m_Keys[static_cast<size_t>(keyID)].m_Comments.resize(m_Keys[static_cast<size_t>(keyID)].m_Comments.size() + 1, comment);
+		m_Keys[static_cast<size_t>(a_keyID)].m_Comments.resize(m_Keys[static_cast<size_t>(a_keyID)].m_Comments.size() + 1, a_comment);
 		return true;
 	}
 	return false;
@@ -751,25 +751,25 @@ bool cIniFile::AddKeyComment(const int keyID, const AString & comment)
 
 
 
-bool cIniFile::AddKeyComment(const AString & keyname, const AString & comment)
+bool cIniFile::AddKeyComment(const AString & a_keyname, const AString & a_comment)
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return false;
 	}
-	return AddKeyComment(keyID, comment);
+	return AddKeyComment(keyID, a_comment);
 }
 
 
 
 
 
-AString cIniFile::GetKeyComment(const int keyID, const int commentID) const
+AString cIniFile::GetKeyComment(const int a_keyID, const int a_commentID) const
 {
-	if ((keyID < static_cast<int>(m_Keys.size())) && (commentID < static_cast<int>(m_Keys[static_cast<size_t>(keyID)].m_Comments.size())))
+	if ((a_keyID < static_cast<int>(m_Keys.size())) && (a_commentID < static_cast<int>(m_Keys[static_cast<size_t>(a_keyID)].m_Comments.size())))
 	{
-		return m_Keys[static_cast<size_t>(keyID)].m_Comments[static_cast<size_t>(commentID)];
+		return m_Keys[static_cast<size_t>(a_keyID)].m_Comments[static_cast<size_t>(a_commentID)];
 	}
 	return "";
 }
@@ -778,26 +778,26 @@ AString cIniFile::GetKeyComment(const int keyID, const int commentID) const
 
 
 
-AString cIniFile::GetKeyComment(const AString & keyname, const int commentID) const
+AString cIniFile::GetKeyComment(const AString & a_keyname, const int a_commentID) const
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return "";
 	}
-	return GetKeyComment(int(keyID), commentID);
+	return GetKeyComment(int(keyID), a_commentID);
 }
 
 
 
 
 
-bool cIniFile::DeleteKeyComment(const int keyID, const int commentID)
+bool cIniFile::DeleteKeyComment(const int a_keyID, const int a_commentID)
 {
-	if ((keyID < static_cast<int>(m_Keys.size())) && (commentID < static_cast<int>(m_Keys[static_cast<size_t>(keyID)].m_Comments.size())))
+	if ((a_keyID < static_cast<int>(m_Keys.size())) && (a_commentID < static_cast<int>(m_Keys[static_cast<size_t>(a_keyID)].m_Comments.size())))
 	{
-		vector<AString>::iterator cpos = m_Keys[static_cast<size_t>(keyID)].m_Comments.begin() + commentID;
-		m_Keys[static_cast<size_t>(keyID)].m_Comments.erase(cpos, cpos + 1);
+		vector<AString>::iterator cpos = m_Keys[static_cast<size_t>(a_keyID)].m_Comments.begin() + a_commentID;
+		m_Keys[static_cast<size_t>(a_keyID)].m_Comments.erase(cpos, cpos + 1);
 		return true;
 	}
 	return false;
@@ -807,25 +807,25 @@ bool cIniFile::DeleteKeyComment(const int keyID, const int commentID)
 
 
 
-bool cIniFile::DeleteKeyComment(const AString & keyname, const int commentID)
+bool cIniFile::DeleteKeyComment(const AString & a_keyname, const int a_commentID)
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return false;
 	}
-	return DeleteKeyComment(int(keyID), commentID);
+	return DeleteKeyComment(int(keyID), a_commentID);
 }
 
 
 
 
 
-bool cIniFile::DeleteKeyComments(const int keyID)
+bool cIniFile::DeleteKeyComments(const int a_keyID)
 {
-	if (keyID < static_cast<int>(m_Keys.size()))
+	if (a_keyID < static_cast<int>(m_Keys.size()))
 	{
-		m_Keys[static_cast<size_t>(keyID)].m_Comments.clear();
+		m_Keys[static_cast<size_t>(a_keyID)].m_Comments.clear();
 		return true;
 	}
 	return false;
@@ -835,9 +835,9 @@ bool cIniFile::DeleteKeyComments(const int keyID)
 
 
 
-bool cIniFile::DeleteKeyComments(const AString & keyname)
+bool cIniFile::DeleteKeyComments(const AString & a_keyname)
 {
-	int keyID = FindKey(keyname);
+	int keyID = FindKey(a_keyname);
 	if (keyID == noID)
 	{
 		return false;
@@ -849,13 +849,13 @@ bool cIniFile::DeleteKeyComments(const AString & keyname)
 
 
 
-AString cIniFile::CheckCase(const AString & s) const
+AString cIniFile::CheckCase(const AString & a_s) const
 {
 	if (!m_IsCaseInsensitive)
 	{
-		return s;
+		return a_s;
 	}
-	AString res(s);
+	AString res(a_s);
 	size_t len = res.length();
 	for (size_t i = 0; i < len; i++)
 	{

--- a/src/IniFile.h
+++ b/src/IniFile.h
@@ -52,7 +52,7 @@ private:
 	std::vector<AString> m_Comments;
 
 	/** If the object is case-insensitive, returns s as lowercase; otherwise returns s as-is */
-	AString CheckCase(const AString & s) const;
+	AString CheckCase(const AString & a_s) const;
 
 	/** Removes the UTF-8 BOMs (Byte order makers), if present. */
 	void RemoveBom(AString & a_line) const;
@@ -103,48 +103,48 @@ public:
 	bool HasValue(const AString & a_KeyName, const AString & a_ValueName) const override;
 
 	/** Returns index of specified key, or noID if not found */
-	int FindKey(const AString & keyname) const;
+	int FindKey(const AString & a_keyname) const;
 
 	/** Returns index of specified value, in the specified key, or noID if not found */
-	int FindValue(const int keyID, const AString & valuename) const;
+	int FindValue(const int a_keyID, const AString & a_valuename) const;
 
 	/** Returns number of keys currently in the ini */
 	int GetNumKeys(void) const { return static_cast<int>(m_Keys.size()); }
 
 	/** Add a key name */
-	int AddKeyName(const AString & keyname) override;
+	int AddKeyName(const AString & a_keyname) override;
 
 	// Returns key names by index.
-	AString GetKeyName(const int keyID) const;
+	AString GetKeyName(const int a_keyID) const;
 
 	// Returns number of values stored for specified key.
-	int GetNumValues(const AString & keyname) const;
-	int GetNumValues(const int keyID) const;
+	int GetNumValues(const AString & a_keyname) const;
+	int GetNumValues(const int a_keyID) const;
 
 	// Returns value name by index for a given keyname or keyID.
-	AString GetValueName(const AString & keyname, const int valueID) const;
-	AString GetValueName(const int keyID, const int valueID) const;
+	AString GetValueName(const AString & a_keyname, const int a_valueID) const;
+	AString GetValueName(const int a_keyID, const int a_valueID) const;
 
 	// Gets value of [keyname] valuename =.
 	// Overloaded to return string, int, and double.
 	// Returns defValue if key / value not found.
-	AString GetValue (const AString & keyname, const AString & valuename, const AString & defValue = "")    const override;
-	AString GetValue (const int keyID,    const int valueID,    const AString & defValue = "")    const;
-	double  GetValueF(const AString & keyname, const AString & valuename, const double    defValue = 0)     const;
-	int     GetValueI(const AString & keyname, const AString & valuename, const int       defValue = 0)     const;
-	bool    GetValueB(const AString & keyname, const AString & valuename, const bool      defValue = false) const
+	AString GetValue (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "")    const override;
+	AString GetValue (const int a_keyID,    const int a_valueID,    const AString & a_defValue = "")    const;
+	double  GetValueF(const AString & a_keyname, const AString & a_valuename, const double    a_defValue = 0)     const;
+	int     GetValueI(const AString & a_keyname, const AString & a_valuename, const int       a_defValue = 0)     const;
+	bool    GetValueB(const AString & a_keyname, const AString & a_valuename, const bool      a_defValue = false) const
 	{
-		return (GetValueI(keyname, valuename, defValue ? 1 : 0) != 0);
+		return (GetValueI(a_keyname, a_valuename, a_defValue ? 1 : 0) != 0);
 	}
 
 	// Gets the value; if not found, write the default to the INI file
-	AString GetValueSet (const AString & keyname, const AString & valuename, const AString & defValue = "") override;
-	double  GetValueSetF(const AString & keyname, const AString & valuename, const double    defValue = 0.0);
-	int     GetValueSetI(const AString & keyname, const AString & valuename, const int       defValue = 0) override;
-	Int64   GetValueSetI(const AString & keyname, const AString & valuename, const Int64     defValue = 0) override;
-	bool    GetValueSetB(const AString & keyname, const AString & valuename, const bool      defValue = false) override
+	AString GetValueSet (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "") override;
+	double  GetValueSetF(const AString & a_keyname, const AString & a_valuename, const double    a_defValue = 0.0);
+	int     GetValueSetI(const AString & a_keyname, const AString & a_valuename, const int       a_defValue = 0) override;
+	Int64   GetValueSetI(const AString & a_keyname, const AString & a_valuename, const Int64     a_defValue = 0) override;
+	bool    GetValueSetB(const AString & a_keyname, const AString & a_valuename, const bool      a_defValue = false) override
 	{
-		return (GetValueSetI(keyname, valuename, defValue ? 1 : 0) != 0);
+		return (GetValueSetI(a_keyname, a_valuename, a_defValue ? 1 : 0) != 0);
 	}
 
 	// Adds a new value to the specified key.
@@ -161,7 +161,7 @@ public:
 	// Specify the optional parameter as false (0) if you do not want the value created if it doesn't exist.
 	// Returns true if value set, false otherwise.
 	// Overloaded to accept string, int, and double.
-	bool SetValue (const int keyID, const int valueID, const AString & value);
+	bool SetValue (const int a_keyID, const int a_valueID, const AString & a_value);
 	bool SetValue (const AString & a_KeyName, const AString & a_ValueName, const AString & a_Value, const bool a_CreateIfNotExists = true) override;
 	bool SetValueI(const AString & a_KeyName, const AString & a_ValueName, const int a_Value, const bool a_CreateIfNotExists = true) override;
 	bool SetValueI(const AString & a_Keyname, const AString & a_ValueName, const Int64 a_Value, const bool a_CreateIfNotExists = true);
@@ -173,12 +173,12 @@ public:
 
 	// Deletes specified value.
 	// Returns true if value existed and deleted, false otherwise.
-	bool DeleteValueByID(const int keyID, const int valueID);
-	bool DeleteValue(const AString & keyname, const AString & valuename) override;
+	bool DeleteValueByID(const int a_keyID, const int a_valueID);
+	bool DeleteValue(const AString & a_keyname, const AString & a_valuename) override;
 
 	// Deletes specified key and all values contained within.
 	// Returns true if key existed and deleted, false otherwise.
-	bool DeleteKey(const AString & keyname);
+	bool DeleteKey(const AString & a_keyname);
 
 	// Header comment functions.
 	// Header comments are those comments before the first key.
@@ -187,13 +187,13 @@ public:
 	int GetNumHeaderComments(void) {return static_cast<int>(m_Comments.size());}
 
 	/** Adds a header comment */
-	void AddHeaderComment(const AString & comment);
+	void AddHeaderComment(const AString & a_comment);
 
 	/** Returns a header comment, or empty string if out of range */
-	AString GetHeaderComment(const int commentID) const;
+	AString GetHeaderComment(const int a_commentID) const;
 
 	/** Deletes a header comment. Returns true if successful */
-	bool DeleteHeaderComment(int commentID);
+	bool DeleteHeaderComment(int a_commentID);
 
 	/** Deletes all header comments */
 	void DeleteHeaderComments(void) {m_Comments.clear();}
@@ -206,28 +206,28 @@ public:
 	// the CIniFile::WriteFile() is called.
 
 	/** Get number of key comments */
-	int GetNumKeyComments(const int keyID) const;
+	int GetNumKeyComments(const int a_keyID) const;
 
 	/** Get number of key comments */
-	int GetNumKeyComments(const AString & keyname) const;
+	int GetNumKeyComments(const AString & a_keyname) const;
 
 	/** Add a key comment */
-	bool AddKeyComment(const int keyID, const AString & comment);
+	bool AddKeyComment(const int a_keyID, const AString & a_comment);
 
 	/** Add a key comment */
-	bool AddKeyComment(const AString & keyname, const AString & comment) override;
+	bool AddKeyComment(const AString & a_keyname, const AString & a_comment) override;
 
 	/** Return a key comment */
-	AString GetKeyComment(const int keyID, const int commentID) const;
-	AString GetKeyComment(const AString & keyname, const int commentID) const override;
+	AString GetKeyComment(const int a_keyID, const int a_commentID) const;
+	AString GetKeyComment(const AString & a_keyname, const int a_commentID) const override;
 
 	// Delete a key comment.
-	bool DeleteKeyComment(const int keyID, const int commentID);
-	bool DeleteKeyComment(const AString & keyname, const int commentID) override;
+	bool DeleteKeyComment(const int a_keyID, const int a_commentID);
+	bool DeleteKeyComment(const AString & a_keyname, const int a_commentID) override;
 
 	// Delete all comments for a key.
-	bool DeleteKeyComments(const int keyID);
-	bool DeleteKeyComments(const AString & keyname);
+	bool DeleteKeyComments(const int a_keyID);
+	bool DeleteKeyComments(const AString & a_keyname);
 };
 
 // tolua_end

--- a/src/Items/ItemHandler.h
+++ b/src/Items/ItemHandler.h
@@ -121,12 +121,12 @@ public:
 
 	struct FoodInfo
 	{
-		int    FoodLevel;
-		double Saturation;
+		int    m_FoodLevel;
+		double m_Saturation;
 
 		FoodInfo(int a_FoodLevel, double a_Saturation) :
-			FoodLevel(a_FoodLevel),
-			Saturation(a_Saturation)
+			m_FoodLevel(a_FoodLevel),
+			m_Saturation(a_Saturation)
 		{
 		}
 	} ;
@@ -167,7 +167,7 @@ public:
 
 protected:
 	int m_ItemType;
-	static cItemHandler * CreateItemHandler(int m_ItemType);
+	static cItemHandler * CreateItemHandler(int a_m_ItemType);
 
 	static cItemHandler * m_ItemHandler[E_ITEM_LAST + 1];
 	static bool m_HandlerInitialized;  // used to detect if the itemhandlers are initialized

--- a/src/Items/ItemHandler.h
+++ b/src/Items/ItemHandler.h
@@ -167,7 +167,7 @@ public:
 
 protected:
 	int m_ItemType;
-	static cItemHandler * CreateItemHandler(int a_m_ItemType);
+	static cItemHandler * CreateItemHandler(int a_ItemType);
 
 	static cItemHandler * m_ItemHandler[E_ITEM_LAST + 1];
 	static bool m_HandlerInitialized;  // used to detect if the itemhandlers are initialized

--- a/src/Items/ItemPainting.h
+++ b/src/Items/ItemPainting.h
@@ -39,7 +39,7 @@ public:
 		{
 			static const struct  // Define all the possible painting titles
 			{
-				AString Title;
+				AString m_Title;
 			} gPaintingTitlesList[] =
 			{
 				{ "Kebab" },

--- a/src/LinearInterpolation.cpp
+++ b/src/LinearInterpolation.cpp
@@ -96,10 +96,10 @@ void LinearInterpolate2DArray(
 	ASSERT(a_DstSizeY < MAX_INTERPOL_SIZEY);
 
 	// Calculate interpolation ratios and src indices along each axis:
-	float RatioX[MAX_INTERPOL_SIZEX];
-	float RatioY[MAX_INTERPOL_SIZEY];
-	int   SrcIdxX[MAX_INTERPOL_SIZEX];
-	int   SrcIdxY[MAX_INTERPOL_SIZEY];
+	float RatioX[g_MAX_INTERPOL_SIZEX];
+	float RatioY[g_MAX_INTERPOL_SIZEY];
+	int   SrcIdxX[g_MAX_INTERPOL_SIZEX];
+	int   SrcIdxY[g_MAX_INTERPOL_SIZEY];
 	for (int x = 1; x < a_DstSizeX; x++)
 	{
 		SrcIdxX[x] = x * (a_SrcSizeX - 1) / (a_DstSizeX - 1);
@@ -166,12 +166,12 @@ void LinearInterpolate3DArray(
 	ASSERT(a_DstSizeZ < MAX_INTERPOL_SIZEZ);
 
 	// Calculate interpolation ratios and src indices along each axis:
-	float RatioX[MAX_INTERPOL_SIZEX];
-	float RatioY[MAX_INTERPOL_SIZEY];
-	float RatioZ[MAX_INTERPOL_SIZEZ];
-	int   SrcIdxX[MAX_INTERPOL_SIZEX];
-	int   SrcIdxY[MAX_INTERPOL_SIZEY];
-	int   SrcIdxZ[MAX_INTERPOL_SIZEZ];
+	float RatioX[g_MAX_INTERPOL_SIZEX];
+	float RatioY[g_MAX_INTERPOL_SIZEY];
+	float RatioZ[g_MAX_INTERPOL_SIZEZ];
+	int   SrcIdxX[g_MAX_INTERPOL_SIZEX];
+	int   SrcIdxY[g_MAX_INTERPOL_SIZEY];
+	int   SrcIdxZ[g_MAX_INTERPOL_SIZEZ];
 	for (int x = 1; x < a_DstSizeX; x++)
 	{
 		SrcIdxX[x] = x * (a_SrcSizeX - 1) / (a_DstSizeX - 1);

--- a/src/LinearInterpolation.h
+++ b/src/LinearInterpolation.h
@@ -15,9 +15,9 @@
 
 // 2D and 3D Interpolation is optimized by precalculating the ratios into static-sized arrays
 // These arrays enforce a max size of the dest array, but the limits are settable here:
-const int MAX_INTERPOL_SIZEX = 256;  ///< Maximum X-size of the interpolated array
-const int MAX_INTERPOL_SIZEY = 512;  ///< Maximum Y-size of the interpolated array
-const int MAX_INTERPOL_SIZEZ = 256;  ///< Maximum Z-size of the interpolated array
+const int g_MAX_INTERPOL_SIZEX = 256;  ///< Maximum X-size of the interpolated array
+const int g_MAX_INTERPOL_SIZEY = 512;  ///< Maximum Y-size of the interpolated array
+const int g_MAX_INTERPOL_SIZEZ = 256;  ///< Maximum Z-size of the interpolated array
 
 
 

--- a/src/Matrix4.h
+++ b/src/Matrix4.h
@@ -21,7 +21,7 @@ class Matrix4
 
 public:
 
-	T cell[16];
+	T m_cell[16];
 
 	// tolua_begin
 
@@ -121,7 +121,7 @@ public:
 		cell[11] = a_Pos.z;
 	}
 
-	inline void Concatenate(const Matrix4 & m2)
+	inline void Concatenate(const Matrix4 & a_m2)
 	{
 		Matrix4 res;
 
@@ -130,10 +130,10 @@ public:
 			for (unsigned int r = 0; r < 4; ++r)
 			{
 				res.cell[r * 4 + c] = (
-					cell[r * 4 + 0] * m2.cell[c + 0] +
-					cell[r * 4 + 1] * m2.cell[c + 4] +
-					cell[r * 4 + 2] * m2.cell[c + 8] +
-					cell[r * 4 + 3] * m2.cell[c + 12]
+					cell[r * 4 + 0] * a_m2.cell[c + 0] +
+					cell[r * 4 + 1] * a_m2.cell[c + 4] +
+					cell[r * 4 + 2] * a_m2.cell[c + 8] +
+					cell[r * 4 + 3] * a_m2.cell[c + 12]
 				);
 			}
 		}
@@ -141,11 +141,11 @@ public:
 		*this = res;
 	}
 
-	inline Vector3<T> Transform(const Vector3<T> & v) const
+	inline Vector3<T> Transform(const Vector3<T> & a_v) const
 	{
-		T x  = cell[0] * v.x + cell[1] * v.y + cell[2]  * v.z + cell[3];
-		T y  = cell[4] * v.x + cell[5] * v.y + cell[6]  * v.z + cell[7];
-		T z  = cell[8] * v.x + cell[9] * v.y + cell[10] * v.z + cell[11];
+		T x  = cell[0] * a_v.x + cell[1] * a_v.y + cell[2]  * a_v.z + cell[3];
+		T y  = cell[4] * a_v.x + cell[5] * a_v.y + cell[6]  * a_v.z + cell[7];
+		T z  = cell[8] * a_v.x + cell[9] * a_v.y + cell[10] * a_v.z + cell[11];
 
 		return Vector3<T>(x, y, z);
 	}

--- a/src/MemorySettingsRepository.cpp
+++ b/src/MemorySettingsRepository.cpp
@@ -6,9 +6,9 @@
 
 
 
-bool cMemorySettingsRepository::KeyExists(const AString keyname) const
+bool cMemorySettingsRepository::KeyExists(const AString a_keyname) const
 {
-	return m_Map.count(keyname) != 0;
+	return m_Map.count(a_keyname) != 0;
 }
 
 
@@ -43,7 +43,7 @@ int cMemorySettingsRepository::AddKeyName(const AString & a_keyname)
 
 
 
-bool cMemorySettingsRepository::AddKeyComment(const AString & keyname, const AString & comment)
+bool cMemorySettingsRepository::AddKeyComment(const AString & a_keyname, const AString & a_comment)
 {
 	return false;
 }
@@ -52,7 +52,7 @@ bool cMemorySettingsRepository::AddKeyComment(const AString & keyname, const ASt
 
 
 
-AString cMemorySettingsRepository::GetKeyComment(const AString & keyname, const int commentID) const
+AString cMemorySettingsRepository::GetKeyComment(const AString & a_keyname, const int a_commentID) const
 {
 	return "";
 }
@@ -61,7 +61,7 @@ AString cMemorySettingsRepository::GetKeyComment(const AString & keyname, const 
 
 
 
-bool cMemorySettingsRepository::DeleteKeyComment(const AString & keyname, const int commentID)
+bool cMemorySettingsRepository::DeleteKeyComment(const AString & a_keyname, const int a_commentID)
 {
 	return false;
 }
@@ -120,17 +120,17 @@ std::vector<std::pair<AString, AString>> cMemorySettingsRepository::GetValues(AS
 
 
 
-AString cMemorySettingsRepository::GetValue (const AString & a_KeyName, const AString & a_ValueName, const AString & defValue)    const
+AString cMemorySettingsRepository::GetValue (const AString & a_KeyName, const AString & a_ValueName, const AString & a_defValue)    const
 {
 	auto outerIter = m_Map.find(a_KeyName);
 	if (outerIter == m_Map.end())
 	{
-		return defValue;
+		return a_defValue;
 	}
 	auto iter = outerIter->second.find(a_ValueName);
 	if (iter == outerIter->second.end())
 	{
-		return defValue;
+		return a_defValue;
 	}
 	return iter->second.getStringValue();
 }
@@ -139,19 +139,19 @@ AString cMemorySettingsRepository::GetValue (const AString & a_KeyName, const AS
 
 
 
-AString cMemorySettingsRepository::GetValueSet (const AString & a_KeyName, const AString & a_ValueName, const AString & defValue)
+AString cMemorySettingsRepository::GetValueSet (const AString & a_KeyName, const AString & a_ValueName, const AString & a_defValue)
 {
 	auto outerIter = m_Map.find(a_KeyName);
 	if (outerIter == m_Map.end())
 	{
-		AddValue(a_KeyName, a_ValueName, defValue);
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, a_defValue);
+		return a_defValue;
 	}
 	auto iter = outerIter->second.find(a_ValueName);
 	if (iter == outerIter->second.end())
 	{
-		AddValue(a_KeyName, a_ValueName, defValue);
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, a_defValue);
+		return a_defValue;
 	}
 	return iter->second.getStringValue();
 }
@@ -160,19 +160,19 @@ AString cMemorySettingsRepository::GetValueSet (const AString & a_KeyName, const
 
 
 
-int cMemorySettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const int defValue)
+int cMemorySettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const int a_defValue)
 {
 	auto outerIter = m_Map.find(a_KeyName);
 	if (outerIter == m_Map.end())
 	{
-		AddValue(a_KeyName, a_ValueName, static_cast<Int64>(defValue));
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, static_cast<Int64>(a_defValue));
+		return a_defValue;
 	}
 	auto iter = outerIter->second.find(a_ValueName);
 	if (iter == outerIter->second.end())
 	{
-		AddValue(a_KeyName, a_ValueName, static_cast<Int64>(defValue));
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, static_cast<Int64>(a_defValue));
+		return a_defValue;
 	}
 	return static_cast<int>(iter->second.getIntValue());
 }
@@ -181,19 +181,19 @@ int cMemorySettingsRepository::GetValueSetI(const AString & a_KeyName, const ASt
 
 
 
-Int64 cMemorySettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const Int64 defValue)
+Int64 cMemorySettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const Int64 a_defValue)
 {
 	auto outerIter = m_Map.find(a_KeyName);
 	if (outerIter == m_Map.end())
 	{
-		AddValue(a_KeyName, a_ValueName, defValue);
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, a_defValue);
+		return a_defValue;
 	}
 	auto iter = outerIter->second.find(a_ValueName);
 	if (iter == outerIter->second.end())
 	{
-		AddValue(a_KeyName, a_ValueName, defValue);
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, a_defValue);
+		return a_defValue;
 	}
 	return iter->second.getIntValue();
 }
@@ -201,19 +201,19 @@ Int64 cMemorySettingsRepository::GetValueSetI(const AString & a_KeyName, const A
 
 
 
-bool cMemorySettingsRepository::GetValueSetB(const AString & a_KeyName, const AString & a_ValueName, const bool defValue)
+bool cMemorySettingsRepository::GetValueSetB(const AString & a_KeyName, const AString & a_ValueName, const bool a_defValue)
 {
 	auto outerIter = m_Map.find(a_KeyName);
 	if (outerIter == m_Map.end())
 	{
-		AddValue(a_KeyName, a_ValueName, defValue);
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, a_defValue);
+		return a_defValue;
 	}
 	auto iter = outerIter->second.find(a_ValueName);
 	if (iter == outerIter->second.end())
 	{
-		AddValue(a_KeyName, a_ValueName, defValue);
-		return defValue;
+		AddValue(a_KeyName, a_ValueName, a_defValue);
+		return a_defValue;
 	}
 	return iter->second.getBoolValue();
 }

--- a/src/MemorySettingsRepository.h
+++ b/src/MemorySettingsRepository.h
@@ -9,17 +9,17 @@ class cMemorySettingsRepository : public cSettingsRepositoryInterface
 {
 public:
 
-	virtual bool KeyExists(const AString keyname) const override;
+	virtual bool KeyExists(const AString a_keyname) const override;
 
 	virtual bool HasValue(const AString & a_KeyName, const AString & a_ValueName) const override;
 
-	virtual int AddKeyName(const AString & keyname) override;
+	virtual int AddKeyName(const AString & a_keyname) override;
 
-	virtual bool AddKeyComment(const AString & keyname, const AString & comment) override;
+	virtual bool AddKeyComment(const AString & a_keyname, const AString & a_comment) override;
 
-	virtual AString GetKeyComment(const AString & keyname, const int commentID) const override;
+	virtual AString GetKeyComment(const AString & a_keyname, const int a_commentID) const override;
 
-	virtual bool DeleteKeyComment(const AString & keyname, const int commentID) override;
+	virtual bool DeleteKeyComment(const AString & a_keyname, const int a_commentID) override;
 
 	virtual void AddValue (const AString & a_KeyName, const AString & a_ValueName, const AString & a_Value) override;
 	void AddValue (const AString & a_KeyName, const AString & a_ValueName, const Int64 a_Value);
@@ -27,18 +27,18 @@ public:
 
 	virtual std::vector<std::pair<AString, AString>> GetValues(AString a_keyName) override;
 
-	virtual AString GetValue (const AString & keyname, const AString & valuename, const AString & defValue = "")    const override;
+	virtual AString GetValue (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "")    const override;
 
 
-	virtual AString GetValueSet (const AString & keyname, const AString & valuename, const AString & defValue = "") override;
-	virtual int     GetValueSetI(const AString & keyname, const AString & valuename, const int       defValue = 0) override;
-	virtual Int64   GetValueSetI(const AString & keyname, const AString & valuename, const Int64     defValue = 0) override;
-	virtual bool    GetValueSetB(const AString & keyname, const AString & valuename, const bool      defValue = false) override;
+	virtual AString GetValueSet (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "") override;
+	virtual int     GetValueSetI(const AString & a_keyname, const AString & a_valuename, const int       a_defValue = 0) override;
+	virtual Int64   GetValueSetI(const AString & a_keyname, const AString & a_valuename, const Int64     a_defValue = 0) override;
+	virtual bool    GetValueSetB(const AString & a_keyname, const AString & a_valuename, const bool      a_defValue = false) override;
 
 	virtual bool SetValue (const AString & a_KeyName, const AString & a_ValueName, const AString & a_Value, const bool a_CreateIfNotExists = true) override;
 	virtual bool SetValueI(const AString & a_KeyName, const AString & a_ValueName, const int a_Value, const bool a_CreateIfNotExists = true) override;
 
-	virtual bool DeleteValue(const AString & keyname, const AString & valuename) override;
+	virtual bool DeleteValue(const AString & a_keyname, const AString & a_valuename) override;
 
 	virtual bool Flush() override;
 
@@ -53,27 +53,27 @@ private:
 
 	struct sValue
 	{
-		sValue(AString value):
+		sValue(AString a_value):
 			#ifdef _DEBUG
 				m_Type(eType::String),
 			#endif
-			m_stringValue (value)
+			m_stringValue (a_value)
 		{
 		}
 
-		sValue(Int64 value):
+		sValue(Int64 a_value):
 			#ifdef _DEBUG
 				m_Type(eType::Int64),
 			#endif
-			m_intValue(value)
+			m_intValue(a_value)
 		{
 		}
 
-		sValue(bool value):
+		sValue(bool a_value):
 			#ifdef _DEBUG
 				m_Type(eType::Bool),
 			#endif
-			m_boolValue(value)
+			m_boolValue(a_value)
 		{
 		}
 

--- a/src/MobSpawner.h
+++ b/src/MobSpawner.h
@@ -19,7 +19,7 @@ public :
 	a_MobFamily is the Family of mobs that this spawner will spawn
 	a_AllowedTypes is the set of types allowed for mobs it will spawn. Empty set would result in no spawn at all
 	Allowed mobs thah are not of the right Family will not be include (no warning). */
-	cMobSpawner(cMonster::eFamily MobFamily, const std::set<eMonsterType> & a_AllowedTypes);
+	cMobSpawner(cMonster::eFamily a_MobFamily, const std::set<eMonsterType> & a_AllowedTypes);
 
 	/** Check if specified block can be a Pack center for this spawner */
 	bool CheckPackCenter(BLOCKTYPE a_BlockType);
@@ -28,7 +28,7 @@ public :
 	If this is the first of a Pack, determine the type of monster
 	a_Biome, BlockType & BlockMeta are used to decide what kind of Mob can Spawn here
 	a_MaxPackSize is set to the maximal size for a pack this type of mob */
-	cMonster * TryToSpawnHere(cChunk * a_Chunk, int A_RelX, int a_RelY, int a_RelZ, EMCSBiome a_Biome, int & a_MaxPackSize);
+	cMonster * TryToSpawnHere(cChunk * a_Chunk, int a_A_RelX, int a_RelY, int a_RelZ, EMCSBiome a_Biome, int & a_MaxPackSize);
 
 	/** Mark the beginning of a new Pack.
 	All mobs of the same Pack are the same type */

--- a/src/Mobs/Horse.cpp
+++ b/src/Mobs/Horse.cpp
@@ -11,7 +11,7 @@
 
 
 
-cHorse::cHorse(int Type, int Color, int Style, int TameTimes) :
+cHorse::cHorse(int a_Type, int a_Color, int a_Style, int a_TameTimes) :
 	super("Horse", mtHorse, "entity.horse.hurt", "entity.horse.death", 1.4, 1.6),
 	cEntityWindowOwner(this),
 	m_bHasChest(false),
@@ -19,10 +19,10 @@ cHorse::cHorse(int Type, int Color, int Style, int TameTimes) :
 	m_bIsRearing(false),
 	m_bIsMouthOpen(false),
 	m_bIsTame(false),
-	m_Type(Type),
-	m_Color(Color),
-	m_Style(Style),
-	m_TimesToTame(TameTimes),
+	m_Type(a_Type),
+	m_Color(a_Color),
+	m_Style(a_Style),
+	m_TimesToTame(a_TameTimes),
 	m_TameAttemptTimes(0),
 	m_RearTickCount(0),
 	m_MaxSpeed(14.0)

--- a/src/Mobs/Horse.h
+++ b/src/Mobs/Horse.h
@@ -15,7 +15,7 @@ class cHorse :
 	typedef cPassiveMonster super;
 
 public:
-	cHorse(int Type, int Color, int Style, int TameTimes);
+	cHorse(int a_Type, int a_Color, int a_Style, int a_TameTimes);
 	virtual ~cHorse() override;
 
 	CLASS_PROTODEF(cHorse)

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1318,7 +1318,7 @@ void cMonster::AddRandomWeaponDropItem(cItems & a_Drops, unsigned int a_LootingL
 
 
 
-void cMonster::HandleDaylightBurning(cChunk & a_Chunk, bool WouldBurn)
+void cMonster::HandleDaylightBurning(cChunk & a_Chunk, bool a_WouldBurn)
 {
 	if (!m_BurnsInDaylight)
 	{
@@ -1337,7 +1337,7 @@ void cMonster::HandleDaylightBurning(cChunk & a_Chunk, bool WouldBurn)
 		return;
 	}
 
-	if (!IsOnFire() && WouldBurn)
+	if (!IsOnFire() && a_WouldBurn)
 	{
 		// Burn for 100 ticks, then decide again
 		StartBurning(100);

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -98,7 +98,7 @@ public:
 	void Unleash(bool a_ShouldDropLeashPickup, bool a_ShouldBroadcast);
 
 	/** Sets entity position to where is leashed this mob */
-	void SetLeashToPos(Vector3d * pos) { m_LeashToPos = std::unique_ptr<Vector3d>(pos); }
+	void SetLeashToPos(Vector3d * a_pos) { m_LeashToPos = std::unique_ptr<Vector3d>(a_pos); }
 
 	/** Gets entity position to where mob should be leashed */
 	Vector3d * GetLeashToPos() const { return m_LeashToPos.get(); }
@@ -282,7 +282,7 @@ protected:
 	bool m_CanPickUpLoot;
 	int m_TicksSinceLastDamaged;  // How many ticks ago we were last damaged by a player?
 
-	void HandleDaylightBurning(cChunk & a_Chunk, bool WouldBurn);
+	void HandleDaylightBurning(cChunk & a_Chunk, bool a_WouldBurn);
 	bool WouldBurnAt(Vector3d a_Location, cChunk & a_Chunk);
 	bool m_BurnsInDaylight;
 	double m_RelativeWalkSpeed;

--- a/src/Mobs/Rabbit.cpp
+++ b/src/Mobs/Rabbit.cpp
@@ -20,10 +20,10 @@ cRabbit::cRabbit(void) :
 
 
 
-cRabbit::cRabbit(eRabbitType Type, int MoreCarrotTicks) :
+cRabbit::cRabbit(eRabbitType a_Type, int a_MoreCarrotTicks) :
 	super("Rabbit", mtRabbit, "entity.rabbit.hurt", "entity.rabbit.death", 0.82, 0.68),
-	m_Type(Type),
-	m_MoreCarrotTicks(MoreCarrotTicks)
+	m_Type(a_Type),
+	m_MoreCarrotTicks(a_MoreCarrotTicks)
 {
 }
 

--- a/src/Mobs/Rabbit.h
+++ b/src/Mobs/Rabbit.h
@@ -29,7 +29,7 @@ class cRabbit :
 
 public:
 	cRabbit();
-	cRabbit(eRabbitType Type, int MoreCarrotTicks = 0);
+	cRabbit(eRabbitType a_Type, int a_MoreCarrotTicks = 0);
 
 	CLASS_PROTODEF(cRabbit)
 

--- a/src/Mobs/Sheep.cpp
+++ b/src/Mobs/Sheep.cpp
@@ -144,7 +144,7 @@ void cSheep::InheritFromParents(cPassiveMonster * a_Parent1, cPassiveMonster * a
 {
 	static const struct
 	{
-		short Parent1, Parent2, Child;
+		short m_Parent1, m_Parent2, m_Child;
 	} ColorInheritance[] =
 	{
 		{ E_META_WOOL_BLUE,   E_META_WOOL_RED,   E_META_WOOL_PURPLE     },

--- a/src/Mobs/Skeleton.cpp
+++ b/src/Mobs/Skeleton.cpp
@@ -9,9 +9,9 @@
 
 
 
-cSkeleton::cSkeleton(bool IsWither) :
+cSkeleton::cSkeleton(bool a_IsWither) :
 	super("Skeleton", mtSkeleton, "entity.skeleton.hurt", "entity.skeleton.death", 0.6, 1.8),
-	m_bIsWither(IsWither)
+	m_bIsWither(a_IsWither)
 {
 	SetBurnsInDaylight(true);
 }

--- a/src/Mobs/Skeleton.h
+++ b/src/Mobs/Skeleton.h
@@ -13,7 +13,7 @@ class cSkeleton :
 	typedef cAggressiveMonster super;
 
 public:
-	cSkeleton(bool IsWither);
+	cSkeleton(bool a_IsWither);
 
 	CLASS_PROTODEF(cSkeleton)
 

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -11,10 +11,10 @@
 
 
 
-cVillager::cVillager(eVillagerType VillagerType) :
+cVillager::cVillager(eVillagerType a_VillagerType) :
 	super("Villager", mtVillager, "entity.villager.hurt", "entity.villager.death", 0.6, 1.8),
 	m_ActionCountDown(-1),
-	m_Type(VillagerType),
+	m_Type(a_VillagerType),
 	m_VillagerAction(false)
 {
 }

--- a/src/Mobs/Villager.h
+++ b/src/Mobs/Villager.h
@@ -25,7 +25,7 @@ public:
 		vtMax
 	} ;
 
-	cVillager(eVillagerType VillagerType);
+	cVillager(eVillagerType a_VillagerType);
 
 	CLASS_PROTODEF(cVillager)
 

--- a/src/MonsterConfig.cpp
+++ b/src/MonsterConfig.cpp
@@ -26,8 +26,8 @@ struct cMonsterConfig::sAttributesStruct
 
 struct cMonsterConfig::sMonsterConfigState
 {
-	AString MonsterTypes;
-	std::list< sAttributesStruct > AttributesList;
+	AString m_MonsterTypes;
+	std::list< sAttributesStruct > m_AttributesList;
 };
 
 

--- a/src/OSSupport/File.cpp
+++ b/src/OSSupport/File.cpp
@@ -25,10 +25,10 @@ cFile::cFile(void) :
 
 
 
-cFile::cFile(const AString & iFileName, eMode iMode) :
+cFile::cFile(const AString & a_iFileName, eMode a_iMode) :
 	m_File(nullptr)
 {
-	Open(iFileName, iMode);
+	Open(a_iFileName, a_iMode);
 }
 
 
@@ -47,7 +47,7 @@ cFile::~cFile()
 
 
 
-bool cFile::Open(const AString & iFileName, eMode iMode)
+bool cFile::Open(const AString & a_iFileName, eMode a_iMode)
 {
 	ASSERT(!IsOpen());  // You should close the file before opening another one
 
@@ -57,7 +57,7 @@ bool cFile::Open(const AString & iFileName, eMode iMode)
 	}
 
 	const char * Mode = nullptr;
-	switch (iMode)
+	switch (a_iMode)
 	{
 		case fmRead:      Mode = "rb";  break;
 		case fmWrite:     Mode = "wb";  break;
@@ -73,10 +73,10 @@ bool cFile::Open(const AString & iFileName, eMode iMode)
 	#ifdef _WIN32
 		m_File = _fsopen((FILE_IO_PREFIX + iFileName).c_str(), Mode, _SH_DENYWR);
 	#else
-		m_File = fopen((FILE_IO_PREFIX + iFileName).c_str(), Mode);
+		m_File = fopen((FILE_IO_PREFIX + a_iFileName).c_str(), Mode);
 	#endif  // _WIN32
 
-	if ((m_File == nullptr) && (iMode == fmReadWrite))
+	if ((m_File == nullptr) && (a_iMode == fmReadWrite))
 	{
 		// Fix for MS not following C spec, opening "a" mode files for writing at the end only
 		// The file open operation has been tried with "read update", fails if file not found
@@ -86,7 +86,7 @@ bool cFile::Open(const AString & iFileName, eMode iMode)
 		#ifdef _WIN32
 			m_File = _fsopen((FILE_IO_PREFIX + iFileName).c_str(), "wb+", _SH_DENYWR);
 		#else
-			m_File = fopen((FILE_IO_PREFIX + iFileName).c_str(), "wb+");
+			m_File = fopen((FILE_IO_PREFIX + a_iFileName).c_str(), "wb+");
 		#endif  // _WIN32
 
 	}
@@ -193,7 +193,7 @@ int cFile::Write(const void * a_Buffer, size_t a_NumBytes)
 
 
 
-long cFile::Seek (int iPosition)
+long cFile::Seek (int a_iPosition)
 {
 	ASSERT(IsOpen());
 
@@ -202,7 +202,7 @@ long cFile::Seek (int iPosition)
 		return -1;
 	}
 
-	if (fseek(m_File, iPosition, SEEK_SET) != 0)
+	if (fseek(m_File, a_iPosition, SEEK_SET) != 0)
 	{
 		return -1;
 	}

--- a/src/OSSupport/File.h
+++ b/src/OSSupport/File.h
@@ -61,12 +61,12 @@ public:
 	cFile(void);
 
 	/** Constructs and opens / creates the file specified, use IsOpen() to check for success */
-	cFile(const AString & iFileName, eMode iMode);
+	cFile(const AString & a_iFileName, eMode a_iMode);
 
 	/** Auto-closes the file, if open */
 	~cFile();
 
-	bool Open(const AString & iFileName, eMode iMode);
+	bool Open(const AString & a_iFileName, eMode a_iMode);
 	void Close(void);
 	bool IsOpen(void) const;
 	bool IsEOF(void) const;
@@ -81,7 +81,7 @@ public:
 	int Write(const void * a_Buffer, size_t a_NumBytes);
 
 	/** Seeks to iPosition bytes from file start, returns old position or -1 for failure; asserts if not open */
-	long Seek (int iPosition);
+	long Seek (int a_iPosition);
 
 	/** Returns the current position (bytes from file start) or -1 for failure; asserts if not open */
 	long Tell (void) const;

--- a/src/OSSupport/NetworkInterfaceEnum.cpp
+++ b/src/OSSupport/NetworkInterfaceEnum.cpp
@@ -52,16 +52,16 @@ static AString PrintAddress(SOCKET_ADDRESS & a_Addr)
 
 #elif !defined(ANDROID)  // _WIN32
 
-static AString PrintAddress(ifaddrs * InterfaceAddress)
+static AString PrintAddress(ifaddrs * a_InterfaceAddress)
 {
-	switch (InterfaceAddress->ifa_addr->sa_family)
+	switch (a_InterfaceAddress->ifa_addr->sa_family)
 	{
 		case AF_INET:
 		{  // IPv4
 			char AddressBuffer[INET_ADDRSTRLEN];
 			sockaddr_in InternetSocket;
 
-			std::memcpy(&InternetSocket, InterfaceAddress->ifa_addr, sizeof(InternetSocket));
+			std::memcpy(&InternetSocket, a_InterfaceAddress->ifa_addr, sizeof(InternetSocket));
 			inet_ntop(AF_INET, &InternetSocket.sin_addr, AddressBuffer, INET_ADDRSTRLEN);
 			return AddressBuffer;
 		}
@@ -70,13 +70,13 @@ static AString PrintAddress(ifaddrs * InterfaceAddress)
 			char AddressBuffer[INET6_ADDRSTRLEN];
 			sockaddr_in6 InternetSocket;
 
-			std::memcpy(&InternetSocket, InterfaceAddress->ifa_addr, sizeof(InternetSocket));
+			std::memcpy(&InternetSocket, a_InterfaceAddress->ifa_addr, sizeof(InternetSocket));
 			inet_ntop(AF_INET6, &InternetSocket.sin6_addr, AddressBuffer, INET6_ADDRSTRLEN);
 			return AddressBuffer;
 		}
 		default:
 		{
-			LOG("Unknown address family: %i", InterfaceAddress->ifa_addr->sa_family);
+			LOG("Unknown address family: %i", a_InterfaceAddress->ifa_addr->sa_family);
 			return "";
 		}
 	}

--- a/src/OSSupport/Queue.h
+++ b/src/OSSupport/Queue.h
@@ -82,14 +82,14 @@ public:
 
 	/** Dequeues an item from the queue if any are present.
 	Returns true if successful. Value of item is undefined if dequeuing was unsuccessful. */
-	bool TryDequeueItem(ItemType & item)
+	bool TryDequeueItem(ItemType & a_item)
 	{
 		cCSLock Lock(m_CS);
 		if (m_Contents.empty())
 		{
 			return false;
 		}
-		item = m_Contents.front();
+		a_item = m_Contents.front();
 		m_Contents.pop_front();
 		m_evtRemoved.Set();
 		return true;

--- a/src/OSSupport/TCPLinkImpl.cpp
+++ b/src/OSSupport/TCPLinkImpl.cpp
@@ -88,12 +88,12 @@ cTCPLinkImplPtr cTCPLinkImpl::Connect(const AString & a_Host, UInt16 a_Port, cTC
 		{
 		}
 
-		void DoConnect(const sockaddr * a_IP, int size)
+		void DoConnect(const sockaddr * a_IP, int a_size)
 		{
 			// Make sure connect is only completed once
 			if (!m_IsConnecting)
 			{
-				int ErrCode = bufferevent_socket_connect(m_Link->m_BufferEvent, a_IP, size);
+				int ErrCode = bufferevent_socket_connect(m_Link->m_BufferEvent, a_IP, a_size);
 				if (ErrCode == 0)
 				{
 					m_IsConnecting = true;

--- a/src/OverridesSettingsRepository.cpp
+++ b/src/OverridesSettingsRepository.cpp
@@ -134,15 +134,15 @@ std::vector<std::pair<AString, AString>> cOverridesSettingsRepository::GetValues
 
 
 
-AString cOverridesSettingsRepository::GetValue(const AString & a_KeyName, const AString & a_ValueName, const AString & defValue) const
+AString cOverridesSettingsRepository::GetValue(const AString & a_KeyName, const AString & a_ValueName, const AString & a_defValue) const
 {
 	if (m_Overrides->HasValue(a_KeyName, a_ValueName))
 	{
-		return m_Overrides->GetValue(a_KeyName, a_ValueName, defValue);
+		return m_Overrides->GetValue(a_KeyName, a_ValueName, a_defValue);
 	}
 	else
 	{
-		return m_Main->GetValue(a_KeyName, a_ValueName, defValue);
+		return m_Main->GetValue(a_KeyName, a_ValueName, a_defValue);
 	}
 }
 
@@ -150,15 +150,15 @@ AString cOverridesSettingsRepository::GetValue(const AString & a_KeyName, const 
 
 
 
-AString cOverridesSettingsRepository::GetValueSet (const AString & a_KeyName, const AString & a_ValueName, const AString & defValue)
+AString cOverridesSettingsRepository::GetValueSet (const AString & a_KeyName, const AString & a_ValueName, const AString & a_defValue)
 {
 	if (m_Overrides->HasValue(a_KeyName, a_ValueName))
 	{
-		return m_Overrides->GetValueSet(a_KeyName, a_ValueName, defValue);
+		return m_Overrides->GetValueSet(a_KeyName, a_ValueName, a_defValue);
 	}
 	else
 	{
-		return m_Main->GetValueSet(a_KeyName, a_ValueName, defValue);
+		return m_Main->GetValueSet(a_KeyName, a_ValueName, a_defValue);
 	}
 }
 
@@ -166,15 +166,15 @@ AString cOverridesSettingsRepository::GetValueSet (const AString & a_KeyName, co
 
 
 
-int cOverridesSettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const int defValue)
+int cOverridesSettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const int a_defValue)
 {
 	if (m_Overrides->HasValue(a_KeyName, a_ValueName))
 	{
-		return m_Overrides->GetValueSetI(a_KeyName, a_ValueName, defValue);
+		return m_Overrides->GetValueSetI(a_KeyName, a_ValueName, a_defValue);
 	}
 	else
 	{
-		return m_Main->GetValueSetI(a_KeyName, a_ValueName, defValue);
+		return m_Main->GetValueSetI(a_KeyName, a_ValueName, a_defValue);
 	}
 }
 
@@ -182,15 +182,15 @@ int cOverridesSettingsRepository::GetValueSetI(const AString & a_KeyName, const 
 
 
 
-Int64 cOverridesSettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const Int64 defValue)
+Int64 cOverridesSettingsRepository::GetValueSetI(const AString & a_KeyName, const AString & a_ValueName, const Int64 a_defValue)
 {
 	if (m_Overrides->HasValue(a_KeyName, a_ValueName))
 	{
-		return m_Overrides->GetValueSetI(a_KeyName, a_ValueName, defValue);
+		return m_Overrides->GetValueSetI(a_KeyName, a_ValueName, a_defValue);
 	}
 	else
 	{
-		return m_Main->GetValueSetI(a_KeyName, a_ValueName, defValue);
+		return m_Main->GetValueSetI(a_KeyName, a_ValueName, a_defValue);
 	}
 }
 
@@ -198,15 +198,15 @@ Int64 cOverridesSettingsRepository::GetValueSetI(const AString & a_KeyName, cons
 
 
 
-bool cOverridesSettingsRepository::GetValueSetB(const AString & a_KeyName, const AString & a_ValueName, const bool defValue)
+bool cOverridesSettingsRepository::GetValueSetB(const AString & a_KeyName, const AString & a_ValueName, const bool a_defValue)
 {
 	if (m_Overrides->HasValue(a_KeyName, a_ValueName))
 	{
-		return m_Overrides->GetValueSetB(a_KeyName, a_ValueName, defValue);
+		return m_Overrides->GetValueSetB(a_KeyName, a_ValueName, a_defValue);
 	}
 	else
 	{
-		return m_Main->GetValueSetB(a_KeyName, a_ValueName, defValue);
+		return m_Main->GetValueSetB(a_KeyName, a_ValueName, a_defValue);
 	}
 }
 

--- a/src/OverridesSettingsRepository.h
+++ b/src/OverridesSettingsRepository.h
@@ -13,33 +13,33 @@ public:
 
 	virtual ~cOverridesSettingsRepository() override = default;
 
-	virtual bool KeyExists(const AString keyname) const override;
+	virtual bool KeyExists(const AString a_keyname) const override;
 
 	virtual bool HasValue(const AString & a_KeyName, const AString & a_ValueName) const override;
 
-	virtual int AddKeyName(const AString & keyname) override;
+	virtual int AddKeyName(const AString & a_keyname) override;
 
-	virtual bool AddKeyComment(const AString & keyname, const AString & comment) override;
+	virtual bool AddKeyComment(const AString & a_keyname, const AString & a_comment) override;
 
-	virtual AString GetKeyComment(const AString & keyname, const int commentID) const override;
+	virtual AString GetKeyComment(const AString & a_keyname, const int a_commentID) const override;
 
-	virtual bool DeleteKeyComment(const AString & keyname, const int commentID) override;
+	virtual bool DeleteKeyComment(const AString & a_keyname, const int a_commentID) override;
 
 	virtual void AddValue (const AString & a_KeyName, const AString & a_ValueName, const AString & a_Value) override;
 
 	virtual std::vector<std::pair<AString, AString>> GetValues(AString a_keyName) override;
 
-	virtual AString GetValue (const AString & keyname, const AString & valuename, const AString & defValue = "")    const override;
+	virtual AString GetValue (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "")    const override;
 
-	virtual AString GetValueSet (const AString & keyname, const AString & valuename, const AString & defValue = "") override;
-	virtual int     GetValueSetI(const AString & keyname, const AString & valuename, const int       defValue = 0) override;
-	virtual Int64   GetValueSetI(const AString & keyname, const AString & valuename, const Int64     defValue = 0) override;
-	virtual bool    GetValueSetB(const AString & keyname, const AString & valuename, const bool      defValue = false) override;
+	virtual AString GetValueSet (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "") override;
+	virtual int     GetValueSetI(const AString & a_keyname, const AString & a_valuename, const int       a_defValue = 0) override;
+	virtual Int64   GetValueSetI(const AString & a_keyname, const AString & a_valuename, const Int64     a_defValue = 0) override;
+	virtual bool    GetValueSetB(const AString & a_keyname, const AString & a_valuename, const bool      a_defValue = false) override;
 
 	virtual bool SetValue (const AString & a_KeyName, const AString & a_ValueName, const AString & a_Value, const bool a_CreateIfNotExists = true) override;
 	virtual bool SetValueI(const AString & a_KeyName, const AString & a_ValueName, const int a_Value, const bool a_CreateIfNotExists = true) override;
 
-	virtual bool DeleteValue(const AString & keyname, const AString & valuename) override;
+	virtual bool DeleteValue(const AString & a_keyname, const AString & a_valuename) override;
 
 	virtual bool Flush() override;
 

--- a/src/Protocol/ForgeHandshake.cpp
+++ b/src/Protocol/ForgeHandshake.cpp
@@ -16,28 +16,28 @@
 /** Discriminator byte values prefixing the FML|HS packets to determine their type. */
 namespace Discriminator
 {
-	static const Int8 ServerHello = 0;
-	static const Int8 ClientHello = 1;
-	static const Int8 ModList = 2;
-	static const Int8 RegistryData = 3;
+	static const Int8 g_ServerHello = 0;
+	static const Int8 g_ClientHello = 1;
+	static const Int8 g_ModList = 2;
+	static const Int8 g_RegistryData = 3;
 	// static const Int8 HandshakeReset = -2;
-	static const Int8 HandshakeAck = -1;
+	static const Int8 g_HandshakeAck = -1;
 }
 
 /** Client handshake state phases. */
 namespace ClientPhase
 {
-	static const Int8 WAITINGSERVERDATA = 2;
-	static const Int8 WAITINGSERVERCOMPLETE = 3;
-	static const Int8 PENDINGCOMPLETE = 4;
-	static const Int8 COMPLETE = 5;
+	static const Int8 g_WAITINGSERVERDATA = 2;
+	static const Int8 g_WAITINGSERVERCOMPLETE = 3;
+	static const Int8 g_PENDINGCOMPLETE = 4;
+	static const Int8 g_COMPLETE = 5;
 }
 
 /** Server handshake state phases. */
 namespace ServerPhase
 {
-	static const Int8 WAITINGCACK = 2;
-	static const Int8 COMPLETE = 3;
+	static const Int8 g_WAITINGCACK = 2;
+	static const Int8 g_COMPLETE = 3;
 }
 
 
@@ -55,7 +55,7 @@ cForgeHandshake::cForgeHandshake(cClientHandle *a_Client) :
 
 
 
-void cForgeHandshake::SetError(const AString & message)
+void cForgeHandshake::SetError(const AString & a_message)
 {
 	LOGD("Forge handshake error: %s", message.c_str());
 	m_Errored = true;
@@ -126,7 +126,7 @@ void cForgeHandshake::SendServerHello()
 	AString Message;
 	cByteBuffer Buf(6);
 	// Discriminator | Byte | Always 0 for ServerHello
-	Buf.WriteBEInt8(Discriminator::ServerHello);
+	Buf.WriteBEInt8(Discriminator::g_ServerHello);
 	// FML protocol Version | Byte | Determined from NetworkRegistery. Currently 2.
 	Buf.WriteBEInt8(2);
 	// Dimension TODO
@@ -232,7 +232,7 @@ void cForgeHandshake::HandleModList(cClientHandle * a_Client, const char * a_Dat
 
 	cByteBuffer Buf(256 * ModCount);
 
-	Buf.WriteBEInt8(Discriminator::ModList);
+	Buf.WriteBEInt8(Discriminator::g_ModList);
 	Buf.WriteVarInt32(static_cast<UInt32>(ModCount));
 	for (const auto & item: ServerMods)
 	{
@@ -261,10 +261,10 @@ void cForgeHandshake::HandleHandshakeAck(cClientHandle * a_Client, const char * 
 
 	switch (Phase)
 	{
-		case ClientPhase::WAITINGSERVERDATA:
+		case ClientPhase::g_WAITINGSERVERDATA:
 		{
 			cByteBuffer Buf(1024);
-			Buf.WriteBEInt8(Discriminator::RegistryData);
+			Buf.WriteBEInt8(Discriminator::g_RegistryData);
 
 			// TODO: send real registry data
 			bool HasMore = false;
@@ -285,30 +285,30 @@ void cForgeHandshake::HandleHandshakeAck(cClientHandle * a_Client, const char * 
 			break;
 		}
 
-		case ClientPhase::WAITINGSERVERCOMPLETE:
+		case ClientPhase::g_WAITINGSERVERCOMPLETE:
 		{
 			LOGD("Client finished receiving registry data; acknowledging");
 
 			AString Ack;
-			Ack.push_back(Discriminator::HandshakeAck);
-			Ack.push_back(ServerPhase::WAITINGCACK);
+			Ack.push_back(Discriminator::g_HandshakeAck);
+			Ack.push_back(ServerPhase::g_WAITINGCACK);
 			m_Client->SendPluginMessage("FML|HS", Ack);
 			break;
 		}
 
-		case ClientPhase::PENDINGCOMPLETE:
+		case ClientPhase::g_PENDINGCOMPLETE:
 		{
 			LOGD("Client is pending completion; sending complete ack");
 
 			AString Ack;
-			Ack.push_back(Discriminator::HandshakeAck);
-			Ack.push_back(ServerPhase::COMPLETE);
+			Ack.push_back(Discriminator::g_HandshakeAck);
+			Ack.push_back(ServerPhase::g_COMPLETE);
 			m_Client->SendPluginMessage("FML|HS", Ack);
 
 			break;
 		}
 
-		case ClientPhase::COMPLETE:
+		case ClientPhase::g_COMPLETE:
 		{
 			// Now finish logging in
 			m_Client->FinishAuthenticate(m_Name, m_UUID, m_Properties);
@@ -350,9 +350,9 @@ void cForgeHandshake::DataReceived(cClientHandle * a_Client, const char * a_Data
 
 	switch (Discriminator)
 	{
-		case Discriminator::ClientHello:  HandleClientHello(a_Client, a_Data, a_Size); break;
-		case Discriminator::ModList:      HandleModList(a_Client, a_Data, a_Size); break;
-		case Discriminator::HandshakeAck: HandleHandshakeAck(a_Client, a_Data, a_Size); break;
+		case Discriminator::g_ClientHello:  HandleClientHello(a_Client, a_Data, a_Size); break;
+		case Discriminator::g_ModList:      HandleModList(a_Client, a_Data, a_Size); break;
+		case Discriminator::g_HandshakeAck: HandleHandshakeAck(a_Client, a_Data, a_Size); break;
 
 		default:
 		{

--- a/src/Protocol/ForgeHandshake.h
+++ b/src/Protocol/ForgeHandshake.h
@@ -22,10 +22,10 @@ public:
 	/** True if the client advertised itself as a Forge client. */
 	bool m_IsForgeClient;
 
-	cForgeHandshake(cClientHandle * client);
+	cForgeHandshake(cClientHandle * a_client);
 
 	/** Add the registered Forge mods to the server ping list packet. */
-	void AugmentServerListPing(Json::Value & ResponseValue);
+	void AugmentServerListPing(Json::Value & a_ResponseValue);
 
 	/** Begin the Forge Modloader Handshake (FML|HS) sequence. */
 	void BeginForgeHandshake(const AString & a_Name, const cUUID & a_UUID, const Json::Value & a_Properties);
@@ -53,7 +53,7 @@ private:
 	void HandleHandshakeAck(cClientHandle * a_Client, const char * a_Data, size_t a_Size);
 
 	/** Set errored state to prevent further handshake message processing. */
-	void SetError(const AString & message);
+	void SetError(const AString & a_message);
 
 	/** Parse the client ModList packet of installed Forge mods and versions. */
 	AStringMap ParseModList(const char * a_Data, size_t a_Size);

--- a/src/Protocol/MojangAPI.cpp
+++ b/src/Protocol/MojangAPI.cpp
@@ -20,10 +20,10 @@
 
 
 /** The maximum age for items to be kept in the cache. Any item older than this will be removed. */
-const Int64 MAX_AGE = 7 * 24 * 60 * 60;  // 7 days ago
+const Int64 g_MAX_AGE = 7 * 24 * 60 * 60;  // 7 days ago
 
 /** The maximum number of names to send in a single query */
-const int MAX_PER_QUERY = 100;
+const int g_MAX_PER_QUERY = 100;
 
 
 
@@ -580,7 +580,7 @@ void cMojangAPI::SaveCachesToDisk(void)
 		db.exec("DELETE FROM UUIDToProfile");
 
 		// Save all cache entries - m_PlayerNameToUUID:
-		Int64 LimitDateTime = time(nullptr) - MAX_AGE;
+		Int64 LimitDateTime = time(nullptr) - g_MAX_AGE;
 		{
 			SQLite::Statement stmt(db, "INSERT INTO PlayerNameToUUID(PlayerName, UUID, DateTime) VALUES (?, ?, ?)");
 			cCSLock Lock(m_CSNameToUUID);
@@ -663,7 +663,7 @@ void cMojangAPI::QueryNamesToUUIDs(AStringVector & a_NamesToQuery)
 		Json::Value root;
 		int Count = 0;
 		AStringVector::iterator itr = a_NamesToQuery.begin(), end = a_NamesToQuery.end();
-		for (; (itr != end) && (Count < MAX_PER_QUERY); ++itr, ++Count)
+		for (; (itr != end) && (Count < g_MAX_PER_QUERY); ++itr, ++Count)
 		{
 			Json::Value req(*itr);
 			root.append(req);
@@ -889,7 +889,7 @@ void cMojangAPI::NotifyNameUUID(const AString & a_PlayerName, const cUUID & a_UU
 
 void cMojangAPI::Update(void)
 {
-	Int64 LimitDateTime = time(nullptr) - MAX_AGE;
+	Int64 LimitDateTime = time(nullptr) - g_MAX_AGE;
 
 	// Re-query all playernames that are stale:
 	AStringVector PlayerNames;

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -53,7 +53,7 @@ Implements the 1.8 protocol classes:
 
 
 /** The slot number that the client uses to indicate "outside the window". */
-static const Int16 SLOT_NUM_OUTSIDE = -999;
+static const Int16 g_SLOT_NUM_OUTSIDE = -999;
 
 
 
@@ -85,8 +85,8 @@ static const Int16 SLOT_NUM_OUTSIDE = -999;
 
 
 
-const int MAX_ENC_LEN = 512;  // Maximum size of the encrypted message; should be 128, but who knows...
-const uLongf MAX_COMPRESSED_PACKET_LEN = 200 KiB;  // Maximum size of compressed packets.
+const int g_MAX_ENC_LEN = 512;  // Maximum size of the encrypted message; should be 128, but who knows...
+const uLongf g_MAX_COMPRESSED_PACKET_LEN = 200 KiB;  // Maximum size of compressed packets.
 
 
 
@@ -1705,10 +1705,10 @@ void cProtocol_1_8_0::SendWindowProperty(const cWindow & a_Window, short a_Prope
 bool cProtocol_1_8_0::CompressPacket(const AString & a_Packet, AString & a_CompressedData)
 {
 	// Compress the data:
-	char CompressedData[MAX_COMPRESSED_PACKET_LEN];
+	char CompressedData[g_MAX_COMPRESSED_PACKET_LEN];
 
 	uLongf CompressedSize = compressBound(static_cast<uLongf>(a_Packet.size()));
-	if (CompressedSize >= MAX_COMPRESSED_PACKET_LEN)
+	if (CompressedSize >= g_MAX_COMPRESSED_PACKET_LEN)
 	{
 		ASSERT(!"Too high packet size.");
 		return false;
@@ -2213,7 +2213,7 @@ void cProtocol_1_8_0::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBu
 	{
 		return;
 	}
-	if ((EncKeyLength > MAX_ENC_LEN) || (EncNonceLength > MAX_ENC_LEN))
+	if ((EncKeyLength > g_MAX_ENC_LEN) || (EncNonceLength > g_MAX_ENC_LEN))
 	{
 		LOGD("Too long encryption");
 		m_Client->Kick("Hacked client");
@@ -2222,7 +2222,7 @@ void cProtocol_1_8_0::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBu
 
 	// Decrypt EncNonce using privkey
 	cRsaPrivateKey & rsaDecryptor = cRoot::Get()->GetServer()->GetPrivateKey();
-	UInt32 DecryptedNonce[MAX_ENC_LEN / sizeof(Int32)];
+	UInt32 DecryptedNonce[g_MAX_ENC_LEN / sizeof(Int32)];
 	int res = rsaDecryptor.Decrypt(reinterpret_cast<const Byte *>(EncNonce.data()), EncNonce.size(), reinterpret_cast<Byte *>(DecryptedNonce), sizeof(DecryptedNonce));
 	if (res != 4)
 	{
@@ -2238,7 +2238,7 @@ void cProtocol_1_8_0::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBu
 	}
 
 	// Decrypt the symmetric encryption key using privkey:
-	Byte DecryptedKey[MAX_ENC_LEN];
+	Byte DecryptedKey[g_MAX_ENC_LEN];
 	res = rsaDecryptor.Decrypt(reinterpret_cast<const Byte *>(EncKey.data()), EncKey.size(), DecryptedKey, sizeof(DecryptedKey));
 	if (res != 16)
 	{
@@ -2718,8 +2718,8 @@ void cProtocol_1_8_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 	eClickAction Action;
 	switch ((Mode << 8) | Button)
 	{
-		case 0x0000: Action = (SlotNum != SLOT_NUM_OUTSIDE) ? caLeftClick  : caLeftClickOutside;  break;
-		case 0x0001: Action = (SlotNum != SLOT_NUM_OUTSIDE) ? caRightClick : caRightClickOutside; break;
+		case 0x0000: Action = (SlotNum != g_SLOT_NUM_OUTSIDE) ? caLeftClick  : caLeftClickOutside;  break;
+		case 0x0001: Action = (SlotNum != g_SLOT_NUM_OUTSIDE) ? caRightClick : caRightClickOutside; break;
 		case 0x0100: Action = caShiftLeftClick;  break;
 		case 0x0101: Action = caShiftRightClick; break;
 		case 0x0200: Action = caNumber1;         break;
@@ -2732,17 +2732,17 @@ void cProtocol_1_8_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 		case 0x0207: Action = caNumber8;         break;
 		case 0x0208: Action = caNumber9;         break;
 		case 0x0302: Action = caMiddleClick;     break;
-		case 0x0400: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caLeftClickOutsideHoldNothing  : caDropKey;     break;
-		case 0x0401: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caRightClickOutsideHoldNothing : caCtrlDropKey; break;
-		case 0x0500: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caLeftPaintBegin               : caUnknown;     break;
-		case 0x0501: Action = (SlotNum != SLOT_NUM_OUTSIDE) ? caLeftPaintProgress            : caUnknown;     break;
-		case 0x0502: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caLeftPaintEnd                 : caUnknown;     break;
-		case 0x0504: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caRightPaintBegin              : caUnknown;     break;
-		case 0x0505: Action = (SlotNum != SLOT_NUM_OUTSIDE) ? caRightPaintProgress           : caUnknown;     break;
-		case 0x0506: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caRightPaintEnd                : caUnknown;     break;
-		case 0x0508: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caMiddlePaintBegin             : caUnknown;     break;
-		case 0x0509: Action = (SlotNum != SLOT_NUM_OUTSIDE) ? caMiddlePaintProgress          : caUnknown;     break;
-		case 0x050a: Action = (SlotNum == SLOT_NUM_OUTSIDE) ? caMiddlePaintEnd               : caUnknown;     break;
+		case 0x0400: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caLeftClickOutsideHoldNothing  : caDropKey;     break;
+		case 0x0401: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caRightClickOutsideHoldNothing : caCtrlDropKey; break;
+		case 0x0500: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caLeftPaintBegin               : caUnknown;     break;
+		case 0x0501: Action = (SlotNum != g_SLOT_NUM_OUTSIDE) ? caLeftPaintProgress            : caUnknown;     break;
+		case 0x0502: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caLeftPaintEnd                 : caUnknown;     break;
+		case 0x0504: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caRightPaintBegin              : caUnknown;     break;
+		case 0x0505: Action = (SlotNum != g_SLOT_NUM_OUTSIDE) ? caRightPaintProgress           : caUnknown;     break;
+		case 0x0506: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caRightPaintEnd                : caUnknown;     break;
+		case 0x0508: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caMiddlePaintBegin             : caUnknown;     break;
+		case 0x0509: Action = (SlotNum != g_SLOT_NUM_OUTSIDE) ? caMiddlePaintProgress          : caUnknown;     break;
+		case 0x050a: Action = (SlotNum == g_SLOT_NUM_OUTSIDE) ? caMiddlePaintEnd               : caUnknown;     break;
 		case 0x0600: Action = caDblClick; break;
 		default:
 		{

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -44,7 +44,7 @@
 
 
 
-cRoot * cRoot::s_Root = nullptr;
+cRoot * cRoot::m_s_Root = nullptr;
 
 
 
@@ -61,7 +61,7 @@ cRoot::cRoot(void) :
 	m_PluginManager(nullptr),
 	m_MojangAPI(nullptr)
 {
-	s_Root = this;
+	m_s_Root = this;
 	m_InputThreadRunFlag.clear();
 }
 
@@ -71,7 +71,7 @@ cRoot::cRoot(void) :
 
 cRoot::~cRoot()
 {
-	s_Root = nullptr;
+	m_s_Root = nullptr;
 }
 
 
@@ -189,7 +189,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 	LOG("Starting server...");
 
 	// cClientHandle::FASTBREAK_PERCENTAGE = settingsRepo->GetValueSetI("AntiCheat", "FastBreakPercentage", 97) / 100.0f;
-	cClientHandle::FASTBREAK_PERCENTAGE = 0;  // AntiCheat disabled due to bugs. We will enabled it once they are fixed. See #3506.
+	cClientHandle::m_FASTBREAK_PERCENTAGE = 0;  // AntiCheat disabled due to bugs. We will enabled it once they are fixed. See #3506.
 
 	m_MojangAPI = new cMojangAPI;
 	bool ShouldAuthenticate = settingsRepo->GetValueSetB("Authentication", "Authenticate", true);

--- a/src/Root.h
+++ b/src/Root.h
@@ -45,7 +45,7 @@ namespace Json
 class cRoot
 {
 public:
-	static cRoot * Get() { return s_Root; }
+	static cRoot * Get() { return m_s_Root; }
 	// tolua_end
 
 	static bool m_TerminateEventRaised;
@@ -245,7 +245,7 @@ private:
 	/** Does the actual work of executing a command */
 	void DoExecuteConsoleCommand(const AString & a_Cmd);
 
-	static cRoot * s_Root;
+	static cRoot * m_s_Root;
 
 	static void InputThread(cRoot & a_Params);
 };  // tolua_export

--- a/src/SettingsRepositoryInterface.h
+++ b/src/SettingsRepositoryInterface.h
@@ -13,22 +13,22 @@ public:
 	virtual ~cSettingsRepositoryInterface() = default;
 
 	/** Returns true iff the specified key exists */
-	virtual bool KeyExists(const AString keyname) const = 0;
+	virtual bool KeyExists(const AString a_keyname) const = 0;
 
 	/** Returns true iff the specified value exists. */
 	virtual bool HasValue(const AString & a_KeyName, const AString & a_ValueName) const = 0;
 
 	/** Add a key name. Return value is not required to mean anything */
-	virtual int AddKeyName(const AString & keyname) = 0;
+	virtual int AddKeyName(const AString & a_keyname) = 0;
 
 	/** Add a key comment, will always fail if the repository does not support comments */
-	virtual bool AddKeyComment(const AString & keyname, const AString & comment) = 0;
+	virtual bool AddKeyComment(const AString & a_keyname, const AString & a_comment) = 0;
 
 	/** Return a key comment, returns "" for repositories that do not return comments */
-	virtual AString GetKeyComment(const AString & keyname, const int commentID) const = 0;
+	virtual AString GetKeyComment(const AString & a_keyname, const int a_commentID) const = 0;
 
 	/** Delete a key comment, will always fail if the repository does not support comments */
-	virtual bool DeleteKeyComment(const AString & keyname, const int commentID) = 0;
+	virtual bool DeleteKeyComment(const AString & a_keyname, const int a_commentID) = 0;
 
 	/** Adds a new value to the specified key.
 	If a value of the same name already exists, creates another one */
@@ -38,13 +38,13 @@ public:
 	virtual std::vector<std::pair<AString, AString>> GetValues(AString a_keyName) = 0;
 
 	/** Get the value at the specified key and value, returns defValue on failure */
-	virtual AString GetValue (const AString & keyname, const AString & valuename, const AString & defValue = "")    const = 0;
+	virtual AString GetValue (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "")    const = 0;
 
 	/** Gets the value; if not found, write the default to the repository */
-	virtual AString GetValueSet (const AString & keyname, const AString & valuename, const AString & defValue = "") = 0;
-	virtual int     GetValueSetI(const AString & keyname, const AString & valuename, const int       defValue = 0) = 0;
-	virtual Int64   GetValueSetI(const AString & keyname, const AString & valuename, const Int64     defValue = 0) = 0;
-	virtual bool    GetValueSetB(const AString & keyname, const AString & valuename, const bool      defValue = false) = 0;
+	virtual AString GetValueSet (const AString & a_keyname, const AString & a_valuename, const AString & a_defValue = "") = 0;
+	virtual int     GetValueSetI(const AString & a_keyname, const AString & a_valuename, const int       a_defValue = 0) = 0;
+	virtual Int64   GetValueSetI(const AString & a_keyname, const AString & a_valuename, const Int64     a_defValue = 0) = 0;
+	virtual bool    GetValueSetB(const AString & a_keyname, const AString & a_valuename, const bool      a_defValue = false) = 0;
 
 	/** Overwrites the value of the key, value pair
 	Specify the optional parameter as false if you do not want the value created if it doesn't exist.
@@ -53,7 +53,7 @@ public:
 	virtual bool SetValueI(const AString & a_KeyName, const AString & a_ValueName, const int a_Value, const bool a_CreateIfNotExists = true) = 0;
 
 	/** Deletes the specified key, value pair */
-	virtual bool DeleteValue(const AString & keyname, const AString & valuename) = 0;
+	virtual bool DeleteValue(const AString & a_keyname, const AString & a_valuename) = 0;
 
 
 	/** Writes the changes to the backing store, if the repository has one */

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -40,7 +40,7 @@
 	#pragma clang diagnostic ignored "-Wglobal-constructors"
 #endif
 
-static const Vector3i gCrossCoords[] =
+static const Vector3i g_gCrossCoords[] =
 {
 	{ 1, 0,  0},
 	{-1, 0,  0},
@@ -52,7 +52,7 @@ static const Vector3i gCrossCoords[] =
 
 
 
-static const Vector3i gNeighborCoords[] =
+static const Vector3i g_gNeighborCoords[] =
 {
 	{ 1,  0,  0},
 	{-1,  0,  0},
@@ -121,10 +121,10 @@ void cFireSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX,
 		auto BurnsForever = ((y > 0) && DoesBurnForever(a_Chunk->GetBlock(x, (y - 1), z)));
 		auto BlockMeta = a_Chunk->GetMeta(x, y, z);
 
-		auto Raining = std::any_of(std::begin(gCrossCoords), std::end(gCrossCoords),
-			[this, AbsPos](Vector3i cc)
+		auto Raining = std::any_of(std::begin(g_gCrossCoords), std::end(g_gCrossCoords),
+			[this, AbsPos](Vector3i a_cc)
 			{
-				return (m_World.IsWeatherWetAtXYZ(AbsPos + cc));
+				return (m_World.IsWeatherWetAtXYZ(AbsPos + a_cc));
 			}
 		);
 
@@ -298,11 +298,11 @@ int cFireSimulator::GetBurnStepTime(cChunk * a_Chunk, int a_RelX, int a_RelY, in
 		IsBlockBelowSolid = cBlockInfo::IsSolid(BlockBelow);
 	}
 
-	for (size_t i = 0; i < ARRAYCOUNT(gCrossCoords); i++)
+	for (size_t i = 0; i < ARRAYCOUNT(g_gCrossCoords); i++)
 	{
 		BLOCKTYPE  BlockType;
 		NIBBLETYPE BlockMeta;
-		if (a_Chunk->UnboundedRelGetBlock(a_RelX + gCrossCoords[i].x, a_RelY, a_RelZ + gCrossCoords[i].z, BlockType, BlockMeta))
+		if (a_Chunk->UnboundedRelGetBlock(a_RelX + g_gCrossCoords[i].x, a_RelY, a_RelZ + g_gCrossCoords[i].z, BlockType, BlockMeta))
 		{
 			if (IsFuel(BlockType))
 			{
@@ -380,7 +380,7 @@ void cFireSimulator::TrySpreadFire(cChunk * a_Chunk, int a_RelX, int a_RelY, int
 
 void cFireSimulator::RemoveFuelNeighbors(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_RelZ)
 {
-	for (auto & Coord : gNeighborCoords)
+	for (auto & Coord : g_gNeighborCoords)
 	{
 		BLOCKTYPE  BlockType;
 		int X = a_RelX + Coord.x;
@@ -441,9 +441,9 @@ bool cFireSimulator::CanStartFireInBlock(cChunk * a_NearChunk, int a_RelX, int a
 		return false;
 	}
 
-	for (size_t i = 0; i < ARRAYCOUNT(gNeighborCoords); i++)
+	for (size_t i = 0; i < ARRAYCOUNT(g_gNeighborCoords); i++)
 	{
-		if (!a_NearChunk->UnboundedRelGetBlock(a_RelX + gNeighborCoords[i].x, a_RelY + gNeighborCoords[i].y, a_RelZ + gNeighborCoords[i].z, BlockType, BlockMeta))
+		if (!a_NearChunk->UnboundedRelGetBlock(a_RelX + g_gNeighborCoords[i].x, a_RelY + g_gNeighborCoords[i].y, a_RelZ + g_gNeighborCoords[i].z, BlockType, BlockMeta))
 		{
 			// Neighbor inaccessible, skip it while evaluating
 			continue;

--- a/src/Simulator/IncrementalRedstoneSimulator/DropSpenserHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/DropSpenserHandler.h
@@ -17,9 +17,9 @@ public:
 	{
 		return (a_Meta & E_META_DROPSPENSER_ACTIVATED) != 0;
 	}
-	inline static NIBBLETYPE SetActivationState(NIBBLETYPE a_Meta, bool IsOn)
+	inline static NIBBLETYPE SetActivationState(NIBBLETYPE a_Meta, bool a_IsOn)
 	{
-		if (IsOn)
+		if (a_IsOn)
 		{
 			return a_Meta | E_META_DROPSPENSER_ACTIVATED;  // set the bit
 		}

--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.h
@@ -39,9 +39,9 @@ public:
 	/** Returns if a block is a mechanism (something that accepts power and does something)
 	Used by torches to determine if they will power a block
 	*/
-	inline static bool IsMechanism(BLOCKTYPE Block)
+	inline static bool IsMechanism(BLOCKTYPE a_Block)
 	{
-		switch (Block)
+		switch (a_Block)
 		{
 			case E_BLOCK_ACACIA_DOOR:
 			case E_BLOCK_ACACIA_FENCE_GATE:

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneHandler.h
@@ -18,19 +18,19 @@ public:
 	{
 	public:
 		PoweringData(BLOCKTYPE a_PoweringBlock, unsigned char a_PowerLevel) :
-			PoweringBlock(a_PoweringBlock),
-			PowerLevel(a_PowerLevel)
+			m_PoweringBlock(a_PoweringBlock),
+			m_PowerLevel(a_PowerLevel)
 		{
 		}
 
 		PoweringData(void) :
-			PoweringBlock(E_BLOCK_AIR),
-			PowerLevel(0)
+			m_PoweringBlock(E_BLOCK_AIR),
+			m_PowerLevel(0)
 		{
 		}
 
-		BLOCKTYPE PoweringBlock;
-		unsigned char PowerLevel;
+		BLOCKTYPE m_PoweringBlock;
+		unsigned char m_PowerLevel;
 
 		inline friend bool operator < (const PoweringData & a_Lhs, const PoweringData & a_Rhs)
 		{

--- a/src/Simulator/VanillaFluidSimulator.cpp
+++ b/src/Simulator/VanillaFluidSimulator.cpp
@@ -14,7 +14,7 @@
 
 
 
-static const int InfiniteCost = 100;
+static const int g_InfiniteCost = 100;
 
 
 
@@ -45,7 +45,7 @@ void cVanillaFluidSimulator::SpreadXZ(cChunk * a_Chunk, int a_RelX, int a_RelY, 
 	Cost[3] = CalculateFlowCost(a_Chunk, a_RelX,     a_RelY, a_RelZ - 1, Z_MINUS);
 
 	// Find the minimum distance:
-	int MinCost = InfiniteCost;
+	int MinCost = g_InfiniteCost;
 	for (unsigned int i = 0; i < ARRAYCOUNT(Cost); ++i)
 	{
 		if (Cost[i] < MinCost)
@@ -79,7 +79,7 @@ void cVanillaFluidSimulator::SpreadXZ(cChunk * a_Chunk, int a_RelX, int a_RelY, 
 
 int cVanillaFluidSimulator::CalculateFlowCost(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_RelZ, Direction a_Dir, unsigned a_Iteration)
 {
-	int Cost = InfiniteCost;
+	int Cost = g_InfiniteCost;
 
 	BLOCKTYPE BlockType;
 	NIBBLETYPE BlockMeta;

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -7,7 +7,7 @@
 
 
 
-cStatInfo cStatInfo::ms_Info[statCount] =
+cStatInfo cStatInfo::m_ms_Info[statCount] =
 {
 	// The order must match the order of enum eStatistic
 
@@ -104,7 +104,7 @@ const AString & cStatInfo::GetName(const eStatistic a_Type)
 {
 	ASSERT((a_Type > statInvalid) && (a_Type < statCount));
 
-	return ms_Info[a_Type].m_Name;
+	return m_ms_Info[a_Type].m_Name;
 }
 
 
@@ -113,11 +113,11 @@ const AString & cStatInfo::GetName(const eStatistic a_Type)
 
 eStatistic cStatInfo::GetType(const AString & a_Name)
 {
-	for (unsigned int i = 0; i < ARRAYCOUNT(ms_Info); ++i)
+	for (unsigned int i = 0; i < ARRAYCOUNT(m_ms_Info); ++i)
 	{
-		if (NoCaseCompare(ms_Info[i].m_Name, a_Name) == 0)
+		if (NoCaseCompare(m_ms_Info[i].m_Name, a_Name) == 0)
 		{
-			return ms_Info[i].m_Type;
+			return m_ms_Info[i].m_Type;
 		}
 	}
 
@@ -132,7 +132,7 @@ eStatistic cStatInfo::GetPrerequisite(const eStatistic a_Type)
 {
 	ASSERT((a_Type > statInvalid) && (a_Type < statCount));
 
-	return ms_Info[a_Type].m_Depends;
+	return m_ms_Info[a_Type].m_Depends;
 }
 
 

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -111,7 +111,7 @@ private:
 
 	eStatistic m_Depends;
 
-	static cStatInfo ms_Info[statCount];
+	static cStatInfo m_ms_Info[statCount];
 };
 
 

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -52,40 +52,40 @@ static unsigned char HexToDec(char a_HexChar)
 
 
 
-AString & Printf(AString & str, const char * format, fmt::ArgList args)
+AString & Printf(AString & a_str, const char * a_format, fmt::ArgList a_args)
 {
 	ASSERT(format != nullptr);
-	str = fmt::sprintf(format, args);
-	return str;
+	a_str = fmt::sprintf(a_format, a_args);
+	return a_str;
 }
 
 
 
 
 
-AString Printf(const char * format, fmt::ArgList args)
+AString Printf(const char * a_format, fmt::ArgList a_args)
 {
 	ASSERT(format != nullptr);
-	return fmt::sprintf(format, args);
+	return fmt::sprintf(a_format, a_args);
 }
 
 
 
 
 
-AStringVector StringSplit(const AString & str, const AString & delim)
+AStringVector StringSplit(const AString & a_str, const AString & a_delim)
 {
 	AStringVector results;
 	size_t cutAt = 0;
 	size_t Prev = 0;
-	while ((cutAt = str.find_first_of(delim, Prev)) != str.npos)
+	while ((cutAt = a_str.find_first_of(a_delim, Prev)) != a_str.npos)
 	{
-		results.push_back(str.substr(Prev, cutAt - Prev));
+		results.push_back(a_str.substr(Prev, cutAt - Prev));
 		Prev = cutAt + 1;
 	}
-	if (Prev < str.length())
+	if (Prev < a_str.length())
 	{
-		results.push_back(str.substr(Prev));
+		results.push_back(a_str.substr(Prev));
 	}
 	return results;
 }
@@ -93,7 +93,7 @@ AStringVector StringSplit(const AString & str, const AString & delim)
 
 
 
-AStringVector StringSplitWithQuotes(const AString & str, const AString & delim)
+AStringVector StringSplitWithQuotes(const AString & a_str, const AString & a_delim)
 {
 	AStringVector results;
 
@@ -101,7 +101,7 @@ AStringVector StringSplitWithQuotes(const AString & str, const AString & delim)
 	size_t Prev = 0;
 	size_t cutAtQuote = 0;
 
-	while ((cutAt = str.find_first_of(delim, Prev)) != str.npos)
+	while ((cutAt = a_str.find_first_of(a_delim, Prev)) != a_str.npos)
 	{
 		if (cutAt == Prev)
 		{
@@ -110,14 +110,14 @@ AStringVector StringSplitWithQuotes(const AString & str, const AString & delim)
 			Prev = Prev + 1;
 			continue;
 		}
-		AString current = str.substr(Prev, cutAt - Prev);
+		AString current = a_str.substr(Prev, cutAt - Prev);
 		if ((current.front() == '"') || (current.front() == '\''))
 		{
 			Prev += 1;
-			cutAtQuote = str.find_first_of(current.front(), Prev);
-			if (cutAtQuote != str.npos)
+			cutAtQuote = a_str.find_first_of(current.front(), Prev);
+			if (cutAtQuote != a_str.npos)
 			{
-				current = str.substr(Prev, cutAtQuote - Prev);
+				current = a_str.substr(Prev, cutAtQuote - Prev);
 				cutAt = cutAtQuote + 1;
 			}
 		}
@@ -126,9 +126,9 @@ AStringVector StringSplitWithQuotes(const AString & str, const AString & delim)
 		Prev = cutAt + 1;
 	}
 
-	if (Prev < str.length())
+	if (Prev < a_str.length())
 	{
-		AString current = str.substr(Prev);
+		AString current = a_str.substr(Prev);
 
 		// If the remant is wrapped in matching quotes, remove them:
 		if (
@@ -185,19 +185,19 @@ AString StringJoin(const AStringVector & a_Strings, const AString & a_Delimeter)
 
 
 
-AStringVector StringSplitAndTrim(const AString & str, const AString & delim)
+AStringVector StringSplitAndTrim(const AString & a_str, const AString & a_delim)
 {
 	AStringVector results;
 	size_t cutAt = 0;
 	size_t Prev = 0;
-	while ((cutAt = str.find_first_of(delim, Prev)) != str.npos)
+	while ((cutAt = a_str.find_first_of(a_delim, Prev)) != a_str.npos)
 	{
-		results.push_back(TrimString(str.substr(Prev, cutAt - Prev)));
+		results.push_back(TrimString(a_str.substr(Prev, cutAt - Prev)));
 		Prev = cutAt + 1;
 	}
-	if (Prev < str.length())
+	if (Prev < a_str.length())
 	{
-		results.push_back(TrimString(str.substr(Prev)));
+		results.push_back(TrimString(a_str.substr(Prev)));
 	}
 	return results;
 }
@@ -205,13 +205,13 @@ AStringVector StringSplitAndTrim(const AString & str, const AString & delim)
 
 
 
-AString TrimString(const AString & str)
+AString TrimString(const AString & a_str)
 {
-	size_t len = str.length();
+	size_t len = a_str.length();
 	size_t start = 0;
 	while (start < len)
 	{
-		if (static_cast<unsigned char>(str[start]) > 32)
+		if (static_cast<unsigned char>(a_str[start]) > 32)
 		{
 			break;
 		}
@@ -225,45 +225,45 @@ AString TrimString(const AString & str)
 	size_t end = len;
 	while (end >= start)
 	{
-		if (static_cast<unsigned char>(str[end]) > 32)
+		if (static_cast<unsigned char>(a_str[end]) > 32)
 		{
 			break;
 		}
 		--end;
 	}
 
-	return str.substr(start, end - start + 1);
+	return a_str.substr(start, end - start + 1);
 }
 
 
 
 
 
-AString & InPlaceLowercase(AString & s)
+AString & InPlaceLowercase(AString & a_s)
 {
-	std::transform(s.begin(), s.end(), s.begin(), ::tolower);
-	return s;
+	std::transform(a_s.begin(), a_s.end(), a_s.begin(), ::tolower);
+	return a_s;
 }
 
 
 
 
 
-AString & InPlaceUppercase(AString & s)
+AString & InPlaceUppercase(AString & a_s)
 {
-	std::transform(s.begin(), s.end(), s.begin(), ::toupper);
-	return s;
+	std::transform(a_s.begin(), a_s.end(), a_s.begin(), ::toupper);
+	return a_s;
 }
 
 
 
 
 
-AString StrToLower(const AString & s)
+AString StrToLower(const AString & a_s)
 {
 	AString res;
-	res.resize(s.size());
-	std::transform(s.begin(), s.end(), res.begin(), ::tolower);
+	res.resize(a_s.size());
+	std::transform(a_s.begin(), a_s.end(), res.begin(), ::tolower);
 	return res;
 }
 
@@ -271,11 +271,11 @@ AString StrToLower(const AString & s)
 
 
 
-AString StrToUpper(const AString & s)
+AString StrToUpper(const AString & a_s)
 {
 	AString res;
-	res.resize(s.size());
-	std::transform(s.begin(), s.end(), res.begin(), ::toupper);
+	res.resize(a_s.size());
+	std::transform(a_s.begin(), a_s.end(), res.begin(), ::toupper);
 	return res;
 }
 
@@ -283,12 +283,12 @@ AString StrToUpper(const AString & s)
 
 
 
-int NoCaseCompare(const AString & s1, const AString & s2)
+int NoCaseCompare(const AString & a_s1, const AString & a_s2)
 {
 	#ifdef _MSC_VER
 		return _stricmp(s1.c_str(), s2.c_str());
 	#else
-		return strcasecmp(s1.c_str(), s2.c_str());
+		return strcasecmp(a_s1.c_str(), a_s2.c_str());
 	#endif  // else _MSC_VER
 }
 
@@ -296,12 +296,12 @@ int NoCaseCompare(const AString & s1, const AString & s2)
 
 
 
-size_t RateCompareString(const AString & s1, const AString & s2)
+size_t RateCompareString(const AString & a_s1, const AString & a_s2)
 {
 	size_t MatchedLetters = 0;
-	size_t s1Length = s1.length();
+	size_t s1Length = a_s1.length();
 
-	if (s1Length > s2.length())
+	if (s1Length > a_s2.length())
 	{
 		// Definitely not a match
 		return 0;
@@ -309,8 +309,8 @@ size_t RateCompareString(const AString & s1, const AString & s2)
 
 	for (size_t i = 0; i < s1Length; i++)
 	{
-		char c1 = static_cast<char>(toupper(s1[i]));
-		char c2 = static_cast<char>(toupper(s2[i]));
+		char c1 = static_cast<char>(toupper(a_s1[i]));
+		char c2 = static_cast<char>(toupper(a_s2[i]));
 		if (c1 == c2)
 		{
 			++MatchedLetters;
@@ -327,19 +327,19 @@ size_t RateCompareString(const AString & s1, const AString & s2)
 
 
 
-void ReplaceString(AString & iHayStack, const AString & iNeedle, const AString & iReplaceWith)
+void ReplaceString(AString & a_iHayStack, const AString & a_iNeedle, const AString & a_iReplaceWith)
 {
 	// find always returns the current position for an empty needle; prevent endless loop
-	if (iNeedle.empty())
+	if (a_iNeedle.empty())
 	{
 		return;
 	}
 
-	size_t pos1 = iHayStack.find(iNeedle);
+	size_t pos1 = a_iHayStack.find(a_iNeedle);
 	while (pos1 != AString::npos)
 	{
-		iHayStack.replace( pos1, iNeedle.size(), iReplaceWith);
-		pos1 = iHayStack.find(iNeedle, pos1 + iReplaceWith.size());
+		a_iHayStack.replace( pos1, a_iNeedle.size(), a_iReplaceWith);
+		pos1 = a_iHayStack.find(a_iNeedle, pos1 + a_iReplaceWith.size());
 	}
 }
 
@@ -449,7 +449,7 @@ Notice from the original file:
 
 
 
-static const Byte trailingBytesForUTF8[256] =
+static const Byte g_trailingBytesForUTF8[256] =
 {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -465,7 +465,7 @@ static const Byte trailingBytesForUTF8[256] =
 
 
 
-static const unsigned int offsetsFromUTF8[6] =
+static const unsigned int g_offsetsFromUTF8[6] =
 {
 	0x00000000UL, 0x00003080UL, 0x000E2080UL,
 	0x03C82080UL, 0xFA082080UL, 0x82082080UL
@@ -475,11 +475,11 @@ static const unsigned int offsetsFromUTF8[6] =
 
 
 
-static bool isLegalUTF8(const unsigned char * source, int length)
+static bool isLegalUTF8(const unsigned char * a_source, int a_length)
 {
 	unsigned char a;
-	const unsigned char * srcptr = source + length;
-	switch (length)
+	const unsigned char * srcptr = a_source + a_length;
+	switch (a_length)
 	{
 		default: return false;
 		// Everything else falls through when "true"...
@@ -491,7 +491,7 @@ static bool isLegalUTF8(const unsigned char * source, int length)
 			{
 				return false;
 			}
-			switch (*source)
+			switch (*a_source)
 			{
 				// no fall-through in this inner switch
 				case 0xe0: if (a < 0xa0) return false; break;
@@ -501,9 +501,9 @@ static bool isLegalUTF8(const unsigned char * source, int length)
 				default:   if (a < 0x80) return false;
 			}
 		}
-		case 1: if ((*source >= 0x80) && (*source < 0xc2)) return false;
+		case 1: if ((*a_source >= 0x80) && (*a_source < 0xc2)) return false;
 	}
-	if (*source > 0xf4)
+	if (*a_source > 0xf4)
 	{
 		return false;
 	}
@@ -528,7 +528,7 @@ std::u16string UTF8ToRawBEUTF16(const AString & a_UTF8)
 	while (source < sourceEnd)
 	{
 		unsigned int ch = 0;
-		unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+		unsigned short extraBytesToRead = g_trailingBytesForUTF8[*source];
 		if (source + extraBytesToRead >= sourceEnd)
 		{
 			return UTF16;
@@ -549,7 +549,7 @@ std::u16string UTF8ToRawBEUTF16(const AString & a_UTF8)
 			case 1: ch += *source++; ch <<= 6;
 			case 0: ch += *source++;
 		}
-		ch -= offsetsFromUTF8[extraBytesToRead];
+		ch -= g_offsetsFromUTF8[extraBytesToRead];
 
 		if (ch <= UNI_MAX_BMP)
 		{
@@ -824,29 +824,29 @@ AString ReplaceAllCharOccurrences(const AString & a_String, char a_From, char a_
 
 
 /** Converts one Hex character in a Base64 encoding into the data value */
-static inline int UnBase64(char c)
+static inline int UnBase64(char a_c)
 {
-	if ((c >='A') && (c <= 'Z'))
+	if ((a_c >='A') && (a_c <= 'Z'))
 	{
-		return c - 'A';
+		return a_c - 'A';
 	}
-	if ((c >='a') && (c <= 'z'))
+	if ((a_c >='a') && (a_c <= 'z'))
 	{
-		return c - 'a' + 26;
+		return a_c - 'a' + 26;
 	}
-	if ((c >= '0') && (c <= '9'))
+	if ((a_c >= '0') && (a_c <= '9'))
 	{
-		return c - '0' + 52;
+		return a_c - '0' + 52;
 	}
-	if (c == '+')
+	if (a_c == '+')
 	{
 		return 62;
 	}
-	if (c == '/')
+	if (a_c == '/')
 	{
 		return 63;
 	}
-	if (c == '=')
+	if (a_c == '=')
 	{
 		return -1;
 	}

--- a/src/StringUtils.h
+++ b/src/StringUtils.h
@@ -24,66 +24,66 @@ typedef std::map<AString, AString> AStringMap;
 
 /** Output the formatted text into the string.
 Returns a_Dst. */
-extern AString & Printf(AString & a_Dst, const char * format, fmt::ArgList args);
+extern AString & Printf(AString & a_Dst, const char * a_format, fmt::ArgList a_args);
 FMT_VARIADIC(AString &, Printf, AString &, const char *)
 
 /** Output the formatted text into string
 Returns the formatted string by value. */
-extern AString Printf(const char * format, fmt::ArgList args);
+extern AString Printf(const char * a_format, fmt::ArgList a_args);
 FMT_VARIADIC(AString, Printf, const char *)
 
 /** Add the formated string to the existing data in the string.
 Returns a_Dst. */
 template <typename... Args>
-extern AString & AppendPrintf(AString & a_Dst, const char * format, const Args & ... args)
+extern AString & AppendPrintf(AString & a_Dst, const char * a_format, const Args & ... a_args)
 {
-	a_Dst += Printf(format, args...);
+	a_Dst += Printf(a_format, a_args...);
 	return a_Dst;
 }
 
 /** Split the string at any of the listed delimiters.
 Return the splitted strings as a stringvector. */
-extern AStringVector StringSplit(const AString & str, const AString & delim);
+extern AStringVector StringSplit(const AString & a_str, const AString & a_delim);
 
 /** Split the string at any of the listed delimiters. Keeps quoted content together
 Resolves issue #490
 Return the splitted strings as a stringvector. */
-extern AStringVector StringSplitWithQuotes(const AString & str, const AString & delim);
+extern AStringVector StringSplitWithQuotes(const AString & a_str, const AString & a_delim);
 
 /** Join a list of strings with the given delimiter between entries. */
 AString StringJoin(const AStringVector & a_Strings, const AString & a_Delimiter);
 
 /** Split the string at any of the listed delimiters and trim each value.
 Returns the splitted strings as a stringvector. */
-extern AStringVector StringSplitAndTrim(const AString & str, const AString & delim);
+extern AStringVector StringSplitAndTrim(const AString & a_str, const AString & a_delim);
 
 /** Trims whitespace at both ends of the string.
 Returns a trimmed copy of the original string. */
-extern AString TrimString(const AString & str);  // tolua_export
+extern AString TrimString(const AString & a_str);  // tolua_export
 
 /** In-place string conversion to uppercase.
 Returns the same string object. */
-extern AString & InPlaceUppercase(AString & s);
+extern AString & InPlaceUppercase(AString & a_s);
 
 /** In-place string conversion to lowercase.
 Returns the same string object. */
-extern AString & InPlaceLowercase(AString & s);
+extern AString & InPlaceLowercase(AString & a_s);
 
 /** Returns an upper-cased copy of the string */
-extern AString StrToUpper(const AString & s);
+extern AString StrToUpper(const AString & a_s);
 
 /** Returns a lower-cased copy of the string */
-extern AString StrToLower(const AString & s);
+extern AString StrToLower(const AString & a_s);
 
 /** Case-insensitive string comparison.
 Returns 0 if the strings are the same, <0 if s1 < s2 and >0 if s1 > s2. */
-extern int NoCaseCompare(const AString & s1, const AString & s2);  // tolua_export
+extern int NoCaseCompare(const AString & a_s1, const AString & a_s2);  // tolua_export
 
 /** Case-insensitive string comparison that returns a rating of equal-ness between [0 - s1.length()]. */
-extern size_t RateCompareString(const AString & s1, const AString & s2);
+extern size_t RateCompareString(const AString & a_s1, const AString & a_s2);
 
 /** Replaces each occurence of iNeedle in iHayStack with iReplaceWith */
-extern void ReplaceString(AString & iHayStack, const AString & iNeedle, const AString & iReplaceWith);  // tolua_export
+extern void ReplaceString(AString & a_iHayStack, const AString & a_iNeedle, const AString & a_iReplaceWith);  // tolua_export
 
 /** Converts a stream of BE shorts into UTF-8 string; returns a_UTF8. */
 extern AString & RawBEToUTF8(const char * a_RawData, size_t a_NumShorts, AString & a_UTF8);

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -12,7 +12,7 @@
 
 
 
-const float FLOAT_EPSILON = 0.0001f;  // TODO: Stash this in some header where it can be reused
+const float g_FLOAT_EPSILON = 0.0001f;  // TODO: Stash this in some header where it can be reused
 
 
 const std::array<const Vector3f, 6>& cTracer::m_NormalTable(void)
@@ -277,20 +277,20 @@ bool cTracer::Trace(const Vector3f & a_Start, const Vector3f & a_Direction, int 
 
 
 // return 1 = hit, other is not hit
-static int LinesCross(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3)
+static int LinesCross(float a_x0, float a_y0, float a_x1, float a_y1, float a_x2, float a_y2, float a_x3, float a_y3)
 {
 	// float linx, liny;
 
-	float d = (x1 - x0) * (y3 - y2) - (y1 - y0) * (x3 - x2);
+	float d = (a_x1 - a_x0) * (a_y3 - a_y2) - (a_y1 - a_y0) * (a_x3 - a_x2);
 	if (std::abs(d) < 0.001)
 	{
 		return 0;
 	}
 
-	float AB = ((y0 - y2) * (x3 - x2) - (x0 - x2) * (y3 - y2)) / d;
+	float AB = ((a_y0 - a_y2) * (a_x3 - a_x2) - (a_x0 - a_x2) * (a_y3 - a_y2)) / d;
 	if ((AB >= 0.0) && (AB <= 1.0))
 	{
-		float CD = ((y0 - y2) * (x1 - x0) - (x0 - x2) * (y1 - y0)) / d;
+		float CD = ((a_y0 - a_y2) * (a_x1 - a_x0) - (a_x0 - a_x2) * (a_y1 - a_y0)) / d;
 		if ((CD >= 0.0) && (CD <= 1.0))
 		{
 			// linx = x0 + AB * (x1 - x0);
@@ -318,7 +318,7 @@ int cTracer::intersect3D_SegmentPlane(const Vector3f & a_Origin, const Vector3f 
 	float     D = a_PlaneNormal.Dot(u);      // dot(Pn.n, u);
 	float     N = -(a_PlaneNormal.Dot(w));  // -dot(a_Plane.n, w);
 
-	if (std::abs(D) < FLOAT_EPSILON)
+	if (std::abs(D) < g_FLOAT_EPSILON)
 	{
 		// segment is parallel to plane
 		if (N == 0.0)

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -19,13 +19,13 @@ class cTracer
 public:
 
 	/** Contains the position of the block that caused the collision */
-	Vector3f BlockHitPosition;
+	Vector3f m_BlockHitPosition;
 
 	/** Contains which face was hit */
-	Vector3f HitNormal;
+	Vector3f m_HitNormal;
 
 	/** Contains the exact position where a collision occured. (BlockHitPosition + Offset on block) */
-	Vector3f RealHit;
+	Vector3f m_RealHit;
 
 
 	cTracer(cWorld * a_World);

--- a/src/UUID.cpp
+++ b/src/UUID.cpp
@@ -11,8 +11,8 @@
 /** UUID normalised in textual form. */
 struct sShortUUID
 {
-	char Data[32]{};
-	bool IsValid = false;
+	char m_Data[32]{};
+	bool m_IsValid = false;
 };
 
 /** Returns the given UUID in shortened form with IsValid indicating success.

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -14,11 +14,11 @@ class Vector3
 
 public:
 
-	T x, y, z;
+	T m_x, m_y, m_z;
 
 
-	inline Vector3(void) : x(0), y(0), z(0) {}
-	inline Vector3(T a_x, T a_y, T a_z) : x(a_x), y(a_y), z(a_z) {}
+	inline Vector3(void) : m_x(0), m_y(0), m_z(0) {}
+	inline Vector3(T a_x, T a_y, T a_z) : m_x(a_x), m_y(a_y), m_z(a_z) {}
 
 
 	#ifdef TOLUA_EXPOSITION  // Hardcoded copy constructors (tolua++ does not support function templates .. yet)
@@ -31,7 +31,7 @@ public:
 	// tolua_end
 	// Conversion constructors where U is not the same as T leaving the copy-constructor implicitly generated
 	template <typename U, typename = typename std::enable_if<!std::is_same<U, T>::value>::type>
-	Vector3(const Vector3<U> & a_Rhs): x(static_cast<T>(a_Rhs.x)), y(static_cast<T>(a_Rhs.y)), z(static_cast<T>(a_Rhs.z)) {}
+	Vector3(const Vector3<U> & a_Rhs): m_x(static_cast<T>(a_Rhs.x)), m_y(static_cast<T>(a_Rhs.y)), m_z(static_cast<T>(a_Rhs.z)) {}
 	// tolua_begin
 
 	inline void Set(T a_x, T a_y, T a_z)

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -15,7 +15,7 @@
 
 
 
-static const char DEFAULT_WEBADMIN_PORTS[] = "8080";
+static const char g_DEFAULT_WEBADMIN_PORTS[] = "8080";
 
 
 
@@ -92,7 +92,7 @@ bool cWebAdmin::Init(void)
 
 	// Read the ports to be used:
 	// Note that historically the ports were stored in the "Port" and "PortsIPv6" values
-	m_Ports = ReadUpgradeIniPorts(m_IniFile, "WebAdmin", "Ports", "Port", "PortsIPv6", DEFAULT_WEBADMIN_PORTS);
+	m_Ports = ReadUpgradeIniPorts(m_IniFile, "WebAdmin", "Ports", "Port", "PortsIPv6", g_DEFAULT_WEBADMIN_PORTS);
 
 	if (!m_HTTPServer.Initialize())
 	{
@@ -237,7 +237,7 @@ bool cWebAdmin::LoadIniFile(void)
 		m_IniFile.AddHeaderComment(" [User:admin]");
 		m_IniFile.AddHeaderComment(" Password=admin");
 		m_IniFile.AddHeaderComment(" Please restart Cuberite to apply changes made in this file!");
-		m_IniFile.SetValue("WebAdmin", "Ports", DEFAULT_WEBADMIN_PORTS);
+		m_IniFile.SetValue("WebAdmin", "Ports", g_DEFAULT_WEBADMIN_PORTS);
 		m_IniFile.WriteFile("webadmin.ini");
 	}
 

--- a/src/WebAdmin.h
+++ b/src/WebAdmin.h
@@ -27,9 +27,9 @@
 // tolua_begin
 struct HTTPFormData
 {
-	std::string Name;
-	std::string Value;
-	std::string Type;
+	std::string m_Name;
+	std::string m_Value;
+	std::string m_Type;
 } ;
 // tolua_end
 
@@ -43,27 +43,27 @@ struct HTTPRequest
 	typedef std::map< std::string, HTTPFormData > FormDataMap;
 
 	/** The entire URL presented to the HTTP server. */
-	AString URL;
+	AString m_URL;
 
 	/** HTTP method used for the request ("GET", "POST" etc.) */
-	AString Method;
+	AString m_Method;
 
 	/** The Path part of the request's URL (excluding GET params). */
-	AString Path;
+	AString m_Path;
 
 	/** Name of the logged-in user. Empty if not logged in. */
-	AString Username;
+	AString m_Username;
 
 	// tolua_end
 
 	/** Parameters given in the URL, after the questionmark */
-	StringStringMap Params;     // >> EXPORTED IN MANUALBINDINGS <<
+	StringStringMap m_Params;     // >> EXPORTED IN MANUALBINDINGS <<
 
 	/** Parameters posted as a part of a form - either in the URL (GET method) or in the body (POST method) */
-	StringStringMap PostParams;  // >> EXPORTED IN MANUALBINDINGS <<
+	StringStringMap m_PostParams;  // >> EXPORTED IN MANUALBINDINGS <<
 
 	/** Same as PostParams */
-	FormDataMap FormData;       // >> EXPORTED IN MANUALBINDINGS <<
+	FormDataMap m_FormData;       // >> EXPORTED IN MANUALBINDINGS <<
 } ;  // tolua_export
 
 
@@ -73,7 +73,7 @@ struct HTTPRequest
 // tolua_begin
 struct HTTPTemplateRequest
 {
-	HTTPRequest Request;
+	HTTPRequest m_Request;
 } ;
 // tolua_end
 
@@ -83,11 +83,11 @@ struct HTTPTemplateRequest
 
 struct sWebAdminPage
 {
-	AString Content;
-	AString PluginName;
-	AString TabTitle;
-	AString TabUrlPath;
-	AString ContentType;
+	AString m_Content;
+	AString m_PluginName;
+	AString m_TabTitle;
+	AString m_TabUrlPath;
+	AString m_ContentType;
 };
 
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -56,11 +56,11 @@
 
 
 
-const int TIME_SUNSET        = 12000;
-const int TIME_NIGHT_START   = 13187;
-const int TIME_NIGHT_END     = 22812;
-const int TIME_SUNRISE       = 23999;
-const int TIME_SPAWN_DIVISOR =   148;
+const int g_TIME_SUNSET        = 12000;
+const int g_TIME_NIGHT_START   = 13187;
+const int g_TIME_NIGHT_END     = 22812;
+const int g_TIME_SUNRISE       = 23999;
+const int g_TIME_SPAWN_DIVISOR =   148;
 
 
 
@@ -1309,21 +1309,21 @@ void cWorld::TickClients(float a_Dt)
 void cWorld::UpdateSkyDarkness(void)
 {
 	int TempTime = std::chrono::duration_cast<cTickTime>(m_TimeOfDay).count();
-	if (TempTime <= TIME_SUNSET)
+	if (TempTime <= g_TIME_SUNSET)
 	{
 		m_SkyDarkness = 0;
 	}
-	else if (TempTime <= TIME_NIGHT_START)
+	else if (TempTime <= g_TIME_NIGHT_START)
 	{
-		m_SkyDarkness = static_cast<NIBBLETYPE>((TIME_NIGHT_START - TempTime) / TIME_SPAWN_DIVISOR);
+		m_SkyDarkness = static_cast<NIBBLETYPE>((g_TIME_NIGHT_START - TempTime) / g_TIME_SPAWN_DIVISOR);
 	}
-	else if (TempTime <= TIME_NIGHT_END)
+	else if (TempTime <= g_TIME_NIGHT_END)
 	{
 		m_SkyDarkness = 8;
 	}
 	else
 	{
-		m_SkyDarkness = static_cast<NIBBLETYPE>((TIME_SUNRISE - TempTime) / TIME_SPAWN_DIVISOR);
+		m_SkyDarkness = static_cast<NIBBLETYPE>((g_TIME_SUNRISE - TempTime) / g_TIME_SPAWN_DIVISOR);
 	}
 }
 
@@ -2189,7 +2189,7 @@ bool cWorld::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlock
 
 
 
-void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed, bool IsPlayerCreated)
+void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed, bool a_IsPlayerCreated)
 {
 	auto & Random = GetRandomProvider();
 	a_FlyAwaySpeed /= 100;  // Pre-divide, so that we don't have to divide each time inside the loop
@@ -2207,7 +2207,7 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 
 		auto Pickup = cpp14::make_unique<cPickup>(
 			a_BlockX, a_BlockY, a_BlockZ,
-			*itr, IsPlayerCreated, SpeedX, SpeedY, SpeedZ
+			*itr, a_IsPlayerCreated, SpeedX, SpeedY, SpeedZ
 		);
 		auto PickupPtr = Pickup.get();
 		PickupPtr->Initialize(std::move(Pickup), *this);
@@ -2218,7 +2218,7 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 
 
 
-void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated)
+void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool a_IsPlayerCreated)
 {
 	for (cItems::const_iterator itr = a_Pickups.begin(); itr != a_Pickups.end(); ++itr)
 	{
@@ -2229,7 +2229,7 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double 
 
 		auto Pickup = cpp14::make_unique<cPickup>(
 			a_BlockX, a_BlockY, a_BlockZ,
-			*itr, IsPlayerCreated, static_cast<float>(a_SpeedX), static_cast<float>(a_SpeedY), static_cast<float>(a_SpeedZ)
+			*itr, a_IsPlayerCreated, static_cast<float>(a_SpeedX), static_cast<float>(a_SpeedY), static_cast<float>(a_SpeedZ)
 		);
 		auto PickupPtr = Pickup.get();
 		PickupPtr->Initialize(std::move(Pickup), *this);
@@ -2255,9 +2255,9 @@ UInt32 cWorld::SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, cons
 
 
 
-UInt32 cWorld::SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta)
+UInt32 cWorld::SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 {
-	auto FallingBlock = cpp14::make_unique<cFallingBlock>(Vector3i(a_X, a_Y, a_Z), BlockType, BlockMeta);
+	auto FallingBlock = cpp14::make_unique<cFallingBlock>(Vector3i(a_X, a_Y, a_Z), a_BlockType, a_BlockMeta);
 	auto FallingBlockPtr = FallingBlock.get();
 	auto ID = FallingBlock->GetUniqueID();
 	if (!FallingBlockPtr->Initialize(std::move(FallingBlock), *this))
@@ -3119,9 +3119,9 @@ std::unique_ptr<cPlayer> cWorld::RemovePlayer(cPlayer & a_Player, bool a_RemoveF
 	}
 	{
 		cCSLock Lock(m_CSPlayersToAdd);
-		m_PlayersToAdd.remove_if([&](const decltype(m_PlayersToAdd)::value_type & value) -> bool
+		m_PlayersToAdd.remove_if([&](const decltype(m_PlayersToAdd)::value_type & a_value) -> bool
 		{
-			return (value.first.get() == &a_Player);
+			return (a_value.first.get() == &a_Player);
 		});
 	}
 	{

--- a/src/World.h
+++ b/src/World.h
@@ -433,17 +433,17 @@ public:
 	// tolua_begin
 
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities: */
-	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool IsPlayerCreated = false) override;
+	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool a_IsPlayerCreated = false) override;
 
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
-	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) override;
+	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool a_IsPlayerCreated = false) override;
 
 	/** Spawns a single pickup containing the specified item. */
 	virtual UInt32 SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) override;
 
 	/** Spawns an falling block entity at the given position.
 	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
-	UInt32 SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta);
+	UInt32 SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 
 	/** Spawns an minecart at the given coordinates.
 	Returns the UniqueID of the spawned minecart, or cEntity::INVALID_ID on failure. */
@@ -743,10 +743,10 @@ public:
 
 	struct BlockTickQueueItem
 	{
-		int X;
-		int Y;
-		int Z;
-		int TicksToWait;
+		int m_X;
+		int m_Y;
+		int m_Z;
+		int m_TicksToWait;
 	};
 
 	/** Queues the block to be ticked after the specified number of game ticks */

--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -11,7 +11,7 @@
 
 
 /** If a list being loaded has more than this number of items, it's considered corrupted. */
-static const int MAX_LIST_ITEMS = 10000;
+static const int g_MAX_LIST_ITEMS = 10000;
 
 
 
@@ -255,7 +255,7 @@ eNBTParseError cParsedNBT::ReadList(eTagType a_ChildrenType)
 	NEEDBYTES(4, eNBTParseError::npListMissingLength);
 	int Count = GetBEInt(m_Data + m_Pos);
 	m_Pos += 4;
-	if ((Count < 0) || (Count > MAX_LIST_ITEMS))
+	if ((Count < 0) || (Count > g_MAX_LIST_ITEMS))
 	{
 		return eNBTParseError::npListInvalidLength;
 	}

--- a/src/WorldStorage/WSSAnvil.h
+++ b/src/WorldStorage/WSSAnvil.h
@@ -142,7 +142,7 @@ protected:
 	/** Loads contentents of an Items[] list tag into a cItemGrid
 	ItemGrid begins at the specified slot offset
 	Slots outside the ItemGrid range are ignored */
-	void LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a_NBT, int a_ItemsTagIdx, int s_SlotOffset = 0);
+	void LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a_NBT, int a_ItemsTagIdx, int a_s_SlotOffset = 0);
 
 	/** Decodes the text contained within a sign.
 	Older versions used direct string representation, newer versions use JSON-formatted string.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,7 +371,7 @@ static void WINAPI serviceMain(DWORD argc, TCHAR *argv[])
 
 
 
-static std::unique_ptr<cMemorySettingsRepository> ParseArguments(int argc, char ** argv)
+static std::unique_ptr<cMemorySettingsRepository> ParseArguments(int a_argc, char ** a_argv)
 {
 	try
 	{
@@ -388,7 +388,7 @@ static std::unique_ptr<cMemorySettingsRepository> ParseArguments(int argc, char 
 		TCLAP::SwitchArg noBufArg        ("",  "no-output-buffering", "Disable output buffering", cmd);
 		TCLAP::SwitchArg noFileLogArg    ("",  "no-log-file",         "Disable logging to file", cmd);
 		TCLAP::SwitchArg runAsServiceArg ("d", "service",             "Run as a service on Windows, or daemon on UNIX like systems", cmd);
-		cmd.parse(argc, argv);
+		cmd.parse(a_argc, a_argv);
 
 		// Copy the parsed args' values into a settings repository:
 		auto repo = cpp14::make_unique<cMemorySettingsRepository>();
@@ -463,7 +463,7 @@ static std::unique_ptr<cMemorySettingsRepository> ParseArguments(int argc, char 
 ////////////////////////////////////////////////////////////////////////////////
 // main:
 
-int main(int argc, char ** argv)
+int main(int a_argc, char ** a_argv)
 {
 	// Magic code to produce dump-files on Windows if the server crashes:
 	#if defined(_WIN32) && !defined(_WIN64) && defined(_MSC_VER)  // 32-bit Windows app compiled in MSVC
@@ -510,7 +510,7 @@ int main(int argc, char ** argv)
 	#endif
 
 	// Make sure m_RunAsService is set correctly before checking it's value
-	ParseArguments(argc, argv);
+	ParseArguments(a_argc, a_argv);
 
 	// Attempt to run as a service
 	if (cRoot::m_RunAsService)
@@ -550,7 +550,7 @@ int main(int argc, char ** argv)
 
 			while (!cRoot::m_TerminateEventRaised)
 			{
-				UniversalMain(ParseArguments(argc, argv));
+				UniversalMain(ParseArguments(a_argc, a_argv));
 			}
 		#endif
 	}
@@ -559,7 +559,7 @@ int main(int argc, char ** argv)
 		while (!cRoot::m_TerminateEventRaised)
 		{
 			// Not running as a service, do normal startup
-			UniversalMain(ParseArguments(argc, argv));
+			UniversalMain(ParseArguments(a_argc, a_argv));
 		}
 	}
 	return EXIT_SUCCESS;


### PR DESCRIPTION
(and I always thought, that reviews would catch 98% of these style violations :fox_face: )

Furthermore I've added the `g_`-Prefix to the coding conventions, because I've seen it being used a lot in the cuberite source.

The only thing I'm unsure is, if constant expressions also should get the prefix. This causes things like this (`Discriminator` is just a namespace):
```cpp
Buf.WriteBEInt8(Discriminator::g_ServerHello);
```
(https://github.com/bibo38/Cuberite/blob/7e7a844b46109b75a6a0c54ac4f9a55de2be03a3/src/Protocol/ForgeHandshake.cpp#L129)

P.S.: @Bond-009 `./clang-tidy.sh -fix` prevents headaches :smile: 