### PR TITLE
Handle the lapis slot separately

### DIFF
--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1485,7 +1485,7 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 	if (a_SlotNum == 1)
 	{
 		// Lapis slot can have a full stack handle it normally, also check for empty hand
-		if ((DraggingItem.m_ItemType <= 0) || ((DraggingItem.m_ItemType == E_ITEM_DYE) && (DraggingItem.m_ItemDamage == E_META_DYE_BLUE)))
+		if ((DraggingItem.IsEmpty()) || ((DraggingItem.m_ItemType == E_ITEM_DYE) && (DraggingItem.m_ItemDamage == E_META_DYE_BLUE)))
 		{
 			return cSlotArea::Clicked(a_Player, a_SlotNum, a_ClickAction, a_ClickedItem);
 		}

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1535,7 +1535,7 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 
 void cSlotAreaEnchanting::DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_Apply, bool a_KeepEmptySlots, bool a_BackFill)
 {
-	if ((a_ItemStack.m_ItemType == E_ITEM_DYE) || (a_ItemStack.m_ItemDamage == E_META_DYE_BLUE))
+	if ((a_ItemStack.m_ItemType == E_ITEM_DYE) && (a_ItemStack.m_ItemDamage == E_META_DYE_BLUE))
 	{
 		// It's lapis, put it in the lapis spot.
 		const cItem * Slot = GetSlot(1, a_Player);

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1482,7 +1482,17 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 		bAsync = true;
 	}
 	cItem & DraggingItem = a_Player.GetDraggingItem();
-
+	if (a_SlotNum == 1)
+	{
+		// Lapis slot can have a full stack handle it normally
+		if (DraggingItem.m_ItemType != E_BLOCK_LAPIS_ORE)
+		{
+			// Don't slot if it's not lapis
+			return;
+		}
+		return cSlotArea::Clicked(a_Player, a_SlotNum, a_ClickAction, a_ClickedItem);
+	}
+	// Slot 0 is where the item to enhance goes.
 	if (DraggingItem.IsEmpty())
 	{
 		// DraggingItem is empty -> Switch draggingitem and slot

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1484,17 +1484,17 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 	cItem & DraggingItem = a_Player.GetDraggingItem();
 	if (a_SlotNum == 1)
 	{
-		// Lapis slot can have a full stack handle it normally
-		if ((DraggingItem.m_ItemType != E_ITEM_DYE) || (DraggingItem.m_ItemDamage != E_META_DYE_BLUE))
+		// Lapis slot can have a full stack handle it normally, also check for empty hand
+		if ((DraggingItem.m_ItemType <= 0) || (DraggingItem.m_ItemType == E_ITEM_DYE) && (DraggingItem.m_ItemDamage == E_META_DYE_BLUE))
 		{
-			// Don't slot if it's not lapis
-			if (bAsync)
-			{
-				m_ParentWindow.BroadcastWholeWindow();
-			}
-			return;
+			return cSlotArea::Clicked(a_Player, a_SlotNum, a_ClickAction, a_ClickedItem);
 		}
-		return cSlotArea::Clicked(a_Player, a_SlotNum, a_ClickAction, a_ClickedItem);
+
+		if (bAsync)
+		{
+			m_ParentWindow.BroadcastWholeWindow();
+		}
+		return;
 	}
 	// Slot 0 is where the item to enhance goes.
 	if (DraggingItem.IsEmpty())
@@ -1535,6 +1535,28 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 
 void cSlotAreaEnchanting::DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_Apply, bool a_KeepEmptySlots, bool a_BackFill)
 {
+	if ((a_ItemStack.m_ItemType == E_ITEM_DYE) || (a_ItemStack.m_ItemDamage == E_META_DYE_BLUE))
+	{
+		// It's lapis, put it in the lapis spot.
+		const cItem * Slot = GetSlot(1, a_Player);
+		char NumFit = ItemHandler(Slot->m_ItemType)->GetMaxStackSize() - Slot->m_ItemCount;
+		if (NumFit <= 0)
+		{
+			// Full stack already
+			return;
+		}
+		NumFit = std::min(NumFit, a_ItemStack.m_ItemCount);
+
+		if (a_Apply)
+		{
+			cItem NewSlot(a_ItemStack);
+			NewSlot.m_ItemCount = Slot->m_ItemCount + NumFit;
+			SetSlot(1, a_Player, NewSlot);
+		}
+		a_ItemStack.m_ItemCount -= NumFit;
+		// Return so we don't put overflow into the enchantment slot
+		return;
+	}
 	const cItem * Slot = GetSlot(0, a_Player);
 	if (!Slot->IsEmpty())
 	{

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1485,7 +1485,7 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 	if (a_SlotNum == 1)
 	{
 		// Lapis slot can have a full stack handle it normally, also check for empty hand
-		if ((DraggingItem.m_ItemType <= 0) || (DraggingItem.m_ItemType == E_ITEM_DYE) && (DraggingItem.m_ItemDamage == E_META_DYE_BLUE))
+		if ((DraggingItem.m_ItemType <= 0) || ((DraggingItem.m_ItemType == E_ITEM_DYE) && (DraggingItem.m_ItemDamage == E_META_DYE_BLUE)))
 		{
 			return cSlotArea::Clicked(a_Player, a_SlotNum, a_ClickAction, a_ClickedItem);
 		}

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1485,7 +1485,7 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 	if (a_SlotNum == 1)
 	{
 		// Lapis slot can have a full stack handle it normally
-		if (DraggingItem.m_ItemType != E_BLOCK_LAPIS_ORE)
+		if (DraggingItem.m_ItemType != E_ITEM_DYE && DraggingItem.m_ItemDamage == E_META_DYE_BLUE)
 		{
 			// Don't slot if it's not lapis
 			return;

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1485,9 +1485,13 @@ void cSlotAreaEnchanting::Clicked(cPlayer & a_Player, int a_SlotNum, eClickActio
 	if (a_SlotNum == 1)
 	{
 		// Lapis slot can have a full stack handle it normally
-		if (DraggingItem.m_ItemType != E_ITEM_DYE && DraggingItem.m_ItemDamage == E_META_DYE_BLUE)
+		if ((DraggingItem.m_ItemType != E_ITEM_DYE) || (DraggingItem.m_ItemDamage != E_META_DYE_BLUE))
 		{
 			// Don't slot if it's not lapis
+			if (bAsync)
+			{
+				m_ParentWindow.BroadcastWholeWindow();
+			}
 			return;
 		}
 		return cSlotArea::Clicked(a_Player, a_SlotNum, a_ClickAction, a_ClickedItem);


### PR DESCRIPTION
This is my attempt at a fix for issue #4112. The root cause of the issue was that the lapis slot was treated exactly the same as the enchanting slot, so it on the server side it would only ever slot one item. 

My fix is to check if its the second slot in the window, then check if it's lapis (it would slot whatever). If it is lapis I call the base click handler. 