### PR TITLE
Allow chests to be opened with non-solid blocks on top of them

### DIFF
--- a/src/BlockEntities/ChestEntity.cpp
+++ b/src/BlockEntities/ChestEntity.cpp
@@ -208,7 +208,7 @@ bool cChestEntity::IsBlocked()
 	return (
 		(GetPosY() < cChunkDef::Height - 1) &&
 		(
-			!cBlockInfo::IsTransparent(GetWorld()->GetBlock(GetPosX(), GetPosY() + 1, GetPosZ())) ||
+			cBlockInfo::FullyOccupiesVoxel(GetWorld()->GetBlock(GetPosX(), GetPosY() + 1, GetPosZ())) ||
 			!cOcelot::IsCatSittingOnBlock(GetWorld(), Vector3d(GetPos()))
 		)
 	);


### PR DESCRIPTION
This allows chests to be opened when the block above them isn't a full block, preserving vanilla behavior (e.g. placing stairs on top of a chest doesn't block the chest)