### PR TITLE
Made Hopper a m_FullyOccupiesVoxel block pursuant to #4250

### DIFF
--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -642,6 +642,7 @@ cBlockInfo::cBlockInfoArray::cBlockInfoArray()
 	Info[E_BLOCK_STONE_BRICKS                 ].m_FullyOccupiesVoxel = true;
 	Info[E_BLOCK_STRUCTURE_BLOCK              ].m_FullyOccupiesVoxel = true;
 	Info[E_BLOCK_WOOL                         ].m_FullyOccupiesVoxel = true;
+	Info[E_BLOCK_HOPPER                       ].m_FullyOccupiesVoxel = true;
 
 
 	// Blocks that can be terraformed


### PR DESCRIPTION
Hello all, first time contributing to this project. I noticed issue #4250 and thought it might be a good place to start digging through the source code and possibly fix the issue. User @changyongGuo commented that they would create a pull request, but I hadn't seen it added yet. As for the proposed fix, I checked the vanilla minecraft behavior, and you can in fact place surface mountable items like switches on hoppers in addition to rail. I think further checking against vanilla behavior might be necessary for more obscure interactions of items with the m_FullyOccupiesVoxel field, such as for breaking ice blocks(?), but as far as I can tell placing a rail on a hopper isn't really a special case. 