### PR TITLE
Fix player skin sending through BungeeCord

### DIFF
--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -154,7 +154,16 @@ cProtocol_1_9_0::cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_Ser
 				UUID.FromString(Params[2]);
 				m_Client->SetUUID(UUID);
 
-				m_Client->SetProperties(Params[3]);
+                Json::Value root;
+                Json::Reader reader;
+                if (!reader.parse(Params[3], root)) {
+                    LOGERROR("Unable to parse player properties: '%s'", Params[3]);
+                } else {
+                    m_Client->SetProperties(root);
+                    LOGD("ipstring: %s", Params[1]);
+                    LOGD("uuid: %s", Params[2]);
+                    LOGD("properties: count=%d,json=%s", root.size(), Params[3]);
+                }
 			}
 			else
 			{
@@ -973,11 +982,14 @@ void cProtocol_1_9_0::SendPlayerListAddPlayer(const cPlayer & a_Player)
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
 	Pkt.WriteString(a_Player.GetPlayerListName());
+    LOGD("Sending player tab list for \"%s\"...", a_Player.GetPlayerListName());
 
 	const Json::Value & Properties = a_Player.GetClientHandle()->GetProperties();
 	Pkt.WriteVarInt32(Properties.size());
 	for (auto & Node : Properties)
 	{
+		LOGD("name: %s", Node.get("name", "").asString());
+		LOGD("value: %s", Node.get("value", "").asString());
 		Pkt.WriteString(Node.get("name", "").asString());
 		Pkt.WriteString(Node.get("value", "").asString());
 		AString Signature = Node.get("signature", "").asString();

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -983,8 +983,6 @@ void cProtocol_1_9_0::SendPlayerListAddPlayer(const cPlayer & a_Player)
 	Pkt.WriteVarInt32(Properties.size());
 	for (auto & Node : Properties)
 	{
-		LOGD("name: %s", Node.get("name", "").asString());
-		LOGD("value: %s", Node.get("value", "").asString());
 		Pkt.WriteString(Node.get("name", "").asString());
 		Pkt.WriteString(Node.get("value", "").asString());
 		AString Signature = Node.get("signature", "").asString();

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -24,15 +24,12 @@ Implements the 1.9 protocol classes:
 #include "../Root.h"
 #include "../Server.h"
 #include "../World.h"
-#include "../EffectID.h"
 #include "../StringCompression.h"
 #include "../CompositeChat.h"
 #include "../Statistics.h"
 
 #include "../WorldStorage/FastNBT.h"
-#include "../WorldStorage/EnchantmentSerializer.h"
 
-#include "../Entities/Boat.h"
 #include "../Entities/ExpOrb.h"
 #include "../Entities/Minecart.h"
 #include "../Entities/FallingBlock.h"
@@ -47,7 +44,6 @@ Implements the 1.9 protocol classes:
 #include "../Items/ItemSpawnEgg.h"
 
 #include "../Mobs/IncludeAllMonsters.h"
-#include "../UI/Window.h"
 #include "../UI/HorseWindow.h"
 
 #include "../BlockEntities/BeaconEntity.h"
@@ -154,16 +150,19 @@ cProtocol_1_9_0::cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_Ser
 				UUID.FromString(Params[2]);
 				m_Client->SetUUID(UUID);
 
-                Json::Value root;
-                Json::Reader reader;
-                if (!reader.parse(Params[3], root)) {
-                    LOGERROR("Unable to parse player properties: '%s'", Params[3]);
-                } else {
-                    m_Client->SetProperties(root);
-                    LOGD("ipstring: %s", Params[1]);
-                    LOGD("uuid: %s", Params[2]);
-                    LOGD("properties: count=%d,json=%s", root.size(), Params[3]);
-                }
+				Json::Value root;
+				Json::Reader reader;
+				if (!reader.parse(Params[3], root))
+				{
+					LOGERROR("Unable to parse player properties: '%s'", Params[3]);
+				}
+				else
+				{
+					m_Client->SetProperties(root);
+					LOGD("ipstring: %s", Params[1]);
+					LOGD("uuid: %s", Params[2]);
+					LOGD("properties: count=%d, json=%s", root.size(), Params[3]);
+				}
 			}
 			else
 			{
@@ -982,7 +981,7 @@ void cProtocol_1_9_0::SendPlayerListAddPlayer(const cPlayer & a_Player)
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
 	Pkt.WriteString(a_Player.GetPlayerListName());
-    LOGD("Sending player tab list for \"%s\"...", a_Player.GetPlayerListName());
+	LOGD("Sending player tab list for \"%s\"...", a_Player.GetPlayerListName());
 
 	const Json::Value & Properties = a_Player.GetClientHandle()->GetProperties();
 	Pkt.WriteVarInt32(Properties.size());

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -978,7 +978,6 @@ void cProtocol_1_9_0::SendPlayerListAddPlayer(const cPlayer & a_Player)
 	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
 	Pkt.WriteString(a_Player.GetPlayerListName());
-	LOGD("Sending player tab list for \"%s\"...", a_Player.GetPlayerListName());
 
 	const Json::Value & Properties = a_Player.GetClientHandle()->GetProperties();
 	Pkt.WriteVarInt32(Properties.size());

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -159,9 +159,6 @@ cProtocol_1_9_0::cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_Ser
 				else
 				{
 					m_Client->SetProperties(root);
-					LOGD("ipstring: %s", Params[1]);
-					LOGD("uuid: %s", Params[2]);
-					LOGD("properties: count=%d, json=%s", root.size(), Params[3]);
 				}
 			}
 			else


### PR DESCRIPTION
This fixes sending of player skins through BungeeCord by actually parsing the JSON instead of setting the player properties as a string.