### PR TITLE
rewrite explosion knock back implement

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3231,17 +3231,16 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "Returns the entity classname that this class implements. Each descendant overrides this function.",
 				},
-        GetEnchantmentBlastKnockbackReduce =
-        {
-          Returns =
-          {
-            {
-              Name = "ReducePercent",
-              Type = "number",
-            },
-          },
-          Notes = "Returns explosion knock back reduce percent from blast protection level.",
-        },
+				GetEnchantmentBlastKnockbackReduce =
+				{
+					Returns =
+					{
+						{
+							Type = "number",
+						},
+					},
+					Notes = "Returns explosion knock back reduce percent from blast protection level.",
+				},
 				GetEnchantmentCoverAgainst =
 				{
 					Params =

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3231,6 +3231,17 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "Returns the entity classname that this class implements. Each descendant overrides this function.",
 				},
+        GetEnchantmentBlastKnockbackReduce =
+        {
+          Returns =
+          {
+            {
+              Name = "ReducePercent",
+              Type = "number",
+            },
+          },
+          Notes = "Returns explosion knock back reduce percent from blast protection level.",
+        },
 				GetEnchantmentCoverAgainst =
 				{
 					Params =

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1814,10 +1814,21 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 				a_Entity.TakeDamage(dtExplosion, nullptr, static_cast<int>((1 / DistanceFromExplosion.Length()) * 6 * ExplosionSizeInt), 0);
 			}
 
-			// Apply force to entities around the explosion - code modified from World.cpp DoExplosionAt()
-			DistanceFromExplosion.Normalize();
-			DistanceFromExplosion *= ExplosionSizeInt * ExplosionSizeInt;
-			a_Entity.AddSpeed(DistanceFromExplosion);
+			double Length = DistanceFromExplosion.Length();
+			if (Length <= ExplosionSizeInt)  // Entity is impacted by explosion
+			{
+				float EntityExposure = a_Entity.GetExplosionExposureRate(ExplosionPos, ExplosionSizeInt);
+
+				// Exposure reduced by armor
+				EntityExposure = EntityExposure * (1.0 - a_Entity.GetEnchantmentBlastKnockbackReduce());
+
+				double Impact = (1 - (Length / ExplosionSizeInt / 2)) * EntityExposure;
+
+				DistanceFromExplosion.Normalize();
+				DistanceFromExplosion *= Impact;
+
+				a_Entity.AddSpeed(DistanceFromExplosion);
+			}
 
 			return false;
 		}

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -690,6 +690,33 @@ int cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType 
 
 
 
+
+float cEntity::GetEnchantmentBlastKnockbackReduce()
+{
+	uint8_t MaxLevel = 0;
+
+	const cItem ArmorItems[] = { GetEquippedHelmet(), GetEquippedChestplate(), GetEquippedLeggings(), GetEquippedBoots() };
+
+	for (auto & Item : ArmorItems)
+	{
+		uint8_t Level = Item.m_Enchantments.GetLevel(cEnchantments::enchBlastProtection);
+		if (Level > MaxLevel)
+		{
+			// Get max blast protection
+			MaxLevel = Level;
+		}
+	}
+
+	// Max blast protect level is 4, each level provide 15% knock back reduction
+	MaxLevel = std::min<uint8_t>(MaxLevel, 4);
+	return MaxLevel * 0.15;
+}
+
+
+
+
+
+
 int cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
 {
 	// Returns the hitpoints out of a_RawDamage that the currently equipped armor would cover
@@ -2241,3 +2268,104 @@ void cEntity::RemoveLeashedMob(cMonster * a_Monster)
 
 	m_LeashedMobs.remove(a_Monster);
 }
+
+
+
+
+
+double cEntity::GetOverlapLengthX(double a_Start, double a_End)
+{
+	double EntityStart = m_Position.x - (m_Width / 2);
+	double EntityEnd = m_Position.x + (m_Width / 2);
+
+	EntityStart = std::max(a_Start, EntityStart);
+	EntityEnd = std::min(a_End, EntityEnd);
+
+	if (EntityStart >= EntityEnd)
+	{
+		return 0;
+	}
+	else
+	{
+		return (EntityEnd - EntityStart);
+	}
+}
+
+
+
+
+
+
+double cEntity::GetOverlapLengthY(double a_Start, double a_End)
+{
+	double EntityStart = m_Position.y - (m_Height / 2);
+	double EntityEnd = m_Position.y + (m_Height / 2);
+
+	EntityStart = std::max(a_Start, EntityStart);
+	EntityEnd = std::min(a_End, EntityEnd);
+
+	if (EntityStart >= EntityEnd)
+	{
+		return 0;
+	}
+	else
+	{
+		return (EntityEnd - EntityStart);
+	}
+}
+
+
+
+
+
+double cEntity::GetOverlapLengthZ(double a_Start, double a_End)
+{
+	double EntityStart = m_Position.z - (m_Width / 2);
+	double EntityEnd = m_Position.z + (m_Width / 2);
+
+	EntityStart = std::max(a_Start, EntityStart);
+	EntityEnd = std::min(a_End, EntityEnd);
+
+	if (EntityStart >= EntityEnd)
+	{
+		return 0;
+	}
+	else
+	{
+		return (EntityEnd - EntityStart);
+	}
+}
+
+
+
+
+
+
+float cEntity::GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_ExlosionPower)
+{
+	double Start, End;
+
+	// Overlap x axis
+	Start = a_ExplosionPosition.x - a_ExlosionPower;
+	End = a_ExplosionPosition.x + a_ExlosionPower;
+
+	double OverlapX = GetOverlapLengthX(Start, End);
+
+	// Overlap y axis
+	Start = a_ExplosionPosition.y - a_ExlosionPower;
+	End = a_ExplosionPosition.y + a_ExlosionPower;
+
+	double OverlapY = GetOverlapLengthY(Start, End);
+
+	// Overlap z axis
+	Start = a_ExplosionPosition.z - a_ExlosionPower;
+	End = a_ExplosionPosition.z + a_ExlosionPower;
+
+	double OverlapZ = GetOverlapLengthZ(Start, End);
+
+	float Rate = (float)(OverlapX * OverlapY * OverlapZ / (m_Width * m_Width * m_Height));
+	return Rate;
+}
+
+
+

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -333,6 +333,10 @@ public:
 	/** Returns the hitpoints that the currently equipped armor's enchantments would cover */
 	virtual int GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage);
 
+	/** Returns explosion knock back reduce percent from blast protection level
+	@return : knock back reduce percent */
+	virtual float GetEnchantmentBlastKnockbackReduce();
+
 	/** Returns the knockback amount that the currently equipped items would cause to a_Receiver on a hit */
 	virtual double GetKnockbackAmountAgainst(const cEntity & a_Receiver);
 
@@ -542,6 +546,12 @@ public:
 	/** Returs whether the entity has any mob leashed to */
 	bool HasAnyMobLeashed() const { return m_LeashedMobs.size() > 0; }
 
+	/** a lightweight calculation approach to get explosion exposure rate
+	@param a_ExplosionPosition : explosion position
+	@param a_ExlosionPower : explosion power
+	@return : exposure rate */
+	virtual float GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_ExlosionPower);
+
 protected:
 	/** Structure storing the portal delay timer and cooldown boolean */
 	struct sPortalCooldownData
@@ -711,5 +721,23 @@ private:
 
 	/** List of leashed mobs to this entity */
 	cMonsterList m_LeashedMobs;
+
+	/** get overlap length within a given range for x axis
+	@param a_Start : range start
+	@param a_End : range end, start should <= end
+	@return : overlap length */
+	double GetOverlapLengthX(double a_Start, double a_End);
+
+	/** get overlap length within a given range for y axis
+	@param a_Start : range start
+	@param a_End : range end, start should <= end
+	@return : overlap length */
+	double GetOverlapLengthY(double a_Start, double a_End);
+
+	/** get overlap length within a given range for z axis
+	@param a_Start : range start
+	@param a_End : range end, start should <= end
+	@return : overlap length */
+	double GetOverlapLengthZ(double a_Start, double a_End);
 
 } ;  // tolua_export

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2988,3 +2988,43 @@ float cPlayer::GetPlayerRelativeBlockHardness(BLOCKTYPE a_Block)
 	// LOGD("blockHardness: %f, digSpeed: %f, canHarvestBlockDivisor: %f\n", blockHardness, digSpeed, canHarvestBlockDivisor);
 	return (blockHardness < 0) ? 0 : ((digSpeed / blockHardness) / canHarvestBlockDivisor);
 }
+
+
+
+
+
+
+float cPlayer::GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_ExlosionPower)
+{
+	if (IsGameModeSpectator())
+	{
+		// No impact from explosion
+		return 0;
+	}
+	else if (IsGameModeCreative())
+	{
+		if (IsOnGround())
+		{
+			return super::GetExplosionExposureRate(a_ExplosionPosition, a_ExlosionPower);
+		}
+		else
+		{
+			// Flying player don't impact from explosion
+			return 0;
+		}
+	}
+	else
+	{
+		return super::GetExplosionExposureRate(a_ExplosionPosition, a_ExlosionPower);
+	}
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -752,6 +752,8 @@ protected:
 	This can be used both for online and offline UUIDs. */
 	AString GetUUIDFileName(const cUUID & a_UUID);
 
+	/** get player explosion exposure rate */
+	virtual float GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_ExlosionPower) override;
 private:
 
 	/** Pins the player to a_Location until Unfreeze() is called.

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1430,7 +1430,6 @@ void cWorld::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_Blo
 	}
 
 	// TODO: Implement block hardiness
-	Vector3d explosion_pos = Vector3d(a_BlockX, a_BlockY, a_BlockZ);
 	cVector3iArray BlocksAffected;
 	m_ChunkMap->DoExplosionAt(a_ExplosionSize, a_BlockX, a_BlockY, a_BlockZ, BlocksAffected);
 	BroadcastSoundEffect("entity.generic.explode", Vector3d(a_BlockX, a_BlockY, a_BlockZ), 1.0f, 0.6f);
@@ -1445,19 +1444,7 @@ void cWorld::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_Blo
 				continue;
 			}
 
-			Vector3d distance_explosion = (*itr)->GetPosition() - explosion_pos;
-			if (distance_explosion.SqrLength() < 4096.0)
-			{
-				double real_distance = std::max(0.004, distance_explosion.Length());
-				double power = a_ExplosionSize / real_distance;
-				if (power <= 1)
-				{
-					power = 0;
-				}
-				distance_explosion.Normalize();
-				distance_explosion *= power;
-				ch->SendExplosion(a_BlockX, a_BlockY, a_BlockZ, static_cast<float>(a_ExplosionSize), BlocksAffected, distance_explosion);
-			}
+			ch->SendExplosion(a_BlockX, a_BlockY, a_BlockZ, static_cast<float>(a_ExplosionSize), BlocksAffected, (*itr)->GetSpeed());
 		}
 	}
 


### PR DESCRIPTION
1, implement method to calculate entity explosion exposure rate
2, rewrite explosion impact based on wiki, add armor blast protection for impact
3, player will not be effected by explosion when flying in creative mode

this commit could solve player can be knock back bug in issue #4139