### PR TITLE
Fix: Create players folder recursively

### DIFF
--- a/src/OSSupport/File.cpp
+++ b/src/OSSupport/File.cpp
@@ -474,7 +474,7 @@ bool cFile::CreateFolderRecursive(const AString & a_FolderPath)
 
 	// Go through each path element and create the folder:
 	auto len = a_FolderPath.length();
-	auto PathSep = GetPathSeparator()[0];
+	auto PathSep = '/';
 	for (decltype(len) i = 0; i < len; i++)
 	{
 		if (a_FolderPath[i] == PathSep)

--- a/src/OSSupport/File.cpp
+++ b/src/OSSupport/File.cpp
@@ -474,10 +474,13 @@ bool cFile::CreateFolderRecursive(const AString & a_FolderPath)
 
 	// Go through each path element and create the folder:
 	auto len = a_FolderPath.length();
-	auto PathSep = '/';
 	for (decltype(len) i = 0; i < len; i++)
 	{
-		if (a_FolderPath[i] == PathSep)
+	#ifdef _WIN32
+		if ((a_FolderPath[i] == '\\') || (a_FolderPath[i] == '/'))
+	#else
+		if (a_FolderPath[i] == '/')
+	#endif
 		{
 			CreateFolder(a_FolderPath.substr(0, i));
 		}


### PR DESCRIPTION
Problem: On a new server the players folder was not created on windows.

Root Cause:
`GetUUIDFolderName` was returning a folder structure for players with `/` while CreateFolderRecursively was checking for `\\` for win32. 

I struggled with the right approach. If I change `GetPathSeparator` it could have other implications. If I change `GetUUIDFolderName` it could also have other implications.

Let me know if you would like me to take a different approach on this fix. 

I know it's just a small fix, but it can save some windows server admins from having to add the players folder as a workaround.