### PR TITLE
Fixes bed item 26 and 355 (bed) being spawned, only 355 spawns now

### DIFF
--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -525,6 +525,7 @@ void cBlockHandler::DropBlock(cChunkInterface & a_ChunkInterface, cWorldInterfac
 				{
 					// Need to access the bed entity to get the color for the item damage
 					ConvertToPickups(a_WorldInterface, Pickups, Meta, a_BlockX, a_BlockY, a_BlockZ);
+					break;
 				}
 				case E_BLOCK_ENDER_CHEST:
 				{


### PR DESCRIPTION
I was compiling the server and found there was a switch fall-through. At first I thought it was intentional, but after debugging I found 2 'bed' items did indeed try to get spawned, of which only 1 actually seems to spawn on the client. Without the fall-through and item reset the bed item still spawns correctly.

I've also looked at the IsValidItem() code, because I thought that would catch the item being invalid to spawn. If fixes in there are needed with regard to this bug, tell me.