### PR TITLE
cIsThread: Reset m_ShouldTerminate after the thread has stopped

### DIFF
--- a/src/ChunkSender.cpp
+++ b/src/ChunkSender.cpp
@@ -79,21 +79,11 @@ cChunkSender::~cChunkSender()
 
 
 
-bool cChunkSender::Start()
-{
-	m_ShouldTerminate = false;
-	return super::Start();
-}
-
-
-
-
-
 void cChunkSender::Stop(void)
 {
 	m_ShouldTerminate = true;
 	m_evtQueue.Set();
-	Wait();
+	super::Stop();
 }
 
 

--- a/src/ChunkSender.h
+++ b/src/ChunkSender.h
@@ -67,8 +67,6 @@ public:
 
 	};
 
-	bool Start();
-
 	void Stop(void);
 
 	/** Queues a chunk to be sent to a specific client */

--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -98,7 +98,7 @@ void cChunkGenerator::Stop(void)
 	m_ShouldTerminate = true;
 	m_Event.Set();
 	m_evtRemoved.Set();  // Wake up anybody waiting for empty queue
-	Wait();
+	super::Stop();
 
 	delete m_Generator;
 	m_Generator = nullptr;

--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -140,7 +140,7 @@ void cLightingThread::Stop(void)
 	m_ShouldTerminate = true;
 	m_evtItemAdded.Set();
 
-	Wait();
+	super::Stop();
 }
 
 

--- a/src/OSSupport/IsThread.cpp
+++ b/src/OSSupport/IsThread.cpp
@@ -60,8 +60,7 @@ cIsThread::cIsThread(const AString & a_ThreadName) :
 
 cIsThread::~cIsThread()
 {
-	m_ShouldTerminate = true;
-	Wait();
+	Stop();
 }
 
 
@@ -110,14 +109,9 @@ bool cIsThread::Start(void)
 
 void cIsThread::Stop(void)
 {
-	if (!m_Thread.joinable())
-	{
-		// The thread hasn't been started or has already been joined
-		return;
-	}
-
 	m_ShouldTerminate = true;
 	Wait();
+	m_ShouldTerminate = false;
 }
 
 

--- a/src/Protocol/Authenticator.cpp
+++ b/src/Protocol/Authenticator.cpp
@@ -77,7 +77,6 @@ void cAuthenticator::Authenticate(int a_ClientID, const AString & a_UserName, co
 void cAuthenticator::Start(cSettingsRepositoryInterface & a_Settings)
 {
 	ReadSettings(a_Settings);
-	m_ShouldTerminate = false;
 	super::Start();
 }
 
@@ -89,7 +88,7 @@ void cAuthenticator::Stop(void)
 {
 	m_ShouldTerminate = true;
 	m_QueueNonempty.Set();
-	Wait();
+	super::Stop();
 }
 
 

--- a/src/WorldStorage/WorldStorage.cpp
+++ b/src/WorldStorage/WorldStorage.cpp
@@ -94,7 +94,7 @@ void cWorldStorage::WaitForFinish(void)
 	// Wait for the thread to finish:
 	m_ShouldTerminate = true;
 	m_Event.Set();  // Wake up the thread if waiting
-	super::Wait();
+	super::Stop();
 	LOGD("World storage thread finished");
 }
 


### PR DESCRIPTION
This allows threads to be restarted after stopping.

Fixes #4257

