### PR TITLE
Fix directory traversal bug

### DIFF
--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -375,13 +375,12 @@ void cWebAdmin::HandleFileRequest(cHTTPServerConnection & a_Connection, cHTTPInc
 		}
 	}
 
-	// Remove all ".." strings:
-	// ReplaceString(FileURL, "..", "");
-
 	// Read the file contents and guess its mime-type, based on the extension:
 	AString Content = "<h2>404 Not Found</h2>";
 	AString ContentType = "text/html";
 	AString Path = Printf(FILE_IO_PREFIX "webadmin/files/%s", FileURL.c_str());
+
+    // Return 404 if the file is not found, or the URL contains '../' (for security reasons)
 	if (FileURL.find("../") == AString::npos && cFile::IsFile(Path))
 	{
 		cFile File(Path, cFile::fmRead);

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -375,8 +375,8 @@ void cWebAdmin::HandleFileRequest(cHTTPServerConnection & a_Connection, cHTTPInc
 		}
 	}
 
-	// Remove all "../" strings:
-	ReplaceString(FileURL, "../", "");
+	// Remove all ".." strings:
+	ReplaceString(FileURL, "..", "");
 
 	// Read the file contents and guess its mime-type, based on the extension:
 	AString Content = "<h2>404 Not Found</h2>";

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -380,7 +380,7 @@ void cWebAdmin::HandleFileRequest(cHTTPServerConnection & a_Connection, cHTTPInc
 	AString ContentType = "text/html";
 	AString Path = Printf(FILE_IO_PREFIX "webadmin/files/%s", FileURL.c_str());
 
-    // Return 404 if the file is not found, or the URL contains '../' (for security reasons)
+	// Return 404 if the file is not found, or the URL contains '../' (for security reasons)
 	if (FileURL.find("../") == AString::npos && cFile::IsFile(Path))
 	{
 		cFile File(Path, cFile::fmRead);
@@ -394,10 +394,10 @@ void cWebAdmin::HandleFileRequest(cHTTPServerConnection & a_Connection, cHTTPInc
 				ContentType = GetContentTypeFromFileExt(Path.substr(LastPointPosition + 1));
 			}
 		}
-        if (ContentType.empty())
-        {
-            ContentType = "application/unknown";
-        }
+		if (ContentType.empty())
+		{
+			ContentType = "application/unknown";
+		}
 	}
 
 	// Send the response:

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -381,7 +381,7 @@ void cWebAdmin::HandleFileRequest(cHTTPServerConnection & a_Connection, cHTTPInc
 	AString Path = Printf(FILE_IO_PREFIX "webadmin/files/%s", FileURL.c_str());
 
 	// Return 404 if the file is not found, or the URL contains '../' (for security reasons)
-	if (FileURL.find("../") == AString::npos && cFile::IsFile(Path))
+	if ((FileURL.find("../") == AString::npos) && cFile::IsFile(Path))
 	{
 		cFile File(Path, cFile::fmRead);
 		AString FileContent;

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -376,13 +376,13 @@ void cWebAdmin::HandleFileRequest(cHTTPServerConnection & a_Connection, cHTTPInc
 	}
 
 	// Remove all ".." strings:
-	ReplaceString(FileURL, "..", "");
+	// ReplaceString(FileURL, "..", "");
 
 	// Read the file contents and guess its mime-type, based on the extension:
 	AString Content = "<h2>404 Not Found</h2>";
-	AString ContentType;
+	AString ContentType = "text/html";
 	AString Path = Printf(FILE_IO_PREFIX "webadmin/files/%s", FileURL.c_str());
-	if (cFile::IsFile(Path))
+	if (FileURL.find("../") == AString::npos && cFile::IsFile(Path))
 	{
 		cFile File(Path, cFile::fmRead);
 		AString FileContent;
@@ -395,10 +395,10 @@ void cWebAdmin::HandleFileRequest(cHTTPServerConnection & a_Connection, cHTTPInc
 				ContentType = GetContentTypeFromFileExt(Path.substr(LastPointPosition + 1));
 			}
 		}
-	}
-	if (ContentType.empty())
-	{
-		ContentType = "application/unknown";
+        if (ContentType.empty())
+        {
+            ContentType = "application/unknown";
+        }
 	}
 
 	// Send the response:


### PR DESCRIPTION
I found a neat little directory traversal bug in the webadmin code.
What the server does is that if the requested URL isn't "/", "/webadmin" or "/~webadmin" it will just try to fetch the corresponding file and send it back. The URL is sanitized before that: since we only want to serve files that are in the `webadmin/files/` directory, we search for `../` in the URL and remove it.

The problem here is that this sanitization doesn't work: if an attacker sends `....//file.foo` the sanitizer will transform it into `../file.foo` and they will have successfully bypassed the filter. For example if I go to `localhost:8080/....//....//webadmin.ini` I get the *webadmin.ini* file containing all the user passwords in plaintext.

I see three ways of fixing this:

* transform the relative path to an absolute path and check that it begins with the full path to *webadmin/files*
* apply the sanitization filter in a loop while there is something to sanitize
* just remove `..` instead of `../`. I think this fixes the bug but it might be less robust than the other two solutions (the first being probably the most robust but also the most complicated since we need to support Windows and Unix paths)