### PR TITLE
WIP: Sol2 interoperability with tolua++

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -63,3 +63,6 @@
 	path = lib/fmt
 	url = https://github.com/fmtlib/fmt.git
 	ignore = dirty
+[submodule "lib/sol2"]
+	path = lib/sol2
+	url = https://github.com/ThePHD/sol2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ add_subdirectory(lib/fmt)
 # sol2 configuration
 add_definitions(-DSOL_CHECK_ARGUMENTS=1)     # perform argument checking
 add_definitions(-DSOL_STRINGS_ARE_NUMBERS=1) # allow coercion from string to numeric types
+add_definitions(-DSOL_ENABLE_INTEROP=1)      # required to work with tolua++ usertypes
 include_directories(SYSTEM "${CMAKE_CURRENT_LIST_DIR}/lib/sol2/single/sol")
 
 # Add proper include directories so that SQLiteCpp can find SQLite3:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,9 @@ endif()
 if (NOT EXISTS ${PROJECT_SOURCE_DIR}/lib/luaproxy/CMakeLists.txt)
 	message(FATAL_ERROR "luaproxy is missing in folder lib/luaproxy. Have you initialized and updated the submodules / downloaded the extra libraries?")
 endif()
+if (NOT EXISTS ${PROJECT_SOURCE_DIR}/lib/sol2/CMakeLists.txt)
+	message(FATAL_ERROR "sol2 is missing in folder lib/sol2. Have you initialized and updated the submodules / downloaded the extra libraries?")
+endif()
 if (NOT EXISTS ${PROJECT_SOURCE_DIR}/lib/sqlite/CMakeLists.txt)
 	message(FATAL_ERROR "sqlite is missing in folder lib/sqlite. Have you initialized and updated the submodules / downloaded the extra libraries?")
 endif()
@@ -261,6 +264,10 @@ add_subdirectory(lib/luaexpat/)
 add_subdirectory(lib/libevent/ EXCLUDE_FROM_ALL)
 add_subdirectory(lib/fmt)
 
+# sol2 configuration
+add_definitions(-DSOL_CHECK_ARGUMENTS=1)     # perform argument checking
+add_definitions(-DSOL_STRINGS_ARE_NUMBERS=1) # allow coercion from string to numeric types
+include_directories(SYSTEM "${CMAKE_CURRENT_LIST_DIR}/lib/sol2/single/sol")
 
 # Add proper include directories so that SQLiteCpp can find SQLite3:
 get_property(SQLITECPP_INCLUDES DIRECTORY "lib/SQLiteCpp/" PROPERTY INCLUDE_DIRECTORIES)

--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -32,6 +32,9 @@ endmacro()
 
 
 macro(set_flags)
+	set(CMAKE_CXX_STANDARD 14)
+	set(CMAKE_CXX_EXTENTIONS OFF)
+
 	# Add coverage processing, if requested:
 	if (NOT MSVC)
 
@@ -74,11 +77,6 @@ macro(set_flags)
 			)
 		endif()
 
-		set(CMAKE_CXX_FLAGS          "${CMAKE_CXX_FLAGS}          -std=c++11")
-		set(CMAKE_CXX_FLAGS_DEBUG    "${CMAKE_CXX_FLAGS_DEBUG}    -std=c++11")
-		set(CMAKE_CXX_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_COVERAGE} -std=c++11")
-		set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}  -std=c++11")
-
 		#on os x clang adds pthread for us but we need to add it for gcc
 		if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 			add_flags_cxx("-stdlib=libc++")
@@ -87,11 +85,6 @@ macro(set_flags)
 			add_flags_cxx("-pthread")
 		endif()
 	elseif (ANDROID)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -std=c++11")
-		set(CMAKE_CXX_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_COVERAGE} -std=c++11")
-		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=c++11")
-		
 		add_flags_cxx("-fsigned-char")
 	else()
 		# Let gcc / clang know that we're compiling a multi-threaded app:
@@ -106,11 +99,6 @@ macro(set_flags)
 				OUTPUT_VARIABLE GCC_VERSION
 			)
 		endif()
-
-		set(CMAKE_CXX_FLAGS          "${CMAKE_CXX_FLAGS}          -std=c++11")
-		set(CMAKE_CXX_FLAGS_DEBUG    "${CMAKE_CXX_FLAGS_DEBUG}    -std=c++11")
-		set(CMAKE_CXX_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_COVERAGE} -std=c++11")
-		set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}  -std=c++11")
 
 		# We use a signed char (fixes #640 on RasPi)
 		add_flags_cxx("-fsigned-char")
@@ -307,20 +295,3 @@ macro(set_exe_flags)
 	endif()
 
 endmacro()
-
-#	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-#		foreach(FILENAME ${ARGN})
-#			message("downgrade_warnings for ${FILENAME}")
-#			set_source_files_properties(${FILENAME} PROPERTIES COMPILE_FLAGS "-Wno-error=sign-conversion -Wno-error=conversion")
-#			set_source_files_properties(${FILENAME} PROPERTIES COMPILE_FLAGS "-Wno-error=missing-prototypes -Wno-error=deprecated")
-#			set_source_files_properties(${FILENAME} PROPERTIES COMPILE_FLAGS "-Wno-error=shadow -Wno-error=old-style-cast  -Wno-error=switch-enum -Wno-error=switch")
-#			set_source_files_properties(${FILENAME} PROPERTIES COMPILE_FLAGS "-Wno-error=float-equal -Wno-error=global-constructors")
-
-#			if ("${CLANG_VERSION}" VERSION_GREATER 3.0)
-#				# flags that are not present in 3.0
-#				set_source_files_properties(${FILENAME} PROPERTIES COMPILE_FLAGS "-Wno-error=covered-switch-default ")
-#				set_source_files_properties(${FILENAME} PROPERTIES COMPILE_FLAGS "-Wno-implicit-fallthrough -Wno-error=extra-semi")
-#				set_source_files_properties(${FILENAME} PROPERTIES COMPILE_FLAGS "-Wno-error=missing-variable-declarations")
-#			endif()
-#		endforeach()
-#	endif()

--- a/src/Bindings/.gitignore
+++ b/src/Bindings/.gitignore
@@ -3,3 +3,4 @@ lua51.dll
 LuaState_Declaration.inc
 LuaState_Implementation.cpp
 LuaState_Typedefs.inc
+SolInterop.h

--- a/src/Bindings/CMakeLists.txt
+++ b/src/Bindings/CMakeLists.txt
@@ -11,7 +11,6 @@ SET (SRCS
 	LuaNameLookup.cpp
 	LuaServerHandle.cpp
 	LuaState.cpp
-	LuaState_Implementation.cpp
 	LuaTCPLink.cpp
 	LuaUDPEndpoint.cpp
 	LuaWindow.cpp
@@ -34,8 +33,6 @@ SET (HDRS
 	LuaNameLookup.h
 	LuaServerHandle.h
 	LuaState.h
-	LuaState_Declaration.inc
-	LuaState_Typedefs.inc
 	LuaTCPLink.h
 	LuaUDPEndpoint.h
 	LuaWindow.h
@@ -43,6 +40,7 @@ SET (HDRS
 	Plugin.h
 	PluginLua.h
 	PluginManager.h
+	SolInterop.h
 	tolua++.h
 )
 
@@ -50,9 +48,7 @@ SET (HDRS
 set (BINDING_OUTPUTS
 	${CMAKE_CURRENT_SOURCE_DIR}/Bindings.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Bindings.h
-	${CMAKE_CURRENT_SOURCE_DIR}/LuaState_Declaration.inc
-	${CMAKE_CURRENT_SOURCE_DIR}/LuaState_Implementation.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/LuaState_Typedefs.inc
+	${CMAKE_CURRENT_SOURCE_DIR}/SolInterop.h
 )
 
 set(BINDING_DEPENDENCIES

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -6,11 +6,7 @@
 #include "Globals.h"
 #include "LuaState.h"
 
-extern "C"
-{
-	#include "lua/src/lualib.h"
-}
-
+#include <lua.hpp>
 #undef TOLUA_TEMPLATE_BIND
 #include "tolua++/include/tolua++.h"
 #include "Bindings.h"
@@ -825,17 +821,6 @@ bool cLuaState::PushFunction(const cRef & a_TableRef, const char * a_FnName)
 
 
 
-void cLuaState::Push(const AString & a_String)
-{
-	ASSERT(IsValid());
-
-	lua_pushlstring(m_LuaState, a_String.data(), a_String.size());
-}
-
-
-
-
-
 void cLuaState::Push(const AStringMap & a_Dictionary)
 {
 	ASSERT(IsValid());
@@ -866,17 +851,6 @@ void cLuaState::Push(const AStringVector & a_Vector)
 		tolua_pushstring(m_LuaState, itr->c_str());
 		lua_rawseti(m_LuaState, newTable, index);
 	}
-}
-
-
-
-
-
-void cLuaState::Push(const char * a_Value)
-{
-	ASSERT(IsValid());
-
-	tolua_pushstring(m_LuaState, a_Value);
 }
 
 
@@ -1036,50 +1010,6 @@ void cLuaState::Push(cLuaUDPEndpoint * a_UDPEndpoint)
 
 
 
-void cLuaState::Push(double a_Value)
-{
-	ASSERT(IsValid());
-
-	tolua_pushnumber(m_LuaState, a_Value);
-}
-
-
-
-
-
-void cLuaState::Push(int a_Value)
-{
-	ASSERT(IsValid());
-
-	tolua_pushnumber(m_LuaState, a_Value);
-}
-
-
-
-
-
-void cLuaState::Push(long a_Value)
-{
-	ASSERT(IsValid());
-
-	tolua_pushnumber(m_LuaState, static_cast<lua_Number>(a_Value));
-}
-
-
-
-
-
-void cLuaState::Push(UInt32 a_Value)
-{
-	ASSERT(IsValid());
-
-	tolua_pushnumber(m_LuaState, a_Value);
-}
-
-
-
-
-
 void cLuaState::Push(std::chrono::milliseconds a_Value)
 {
 	ASSERT(IsValid());
@@ -1174,16 +1104,6 @@ bool cLuaState::GetStackValue(int a_StackPos, AStringVector & a_Value)
 		}
 	);
 	return isValid;
-}
-
-
-
-
-
-bool cLuaState::GetStackValue(int a_StackPos, bool & a_ReturnedVal)
-{
-	a_ReturnedVal = (tolua_toboolean(m_LuaState, a_StackPos, a_ReturnedVal ? 1 : 0) > 0);
-	return true;
 }
 
 
@@ -1345,20 +1265,6 @@ bool cLuaState::GetStackValue(int a_StackPos, cTrackedRefSharedPtr & a_Ref)
 
 
 
-bool cLuaState::GetStackValue(int a_StackPos, double & a_ReturnedVal)
-{
-	if (lua_isnumber(m_LuaState, a_StackPos))
-	{
-		a_ReturnedVal = tolua_tonumber(m_LuaState, a_StackPos, a_ReturnedVal);
-		return true;
-	}
-	return false;
-}
-
-
-
-
-
 bool cLuaState::GetStackValue(int a_StackPos, eBlockFace & a_ReturnedVal)
 {
 	if (!lua_isnumber(m_LuaState, a_StackPos))
@@ -1387,20 +1293,6 @@ bool cLuaState::GetStackValue(int a_StackPos, eWeather & a_ReturnedVal)
 		static_cast<int>(wSunny), static_cast<int>(wThunderstorm))
 	);
 	return true;
-}
-
-
-
-
-
-bool cLuaState::GetStackValue(int a_StackPos, float & a_ReturnedVal)
-{
-	if (lua_isnumber(m_LuaState, a_StackPos))
-	{
-		a_ReturnedVal = static_cast<float>(tolua_tonumber(m_LuaState, a_StackPos, a_ReturnedVal));
-		return true;
-	}
-	return false;
 }
 
 

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -657,13 +657,12 @@ public:
 	template <typename T>
 	bool GetStackValue(int a_StackPos, T & a_Value)
 	{
-		sol::optional<T> Val = sol::stack::check_get<T>(m_LuaState, a_StackPos);
-		if (!Val)
+		if (!sol::stack::check<T>(m_LuaState, a_StackPos))
 		{
 			return false;
 		}
 
-		a_Value = Val.value();
+		a_Value = sol::stack::get<T>(m_LuaState, a_StackPos);
 		return true;
 	}
 

--- a/src/Bindings/ManualBindings.h
+++ b/src/Bindings/ManualBindings.h
@@ -16,6 +16,8 @@
 
 // fwd:
 struct tolua_Error;
+class cPluginLua;
+class cBoundingBox;
 
 
 

--- a/src/Bindings/ManualBindings_BlockArea.cpp
+++ b/src/Bindings/ManualBindings_BlockArea.cpp
@@ -11,6 +11,8 @@
 #include "PluginLua.h"
 #include "../WorldStorage/SchematicFileSerializer.h"
 
+#include "../BlockEntities/BlockEntity.h"
+
 
 
 

--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -12,260 +12,178 @@
 #include "PluginLua.h"
 #include "LuaChunkStay.h"
 
+#include "../Entities/Player.h"
 
-/** Check that a Lua parameter is either a vector or 3 numbers in sequence
-\param L The Lua state
-\param a_VectorName name of the vector class e.g. "Vector3<int>"
-\param a_Index Index to the start of the vector in the parameter list
-\param[out] a_NextIndex Index of the next parameter after the vector
-\retval true if the parameter is a vector or 3 numbers */
-static bool CheckParamVectorOr3Numbers(cLuaState & L, const char * a_VectorName, int a_Index, int & a_NextIndex)
+#include "../BlockEntities/BeaconEntity.h"
+#include "../BlockEntities/BedEntity.h"
+#include "../BlockEntities/BrewingstandEntity.h"
+#include "../BlockEntities/ChestEntity.h"
+#include "../BlockEntities/CommandBlockEntity.h"
+#include "../BlockEntities/DispenserEntity.h"
+#include "../BlockEntities/DropperEntity.h"
+#include "../BlockEntities/FlowerPotEntity.h"
+#include "../BlockEntities/FurnaceEntity.h"
+#include "../BlockEntities/MobHeadEntity.h"
+#include "../BlockEntities/NoteEntity.h"
+
+
+
+
+
+static void BindSolFunctions(lua_State * tolua_S)
 {
-	if (L.IsParamUserType(a_Index, a_VectorName))
-	{
-		a_NextIndex = a_Index + 1;
-		return L.CheckParamUserType(a_Index, a_VectorName);
-	}
+	sol::table World(tolua_S);
+	World["BroadcastBlockAction"] = sol::overload(
+		[](sol::this_state a_L, cWorld & a_World, int a_BlockX, int a_BlockY, int a_BlockZ, Byte a_Byte1, Byte a_Byte2, BLOCKTYPE a_BlockType, cClientHandle * a_ClientHandle)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastBlockAction with 3 position arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastBlockAction({a_BlockX, a_BlockY, a_BlockZ}, a_Byte1, a_Byte2, a_BlockType, a_ClientHandle);
+		},
+		[](sol::this_state a_L, cWorld & a_World, int a_BlockX, int a_BlockY, int a_BlockZ, Byte a_Byte1, Byte a_Byte2, BLOCKTYPE a_BlockType)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastBlockAction with 3 position arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastBlockAction({a_BlockX, a_BlockY, a_BlockZ}, a_Byte1, a_Byte2, a_BlockType);
+		},
+		[](cWorld & a_World, Vector3i & a_BlockPos, Byte a_Byte1, Byte a_Byte2, BLOCKTYPE a_BlockType, cClientHandle * a_ClientHandle)
+		{
+			return a_World.BroadcastBlockAction(a_BlockPos, a_Byte1, a_Byte2, a_BlockType, a_ClientHandle);
+		},
+		[](cWorld & a_World, Vector3i & a_BlockPos, Byte a_Byte1, Byte a_Byte2, BLOCKTYPE a_BlockType)
+		{
+			return a_World.BroadcastBlockAction(a_BlockPos, a_Byte1, a_Byte2, a_BlockType);
+		}
+	);
 
-	a_NextIndex = a_Index + 3;
-	return L.CheckParamNumber(a_Index, a_Index + 2);
-}
+	World["BroadcastSoundEffect"] = sol::overload(
+		[](sol::this_state a_L, cWorld & a_World, AString a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch, cClientHandle * a_Exclude)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastSoundEffect with 3 position arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastSoundEffect(a_SoundName, {a_X, a_Y, a_Z}, a_Volume, a_Pitch, a_Exclude);
+		},
+		[](sol::this_state a_L, cWorld & a_World, AString a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastSoundEffect with 3 position arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastSoundEffect(a_SoundName, {a_X, a_Y, a_Z}, a_Volume, a_Pitch);
+		},
+		[](cWorld & a_World, AString a_SoundName, Vector3d a_SoundPos, float a_Volume, float a_Pitch, cClientHandle * a_Exclude)
+		{
+			return a_World.BroadcastSoundEffect(a_SoundName, a_SoundPos, a_Volume, a_Pitch, a_Exclude);
+		},
+		[](cWorld & a_World, AString a_SoundName, Vector3d a_SoundPos, float a_Volume, float a_Pitch)
+		{
+			return a_World.BroadcastSoundEffect(a_SoundName, a_SoundPos, a_Volume, a_Pitch);
+		}
+	);
 
+	World["BroadcastSoundParticleEffect"] = sol::overload(
+		[](sol::this_state a_L, cWorld & a_World, EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data, cClientHandle * a_Exclude)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastSoundParticleEffect with 3 position arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastSoundParticleEffect(a_EffectID, {a_SrcX, a_SrcY, a_SrcZ}, a_Data, a_Exclude);
+		},
+		[](sol::this_state a_L, cWorld & a_World, EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastSoundParticleEffect with 3 position arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastSoundParticleEffect(a_EffectID, {a_SrcX, a_SrcY, a_SrcZ}, a_Data);
+		},
+		[](cWorld & a_World, EffectID a_EffectID, Vector3i a_SrcPos, int a_Data, cClientHandle * a_Exclude)
+		{
+			return a_World.BroadcastSoundParticleEffect(a_EffectID, a_SrcPos, a_Data, a_Exclude);
+		},
+		[](cWorld & a_World, EffectID a_EffectID, Vector3i a_SrcPos, int a_Data)
+		{
+			return a_World.BroadcastSoundParticleEffect(a_EffectID, a_SrcPos, a_Data);
+		}
+	);
 
-
-
-
-/** Get a vector from the stack, which may be represented in lua as either a `Vector3<T>` or 3 numbers */
-template <typename T>
-static bool GetStackVectorOr3Numbers(cLuaState & L, int a_Index, Vector3<T> & a_Return)
-{
-	Vector3<T> * UserType;
-	if (L.GetStackValue(a_Index, UserType))
-	{
-		a_Return = *UserType;
-		return true;
-	}
-	return L.GetStackValues(a_Index, a_Return.x, a_Return.y, a_Return.z);
-}
-
-
-
-
-
-static int tolua_cWorld_BroadcastBlockAction(lua_State * tolua_S)
-{
-	/* Function signature:
-	void BroadcastBlockAction(number a_BlockX, number a_BlockY, number a_BlockZ, number a_number1, number a_number2, number a_BlockType, cClientHandle a_Exclude)
-	--or--
-	void BroadcastBlockAction(Vector3<int> a_BlockPos, number a_Byte1, number a_Byte2, number a_BlockType, cClientHandle a_Exclude)
-	*/
-
-	cLuaState L(tolua_S);
-	int Byte1Index;
-	if (
-		!L.CheckParamSelf("cWorld") ||
-		!CheckParamVectorOr3Numbers(L, "Vector3<int>", 2, Byte1Index) ||
-		!L.CheckParamNumber(Byte1Index, Byte1Index + 2)
-	)
-	{
-		return 0;
-	}
-
-	if (Byte1Index != 3)  // Not the vector overload
-	{
-		L.LogStackTrace();
-		LOGWARN("BroadcastBlockAction with 3 position arguments is deprecated, use vector-parametered version instead.");
-	}
-
-	// Read the params:
-	cWorld * Self;
-	Vector3i BlockPos;
-	Byte Byte1, Byte2;
-	BLOCKTYPE BlockType;
-	const cClientHandle * Exclude = nullptr;
-
-	if (
-		!L.GetStackValues(1, Self) ||
-		!GetStackVectorOr3Numbers(L, 2, BlockPos) ||
-		!L.GetStackValues(Byte1Index, Byte1, Byte2, BlockType)
-	)
-	{
-		return 0;
-	}
-
-	// Optional param
-	L.GetStackValue(Byte1Index + 3, Exclude);
-
-	Self->BroadcastBlockAction(BlockPos, Byte1, Byte2, BlockType, Exclude);
-	return 0;
-}
-
-
-
-
-
-static int tolua_cWorld_BroadcastSoundEffect(lua_State * tolua_S)
-{
-	/* Function signature:
-	void BroadcastSoundEffect(string a_SoundName, number a_X, number a_Y, number a_Z, number a_Volume, number a_Pitch, [cClientHandle * a_Exclude])
-	--or--
-	void BroadcastSoundEffect(string a_SoundName, Vector3d, number a_Volume, number a_Pitch, [cClientHandle a_Exclude])
-	*/
-	cLuaState L(tolua_S);
-	int VolumeIndex;
-	if (
-		!L.CheckParamSelf("cWorld") ||
-		!L.CheckParamString(2) ||
-		!CheckParamVectorOr3Numbers(L, "Vector3<double>", 3, VolumeIndex) ||
-		!L.CheckParamNumber(VolumeIndex, VolumeIndex + 1)
-	)
-	{
-		return 0;
-	}
-
-	if (VolumeIndex != 4)  // Not the vector overload
-	{
-		L.LogStackTrace();
-		LOGWARN("BroadcastSoundEffect with 3 position arguments is deprecated, use vector-parametered version instead.");
-	}
-
-	// Read the params:
-	cWorld * Self;
-	AString SoundName;
-	Vector3d BlockPos;
-	float Volume, Pitch;
-	const cClientHandle * Exclude = nullptr;
-
-	if (
-		!L.GetStackValues(1, Self, SoundName) ||
-		!GetStackVectorOr3Numbers(L, 3, BlockPos) ||
-		!L.GetStackValues(VolumeIndex, Volume, Pitch)
-	)
-	{
-		return 0;
-	}
-
-	// Optional param
-	L.GetStackValue(VolumeIndex + 2, Exclude);
-
-	Self->BroadcastSoundEffect(SoundName, BlockPos, Volume, Pitch, Exclude);
-	return 0;
-}
-
-
-
-
-
-static int tolua_cWorld_BroadcastSoundParticleEffect(lua_State * tolua_S)
-{
-	/* Function signature:
-	World:BroadcastSoundParticleEffect(EffectID a_EffectID, Vector3i a_SrcPos, number a_Data, [cClientHandle a_Exclude])
-	--or--
-	void BroadcastSoundParticleEffect(EffectID a_EffectID, number a_SrcX, number a_SrcY, number a_SrcZ, number a_Data, [cClientHandle a_Exclude])
-	*/
-	cLuaState L(tolua_S);
-	int DataIndex;
-	if (
-		!L.CheckParamSelf("cWorld") ||
-		!L.CheckParamNumber(2) ||
-		!CheckParamVectorOr3Numbers(L, "Vector3<int>", 3, DataIndex) ||
-		!L.CheckParamNumber(DataIndex)
-	)
-	{
-		return 0;
-	}
-
-	if (DataIndex != 4)  // Not the vector overload
-	{
-		L.LogStackTrace();
-		LOGWARN("BroadcastSoundParticleEffect with 3 position arguments is deprecated, use vector-parametered version instead.");
-	}
-
-	// Read the params:
-	cWorld * World = nullptr;
-	Int32 EffectId;
-	Vector3i SrcPos;
-	int Data;
-	cClientHandle * ExcludeClient = nullptr;
-
-	if (
-		!L.GetStackValues(1, World, EffectId) ||
-		!GetStackVectorOr3Numbers(L, 3, SrcPos) ||
-		!L.GetStackValue(DataIndex, Data)
-	)
-	{
-		return 0;
-	}
-
-	// Optional param
-	L.GetStackValue(DataIndex + 1, ExcludeClient);
-
-	World->BroadcastSoundParticleEffect(static_cast<EffectID>(EffectId), SrcPos, Data, ExcludeClient);
-	return 0;
-}
-
-
-
-
-
-static int tolua_cWorld_BroadcastParticleEffect(lua_State * tolua_S)
-{
-	/* Function signature:
-	World:BroadcastParticleEffect("Name", PosX, PosY, PosZ, OffX, OffY, OffZ, ParticleData, ParticleAmount, [ExcludeClient], [OptionalParam1], [OptionalParam2])
-	--or--
-	World:BroadcastParticleEffect("Name", SrcPos, Offset, ParticleData, ParticleAmount, [ExcludeClient], [OptionalParam1], [OptionalParam2])
-	*/
-	cLuaState L(tolua_S);
-	int OffsetIndex, ParticleDataIndex;
-	if (
-		!L.CheckParamSelf("cWorld") ||
-		!L.CheckParamString(2) ||
-		!CheckParamVectorOr3Numbers(L, "Vector3<float>", 3, OffsetIndex) ||
-		!CheckParamVectorOr3Numbers(L, "Vector3<float>", OffsetIndex, ParticleDataIndex)
-	)
-	{
-		return 0;
-	}
-
-	if ((OffsetIndex != 4) || (ParticleDataIndex != 5))  // Not the vector overload
-	{
-		L.LogStackTrace();
-		LOGWARN("BroadcastParticleEffect with 3 position and 3 offset arguments is deprecated, use vector-parametered version instead.");
-	}
-
-	// Read the params:
-	cWorld * World = nullptr;
-	AString Name;
-	Vector3f SrcPos, Offset;
-	float ParticleData;
-	int ParticleAmount;
-	cClientHandle * ExcludeClient = nullptr;
-
-	if (
-		!L.GetStackValues(1, World, Name) ||
-		!GetStackVectorOr3Numbers(L, 3, SrcPos) ||
-		!GetStackVectorOr3Numbers(L, OffsetIndex, Offset) ||
-		!L.GetStackValues(ParticleDataIndex, ParticleData, ParticleAmount)
-	)
-	{
-		return 0;
-	}
-
-	// Read up to 3 more optional params:
-	L.GetStackValue(ParticleDataIndex + 2, ExcludeClient);
-
-	std::array<int, 2> Data;
-	bool HasData = L.GetStackValues(ParticleDataIndex + 3, Data[0], Data[1]);
-
-	if (HasData)
-	{
-		World->BroadcastParticleEffect(Name, SrcPos, Offset, ParticleData, ParticleAmount, Data, ExcludeClient);
-	}
-	else
-	{
-		World->BroadcastParticleEffect(Name, SrcPos, Offset, ParticleData, ParticleAmount, ExcludeClient);
-	}
-	return 0;
+	World["BroadcastParticleEffect"] = sol::overload(
+		[](
+			sol::this_state a_L, cWorld & a_World, AString a_Name,
+			float a_PosX, float a_PosY, float a_PosZ, float a_OffX, float a_OffY, float a_OffZ,
+			float a_ParticleData, int a_ParticleAmount, cClientHandle * a_Exclude
+		)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastParticleEffect with 3 position and 3 offset arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastParticleEffect(
+				a_Name, {a_PosX, a_PosY, a_PosZ}, {a_OffX, a_OffY, a_OffZ},
+				a_ParticleData, a_ParticleAmount, a_Exclude
+			);
+		},
+		[](
+			sol::this_state a_L, cWorld & a_World, AString a_Name,
+			float a_PosX, float a_PosY, float a_PosZ, float a_OffX, float a_OffY, float a_OffZ,
+			float a_ParticleData, int a_ParticleAmount
+		)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastParticleEffect with 3 position and 3 offset arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastParticleEffect(
+				a_Name, {a_PosX, a_PosY, a_PosZ}, {a_OffX, a_OffY, a_OffZ},
+				a_ParticleData, a_ParticleAmount
+			);
+		},
+		[](
+			sol::this_state a_L, cWorld & a_World, AString a_Name, float a_PosX, float a_PosY, float a_PosZ,
+			float a_OffX, float a_OffY, float a_OffZ, float a_ParticleData, int a_ParticleAmount,
+			cClientHandle * a_Exclude
+		)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastParticleEffect with 3 position and 3 offset arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastParticleEffect(
+				a_Name, {a_PosX, a_PosY, a_PosZ}, {a_OffX, a_OffY, a_OffZ},
+				a_ParticleData, a_ParticleAmount, a_Exclude
+			);
+		},
+		[](
+			sol::this_state a_L, cWorld & a_World, AString a_Name, float a_PosX, float a_PosY, float a_PosZ,
+			float a_OffX, float a_OffY, float a_OffZ, float a_ParticleData, int a_ParticleAmount
+		)
+		{
+			cLuaState::LogStackTrace(a_L);
+			LOGWARN("BroadcastParticleEffect with 3 position and 3 offset arguments is deprecated, use vector-parametered version instead.");
+			return a_World.BroadcastParticleEffect(
+				a_Name, {a_PosX, a_PosY, a_PosZ}, {a_OffX, a_OffY, a_OffZ},
+				a_ParticleData, a_ParticleAmount
+			);
+		},
+		[](
+			cWorld & a_World, AString a_Name, Vector3f a_SrcPos, Vector3f a_Offset,
+			float a_ParticleData, int a_ParticleAmount, cClientHandle * a_Exclude,
+			int a_Data1, int a_Data2
+		)
+		{
+			std::array<int, 2> Data{{a_Data1, a_Data2}};
+			return a_World.BroadcastParticleEffect(
+				a_Name, a_SrcPos, a_Offset, a_ParticleData, a_ParticleAmount, Data, a_Exclude
+			);
+		},
+		[](
+			cWorld & a_World, AString a_Name, Vector3f a_SrcPos, Vector3f a_Offset,
+			float a_ParticleData, int a_ParticleAmount, cClientHandle * a_Exclude
+		)
+		{
+			return a_World.BroadcastParticleEffect(
+				a_Name, a_SrcPos, a_Offset, a_ParticleData, a_ParticleAmount, a_Exclude
+			);
+		},
+		[](
+			cWorld & a_World, AString a_Name, Vector3f a_SrcPos, Vector3f a_Offset,
+			float a_ParticleData, int a_ParticleAmount
+		)
+		{
+			return a_World.BroadcastParticleEffect(
+				a_Name, a_SrcPos, a_Offset, a_ParticleData, a_ParticleAmount
+			);
+		}
+	);
 }
 
 
@@ -878,10 +796,7 @@ void cManualBindings::BindWorld(lua_State * tolua_S)
 {
 	tolua_beginmodule(tolua_S, nullptr);
 		tolua_beginmodule(tolua_S, "cWorld");
-			tolua_function(tolua_S, "BroadcastBlockAction",         tolua_cWorld_BroadcastBlockAction);
-			tolua_function(tolua_S, "BroadcastSoundEffect",         tolua_cWorld_BroadcastSoundEffect);
-			tolua_function(tolua_S, "BroadcastSoundParticleEffect", tolua_cWorld_BroadcastSoundParticleEffect);
-			tolua_function(tolua_S, "BroadcastParticleEffect",      tolua_cWorld_BroadcastParticleEffect);
+			BindSolFunctions(tolua_S);
 			tolua_function(tolua_S, "ChunkStay",                    tolua_cWorld_ChunkStay);
 			tolua_function(tolua_S, "DoExplosionAt",                tolua_cWorld_DoExplosionAt);
 			tolua_function(tolua_S, "DoWithBeaconAt",               DoWithXYZ<cWorld, cBeaconEntity,       &cWorld::DoWithBeaconAt>);

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -12,11 +12,25 @@
 #endif
 
 #include "PluginLua.h"
+#include "../ClientHandle.h"
 #include "../CommandOutput.h"
+#include "../CraftingRecipes.h"
 #include "PluginManager.h"
 #include "../Item.h"
 #include "../Root.h"
 #include "../WebAdmin.h"
+#include "../World.h"
+
+#include "../Entities/GhastFireballEntity.h"
+#include "../Entities/Player.h"
+#include "../Entities/Pickup.h"
+#include "../Entities/TNTEntity.h"
+#include "../Entities/WitherSkullEntity.h"
+
+#include "../BlockEntities/BrewingstandEntity.h"
+#include "../BlockEntities/HopperEntity.h"
+
+#include "../Generating/ChunkDesc.h"
 
 extern "C"
 {

--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -2093,11 +2093,12 @@ bool cBlockArea::SetSize(int a_SizeX, int a_SizeY, int a_SizeZ, int a_DataTypes)
 	NIBBLEARRAY NewLight;
 	NIBBLEARRAY NewSkyLight;
 	cBlockEntitiesPtr NewBlockEntities;
+	auto NumBlocks = static_cast<size_t>(a_SizeX * a_SizeY * a_SizeZ);
 
 	// Try to allocate the new storage
 	if ((a_DataTypes & baTypes) != 0)
 	{
-		NewBlocks.reset(new BLOCKTYPE[a_SizeX * a_SizeY * a_SizeZ]);
+		NewBlocks.reset(new BLOCKTYPE[NumBlocks]);
 		if (NewBlocks == nullptr)
 		{
 			return false;
@@ -2105,7 +2106,7 @@ bool cBlockArea::SetSize(int a_SizeX, int a_SizeY, int a_SizeZ, int a_DataTypes)
 	}
 	if ((a_DataTypes & baMetas) != 0)
 	{
-		NewMetas.reset(new NIBBLETYPE[a_SizeX * a_SizeY * a_SizeZ]);
+		NewMetas.reset(new NIBBLETYPE[NumBlocks]);
 		if (NewMetas == nullptr)
 		{
 			return false;
@@ -2113,7 +2114,7 @@ bool cBlockArea::SetSize(int a_SizeX, int a_SizeY, int a_SizeZ, int a_DataTypes)
 	}
 	if ((a_DataTypes & baLight) != 0)
 	{
-		NewLight.reset(new NIBBLETYPE[a_SizeX * a_SizeY * a_SizeZ]);
+		NewLight.reset(new NIBBLETYPE[NumBlocks]);
 		if (NewLight == nullptr)
 		{
 			return false;
@@ -2121,7 +2122,7 @@ bool cBlockArea::SetSize(int a_SizeX, int a_SizeY, int a_SizeZ, int a_DataTypes)
 	}
 	if ((a_DataTypes & baSkyLight) != 0)
 	{
-		NewSkyLight.reset(new NIBBLETYPE[a_SizeX * a_SizeY * a_SizeZ]);
+		NewSkyLight.reset(new NIBBLETYPE[NumBlocks]);
 		if (NewSkyLight == nullptr)
 		{
 			return false;
@@ -2266,7 +2267,7 @@ void cBlockArea::CropBlockTypes(int a_AddMinX, int a_SubMaxX, int a_AddMinY, int
 	int NewSizeX = GetSizeX() - a_AddMinX - a_SubMaxX;
 	int NewSizeY = GetSizeY() - a_AddMinY - a_SubMaxY;
 	int NewSizeZ = GetSizeZ() - a_AddMinZ - a_SubMaxZ;
-	BLOCKARRAY NewBlockTypes{ new BLOCKTYPE[NewSizeX * NewSizeY * NewSizeZ] };
+	BLOCKARRAY NewBlockTypes{ new BLOCKTYPE[static_cast<size_t>(NewSizeX * NewSizeY * NewSizeZ)] };
 	size_t idx = 0;
 	for (int y = 0; y < NewSizeY; y++)
 	{
@@ -2291,7 +2292,7 @@ void cBlockArea::CropNibbles(NIBBLEARRAY & a_Array, int a_AddMinX, int a_SubMaxX
 	int NewSizeX = GetSizeX() - a_AddMinX - a_SubMaxX;
 	int NewSizeY = GetSizeY() - a_AddMinY - a_SubMaxY;
 	int NewSizeZ = GetSizeZ() - a_AddMinZ - a_SubMaxZ;
-	NIBBLEARRAY NewNibbles{ new NIBBLETYPE[NewSizeX * NewSizeY * NewSizeZ] };
+	NIBBLEARRAY NewNibbles{ new NIBBLETYPE[static_cast<size_t>(NewSizeX * NewSizeY * NewSizeZ)] };
 	size_t idx = 0;
 	for (int y = 0; y < NewSizeY; y++)
 	{

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories (SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/../lib/")
 include_directories (SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/../lib/jsoncpp/include")
 include_directories (SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/../lib/mbedtls/include")
 include_directories (SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/../lib/libevent/include")
+include_directories (SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/../lib/lua/src")
 
 set(FOLDERS
 	OSSupport HTTP Items Blocks Protocol Generating mbedTLS++ Bindings

--- a/src/CraftingRecipes.cpp
+++ b/src/CraftingRecipes.cpp
@@ -18,7 +18,7 @@
 cCraftingGrid::cCraftingGrid(int a_Width, int a_Height) :
 	m_Width(a_Width),
 	m_Height(a_Height),
-	m_Items(new cItem[a_Width * a_Height])
+	m_Items(new cItem[static_cast<size_t>(a_Width * a_Height)])
 {
 }
 
@@ -27,9 +27,7 @@ cCraftingGrid::cCraftingGrid(int a_Width, int a_Height) :
 
 
 cCraftingGrid::cCraftingGrid(const cItem * a_Items, int a_Width, int a_Height) :
-	m_Width(a_Width),
-	m_Height(a_Height),
-	m_Items(new cItem[a_Width * a_Height])
+	cCraftingGrid(a_Width, a_Height)
 {
 	for (int i = a_Width * a_Height - 1; i >= 0; i--)
 	{
@@ -42,9 +40,7 @@ cCraftingGrid::cCraftingGrid(const cItem * a_Items, int a_Width, int a_Height) :
 
 
 cCraftingGrid::cCraftingGrid(const cCraftingGrid & a_Original) :
-	m_Width(a_Original.m_Width),
-	m_Height(a_Original.m_Height),
-	m_Items(new cItem[a_Original.m_Width * a_Original.m_Height])
+	cCraftingGrid(a_Original.m_Width, a_Original.m_Height)
 {
 	for (int i = m_Width * m_Height - 1; i >= 0; i--)
 	{

--- a/src/Generating/CompoGen.cpp
+++ b/src/Generating/CompoGen.cpp
@@ -340,8 +340,8 @@ void cCompoGenNether::InitializeCompoGen(cIniFile & a_IniFile)
 cCompoGenCache::cCompoGenCache(cTerrainCompositionGenPtr a_Underlying, int a_CacheSize) :
 	m_Underlying(a_Underlying),
 	m_CacheSize(a_CacheSize),
-	m_CacheOrder(new int[a_CacheSize]),
-	m_CacheData(new sCacheData[a_CacheSize]),
+	m_CacheOrder(new int[static_cast<size_t>(a_CacheSize)]),
+	m_CacheData(new sCacheData[static_cast<size_t>(a_CacheSize)]),
 	m_NumHits(0),
 	m_NumMisses(0),
 	m_TotalChain(0)

--- a/src/LazyArray.h
+++ b/src/LazyArray.h
@@ -83,7 +83,7 @@ public:
 	{
 		if (m_Array == nullptr)
 		{
-			m_Array.reset(new T[m_Size]);
+			m_Array.reset(new T[static_cast<size_t>(m_Size)]);
 		}
 		return m_Array.get();
 	}

--- a/src/Noise/OctavedNoise.h
+++ b/src/Noise/OctavedNoise.h
@@ -61,7 +61,7 @@ public:
 		std::unique_ptr<NOISE_DATATYPE[]> workspaceHeap;
 		if (a_Workspace == nullptr)
 		{
-			workspaceHeap.reset(new NOISE_DATATYPE[a_SizeX * a_SizeY]);
+			workspaceHeap.reset(new NOISE_DATATYPE[static_cast<size_t>(a_SizeX * a_SizeY)]);
 			a_Workspace = workspaceHeap.get();
 		}
 
@@ -121,7 +121,7 @@ public:
 		std::unique_ptr<NOISE_DATATYPE[]> workspaceHeap;
 		if (a_Workspace == nullptr)
 		{
-			workspaceHeap.reset(new NOISE_DATATYPE[a_SizeX * a_SizeY * a_SizeZ]);
+			workspaceHeap.reset(new NOISE_DATATYPE[static_cast<size_t>(a_SizeX * a_SizeY * a_SizeZ)]);
 			a_Workspace = workspaceHeap.get();
 		}
 

--- a/src/Simulator/DelayedFluidSimulator.cpp
+++ b/src/Simulator/DelayedFluidSimulator.cpp
@@ -44,7 +44,7 @@ bool cDelayedFluidSimulatorChunkData::cSlot::Add(int a_RelX, int a_RelY, int a_R
 // cDelayedFluidSimulatorChunkData:
 
 cDelayedFluidSimulatorChunkData::cDelayedFluidSimulatorChunkData(int a_TickDelay) :
-	m_Slots(new cSlot[a_TickDelay])
+	m_Slots(new cSlot[static_cast<size_t>(a_TickDelay)])
 {
 }
 


### PR DESCRIPTION
This hopefully answers the third check mark in #4276.

With this, sol is able to fully interoperate with usertypes that are bound by tolua++.  That includes getting and pushing from/to the stack as well as adding new functions.  This will allow us to switch out the manual bindings without having to rewrite the bindings for the types that are taken as parameters.

This would be a temporary solution to help in the transition to sol2, after which we could hopefully drop tolua entirely.