### PR TITLE
Support cygwin compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,6 @@ endif()
 
 if (CYGWIN)
 	add_definitions(-D_GNU_SOURCE)
-	set(M_PI 3.14159265358979323846264338327950288) # This should be moved elsewhere
 	target_compile_options(SQLiteCpp PRIVATE -fno-stack-protector)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,12 @@ if (WIN32)
 	add_subdirectory(lib/luaproxy/)
 endif()
 
+if (CYGWIN)
+	add_definitions(-D_GNU_SOURCE)
+	set(M_PI 3.14159265358979323846264338327950288) # This should be moved elsewhere
+	target_compile_options(SQLiteCpp PRIVATE -fno-stack-protector)
+endif()
+
 # We use EXCLUDE_FROM_ALL so that only the explicit dependencies are used
 # (mbedTLS also has test and example programs in their CMakeLists.txt, we don't want those)
 include(lib/mbedtls.cmake EXCLUDE_FROM_ALL)

--- a/src/OSSupport/Errors.cpp
+++ b/src/OSSupport/Errors.cpp
@@ -23,7 +23,7 @@ AString GetOSErrorString( int a_ErrNo)
 	// According to https://linux.die.net/man/3/strerror_r there are two versions of strerror_r():
 
 	// GNU version of strerror_r()
-	#if defined(__GLIBC__) && defined( _GNU_SOURCE) && !defined(ANDROID) \
+	#if (defined(__GLIBC__) && defined( _GNU_SOURCE) && !defined(ANDROID)) \
 		|| defined(__CYGWIN__)
 
 	char * res = strerror_r( errno, buffer, ARRAYCOUNT(buffer));

--- a/src/OSSupport/Errors.cpp
+++ b/src/OSSupport/Errors.cpp
@@ -22,7 +22,9 @@ AString GetOSErrorString( int a_ErrNo)
 
 	// According to https://linux.die.net/man/3/strerror_r there are two versions of strerror_r():
 
-	#if defined(__GLIBC__) && defined( _GNU_SOURCE) && !defined(ANDROID)  // GNU version of strerror_r()
+	// GNU version of strerror_r()
+	#if defined(__GLIBC__) && defined( _GNU_SOURCE) && !defined(ANDROID) \
+		|| defined(__CYGWIN__)
 
 	char * res = strerror_r( errno, buffer, ARRAYCOUNT(buffer));
 	if (res != nullptr)


### PR DESCRIPTION
Hello! 

Although I know that only MSVC is supported on Windows, I still wanted
to try building with cygwin and fixed the issues along the way.

1) `M_PI` is not in <math.h> in cygwin. (Any suggestions for a better
place for our define?)
2) `strerror_r` is supported ONLY with _GNU_SOURCE flag.
3) gcc 7.1 in cygwin throws linker error with `stack-protector-all`.
I didn't want to modify any library variables so I've disabled stack
protector only for SQLiteCpp if we're building with cygwin.

After those, cygwin successfuly builds and everything seems to be fine
compilation-wise.