### PR TITLE
cPawn: Reset last ground height in ResetPosition

### DIFF
--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -671,7 +671,7 @@ protected:
 
 	/** Set the entities position and last sent position.
 	Only to be used when the caller will broadcast a teleport or equivalent to clients. */
-	void ResetPosition(Vector3d a_NewPos);
+	virtual void ResetPosition(Vector3d a_NewPos);
 
 private:
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -486,3 +486,13 @@ cEntityEffect * cPawn::GetEntityEffect(cEntityEffect::eType a_EffectType)
 	auto itr = m_EntityEffects.find(a_EffectType);
 	return (itr != m_EntityEffects.end()) ? itr->second.get() : nullptr;
 }
+
+
+
+
+
+void cPawn::ResetPosition(Vector3d a_NewPosition)
+{
+	super::ResetPosition(a_NewPosition);
+	m_LastGroundHeight = GetPosY();
+}

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -77,6 +77,8 @@ protected:
 	double m_LastGroundHeight;
 	bool m_bTouchGround;
 
+	virtual void ResetPosition(Vector3d a_NewPosition) override;
+
 private:
 
 	/** A list of all monsters that are targeting this pawn. */

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1641,7 +1641,6 @@ void cPlayer::TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ)
 	{
 		ResetPosition({a_PosX, a_PosY, a_PosZ});
 		FreezeInternal(GetPosition(), false);
-		m_LastGroundHeight = a_PosY;
 		m_bIsTeleporting = true;
 
 		m_World->BroadcastTeleportEntity(*this, GetClientHandle());


### PR DESCRIPTION
Prevents fall damage after teleporting/portaling to a lower height.

Fixes #3457