### PR TITLE
Reimplemented fall particles

### DIFF
--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -428,9 +428,14 @@ void cPawn::HandleFalling(void)
 			TakeDamage(dtFalling, nullptr, Damage, Damage, 0);
 
 			// Fall particles
-			// TODO: Re-enable this when effects in 1.9 aren't broken (right now this uses the wrong effect ID in 1.9 and the right one in 1.8)
-			// int ParticleSize = static_cast<int>((std::min(15, Damage) - 1.f) * ((50.f - 20.f) / (15.f - 1.f)) + 20.f);
-			// GetWorld()->BroadcastSoundParticleEffect(EffectID::PARTICLE_FALL_PARTICLES, POSX_TOINT, POSY_TOINT - 1, POSZ_TOINT, ParticleSize);
+			GetWorld()->BroadcastParticleEffect(
+				"blockdust",
+				GetPosition(),
+				{ 0, 0, 0 },
+				(Damage - 1.f) * ((0.3f - 0.1f) / (15.f - 1.f)) + 0.1f,  // Map damage (1 - 15) to particle speed (0.1 - 0.3)
+				static_cast<int>((Damage - 1.f) * ((50.f - 20.f) / (15.f - 1.f)) + 20.f),  // Map damage (1 - 15) to particle quantity (20 - 50)
+				{ { GetWorld()->GetBlock(POS_TOINT - Vector3i(0, 1, 0)), 0 } }
+			);
 		}
 
 		m_bTouchGround = true;


### PR DESCRIPTION
Regression when 1.9.x support introduced in #3135, originally implemented in #461.