### PR TITLE
Optimise chunk set

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -322,26 +322,15 @@ void cChunk::SetAllData(cSetChunkData & a_SetChunkData)
 	memcpy(m_BiomeMap, a_SetChunkData.GetBiomes(), sizeof(m_BiomeMap));
 	memcpy(m_HeightMap, a_SetChunkData.GetHeightMap(), sizeof(m_HeightMap));
 
-	m_ChunkData.SetBlockTypes(a_SetChunkData.GetBlockTypes());
-	m_ChunkData.SetMetas(a_SetChunkData.GetBlockMetas());
-	if (a_SetChunkData.IsLightValid())
-	{
-		m_ChunkData.SetBlockLight(a_SetChunkData.GetBlockLight());
-		m_ChunkData.SetSkyLight(a_SetChunkData.GetSkyLight());
-		m_IsLightValid = true;
-	}
-	else
-	{
-		m_IsLightValid = false;
-	}
+	m_ChunkData.Assign(std::move(a_SetChunkData.GetChunkData()));
+	m_IsLightValid = a_SetChunkData.IsLightValid();
 
 	// Clear the block entities present - either the loader / saver has better, or we'll create empty ones:
 	for (auto & KeyPair : m_BlockEntities)
 	{
 		delete KeyPair.second;
 	}
-	m_BlockEntities.clear();
-	std::swap(a_SetChunkData.GetBlockEntities(), m_BlockEntities);
+	m_BlockEntities = std::move(a_SetChunkData.GetBlockEntities());
 
 	// Check that all block entities have a valid blocktype at their respective coords (DEBUG-mode only):
 	#ifdef _DEBUG

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -129,7 +129,7 @@ public:
 	void WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlockY, int a_MinBlockZ, int a_DataTypes);
 
 	/** Returns true if there is a block entity at the coords specified */
-	bool HasBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ);
+	bool HasBlockEntityAt(Vector3i a_BlockPos);
 
 	/** Sets or resets the internal flag that prevents chunk from being unloaded.
 	The flag is cumulative - it can be set multiple times and then needs to be un-set that many times

--- a/src/ChunkData.cpp
+++ b/src/ChunkData.cpp
@@ -113,7 +113,7 @@ void cChunkData::Assign(cChunkData && a_Other)
 		return;
 	}
 
-	if (&m_Pool != &a_Other.m_Pool)
+	if (m_Pool != a_Other.m_Pool)
 	{
 		// Cannot transfer the memory, do a copy instead
 		const cChunkData & CopyOther = a_Other;

--- a/src/ChunkDataCallback.h
+++ b/src/ChunkDataCallback.h
@@ -115,13 +115,13 @@ public:
 	};
 
 	cChunkDataCopyCollector():
-		m_Pool(cpp14::make_unique<MemCallbacks>()),
+		m_Pool(cpp14::make_unique<MemCallbacks>(), cChunkData::NumSections),  // Keep 1 chunk worth of reserve
 		m_Data(m_Pool)
 	{
 	}
 
 
-	cListAllocationPool<cChunkData::sChunkSection, cChunkData::NumSections> m_Pool;  // Keep 1 chunk worth of reserve
+	cListAllocationPool<cChunkData::sChunkSection> m_Pool;
 	cChunkData m_Data;
 
 protected:

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -207,19 +207,19 @@ public:
 	}
 
 
-	inline static Vector3i IndexToCoordinate( unsigned int index)
+	inline static Vector3i IndexToCoordinate(size_t index)
 	{
 		#if AXIS_ORDER == AXIS_ORDER_XZY
 			return Vector3i(  // 1.2
-				index % cChunkDef::Width,                       // X
-				index / (cChunkDef::Width * cChunkDef::Width),  // Y
-				(index / cChunkDef::Width) % cChunkDef::Width   // Z
+				static_cast<int>(index % cChunkDef::Width),                       // X
+				static_cast<int>(index / (cChunkDef::Width * cChunkDef::Width)),  // Y
+				static_cast<int>((index / cChunkDef::Width) % cChunkDef::Width)   // Z
 			);
 		#elif AXIS_ORDER == AXIS_ORDER_YZX
 			return Vector3i(  // 1.1
-				index / (cChunkDef::Height * cChunkDef::Width),  // X
-				index % cChunkDef::Height,                       // Y
-				(index / cChunkDef::Height) % cChunkDef::Width   // Z
+				static_cast<int>(index / (cChunkDef::Height * cChunkDef::Width)),  // X
+				static_cast<int>(index % cChunkDef::Height),                       // Y
+				static_cast<int>((index / cChunkDef::Height) % cChunkDef::Width)   // Z
 			);
 		#endif
 	}

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -38,10 +38,8 @@
 cChunkMap::cChunkMap(cWorld * a_World) :
 	m_World(a_World),
 	m_Pool(
-		new cListAllocationPool<cChunkData::sChunkSection, 1600>(
-			std::unique_ptr<cAllocationPool<cChunkData::sChunkSection>::cStarvationCallbacks>(
-				new cStarvationCallbacks()
-			)
+		cpp14::make_unique<cListAllocationPool<cChunkData::sChunkSection>>(
+			cpp14::make_unique<cStarvationCallbacks>(), 1600u
 		)
 	)
 {

--- a/src/SetChunkData.cpp
+++ b/src/SetChunkData.cpp
@@ -94,11 +94,23 @@ cSetChunkData::cSetChunkData(
 
 void cSetChunkData::CalculateHeightMap(void)
 {
+	// Find the heighest present section in the chunk
+	size_t MaxSection = 0;
+	for (size_t i = cChunkData::NumSections - 1; i != 0; --i)
+	{
+		if (m_ChunkData.GetSection(i) != nullptr)
+		{
+			MaxSection = i;
+			break;
+		}
+	}
+	const int MaxHeight = static_cast<int>(MaxSection + 1) * cChunkData::SectionHeight - 1;
+
 	for (int x = 0; x < cChunkDef::Width; x++)
 	{
 		for (int z = 0; z < cChunkDef::Width; z++)
 		{
-			for (int y = cChunkDef::Height - 1; y > -1; y--)
+			for (int y = MaxHeight; y > -1; y--)
 			{
 				if (m_ChunkData.GetBlock({x, y, z}) != E_BLOCK_AIR)
 				{

--- a/src/SetChunkData.h
+++ b/src/SetChunkData.h
@@ -53,7 +53,7 @@ public:
 	cChunkData & GetChunkData(void) { return m_ChunkData; }
 
 	/** Returns the internal storage for heightmap, read-only. */
-	cChunkDef::HeightMap & GetHeightMap(void) { return m_HeightMap; }
+	const cChunkDef::HeightMap & GetHeightMap(void) const { return m_HeightMap; }
 
 	/** Returns the internal storage for biomes, read-write. */
 	cChunkDef::BiomeMap & GetBiomes(void) { return m_Biomes; }

--- a/src/SetChunkData.h
+++ b/src/SetChunkData.h
@@ -3,11 +3,9 @@
 
 // Declares the cSetChunkData class used for sending loaded / generated chunk data into cWorld
 
-
-
-
-
 #pragma once
+
+#include "ChunkData.h"
 
 
 
@@ -51,20 +49,11 @@ public:
 	int GetChunkX(void) const { return m_ChunkX; }
 	int GetChunkZ(void) const { return m_ChunkZ; }
 
-	/** Returns the internal storage of the block types, read-only. */
-	const cChunkDef::BlockTypes & GetBlockTypes(void) const { return m_BlockTypes; }
-
-	/** Returns the internal storage of the block types, read-only. */
-	const cChunkDef::BlockNibbles & GetBlockMetas(void) const { return m_BlockMetas; }
-
-	/** Returns the internal storage of the block light, read-only. */
-	const cChunkDef::BlockNibbles & GetBlockLight(void) const { return m_BlockLight; }
-
-	/** Returns the internal storage of the block types, read-only. */
-	const cChunkDef::BlockNibbles & GetSkyLight(void) const { return m_SkyLight; }
+	/** Returns the internal storage of block types, metas and lighting. */
+	cChunkData & GetChunkData(void) { return m_ChunkData; }
 
 	/** Returns the internal storage for heightmap, read-only. */
-	const cChunkDef::HeightMap & GetHeightMap(void) const { return m_HeightMap; }
+	cChunkDef::HeightMap & GetHeightMap(void) { return m_HeightMap; }
 
 	/** Returns the internal storage for biomes, read-write. */
 	cChunkDef::BiomeMap & GetBiomes(void) { return m_Biomes; }
@@ -101,10 +90,8 @@ protected:
 	int m_ChunkX;
 	int m_ChunkZ;
 
-	cChunkDef::BlockTypes m_BlockTypes;
-	cChunkDef::BlockNibbles m_BlockMetas;
-	cChunkDef::BlockNibbles m_BlockLight;
-	cChunkDef::BlockNibbles m_SkyLight;
+	cListAllocationPool<cChunkData::sChunkSection> m_Pool;
+	cChunkData m_ChunkData;
 	cChunkDef::HeightMap m_HeightMap;
 	cChunkDef::BiomeMap m_Biomes;
 	cEntityList m_Entities;

--- a/tests/ChunkData/ArraytoCoord.cpp
+++ b/tests/ChunkData/ArraytoCoord.cpp
@@ -11,14 +11,19 @@ int main(int argc, char** argv)
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
 	{
-		virtual cChunkData::sChunkSection * Allocate()
+		virtual cChunkData::sChunkSection * Allocate() override
 		{
 			return new cChunkData::sChunkSection();
 		}
 
-		virtual void Free(cChunkData::sChunkSection * a_Ptr)
+		virtual void Free(cChunkData::sChunkSection * a_Ptr) override
 		{
 			delete a_Ptr;
+		}
+
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		{
+			return false;
 		}
 	} Pool;
 	{

--- a/tests/ChunkData/Coordinates.cpp
+++ b/tests/ChunkData/Coordinates.cpp
@@ -11,14 +11,19 @@ int main(int argc, char** argv)
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
 	{
-		virtual cChunkData::sChunkSection * Allocate()
+		virtual cChunkData::sChunkSection * Allocate() override
 		{
 			return new cChunkData::sChunkSection();
 		}
 
-		virtual void Free(cChunkData::sChunkSection * a_Ptr)
+		virtual void Free(cChunkData::sChunkSection * a_Ptr) override
 		{
 			delete a_Ptr;
+		}
+
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		{
+			return false;
 		}
 	} Pool;
 	{

--- a/tests/ChunkData/Copies.cpp
+++ b/tests/ChunkData/Copies.cpp
@@ -11,14 +11,19 @@ int main(int argc, char** argv)
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
 	{
-		virtual cChunkData::sChunkSection * Allocate()
+		virtual cChunkData::sChunkSection * Allocate() override
 		{
 			return new cChunkData::sChunkSection();
 		}
 
-		virtual void Free(cChunkData::sChunkSection * a_Ptr)
+		virtual void Free(cChunkData::sChunkSection * a_Ptr) override
 		{
 			delete a_Ptr;
+		}
+
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection>&) const NOEXCEPT override
+		{
+			return false;
 		}
 	} Pool;
 	{

--- a/tests/ChunkData/CopyBlocks.cpp
+++ b/tests/ChunkData/CopyBlocks.cpp
@@ -21,15 +21,20 @@ int main(int argc, char ** argv)
 	// Set up a cChunkData with known contents - all blocks 0x01, all metas 0x02:
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
-		virtual cChunkData::sChunkSection * Allocate()
+	{
+		virtual cChunkData::sChunkSection * Allocate() override
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
-		virtual void Free(cChunkData::sChunkSection * a_Ptr)
+
+		virtual void Free(cChunkData::sChunkSection * a_Ptr) override
 		{
 			delete a_Ptr;
+		}
+
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		{
+			return false;
 		}
 	} Pool;
 	cChunkData Data(Pool);

--- a/tests/ChunkData/creatable.cpp
+++ b/tests/ChunkData/creatable.cpp
@@ -8,15 +8,20 @@ int main(int argc, char** argv)
 
 	class cMockAllocationPool
 		: public cAllocationPool<cChunkData::sChunkSection>
- 	{
-		virtual cChunkData::sChunkSection * Allocate()
+	{
+		virtual cChunkData::sChunkSection * Allocate() override
 		{
 			return new cChunkData::sChunkSection();
 		}
-		
-		virtual void Free(cChunkData::sChunkSection * a_Ptr)
+
+		virtual void Free(cChunkData::sChunkSection * a_Ptr) override
 		{
 			delete a_Ptr;
+		}
+
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		{
+			return false;
 		}
 	} Pool;
 	cChunkData buffer(Pool);


### PR DESCRIPTION
Closes #1244

Initially I was just going to add the `cChunkData` to `cSetChunkData` but profiling revealed that the copying wasn't even the biggest slowdown.  Much more time was being spent in `cChunk::CreateBlockEntities` and `cChunk::WakeUpSimulators` than was in `memcpy` so I've made those significantly faster as well.

Optimisations performed:
 * `cSetChunkData` now stores blocks in a `cChunkData` object
 * `cChunkData` objects can now perform moves even if they are using different pools
 * `cChunk::CreateBlockEntities` now iterates in the correct order and only over present chunk sections
 * Similarly for `cChunk::WakeUpSimulators`
 * `cSetChunkData::CalculateHeightMap` now shortcuts to the highest present chunk section before checking blocks directly

Performance results from timing Cuberite start-up with the world already generated:

| Current Master | This PR      |
|----------------|--------------|
| 1282 ± 76 ms   | 1023 ± 45 ms |

![image](https://user-images.githubusercontent.com/13238737/43050237-cd44921c-8df4-11e8-81e7-a9d21663d64c.png)

