### PR TITLE
Changes to client's right clicking on a block

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1423,8 +1423,6 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 	cWorld * World = m_Player->GetWorld();
 	cPluginManager * PlgMgr = cRoot::Get()->GetPluginManager();
 
-	bool Success = false;
-
 	bool SuccessBlockUsable = false;
 	bool SuccessPlaceable = false;
 	bool SuccessItemUsable = false;
@@ -1490,9 +1488,7 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 		}
 	}
 
-	Success = (SuccessBlockUsable || SuccessPlaceable || SuccessItemUsable);
-
-	if (!Success)
+	if (!SuccessBlockUsable && !SuccessPlaceable && !SuccessItemUsable)
 	{
 		// Update the target block including the block above and below for 2 block high things
 		AddFaceDirection(a_BlockX, a_BlockY, a_BlockZ, a_BlockFace);

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1476,7 +1476,7 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 			SuccessPlaceable = ItemHandler->OnPlayerPlace(*World, *m_Player, HeldItem, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ);
 		}
 
-		if(!SuccessBlockUsable && !SuccessPlaceable)
+		if (!SuccessBlockUsable && !SuccessPlaceable)
 		{
 			// Use an item in hand with a target block
 			if (!PlgMgr->CallHookPlayerUsingItem(*m_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ))


### PR DESCRIPTION
Placing blocks next to a block that also counts as usable was not possible, e.g. for fences (usable with mob leashes). 

With first checking if the block is usable, the method ignored following actions like placing blocks next to it or using the item in the player's hand in case using the block didn't work.
The ClientHandle should now be able to find exactly one executable action (if possible).