### PR TITLE
fix block area rotation bug

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -63,3 +63,4 @@ williamhatcher (Helped with API documentation updates and bug fixes)
 worktycho
 xoft (Mattes Dolak/madmaxoft on GH)
 Yeeeeezus (Donated AlchemistVillage prefabs)
+changyongGuo

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3317,6 +3317,16 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "Returns the weapon that the entity has equipped. Returns an empty cItem if no weapon equipped or not applicable.",
 				},
+        GetEquippedShield =
+        {
+          Returns =
+          {
+            {
+              Type = "cItem",
+            },
+          },
+          Notes = "Returns the shield that the entity has equipped. Returns an empty cItem if no shield equipped or not applicable.",
+        },
 				GetGravity =
 				{
 					Returns =
@@ -6311,16 +6321,6 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 						},
 					},
 					Notes = "Returns the item in the \"boots\" slot of the armor grid. Note that the returned item is read-only",
-				},
-				GetEquippedShield =
-				{
-					Returns =
-					{
-						{
-							Type = "cItem",
-						},
-					},
-					Notes = "Returns the item in the \"shield\" slot of the armor grid. Note that the returned item is read-only",
 				},
 				GetEquippedChestplate =
 				{

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -6312,6 +6312,16 @@ These ItemGrids are available in the API and can be manipulated by the plugins, 
 					},
 					Notes = "Returns the item in the \"boots\" slot of the armor grid. Note that the returned item is read-only",
 				},
+				GetEquippedShield =
+				{
+					Returns =
+					{
+						{
+							Type = "cItem",
+						},
+					},
+					Notes = "Returns the item in the \"shield\" slot of the armor grid. Note that the returned item is read-only",
+				},
 				GetEquippedChestplate =
 				{
 					Returns =

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3317,16 +3317,16 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "Returns the weapon that the entity has equipped. Returns an empty cItem if no weapon equipped or not applicable.",
 				},
-        GetEquippedShield =
-        {
-          Returns =
-          {
-            {
-              Type = "cItem",
-            },
-          },
-          Notes = "Returns the shield that the entity has equipped. Returns an empty cItem if no shield equipped or not applicable.",
-        },
+				GetOffHandEquipedItem =
+				{
+					Returns =
+					{
+						{
+							Type = "cItem",
+						},
+					},
+					Notes = "Returns the item that the entity has equipped on off-hand. Returns an empty cItem if no item equipped or not applicable.",
+				},
 				GetGravity =
 				{
 					Returns =

--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -1200,7 +1200,7 @@ void cBlockArea::MirrorXY(void)
 	int MaxZ = m_Size.z - 1;
 	for (int y = 0; y < m_Size.y; y++)
 	{
-		for (int z = 0; z <= HalfZ; z++)
+		for (int z = 0; z < HalfZ; z++)
 		{
 			for (int x = 0; x < m_Size.x; x++)
 			{
@@ -1255,7 +1255,7 @@ void cBlockArea::MirrorXZ(void)
 	// We are guaranteed that both blocktypes and blockmetas exist; mirror both at the same time:
 	int HalfY = m_Size.y / 2;
 	int MaxY = m_Size.y - 1;
-	for (int y = 0; y <= HalfY; y++)
+	for (int y = 0; y < HalfY; y++)
 	{
 		for (int z = 0; z < m_Size.z; z++)
 		{
@@ -1316,7 +1316,7 @@ void cBlockArea::MirrorYZ(void)
 	{
 		for (int z = 0; z < m_Size.z; z++)
 		{
-			for (int x = 0; x <= HalfX; x++)
+			for (int x = 0; x < HalfX; x++)
 			{
 				auto Idx1 = MakeIndex(x, y, z);
 				auto Idx2 = MakeIndex(MaxX - x, y, z);

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1188,7 +1188,14 @@ void cClientHandle::HandleLeftClick(int a_BlockX, int a_BlockY, int a_BlockZ, eB
 
 		case DIG_STATUS_SWAP_ITEM_IN_HAND:
 		{
-			// TODO: Not yet implemented
+
+			cItem EquippedItem = m_Player->GetEquippedItem();
+			cItem OffhandItem = m_Player->GetEquippedShield();
+
+			cInventory & Intentory = m_Player->GetInventory();
+			Intentory.SetShieldSlot(EquippedItem);
+			Intentory.SetHotbarSlot(Intentory.GetEquippedSlotNum(), OffhandItem);
+
 			return;
 		}
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1190,7 +1190,7 @@ void cClientHandle::HandleLeftClick(int a_BlockX, int a_BlockY, int a_BlockZ, eB
 		{
 
 			cItem EquippedItem = m_Player->GetEquippedItem();
-			cItem OffhandItem = m_Player->GetEquippedShield();
+			cItem OffhandItem = m_Player->GetOffHandEquipedItem();
 
 			cInventory & Intentory = m_Player->GetInventory();
 			Intentory.SetShieldSlot(EquippedItem);

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -351,6 +351,9 @@ public:
 	/** Returns the currently equipped boots; empty item if none */
 	virtual cItem GetEquippedBoots(void) const { return cItem(); }
 
+	/** Returns the currently equipped shield; empty item if none */
+	virtual cItem GetEquippedShield(void) const { return cItem(); }
+
 	/** Applies damage to the armor after the armor blocked the given amount */
 	virtual void ApplyArmorDamage(int DamageBlocked);
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -351,8 +351,8 @@ public:
 	/** Returns the currently equipped boots; empty item if none */
 	virtual cItem GetEquippedBoots(void) const { return cItem(); }
 
-	/** Returns the currently equipped shield; empty item if none */
-	virtual cItem GetEquippedShield(void) const { return cItem(); }
+	/** Returns the currently offhand equipped item; empty item if none */
+	virtual cItem GetOffHandEquipedItem(void) const { return cItem(); }
 
 	/** Applies damage to the armor after the armor blocked the given amount */
 	virtual void ApplyArmorDamage(int DamageBlocked);

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -71,6 +71,9 @@ public:
 	/** Returns the currently equipped boots; empty item if none */
 	virtual cItem GetEquippedBoots(void) const override { return m_Inventory.GetEquippedBoots(); }
 
+	/** Returns the currently equipped shield; empty item if none */
+	virtual cItem GetEquippedShield(void) const override { return m_Inventory.GetShieldSlot(); }
+
 	virtual void ApplyArmorDamage(int DamageBlocked) override;
 
 	// tolua_begin

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -71,8 +71,8 @@ public:
 	/** Returns the currently equipped boots; empty item if none */
 	virtual cItem GetEquippedBoots(void) const override { return m_Inventory.GetEquippedBoots(); }
 
-	/** Returns the currently equipped shield; empty item if none */
-	virtual cItem GetEquippedShield(void) const override { return m_Inventory.GetShieldSlot(); }
+	/** Returns the currently offhand equipped item; empty item if none */
+	virtual cItem GetOffHandEquipedItem(void) const override { return m_Inventory.GetShieldSlot(); }
 
 	virtual void ApplyArmorDamage(int DamageBlocked) override;
 


### PR DESCRIPTION
fix mirror method bug in class cBlockArea.
this bug is caused by wrong block type switch during mirror block group.
this commit will fix issue #4232

before fix:
![before](https://user-images.githubusercontent.com/18135614/41808993-b3c9f48c-7718-11e8-9fa7-3945c7a6d857.PNG)

after fix:
![after](https://user-images.githubusercontent.com/18135614/41808995-b94b194a-7718-11e8-9f21-5b9f39221c63.PNG)
