### PR TITLE
Check for nil in cWorld:SpawnSplitExperienceOrbs binding

### DIFF
--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -898,7 +898,8 @@ static int tolua_cWorld_SpawnSplitExperienceOrbs(lua_State* tolua_S)
 		tolua_error(tolua_S, "Invalid 'self' in function 'SpawnSplitExperienceOrbs'", nullptr);
 		return 0;
 	}
-	if (Position == nullptr) {
+	if (Position == nullptr)
+	{
 		tolua_error(tolua_S, "Error in function 'SpawnSplitExperienceOrbs' arg #2. Value must not be nil.", nullptr);
 		return 0;
 	}

--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -890,12 +890,16 @@ static int tolua_cWorld_SpawnSplitExperienceOrbs(lua_State* tolua_S)
 	}
 
 	cWorld * self = nullptr;
-	Vector3d * Position;
+	Vector3d * Position = nullptr;
 	int Reward;
 	L.GetStackValues(1, self, Position, Reward);
 	if (self == nullptr)
 	{
 		tolua_error(tolua_S, "Invalid 'self' in function 'SpawnSplitExperienceOrbs'", nullptr);
+		return 0;
+	}
+	if (Position == nullptr) {
+		tolua_error(tolua_S, "Error in function 'SpawnSplitExperienceOrbs' arg #2. Value must not be nil.", nullptr);
 		return 0;
 	}
 


### PR DESCRIPTION
Adds explicit nil check for 'position' parameter to prevent crashes if invalid.

Fixes #4352 