### PR TITLE
Buckets: Be able to place fluids through other fluids.

### DIFF
--- a/src/Bindings/LuaServerHandle.cpp
+++ b/src/Bindings/LuaServerHandle.cpp
@@ -143,7 +143,7 @@ cTCPLink::cCallbacksPtr cLuaServerHandle::OnIncomingConnection(const AString & a
 	cCSLock Lock(m_CSConnections);
 	m_Connections.push_back(res);
 
-	return res;
+	return std::move(res);
 }
 
 

--- a/src/Items/ItemBucket.h
+++ b/src/Items/ItemBucket.h
@@ -242,7 +242,7 @@ public:
 
 			virtual bool OnNextBlock(int a_CBBlockX, int a_CBBlockY, int a_CBBlockZ, BLOCKTYPE a_CBBlockType, NIBBLETYPE a_CBBlockMeta, eBlockFace a_CBEntryFace) override
 			{
-				if (a_CBBlockType != E_BLOCK_AIR && !IsBlockLiquid(a_CBBlockType))
+				if ((a_CBBlockType != E_BLOCK_AIR) && !IsBlockLiquid(a_CBBlockType))
 				{
 					m_ReplacedBlockType = a_CBBlockType;
 					m_ReplacedBlockMeta = a_CBBlockMeta;

--- a/src/Items/ItemBucket.h
+++ b/src/Items/ItemBucket.h
@@ -242,12 +242,12 @@ public:
 
 			virtual bool OnNextBlock(int a_CBBlockX, int a_CBBlockY, int a_CBBlockZ, BLOCKTYPE a_CBBlockType, NIBBLETYPE a_CBBlockMeta, eBlockFace a_CBEntryFace) override
 			{
-				if (a_CBBlockType != E_BLOCK_AIR)
+				if (a_CBBlockType != E_BLOCK_AIR && !IsBlockLiquid(a_CBBlockType))
 				{
 					m_ReplacedBlockType = a_CBBlockType;
 					m_ReplacedBlockMeta = a_CBBlockMeta;
 					m_EntryFace = static_cast<eBlockFace>(a_CBEntryFace);
-					if (!cFluidSimulator::CanWashAway(a_CBBlockType) && !IsBlockLiquid(a_CBBlockType))
+					if (!cFluidSimulator::CanWashAway(a_CBBlockType))
 					{
 						AddFaceDirection(a_CBBlockX, a_CBBlockY, a_CBBlockZ, a_CBEntryFace);  // Was an unwashawayable block, can't overwrite it!
 					}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -323,7 +323,7 @@ cTCPLink::cCallbacksPtr cServer::OnConnectionAccepted(const AString & a_RemoteIP
 	NewHandle->SetSelf(NewHandle);
 	cCSLock Lock(m_CSClients);
 	m_Clients.push_back(NewHandle);
-	return NewHandle;
+	return std::move(NewHandle);
 }
 
 


### PR DESCRIPTION
close #4306 

Also fixes some compiler errors I was getting

```
[ 77%] Building CXX object src/Bindings/CMakeFiles/Bindings.dir/LuaServerHandle.cpp.o
/path/cuberite/src/Bindings/LuaServerHandle.cpp:146:9: error: 
      prior to the resolution of a defect report against ISO C++11, local
      variable 'res' would have been copied despite being returned by name, due
      to its not matching the function return type
      ('shared_ptr<cTCPLink::cCallbacks>' vs 'shared_ptr<cLuaTCPLink>')
      [-Werror,-Wreturn-std-move-in-c++11]
        return res;
               ^~~
/path/cuberite/src/Bindings/LuaServerHandle.cpp:146:9: note: 
      call 'std::move' explicitly to avoid copying on older compilers
        return res;
               ^~~
               std::move(res)
1 error generated.
```

```
[ 97%] Building CXX object src/CMakeFiles/Cuberite.dir/Server.cpp.o
/path/cuberite/src/Server.cpp:326:9: error: prior to
      the resolution of a defect report against ISO C++11, local variable
      'NewHandle' would have been copied despite being returned by name, due to
      its not matching the function return type
      ('shared_ptr<cTCPLink::cCallbacks>' vs 'shared_ptr<cClientHandle>')
      [-Werror,-Wreturn-std-move-in-c++11]
        return NewHandle;
               ^~~~~~~~~
/path/cuberite/src/Server.cpp:326:9: note: call
      'std::move' explicitly to avoid copying on older compilers
        return NewHandle;
               ^~~~~~~~~
               std::move(NewHandle)
1 error generated.
```