### PR TITLE
Make Nether portals spawn the player inside of them

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1546,9 +1546,6 @@ bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 	// Take note of old chunk coords
 	auto OldChunkCoords = cChunkDef::BlockToChunk(GetPosition());
 
-	// Prevent the entity from teleporting back immediately, in case the destination is a portal
-	m_PortalCooldownData.m_ShouldPreventTeleportation = true;
-
 	// Set position to the new position
 	ResetPosition(a_NewPosition);
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1546,6 +1546,9 @@ bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 	// Take note of old chunk coords
 	auto OldChunkCoords = cChunkDef::BlockToChunk(GetPosition());
 
+	// Prevent the entity from teleporting back immediately, in case the destination is a portal
+	m_PortalCooldownData.m_ShouldPreventTeleportation = true;
+
 	// Set position to the new position
 	ResetPosition(a_NewPosition);
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -386,8 +386,8 @@ void cPlayer::TickFreezeCode()
 				{
 					// If we find a position with enough space for the player
 					if (
-						(Chunk->GetBlock(Rel.x, NewY, Rel.z) == E_BLOCK_AIR) &&
-						(Chunk->GetBlock(Rel.x, NewY + 1, Rel.z) == E_BLOCK_AIR)
+						!cBlockInfo::IsSolid(Chunk->GetBlock(Rel.x, NewY, Rel.z)) &&
+						!cBlockInfo::IsSolid(Chunk->GetBlock(Rel.x, NewY + 1, Rel.z))
 					)
 					{
 						// If the found position is not the same as the original
@@ -2071,6 +2071,9 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 
 		// Broadcast the player into the new world.
 		a_World->BroadcastSpawnEntity(*this);
+
+		// Prevent the player from teleporting back immediately, in case the destination is a portal
+		m_PortalCooldownData.m_ShouldPreventTeleportation = true;
 
 		// Queue add to new world and removal from the old one
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2072,9 +2072,6 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 		// Broadcast the player into the new world.
 		a_World->BroadcastSpawnEntity(*this);
 
-		// Prevent the player from teleporting back immediately, in case the destination is a portal
-		m_PortalCooldownData.m_ShouldPreventTeleportation = true;
-
 		// Queue add to new world and removal from the old one
 
 		// Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value

--- a/src/NetherPortalScanner.cpp
+++ b/src/NetherPortalScanner.cpp
@@ -9,7 +9,7 @@
 
 
 
-const double cNetherPortalScanner::OutOffset = 2;
+const double cNetherPortalScanner::OutOffset = 0.5;
 const double cNetherPortalScanner::AcrossOffset = 0.5;
 
 
@@ -278,7 +278,7 @@ void cNetherPortalScanner::OnDisabled(void)
 		FLOGD("Building nether portal at {0}", m_PortalLoc);
 		BuildNetherPortal(m_PortalLoc, m_Dir, m_BuildPlatform);
 		m_PortalLoc.x += 1;
-		m_PortalLoc.y += 2;
+		m_PortalLoc.y += 1;
 		m_PortalLoc.z += 1;
 	}
 


### PR DESCRIPTION
Currently the player is spawned immediately in front of them. 

Simply changing `cNetherPortalScanner::OutOffset` to `0.5` wasn't enough, as the player would always be spawned on top of the portal, however checking for non-solid blocks instead of air fixes this.