### PR TITLE
ignore build collision for block type is flower

### DIFF
--- a/src/Blocks/BlockFlower.h
+++ b/src/Blocks/BlockFlower.h
@@ -16,6 +16,11 @@ public:
 	{
 	}
 
+	virtual bool DoesIgnoreBuildCollision(cChunkInterface & a_ChunkInterface, Vector3i a_Pos, cPlayer & a_Player, NIBBLETYPE a_Meta) override
+	{
+		return true;
+	}
+
 	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta) override
 	{
 		NIBBLETYPE Meta = a_BlockMeta & 0x7;


### PR DESCRIPTION
fix bug that block can be put onto flower.

![capture](https://user-images.githubusercontent.com/18135614/41818056-d117d95c-77d9-11e8-81b8-5f411dfb2dd5.PNG)
