### PR TITLE
cBlockArea: Write all present data types by default

### DIFF
--- a/Server/Plugins/APIDump/Classes/BlockArea.lua
+++ b/Server/Plugins/APIDump/Classes/BlockArea.lua
@@ -1898,7 +1898,7 @@ return
 							Type = "boolean",
 						},
 					},
-					Notes = "Writes the area into World at the specified coords, returns true if successful. baTypes and baMetas are written.",
+					Notes = "Writes the area into World at the specified coords, returns true if successful. All present data types are written.",
 				},
 				{
 					Params =
@@ -1952,7 +1952,7 @@ return
 							Type = "boolean",
 						},
 					},
-					Notes = "Writes the area into World at the specified coords, returns true if successful. baTypes and baMetas are written.",
+					Notes = "Writes the area into World at the specified coords, returns true if successful. All present data types are written.",
 				},
 				{
 					Params =

--- a/src/Bindings/ManualBindings_BlockArea.cpp
+++ b/src/Bindings/ManualBindings_BlockArea.cpp
@@ -700,20 +700,23 @@ static int tolua_cBlockArea_Write(lua_State * a_LuaState)
 
 	// Check and get the overloaded params:
 	Vector3i coords;
-	int dataTypes = cBlockArea::baTypes | cBlockArea::baMetas | cBlockArea::baBlockEntities;
+	int dataTypes = 0;
 	auto dataTypesIdx = readVector3iOverloadParams(L, 3, coords, "coords");
-	L.GetStackValues(dataTypesIdx, dataTypes);
+	auto HasDataTypes = L.GetStackValues(dataTypesIdx, dataTypes);
 
 	// Check the dataType parameter validity:
-	if (!cBlockArea::IsValidDataTypeCombination(dataTypes))
+	if (HasDataTypes)
 	{
-		return L.ApiParamError("Invalid datatype combination (%d).", dataTypes);
-	}
-	if ((self->GetDataTypes() & dataTypes) != dataTypes)
-	{
-		return L.ApiParamError("Requesting datatypes not present in the cBlockArea. Got only 0x%02x, requested 0x%02x",
-			self->GetDataTypes(), dataTypes
-		);
+		if (!cBlockArea::IsValidDataTypeCombination(dataTypes))
+		{
+			return L.ApiParamError("Invalid datatype combination (%d).", dataTypes);
+		}
+		if ((self->GetDataTypes() & dataTypes) != dataTypes)
+		{
+			return L.ApiParamError("Requesting datatypes not present in the cBlockArea. Got only 0x%02x, requested 0x%02x",
+				self->GetDataTypes(), dataTypes
+			);
+		}
 	}
 
 	// Check and adjust the coord params:
@@ -735,7 +738,14 @@ static int tolua_cBlockArea_Write(lua_State * a_LuaState)
 	}
 
 	// Do the actual write:
-	L.Push(self->Write(*world, coords, dataTypes));
+	if (HasDataTypes)
+	{
+		L.Push(self->Write(*world, coords, dataTypes));
+	}
+	else
+	{
+		L.Push(self->Write(*world, coords));
+	}
 	return 1;
 }
 

--- a/src/BlockArea.h
+++ b/src/BlockArea.h
@@ -120,11 +120,27 @@ public:
 
 	/** Writes the area back into cWorld at the coords specified. Returns true if successful in all chunks, false if only partially / not at all.
 	Doesn't wake up the simulators. */
-	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes = baTypes | baMetas | baBlockEntities);
+	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes);
 
 	/** Writes the area back into cWorld at the coords specified. Returns true if successful in all chunks, false if only partially / not at all.
 	Doesn't wake up the simulators. */
-	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, const Vector3i & a_MinCoords, int a_DataTypes = baTypes | baMetas | baBlockEntities);
+	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ)
+	{
+		// Write all available data
+		return Write(a_ForEachChunkProvider, a_MinBlockX, a_MinBlockY, a_MinBlockZ, GetDataTypes());
+	}
+
+	/** Writes the area back into cWorld at the coords specified. Returns true if successful in all chunks, false if only partially / not at all.
+	Doesn't wake up the simulators. */
+	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, const Vector3i & a_MinCoords, int a_DataTypes);
+
+	/** Writes the area back into cWorld at the coords specified. Returns true if successful in all chunks, false if only partially / not at all.
+	Doesn't wake up the simulators. */
+	bool Write(cForEachChunkProvider & a_ForEachChunkProvider, const Vector3i & a_MinCoords)
+	{
+		// Write all available data
+		return Write(a_ForEachChunkProvider, a_MinCoords.x, a_MinCoords.y, a_MinCoords.z, GetDataTypes());
+	}
 
 	// tolua_begin
 


### PR DESCRIPTION
Fixes cuberite/WorldEdit#130
This is essentially @madmaxoft's solution:
>Basically, the universal fix is to write something like:
>```lua
>area:Write(..., area:GetDataTypes())
>```
>But that results in boilerplate code that no-one ever touches :(

But this way the boilerplate is gone and instead the behaviour is part of the API.
