### PR TITLE
Circle 2.0: Use workspace instead of cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,16 @@ jobs:
     steps:
     - checkout
     - run: git submodule update --init
-    - save_cache:
-        key: "cuberite-{{ .Environment.CIRCLE_SHA1 }}"
+    - persist_to_workspace:
+        root: ~/
         paths:
-        - ~/cuberite
+        - cuberite
 
   check_basic_style:
     working_directory: ~/cuberite/src
     docker: *cube_docker
     steps:
-    - restore_cache: { keys: [ "cuberite-{{ .Environment.CIRCLE_SHA1 }}" ] }
+    - attach_workspace: { at: ~/ }
     - run: find . -name \*.cpp -or -name \*.h > AllFiles.lst
     - run: lua CheckBasicStyle.lua
     - run: cd Bindings && lua CheckBindingsDependencies.lua
@@ -25,7 +25,7 @@ jobs:
     working_directory: ~/cuberite
     docker: *cube_docker
     steps:
-    - restore_cache: { keys: [ "cuberite-{{ .Environment.CIRCLE_SHA1 }}" ] }
+    - attach_workspace: { at: ~/ }
     - run: ./clang-tidy.sh -j 2
 
 workflows:


### PR DESCRIPTION
Circle builds are failing with a warning in the `save_cache` step:

    Warning: skipping this step: disabled in configuration

It seems that caching has been disabled for PRs and the suggested fix is to use workspaces instead:
https://discuss.circleci.com/t/saving-cache-stopped-working-warning-skipping-this-step-disabled-in-configuration/24423/20