### PR TITLE
Ocelots no longer multiply exponentially

### DIFF
--- a/src/Mobs/Ocelot.cpp
+++ b/src/Mobs/Ocelot.cpp
@@ -11,6 +11,15 @@
 
 
 
+// TODO: Ocelots should have a chance of spawning with two kittens
+/*
+	if (!IsBaby() && GetRandomProvider().RandBool(1.0 / 7.0))
+	{
+		m_World->SpawnMob(GetPosX(), GetPosY(), GetPosZ(), m_MobType, true);
+		m_World->SpawnMob(GetPosX(), GetPosY(), GetPosZ(), m_MobType, true);
+	}
+*/
+
 cOcelot::cOcelot(void) :
 	super("Ocelot", mtOcelot, "entity.cat.hurt", "entity.cat.death", 0.6, 0.8),
 	m_IsSitting(false),
@@ -179,20 +188,6 @@ void cOcelot::OnRightClicked(cPlayer & a_Player)
 		SetIsSitting(!IsSitting());
 	}
 	m_World->BroadcastEntityMetadata(*this);
-}
-
-
-
-
-
-void cOcelot::SpawnOn(cClientHandle & a_ClientHandle)
-{
-	super::SpawnOn(a_ClientHandle);
-	if (!IsBaby() && GetRandomProvider().RandBool(1.0 / 7.0))
-	{
-		m_World->SpawnMob(GetPosX(), GetPosY(), GetPosZ(), m_MobType, true);
-		m_World->SpawnMob(GetPosX(), GetPosY(), GetPosZ(), m_MobType, true);
-	}
 }
 
 

--- a/src/Mobs/Ocelot.h
+++ b/src/Mobs/Ocelot.h
@@ -30,7 +30,6 @@ public:
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void TickFollowPlayer();
-	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 	virtual void GetBreedingItems(cItems & a_Items) override
 	{
 		a_Items.Add(E_ITEM_RAW_FISH);


### PR DESCRIPTION
Along with a call to `destroyentities`, this fixes #4271

I'm guessing the intention of this code was to modify the normal spawning of ocelots. However, `cEntity::SpawnOn` is actually called to send the entity to an individual client.  That means this code was run for every single player, every time they were sent a chunk with ocelots in it.  Thus, the ocelots population would grow exponentially as players log in and move around.