### PR TITLE
Added null check for position

### DIFF
--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -487,6 +487,11 @@ static int tolua_cWorld_DoWithNearestPlayer(lua_State * tolua_S)
 	bool CheckLineOfSight = true, IgnoreSpectators = true;  // Defaults for the optional params
 	L.GetStackValues(1, Self, Position, RangeLimit, FnRef, CheckLineOfSight, IgnoreSpectators);
 
+	if (Position == nullptr)
+	{
+		return L.ApiParamError("Expected a non-nil Vector3d for parameter #2");
+	}
+
 	if (!FnRef.IsValid())
 	{
 		return L.ApiParamError("Expected a valid callback function for parameter #3");


### PR DESCRIPTION
This check if the passed position is not null. The current error, when position is null is something about a invalid callback and this could be confusing.
