### PR TITLE
Limit the size of cListAllocationPool's free list

### DIFF
--- a/src/AllocationPool.h
+++ b/src/AllocationPool.h
@@ -11,18 +11,18 @@ class cAllocationPool
 public:
 	class cStarvationCallbacks
 	{
-		public:
-			virtual ~cStarvationCallbacks() {}
+	public:
+		virtual ~cStarvationCallbacks() {}
 
-			/** Is called when the reserve buffer starts to be used */
-			virtual void OnStartUsingReserve() = 0;
+		/** Is called when the reserve buffer starts to be used */
+		virtual void OnStartUsingReserve() = 0;
 
-			/** Is called once the reserve buffer has returned to normal size */
-			virtual void OnEndUsingReserve() = 0;
+		/** Is called once the reserve buffer has returned to normal size */
+		virtual void OnEndUsingReserve() = 0;
 
-			/** Is called when the allocation pool is unable to allocate memory. Will be repeatedly
+		/** Is called when the allocation pool is unable to allocate memory. Will be repeatedly
 			called if it does not free sufficient memory */
-			virtual void OnOutOfReserve() = 0;
+		virtual void OnOutOfReserve() = 0;
 	};
 
 	virtual ~cAllocationPool() {}
@@ -65,11 +65,12 @@ class cListAllocationPool:
 {
 public:
 
-	cListAllocationPool(std::unique_ptr<typename cAllocationPool<T>::cStarvationCallbacks> a_Callbacks, size_t a_NumElementsInReserve):
-		m_NumElementsInReserve(a_NumElementsInReserve),
+	cListAllocationPool(std::unique_ptr<typename cAllocationPool<T>::cStarvationCallbacks> a_Callbacks, size_t a_MinElementsInReserve, size_t a_MaxElementsInReserve) :
+		m_MinElementsInReserve(a_MinElementsInReserve),
+		m_MaxElementsInReserve(a_MaxElementsInReserve),
 		m_Callbacks(std::move(a_Callbacks))
 	{
-		for (size_t i = 0; i < m_NumElementsInReserve; i++)
+		for (size_t i = 0; i < m_MinElementsInReserve; i++)
 		{
 			void * space = malloc(sizeof(T));
 			if (space == nullptr)
@@ -86,7 +87,7 @@ public:
 	{
 		while (!m_FreeList.empty())
 		{
-			free (m_FreeList.front());
+			free(m_FreeList.front());
 			m_FreeList.pop_front();
 		}
 	}
@@ -94,7 +95,7 @@ public:
 
 	virtual T * Allocate() override
 	{
-		if (m_FreeList.size() <= m_NumElementsInReserve)
+		if (m_FreeList.size() <= m_MinElementsInReserve)
 		{
 			void * space = malloc(sizeof(T));
 			if (space != nullptr)
@@ -113,7 +114,7 @@ public:
 					#pragma pop_macro("new")
 				#endif
 			}
-			else if (m_FreeList.size() == m_NumElementsInReserve)
+			else if (m_FreeList.size() == m_MinElementsInReserve)
 			{
 				m_Callbacks->OnStartUsingReserve();
 			}
@@ -151,10 +152,17 @@ public:
 		{
 			return;
 		}
-		// placement destruct.
-		a_ptr->~T();
+
+		a_ptr->~T();  // placement destruct.
+
+		if (m_FreeList.size() >= m_MaxElementsInReserve)
+		{
+			free(a_ptr);
+			return;
+		}
+
 		m_FreeList.push_front(a_ptr);
-		if (m_FreeList.size() == m_NumElementsInReserve)
+		if (m_FreeList.size() == m_MinElementsInReserve)
 		{
 			m_Callbacks->OnEndUsingReserve();
 		}
@@ -162,7 +170,9 @@ public:
 
 private:
 	/** The minimum number of elements to keep in the free list before malloc fails */
-	size_t m_NumElementsInReserve;
+	size_t m_MinElementsInReserve;
+	/** Maximum free list size before returning memory to the OS */
+	size_t m_MaxElementsInReserve;
 	std::list<void *> m_FreeList;
 	std::unique_ptr<typename cAllocationPool<T>::cStarvationCallbacks> m_Callbacks;
 

--- a/src/ChunkDataCallback.h
+++ b/src/ChunkDataCallback.h
@@ -115,7 +115,7 @@ public:
 	};
 
 	cChunkDataCopyCollector():
-		m_Pool(cpp14::make_unique<MemCallbacks>(), cChunkData::NumSections),  // Keep 1 chunk worth of reserve
+		m_Pool(cpp14::make_unique<MemCallbacks>(), 0, cChunkData::NumSections),  // Keep 1 chunk worth of reserve
 		m_Data(m_Pool)
 	{
 	}

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -39,7 +39,7 @@ cChunkMap::cChunkMap(cWorld * a_World) :
 	m_World(a_World),
 	m_Pool(
 		cpp14::make_unique<cListAllocationPool<cChunkData::sChunkSection>>(
-			cpp14::make_unique<cStarvationCallbacks>(), 1600u
+			cpp14::make_unique<cStarvationCallbacks>(), 1600u, 5000u
 		)
 	)
 {

--- a/src/SetChunkData.cpp
+++ b/src/SetChunkData.cpp
@@ -26,7 +26,7 @@ struct sMemCallbacks:
 cSetChunkData::cSetChunkData(int a_ChunkX, int a_ChunkZ, bool a_ShouldMarkDirty) :
 	m_ChunkX(a_ChunkX),
 	m_ChunkZ(a_ChunkZ),
-	m_Pool(cpp14::make_unique<sMemCallbacks>(), cChunkData::NumSections),
+	m_Pool(cpp14::make_unique<sMemCallbacks>(), 0u, cChunkData::NumSections),
 	m_ChunkData(m_Pool),
 	m_IsLightValid(false),
 	m_IsHeightMapValid(false),


### PR DESCRIPTION
Fixes #4314 

Since #4260, most chunk sections are actually allocated in the WorldStorage and ChunkGenerator threads which don't have access to the world's allocation pool.  However, when the chunks are freed they are kept in the world's free lists.  This asymmetry means the free list will essentially grow unbounded and the memory isn't actually reused. The exception being the few occasions when chunk sections are allocated from the world tick thread directly.

This just limits the max size of the free list. It might be better if the Generator and Storage threads could use the same allocation pool but that would mean making `cListAllocationPool` thread safe.

At this point it might make more sense to just remove `cAllocationPool` for good.  It seems very unlikely that cuberite could handle 'out of memory' gracefully.