### PR TITLE
fix block area rotation bug

### DIFF
--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -1200,7 +1200,7 @@ void cBlockArea::MirrorXY(void)
 	int MaxZ = m_Size.z - 1;
 	for (int y = 0; y < m_Size.y; y++)
 	{
-		for (int z = 0; z <= HalfZ; z++)
+		for (int z = 0; z < HalfZ; z++)
 		{
 			for (int x = 0; x < m_Size.x; x++)
 			{
@@ -1255,7 +1255,7 @@ void cBlockArea::MirrorXZ(void)
 	// We are guaranteed that both blocktypes and blockmetas exist; mirror both at the same time:
 	int HalfY = m_Size.y / 2;
 	int MaxY = m_Size.y - 1;
-	for (int y = 0; y <= HalfY; y++)
+	for (int y = 0; y < HalfY; y++)
 	{
 		for (int z = 0; z < m_Size.z; z++)
 		{
@@ -1316,7 +1316,7 @@ void cBlockArea::MirrorYZ(void)
 	{
 		for (int z = 0; z < m_Size.z; z++)
 		{
-			for (int x = 0; x <= HalfX; x++)
+			for (int x = 0; x < HalfX; x++)
 			{
 				auto Idx1 = MakeIndex(x, y, z);
 				auto Idx2 = MakeIndex(MaxX - x, y, z);


### PR DESCRIPTION
re-submit pull request because of wrong code base in last pull request #4242.

fix mirror method bug in class cBlockArea.
this bug is caused by wrong block type switch during mirror block group.
this commit will fix issue #4232

before fix:
![41808993-b3c9f48c-7718-11e8-9fa7-3945c7a6d857](https://user-images.githubusercontent.com/18135614/41815442-df596fd0-779d-11e8-9e55-11061b96785c.PNG)

after fix:
![41808995-b94b194a-7718-11e8-9f21-5b9f39221c63](https://user-images.githubusercontent.com/18135614/41815444-e2e787ae-779d-11e8-96cc-096c39342e91.PNG)


