### PR TITLE
Separate the Generator from World and Plugin interfaces

### DIFF
--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -727,9 +727,9 @@ static int tolua_cWorld_PrepareChunk(lua_State * tolua_S)
 	{
 	public:
 		// cChunkCoordCallback override:
-		virtual void Call(int a_CBChunkX, int a_CBChunkZ, bool a_IsSuccess) override
+		virtual void Call(cChunkCoords a_Coords, bool a_IsSuccess) override
 		{
-			m_LuaCallback.Call(a_CBChunkX, a_CBChunkZ, a_IsSuccess);
+			m_LuaCallback.Call(a_Coords.m_ChunkX, a_Coords.m_ChunkZ, a_IsSuccess);
 		}
 
 		cLuaState::cOptionalCallback m_LuaCallback;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ SET (SRCS
 	ChatColor.cpp
 	Chunk.cpp
 	ChunkData.cpp
+	ChunkGeneratorThread.cpp
 	ChunkMap.cpp
 	ChunkSender.cpp
 	ChunkStay.cpp
@@ -100,6 +101,7 @@ SET (HDRS
 	ChunkData.h
 	ChunkDataCallback.h
 	ChunkDef.h
+	ChunkGeneratorThread.h
 	ChunkMap.h
 	ChunkSender.h
 	ChunkStay.h

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -50,23 +50,6 @@
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// sSetBlock:
-
-sSetBlock::sSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta):
-	m_RelX(a_BlockX),
-	m_RelY(a_BlockY),
-	m_RelZ(a_BlockZ),
-	m_BlockType(a_BlockType),
-	m_BlockMeta(a_BlockMeta)
-{
-	cChunkDef::AbsoluteToRelative(m_RelX, m_RelY, m_RelZ, m_ChunkX, m_ChunkZ);
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 // cChunk:
 
 cChunk::cChunk(
@@ -276,7 +259,7 @@ void cChunk::MarkLoadFailed(void)
 	// If the chunk is marked as needed, generate it:
 	if (m_ShouldGenerateIfLoadFailed)
 	{
-		m_World->GetGenerator().QueueGenerateChunk(m_PosX, m_PosZ, false);
+		m_World->GetGenerator().QueueGenerateChunk({m_PosX, m_PosZ}, false);
 	}
 	else
 	{

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -65,6 +65,12 @@ public:
 	{
 		return ((m_ChunkX == a_Other.m_ChunkX) && (m_ChunkZ == a_Other.m_ChunkZ));
 	}
+
+	/** Returns a string that describes the chunk coords, suitable for logging. */
+	AString ToString() const
+	{
+		return Printf("[%d, %d]", m_ChunkX, m_ChunkZ);
+	}
 } ;
 
 
@@ -445,7 +451,15 @@ struct sSetBlock
 	BLOCKTYPE m_BlockType;
 	NIBBLETYPE m_BlockMeta;
 
-	sSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
+	sSetBlock(int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta):
+		m_RelX(a_BlockX),
+		m_RelY(a_BlockY),
+		m_RelZ(a_BlockZ),
+		m_BlockType(a_BlockType),
+		m_BlockMeta(a_BlockMeta)
+	{
+		cChunkDef::AbsoluteToRelative(m_RelX, m_RelY, m_RelZ, m_ChunkX, m_ChunkZ);
+	}
 
 	sSetBlock(int a_ChunkX, int a_ChunkZ, int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) :
 		m_RelX(a_RelX), m_RelY(a_RelY), m_RelZ(a_RelZ),
@@ -525,7 +539,7 @@ public:
 	virtual ~cChunkCoordCallback() {}
 
 	/** Called with the chunk's coords, and an optional operation status flag for operations that support it. */
-	virtual void Call(int a_ChunkX, int a_ChunkZ, bool a_IsSuccess) = 0;
+	virtual void Call(cChunkCoords a_Coords, bool a_IsSuccess) = 0;
 } ;
 
 

--- a/src/ChunkGeneratorThread.cpp
+++ b/src/ChunkGeneratorThread.cpp
@@ -1,0 +1,264 @@
+#include "Globals.h"
+#include "ChunkGeneratorThread.h"
+#include "Generating/ChunkGenerator.h"
+#include "Generating/ChunkDesc.h"
+
+
+
+
+
+/** If the generation queue size exceeds this number, a warning will be output */
+const size_t QUEUE_WARNING_LIMIT = 1000;
+
+/** If the generation queue size exceeds this number, chunks with no clients will be skipped */
+const size_t QUEUE_SKIP_LIMIT = 500;
+
+
+
+
+
+cChunkGeneratorThread::cChunkGeneratorThread(void) :
+	Super("cChunkGeneratorThread"),
+	m_Generator(nullptr),
+	m_PluginInterface(nullptr),
+	m_ChunkSink(nullptr)
+{
+}
+
+
+
+
+
+cChunkGeneratorThread::~cChunkGeneratorThread()
+{
+	Stop();
+}
+
+
+
+
+
+bool cChunkGeneratorThread::Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile)
+{
+	m_PluginInterface = &a_PluginInterface;
+	m_ChunkSink = &a_ChunkSink;
+
+	m_Generator = cChunkGenerator::CreateFromIniFile(a_IniFile);
+	if (m_Generator == nullptr)
+	{
+		LOGERROR("Generator could not start, aborting the server");
+		return false;
+	}
+	return true;
+}
+
+
+
+
+
+void cChunkGeneratorThread::Stop(void)
+{
+	m_ShouldTerminate = true;
+	m_Event.Set();
+	m_evtRemoved.Set();  // Wake up anybody waiting for empty queue
+	Super::Stop();
+	m_Generator.reset();
+}
+
+
+
+
+
+void cChunkGeneratorThread::QueueGenerateChunk(
+	cChunkCoords a_Coords,
+	bool a_ForceRegeneration,
+	cChunkCoordCallback * a_Callback
+)
+{
+	ASSERT(m_ChunkSink->IsChunkQueued(a_Coords));
+
+	{
+		cCSLock Lock(m_CS);
+
+		// Add to queue, issue a warning if too many:
+		if (m_Queue.size() >= QUEUE_WARNING_LIMIT)
+		{
+			LOGWARN("WARNING: Adding chunk %s to generation queue; Queue is too big! (%zu)", a_Coords.ToString().c_str(), m_Queue.size());
+		}
+		m_Queue.push_back(QueueItem{a_Coords, a_ForceRegeneration, a_Callback});
+	}
+
+	m_Event.Set();
+}
+
+
+
+
+
+void cChunkGeneratorThread::GenerateBiomes(cChunkCoords a_Coords, cChunkDef::BiomeMap & a_BiomeMap)
+{
+	if (m_Generator != nullptr)
+	{
+		m_Generator->GenerateBiomes(a_Coords.m_ChunkX, a_Coords.m_ChunkZ, a_BiomeMap);
+	}
+}
+
+
+
+
+
+void cChunkGeneratorThread::WaitForQueueEmpty(void)
+{
+	cCSLock Lock(m_CS);
+	while (!m_ShouldTerminate && !m_Queue.empty())
+	{
+		cCSUnlock Unlock(Lock);
+		m_evtRemoved.Wait();
+	}
+}
+
+
+
+
+
+int cChunkGeneratorThread::GetQueueLength(void) const
+{
+	cCSLock Lock(m_CS);
+	return static_cast<int>(m_Queue.size());
+}
+
+
+
+
+
+int cChunkGeneratorThread::GetSeed() const
+{
+	return m_Generator->GetSeed();
+}
+
+
+
+
+
+EMCSBiome cChunkGeneratorThread::GetBiomeAt(int a_BlockX, int a_BlockZ)
+{
+	ASSERT(m_Generator != nullptr);
+	return m_Generator->GetBiomeAt(a_BlockX, a_BlockZ);
+}
+
+
+
+
+
+void cChunkGeneratorThread::Execute(void)
+{
+	// To be able to display performance information, the generator counts the chunks generated.
+	// When the queue gets empty, the count is reset, so that waiting for the queue is not counted into the total time.
+	int NumChunksGenerated = 0;  // Number of chunks generated since the queue was last empty
+	clock_t GenerationStart = clock();  // Clock tick when the queue started to fill
+	clock_t LastReportTick = clock();  // Clock tick of the last report made (so that performance isn't reported too often)
+
+	while (!m_ShouldTerminate)
+	{
+		cCSLock Lock(m_CS);
+		while (m_Queue.empty())
+		{
+			if ((NumChunksGenerated > 16) && (clock() - LastReportTick > CLOCKS_PER_SEC))
+			{
+				/* LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
+					static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC/ (clock() - GenerationStart),
+					NumChunksGenerated
+				); */
+			}
+			cCSUnlock Unlock(Lock);
+			m_Event.Wait();
+			if (m_ShouldTerminate)
+			{
+				return;
+			}
+			NumChunksGenerated = 0;
+			GenerationStart = clock();
+			LastReportTick = clock();
+		}
+
+		if (m_Queue.empty())
+		{
+			// Sometimes the queue remains empty
+			// If so, we can't do any front() operations on it!
+			continue;
+		}
+
+		auto item = m_Queue.front();  // Get next chunk from the queue
+		bool SkipEnabled = (m_Queue.size() > QUEUE_SKIP_LIMIT);
+		m_Queue.erase(m_Queue.begin());  // Remove the item from the queue
+		Lock.Unlock();  // Unlock ASAP
+		m_evtRemoved.Set();
+
+		// Display perf info once in a while:
+		if ((NumChunksGenerated > 512) && (clock() - LastReportTick > 2 * CLOCKS_PER_SEC))
+		{
+			LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
+				static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC / (clock() - GenerationStart),
+				NumChunksGenerated
+			);
+			LastReportTick = clock();
+		}
+
+		// Skip the chunk if it's already generated and regeneration is not forced. Report as success:
+		if (!item.m_ForceRegeneration && m_ChunkSink->IsChunkValid(item.m_Coords))
+		{
+			LOGD("Chunk %s already generated, skipping generation", item.m_Coords.ToString().c_str());
+			if (item.m_Callback != nullptr)
+			{
+				item.m_Callback->Call(item.m_Coords, true);
+			}
+			continue;
+		}
+
+		// Skip the chunk if the generator is overloaded:
+		if (SkipEnabled && !m_ChunkSink->HasChunkAnyClients(item.m_Coords))
+		{
+			LOGWARNING("Chunk generator overloaded, skipping chunk %s", item.m_Coords.ToString().c_str());
+			if (item.m_Callback != nullptr)
+			{
+				item.m_Callback->Call(item.m_Coords, false);
+			}
+			continue;
+		}
+
+		// Generate the chunk:
+		DoGenerate(item.m_Coords);
+		if (item.m_Callback != nullptr)
+		{
+			item.m_Callback->Call(item.m_Coords, true);
+		}
+		NumChunksGenerated++;
+	}  // while (!bStop)
+}
+
+
+
+
+
+void cChunkGeneratorThread::DoGenerate(cChunkCoords a_Coords)
+{
+	ASSERT(m_PluginInterface != nullptr);
+	ASSERT(m_ChunkSink != nullptr);
+
+	cChunkDesc ChunkDesc(a_Coords);
+	m_PluginInterface->CallHookChunkGenerating(ChunkDesc);
+	m_Generator->Generate(a_Coords.m_ChunkX, a_Coords.m_ChunkZ, ChunkDesc);
+	m_PluginInterface->CallHookChunkGenerated(ChunkDesc);
+
+	#ifdef _DEBUG
+		// Verify that the generator has produced valid data:
+		ChunkDesc.VerifyHeightmap();
+	#endif
+
+	m_ChunkSink->OnChunkGenerated(ChunkDesc);
+}
+
+
+
+
+

--- a/src/ChunkGeneratorThread.h
+++ b/src/ChunkGeneratorThread.h
@@ -1,0 +1,159 @@
+#pragma once
+
+#include "OSSupport/IsThread.h"
+
+
+
+
+
+// fwd:
+class cIniFile;
+class cChunkDesc;
+class cChunkGenerator;
+
+
+
+
+
+/** Takes requests for generating chunks and processes them in a separate thread one by one.
+The requests are not added to the queue if there is already a request with the same coords.
+Before generating, the thread checks if the chunk hasn't been already generated.
+It is theoretically possible to have multiple generator threads by having multiple instances of this object,
+but then it MAY happen that the chunk is generated twice.
+If the generator queue is overloaded, the generator skips chunks with no clients in them. */
+class cChunkGeneratorThread :
+	public cIsThread
+{
+	using Super = cIsThread;
+
+public:
+
+	/** The interface through which the plugins are called for their OnChunkGenerating / OnChunkGenerated hooks. */
+	class cPluginInterface
+	{
+	public:
+		// Force a virtual destructor
+		virtual ~cPluginInterface() {}
+
+		/** Called when the chunk is about to be generated.
+		The generator may be partly or fully overriden by the implementation. */
+		virtual void CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) = 0;
+
+		/** Called after the chunk is generated, before it is handed to the chunk sink.
+		a_ChunkDesc contains the generated chunk data. Implementation may modify this data. */
+		virtual void CallHookChunkGenerated(cChunkDesc & a_ChunkDesc) = 0;
+	} ;
+
+
+	/** The interface through which the generated chunks are handed to the cWorld or whoever created us. */
+	class cChunkSink
+	{
+	public:
+		// Force a virtual destructor
+		virtual ~cChunkSink() {}
+
+		/** Called after the chunk has been generated
+		The interface may store the chunk, send it over network, whatever.
+		The chunk is not expected to be modified, but the generator will survive if the implementation
+		changes the data within. All changes are ignored, though. */
+		virtual void OnChunkGenerated(cChunkDesc & a_ChunkDesc) = 0;
+
+		/** Called just before the chunk generation is started,
+		to verify that it hasn't been generated in the meantime.
+		If this callback returns true, the chunk is not generated. */
+		virtual bool IsChunkValid(cChunkCoords a_Coords) = 0;
+
+		/** Called when the generator is overloaded to skip chunks that are no longer needed.
+		If this callback returns false, the chunk is not generated. */
+		virtual bool HasChunkAnyClients(cChunkCoords a_Coords) = 0;
+
+		/** Called to check whether the specified chunk is in the queued state.
+		Currently used only in Debug-mode asserts. */
+		virtual bool IsChunkQueued(cChunkCoords a_Coords) = 0;
+	} ;
+
+
+	cChunkGeneratorThread (void);
+	virtual ~cChunkGeneratorThread() override;
+
+	/** Read settings from the ini file and initialize in preperation for being started. */
+	bool Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile);
+
+	void Stop(void);
+
+	/** Queues the chunk for generation
+	If a-ForceGenerate is set, the chunk is regenerated even if the data is already present in the chunksink.
+	a_Callback is called after the chunk is generated. If the chunk was already present, the callback is still called, even if not regenerating.
+	It is legal to set the callback to nullptr, no callback is called then.
+	If the generator becomes overloaded and skips this chunk, the callback is still called. */
+	void QueueGenerateChunk(cChunkCoords a_Coords, bool a_ForceRegeneration, cChunkCoordCallback * a_Callback = nullptr);
+
+	/** Generates the biomes for the specified chunk (directly, not in a separate thread). Used by the world loader if biomes failed loading. */
+	void GenerateBiomes(cChunkCoords a_Coords, cChunkDef::BiomeMap & a_BiomeMap);
+
+	void WaitForQueueEmpty();
+
+	int GetQueueLength() const;
+
+	int GetSeed() const;
+
+	/** Returns the biome at the specified coords. Used by ChunkMap if an invalid chunk is queried for biome */
+	EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ);
+
+
+private:
+
+	struct QueueItem
+	{
+		/** The chunk coords */
+		cChunkCoords m_Coords;
+
+		/** Force the regeneration of an already existing chunk */
+		bool m_ForceRegeneration;
+
+		/** Callback to call after generating. */
+		cChunkCoordCallback * m_Callback;
+
+		QueueItem(cChunkCoords a_Coords, bool a_ForceRegeneration, cChunkCoordCallback * a_Callback):
+			m_Coords(a_Coords),
+			m_ForceRegeneration(a_ForceRegeneration),
+			m_Callback(a_Callback)
+		{
+		}
+	};
+
+	using Queue = std::list<QueueItem>;
+
+
+	/** CS protecting access to the queue. */
+	mutable cCriticalSection m_CS;
+
+	/** Queue of the chunks to be generated. Protected against multithreaded access by m_CS. */
+	Queue m_Queue;
+
+	/** Set when an item is added to the queue or the thread should terminate. */
+	cEvent m_Event;
+
+	/** Set when an item is removed from the queue. */
+	cEvent m_evtRemoved;
+
+	/** The actual chunk generator engine used. */
+	std::unique_ptr<cChunkGenerator> m_Generator;
+
+	/** The plugin interface that may modify the generated chunks */
+	cPluginInterface * m_PluginInterface;
+
+	/** The destination where the generated chunks are sent */
+	cChunkSink * m_ChunkSink;
+
+
+	// cIsThread override:
+	virtual void Execute(void) override;
+
+	/** Generates the specified chunk and sets it into the chunksink. */
+	void DoGenerate(cChunkCoords a_Coords);
+};
+
+
+
+

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1798,7 +1798,7 @@ void cChunkMap::PrepareChunk(int a_ChunkX, int a_ChunkZ, std::unique_ptr<cChunkC
 	// The chunk is present and lit, just call the callback, report as success:
 	if (a_Callback != nullptr)
 	{
-		a_Callback->Call(a_ChunkX, a_ChunkZ, true);
+		a_Callback->Call({a_ChunkX, a_ChunkZ}, true);
 	}
 }
 
@@ -1831,34 +1831,34 @@ bool cChunkMap::GenerateChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * 
 			}
 
 			// cChunkCoordCallback override:
-			virtual void Call(int a_CBChunkX, int a_CBChunkZ, bool a_CBIsSuccess) override
+			virtual void Call(cChunkCoords a_Coords, bool a_CBIsSuccess) override
 			{
 				// If success is reported, the chunk is already valid, no need to do anything else:
 				if (a_CBIsSuccess)
 				{
 					if (m_Callback != nullptr)
 					{
-						m_Callback->Call(a_CBChunkX, a_CBChunkZ, true);
+						m_Callback->Call(a_Coords, true);
 					}
 					return;
 				}
 
 				// The chunk failed to load, generate it:
 				cCSLock CBLock(m_ChunkMap.m_CSChunks);
-				cChunkPtr CBChunk = m_ChunkMap.GetChunkNoLoad(a_CBChunkX, a_CBChunkZ);
+				cChunkPtr CBChunk = m_ChunkMap.GetChunkNoLoad(a_Coords.m_ChunkX, a_Coords.m_ChunkZ);
 
 				if (CBChunk == nullptr)
 				{
 					// An error occurred, but we promised to call the callback, so call it even when there's no real chunk data:
 					if (m_Callback != nullptr)
 					{
-						m_Callback->Call(a_CBChunkX, a_CBChunkZ, false);
+						m_Callback->Call(a_Coords, false);
 					}
 					return;
 				}
 
 				CBChunk->SetPresence(cChunk::cpQueued);
-				m_World.GetGenerator().QueueGenerateChunk(a_CBChunkX, a_CBChunkZ, false, m_Callback);
+				m_World.GetGenerator().QueueGenerateChunk(a_Coords, false, m_Callback);
 			}
 
 		protected:
@@ -1873,7 +1873,7 @@ bool cChunkMap::GenerateChunk(int a_ChunkX, int a_ChunkZ, cChunkCoordCallback * 
 	// The chunk is valid, just call the callback:
 	if (a_Callback != nullptr)
 	{
-		a_Callback->Call(a_ChunkX, a_ChunkZ, true);
+		a_Callback->Call({a_ChunkX, a_ChunkZ}, true);
 	}
 	return true;
 }

--- a/src/ChunkSender.cpp
+++ b/src/ChunkSender.cpp
@@ -27,11 +27,11 @@
 class cNotifyChunkSender :
 	public cChunkCoordCallback
 {
-	virtual void Call(int a_ChunkX, int a_ChunkZ, bool a_IsSuccess) override
+	virtual void Call(cChunkCoords a_Coords, bool a_IsSuccess) override
 	{
 		cChunkSender & ChunkSender = m_ChunkSender;
 		m_World.DoWithChunk(
-			a_ChunkX, a_ChunkZ,
+			a_Coords.m_ChunkX, a_Coords.m_ChunkZ,
 			[&ChunkSender] (cChunk & a_Chunk) -> bool
 			{
 				ChunkSender.QueueSendChunkTo(a_Chunk.GetPosX(), a_Chunk.GetPosZ(), cChunkSender::E_CHUNK_PRIORITY_MIDHIGH, a_Chunk.GetAllClients());

--- a/src/Generating/ChunkDesc.cpp
+++ b/src/Generating/ChunkDesc.cpp
@@ -13,9 +13,8 @@
 
 
 
-cChunkDesc::cChunkDesc(int a_ChunkX, int a_ChunkZ) :
-	m_ChunkX(a_ChunkX),
-	m_ChunkZ(a_ChunkZ),
+cChunkDesc::cChunkDesc(cChunkCoords a_Coords) :
+	m_Coords(a_Coords),
 	m_bUseDefaultBiomes(true),
 	m_bUseDefaultHeight(true),
 	m_bUseDefaultComposition(true),
@@ -43,10 +42,9 @@ cChunkDesc::~cChunkDesc()
 
 
 
-void cChunkDesc::SetChunkCoords(int a_ChunkX, int a_ChunkZ)
+void cChunkDesc::SetChunkCoords(cChunkCoords a_Coords)
 {
-	m_ChunkX = a_ChunkX;
-	m_ChunkZ = a_ChunkZ;
+	m_Coords = a_Coords;
 }
 
 
@@ -369,9 +367,9 @@ void cChunkDesc::ReadBlockArea(cBlockArea & a_Dest, int a_MinRelX, int a_MaxRelX
 	int SizeY = a_MaxRelY - a_MinRelY;
 	int SizeZ = a_MaxRelZ - a_MinRelZ;
 	a_Dest.Clear();
-	a_Dest.m_Origin.x = m_ChunkX * cChunkDef::Width + a_MinRelX;
+	a_Dest.m_Origin.x = m_Coords.m_ChunkX * cChunkDef::Width + a_MinRelX;
 	a_Dest.m_Origin.y = a_MinRelY;
-	a_Dest.m_Origin.z = m_ChunkZ * cChunkDef::Width + a_MinRelZ;
+	a_Dest.m_Origin.z = m_Coords.m_ChunkZ * cChunkDef::Width + a_MinRelZ;
 	a_Dest.SetSize(SizeX, SizeY, SizeZ, cBlockArea::baTypes | cBlockArea::baMetas);
 
 	for (int y = 0; y < SizeY; y++)
@@ -593,8 +591,8 @@ cBlockEntity * cChunkDesc::GetBlockEntity(int a_RelX, int a_RelY, int a_RelZ)
 		}
 	}
 
-	int AbsX = a_RelX + m_ChunkX * cChunkDef::Width;
-	int AbsZ = a_RelZ + m_ChunkZ * cChunkDef::Width;
+	int AbsX = a_RelX + m_Coords.m_ChunkX * cChunkDef::Width;
+	int AbsZ = a_RelZ + m_Coords.m_ChunkZ * cChunkDef::Width;
 
 	// The block entity is not created yet, try to create it and add to list:
 	cBlockEntity * be = cBlockEntity::CreateByBlockType(GetBlockType(a_RelX, a_RelY, a_RelZ), GetBlockMeta(a_RelX, a_RelY, a_RelZ), AbsX, a_RelY, AbsZ);

--- a/src/Generating/ChunkDesc.cpp
+++ b/src/Generating/ChunkDesc.cpp
@@ -87,7 +87,7 @@ void cChunkDesc::SetBlockType(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Bl
 
 
 
-BLOCKTYPE cChunkDesc::GetBlockType(int a_RelX, int a_RelY, int a_RelZ)
+BLOCKTYPE cChunkDesc::GetBlockType(int a_RelX, int a_RelY, int a_RelZ) const
 {
 	return cChunkDef::GetBlock(m_BlockArea.GetBlockTypes(), a_RelX, a_RelY, a_RelZ);
 }
@@ -96,7 +96,7 @@ BLOCKTYPE cChunkDesc::GetBlockType(int a_RelX, int a_RelY, int a_RelZ)
 
 
 
-NIBBLETYPE cChunkDesc::GetBlockMeta(int a_RelX, int a_RelY, int a_RelZ)
+NIBBLETYPE cChunkDesc::GetBlockMeta(int a_RelX, int a_RelY, int a_RelZ) const
 {
 	return m_BlockArea.GetRelBlockMeta(a_RelX, a_RelY, a_RelZ);
 }
@@ -123,7 +123,7 @@ void cChunkDesc::SetBiome(int a_RelX, int a_RelZ, EMCSBiome a_BiomeID)
 
 
 
-EMCSBiome cChunkDesc::GetBiome(int a_RelX, int a_RelZ)
+EMCSBiome cChunkDesc::GetBiome(int a_RelX, int a_RelZ) const
 {
 	return cChunkDef::GetBiome(m_BiomeMap, a_RelX, a_RelZ);
 }
@@ -141,7 +141,7 @@ void cChunkDesc::SetHeight(int a_RelX, int a_RelZ, HEIGHTTYPE a_Height)
 
 
 
-HEIGHTTYPE cChunkDesc::GetHeight(int a_RelX, int a_RelZ)
+HEIGHTTYPE cChunkDesc::GetHeight(int a_RelX, int a_RelZ) const
 {
 	return cChunkDef::GetHeight(m_HeightMap, a_RelX, a_RelZ);
 }

--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -65,18 +65,18 @@ public:
 	// tolua_begin
 
 	void       SetBlockType(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockType);
-	BLOCKTYPE  GetBlockType(int a_RelX, int a_RelY, int a_RelZ);
+	BLOCKTYPE  GetBlockType(int a_RelX, int a_RelY, int a_RelZ) const;
 
 	void       SetBlockMeta(int a_RelX, int a_RelY, int a_RelZ, NIBBLETYPE a_BlockMeta);
-	NIBBLETYPE GetBlockMeta(int a_RelX, int a_RelY, int a_RelZ);
+	NIBBLETYPE GetBlockMeta(int a_RelX, int a_RelY, int a_RelZ) const;
 
 	void       SetBiome(int a_RelX, int a_RelZ, EMCSBiome a_BiomeID);
-	EMCSBiome  GetBiome(int a_RelX, int a_RelZ);
+	EMCSBiome  GetBiome(int a_RelX, int a_RelZ) const;
 
 	// These operate on the heightmap, so they could get out of sync with the data
 	// Use UpdateHeightmap() to re-calculate heightmap from the block data
 	void       SetHeight(int a_RelX, int a_RelZ, HEIGHTTYPE a_Height);
-	HEIGHTTYPE GetHeight(int a_RelX, int a_RelZ);
+	HEIGHTTYPE GetHeight(int a_RelX, int a_RelZ) const;
 
 	// tolua_end
 

--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -39,15 +39,21 @@ public:
 	typedef NIBBLETYPE BlockNibbleBytes[cChunkDef::NumBlocks];
 
 
-	cChunkDesc(int a_ChunkX, int a_ChunkZ);
+	cChunkDesc(cChunkCoords a_Coords);
 	~cChunkDesc();
 
-	void SetChunkCoords(int a_ChunkX, int a_ChunkZ);
+	void SetChunkCoords(cChunkCoords a_Coords);
 
 	// tolua_begin
 
-	int GetChunkX(void) const { return m_ChunkX; }
-	int GetChunkZ(void) const { return m_ChunkZ; }
+	int GetChunkX() const { return m_Coords.m_ChunkX; }  // Prefer GetChunkCoords() instead
+	int GetChunkZ() const { return m_Coords.m_ChunkZ; }  // Prefer GetChunkCoords() instead
+
+	// tolua_end
+
+	cChunkCoords GetChunkCoords() const { return m_Coords; }
+
+	// tolua_begin
 
 	void       FillBlocks(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 	void       SetBlockTypeMeta(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
@@ -225,8 +231,7 @@ public:
 	#endif  // _DEBUG
 
 private:
-	int m_ChunkX;
-	int m_ChunkZ;
+	cChunkCoords m_Coords;
 
 	cChunkDef::BiomeMap     m_BiomeMap;
 	cBlockArea              m_BlockArea;

--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -25,6 +25,8 @@ void cChunkGenerator::Initialize(cIniFile & a_IniFile)
 		LOGINFO("Chosen a new random seed for world: %d", m_Seed);
 		a_IniFile.SetValueI("Seed", "Seed", m_Seed);
 	}
+
+	m_Dimension = StringToDimension(a_IniFile.GetValue("General", "Dimension", "Overworld"));
 }
 
 

--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -12,46 +12,8 @@
 
 
 
-/** If the generation queue size exceeds this number, a warning will be output */
-const unsigned int QUEUE_WARNING_LIMIT = 1000;
-
-/** If the generation queue size exceeds this number, chunks with no clients will be skipped */
-const unsigned int QUEUE_SKIP_LIMIT = 500;
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// cChunkGenerator:
-
-cChunkGenerator::cChunkGenerator(void) :
-	super("cChunkGenerator"),
-	m_Seed(0),  // Will be overwritten by the actual generator
-	m_Generator(nullptr),
-	m_PluginInterface(nullptr),
-	m_ChunkSink(nullptr)
+void cChunkGenerator::Initialize(cIniFile & a_IniFile)
 {
-}
-
-
-
-
-
-cChunkGenerator::~cChunkGenerator()
-{
-	Stop();
-}
-
-
-
-
-
-bool cChunkGenerator::Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile)
-{
-	m_PluginInterface = &a_PluginInterface;
-	m_ChunkSink = &a_ChunkSink;
-
 	// Get the seed; create a new one and log it if not found in the INI file:
 	if (a_IniFile.HasValue("Seed", "Seed"))
 	{
@@ -63,12 +25,20 @@ bool cChunkGenerator::Initialize(cPluginInterface & a_PluginInterface, cChunkSin
 		LOGINFO("Chosen a new random seed for world: %d", m_Seed);
 		a_IniFile.SetValueI("Seed", "Seed", m_Seed);
 	}
+}
 
+
+
+
+
+std::unique_ptr<cChunkGenerator> cChunkGenerator::CreateFromIniFile(cIniFile & a_IniFile)
+{
 	// Get the generator engine based on the INI file settings:
+	std::unique_ptr<cChunkGenerator> res;
 	AString GeneratorName = a_IniFile.GetValueSet("Generator", "Generator", "Composable");
 	if (NoCaseCompare(GeneratorName, "Noise3D") == 0)
 	{
-		m_Generator = new cNoise3DGenerator(*this);
+		res.reset(new cNoise3DGenerator());
 	}
 	else
 	{
@@ -76,90 +46,17 @@ bool cChunkGenerator::Initialize(cPluginInterface & a_PluginInterface, cChunkSin
 		{
 			LOGWARN("[Generator]::Generator value \"%s\" not recognized, using \"Composable\".", GeneratorName.c_str());
 		}
-		m_Generator = new cComposableGenerator(*this);
+		res.reset(new cComposableGenerator());
 	}
 
-	if (m_Generator == nullptr)
+	if (res == nullptr)
 	{
 		LOGERROR("Generator could not start, aborting the server");
-		return false;
+		return nullptr;
 	}
 
-	m_Generator->Initialize(a_IniFile);
-	return true;
-}
-
-
-
-
-
-void cChunkGenerator::Stop(void)
-{
-	m_ShouldTerminate = true;
-	m_Event.Set();
-	m_evtRemoved.Set();  // Wake up anybody waiting for empty queue
-	super::Stop();
-
-	delete m_Generator;
-	m_Generator = nullptr;
-}
-
-
-
-
-
-void cChunkGenerator::QueueGenerateChunk(int a_ChunkX, int a_ChunkZ, bool a_ForceGenerate, cChunkCoordCallback * a_Callback)
-{
-	ASSERT(m_ChunkSink->IsChunkQueued(a_ChunkX, a_ChunkZ));
-
-	{
-		cCSLock Lock(m_CS);
-
-		// Add to queue, issue a warning if too many:
-		if (m_Queue.size() >= QUEUE_WARNING_LIMIT)
-		{
-			LOGWARN("WARNING: Adding chunk [%i, %i] to generation queue; Queue is too big! (%zu)", a_ChunkX, a_ChunkZ, m_Queue.size());
-		}
-		m_Queue.push_back(cQueueItem{a_ChunkX, a_ChunkZ, a_ForceGenerate, a_Callback});
-	}
-
-	m_Event.Set();
-}
-
-
-
-
-
-void cChunkGenerator::GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap)
-{
-	if (m_Generator != nullptr)
-	{
-		m_Generator->GenerateBiomes(a_ChunkX, a_ChunkZ, a_BiomeMap);
-	}
-}
-
-
-
-
-
-void cChunkGenerator::WaitForQueueEmpty(void)
-{
-	cCSLock Lock(m_CS);
-	while (!m_ShouldTerminate && !m_Queue.empty())
-	{
-		cCSUnlock Unlock(Lock);
-		m_evtRemoved.Wait();
-	}
-}
-
-
-
-
-
-int cChunkGenerator::GetQueueLength(void)
-{
-	cCSLock Lock(m_CS);
-	return static_cast<int>(m_Queue.size());
+	res->Initialize(a_IniFile);
+	return res;
 }
 
 
@@ -167,166 +64,6 @@ int cChunkGenerator::GetQueueLength(void)
 
 
 EMCSBiome cChunkGenerator::GetBiomeAt(int a_BlockX, int a_BlockZ)
-{
-	ASSERT(m_Generator != nullptr);
-	return m_Generator->GetBiomeAt(a_BlockX, a_BlockZ);
-}
-
-
-
-
-
-BLOCKTYPE cChunkGenerator::GetIniBlock(cIniFile & a_IniFile, const AString & a_SectionName, const AString & a_ValueName, const AString & a_Default)
-{
-	AString BlockType = a_IniFile.GetValueSet(a_SectionName, a_ValueName, a_Default);
-	int Block = BlockStringToType(BlockType);
-	if (Block < 0)
-	{
-		LOGWARN("[%s].%s Could not parse block value \"%s\". Using default: \"%s\".", a_SectionName.c_str(), a_ValueName.c_str(), BlockType.c_str(), a_Default.c_str());
-		return static_cast<BLOCKTYPE>(BlockStringToType(a_Default));
-	}
-	return static_cast<BLOCKTYPE>(Block);
-}
-
-
-
-
-
-void cChunkGenerator::Execute(void)
-{
-	// To be able to display performance information, the generator counts the chunks generated.
-	// When the queue gets empty, the count is reset, so that waiting for the queue is not counted into the total time.
-	int NumChunksGenerated = 0;  // Number of chunks generated since the queue was last empty
-	clock_t GenerationStart = clock();  // Clock tick when the queue started to fill
-	clock_t LastReportTick = clock();  // Clock tick of the last report made (so that performance isn't reported too often)
-
-	while (!m_ShouldTerminate)
-	{
-		cCSLock Lock(m_CS);
-		while (m_Queue.empty())
-		{
-			if ((NumChunksGenerated > 16) && (clock() - LastReportTick > CLOCKS_PER_SEC))
-			{
-				/* LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
-					static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC/ (clock() - GenerationStart),
-					NumChunksGenerated
-				); */
-			}
-			cCSUnlock Unlock(Lock);
-			m_Event.Wait();
-			if (m_ShouldTerminate)
-			{
-				return;
-			}
-			NumChunksGenerated = 0;
-			GenerationStart = clock();
-			LastReportTick = clock();
-		}
-
-		if (m_Queue.empty())
-		{
-			// Sometimes the queue remains empty
-			// If so, we can't do any front() operations on it!
-			continue;
-		}
-
-		cQueueItem item = m_Queue.front();  // Get next chunk from the queue
-		bool SkipEnabled = (m_Queue.size() > QUEUE_SKIP_LIMIT);
-		m_Queue.erase(m_Queue.begin());  // Remove the item from the queue
-		Lock.Unlock();  // Unlock ASAP
-		m_evtRemoved.Set();
-
-		// Display perf info once in a while:
-		if ((NumChunksGenerated > 512) && (clock() - LastReportTick > 2 * CLOCKS_PER_SEC))
-		{
-			LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
-				static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC / (clock() - GenerationStart),
-				NumChunksGenerated
-			);
-			LastReportTick = clock();
-		}
-
-		// Skip the chunk if it's already generated and regeneration is not forced. Report as success:
-		if (!item.m_ForceGenerate && m_ChunkSink->IsChunkValid(item.m_ChunkX, item.m_ChunkZ))
-		{
-			LOGD("Chunk [%d, %d] already generated, skipping generation", item.m_ChunkX, item.m_ChunkZ);
-			if (item.m_Callback != nullptr)
-			{
-				item.m_Callback->Call(item.m_ChunkX, item.m_ChunkZ, true);
-			}
-			continue;
-		}
-
-		// Skip the chunk if the generator is overloaded:
-		if (SkipEnabled && !m_ChunkSink->HasChunkAnyClients(item.m_ChunkX, item.m_ChunkZ))
-		{
-			LOGWARNING("Chunk generator overloaded, skipping chunk [%d, %d]", item.m_ChunkX, item.m_ChunkZ);
-			if (item.m_Callback != nullptr)
-			{
-				item.m_Callback->Call(item.m_ChunkX, item.m_ChunkZ, false);
-			}
-			continue;
-		}
-
-		// Generate the chunk:
-		// LOGD("Generating chunk [%d, %d]", item.m_ChunkX, item.m_ChunkZ);
-		DoGenerate(item.m_ChunkX, item.m_ChunkZ);
-		if (item.m_Callback != nullptr)
-		{
-			item.m_Callback->Call(item.m_ChunkX, item.m_ChunkZ, true);
-		}
-		NumChunksGenerated++;
-	}  // while (!bStop)
-}
-
-
-
-
-
-void cChunkGenerator::DoGenerate(int a_ChunkX, int a_ChunkZ)
-{
-	ASSERT(m_PluginInterface != nullptr);
-	ASSERT(m_ChunkSink != nullptr);
-
-	cChunkDesc ChunkDesc(a_ChunkX, a_ChunkZ);
-	m_PluginInterface->CallHookChunkGenerating(ChunkDesc);
-	m_Generator->DoGenerate(a_ChunkX, a_ChunkZ, ChunkDesc);
-	m_PluginInterface->CallHookChunkGenerated(ChunkDesc);
-
-	#ifdef _DEBUG
-		// Verify that the generator has produced valid data:
-		ChunkDesc.VerifyHeightmap();
-	#endif
-
-	m_ChunkSink->OnChunkGenerated(ChunkDesc);
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// cChunkGenerator::cGenerator:
-
-cChunkGenerator::cGenerator::cGenerator(cChunkGenerator & a_ChunkGenerator) :
-	m_ChunkGenerator(a_ChunkGenerator)
-{
-}
-
-
-
-
-
-void cChunkGenerator::cGenerator::Initialize(cIniFile & a_IniFile)
-{
-	UNUSED(a_IniFile);
-}
-
-
-
-
-
-EMCSBiome cChunkGenerator::cGenerator::GetBiomeAt(int a_BlockX, int a_BlockZ)
 {
 	cChunkDef::BiomeMap Biomes;
 	int Y = 0;

--- a/src/Generating/ChunkGenerator.h
+++ b/src/Generating/ChunkGenerator.h
@@ -50,6 +50,9 @@ protected:
 
 	/** The main seed, read from the INI file, used for the entire generator. */
 	int m_Seed;
+
+	/** The dimension, read from the INI file. */
+	eDimension m_Dimension;
 };
 
 

--- a/src/Generating/ChunkGenerator.h
+++ b/src/Generating/ChunkGenerator.h
@@ -1,24 +1,4 @@
-
-// ChunkGenerator.h
-
-// Interfaces to the cChunkGenerator class representing the thread that generates chunks
-
-/*
-The object takes requests for generating chunks and processes them in a separate thread one by one.
-The requests are not added to the queue if there is already a request with the same coords
-Before generating, the thread checks if the chunk hasn't been already generated.
-It is theoretically possible to have multiple generator threads by having multiple instances of this object,
-but then it MAY happen that the chunk is generated twice.
-If the generator queue is overloaded, the generator skips chunks with no clients in them
-*/
-
-
-
-
-
 #pragma once
-
-#include "../OSSupport/IsThread.h"
 
 
 
@@ -32,158 +12,44 @@ class cChunkDesc;
 
 
 
-class cChunkGenerator :
-	public cIsThread
+/** The interface that all chunk generators must implement to provide the generated chunks.
+Also a static factory that creates the descendants based on INI file settings.
+The cChunkGeneratorThread uses this interface to generate chunks for a single world.
+Ths calls to generate chunks are synchronous - they don't return until the chunk is fully generated. */
+class cChunkGenerator
 {
-	typedef cIsThread super;
-
 public:
-	/** The interface that a class has to implement to become a generator */
-	class cGenerator
-	{
-	public:
-		cGenerator(cChunkGenerator & a_ChunkGenerator);
-		virtual ~cGenerator() {}  // Force a virtual destructor
+	virtual ~cChunkGenerator() {}  // Force a virtual destructor
 
-		/** Called to initialize the generator on server startup. */
-		virtual void Initialize(cIniFile & a_IniFile);
+	/** Called to initialize the generator on server startup.
+	Descendants should call Super::Initialize() before initializing themselves. */
+	virtual void Initialize(cIniFile & a_IniFile);
 
-		/** Generates the biomes for the specified chunk (directly, not in a separate thread). Used by the world loader if biomes failed loading. */
-		virtual void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap) = 0;
+	/** Generates the biomes for the specified chunk.
+	Used by the world loader if biomes failed loading. */
+	virtual void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap) = 0;
 
-		/** Returns the biome at the specified coords. Used by ChunkMap if an invalid chunk is queried for biome. Default implementation uses GenerateBiomes(). */
-		virtual EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ);
+	/** Returns the biome at the specified coords.
+	Used by ChunkMap if an invalid chunk is queried for biome.
+	The default implementation uses GenerateBiomes(). */
+	virtual EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ);
 
-		/** Called in a separate thread to do the actual chunk generation. Generator should generate into a_ChunkDesc. */
-		virtual void DoGenerate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) = 0;
+	/** Does the actual chunk generation.
+	Descendants need to override this and generate into a_ChunkDesc. */
+	virtual void Generate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) = 0;
 
-	protected:
-		cChunkGenerator & m_ChunkGenerator;
-	} ;
-
-
-	/** The interface through which the plugins are called for their OnChunkGenerating / OnChunkGenerated hooks. */
-	class cPluginInterface
-	{
-	public:
-		// Force a virtual destructor
-		virtual ~cPluginInterface() {}
-
-		/** Called when the chunk is about to be generated.
-		The generator may be partly or fully overriden by the implementation. */
-		virtual void CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) = 0;
-
-		/** Called after the chunk is generated, before it is handed to the chunk sink.
-		a_ChunkDesc contains the generated chunk data. Implementation may modify this data. */
-		virtual void CallHookChunkGenerated(cChunkDesc & a_ChunkDesc) = 0;
-	} ;
-
-
-	/** The interface through which the generated chunks are handed to the cWorld or whoever created us. */
-	class cChunkSink
-	{
-	public:
-		// Force a virtual destructor
-		virtual ~cChunkSink() {}
-
-		/** Called after the chunk has been generated
-		The interface may store the chunk, send it over network, whatever.
-		The chunk is not expected to be modified, but the generator will survive if the implementation
-		changes the data within. All changes are ignored, though. */
-		virtual void OnChunkGenerated(cChunkDesc & a_ChunkDesc) = 0;
-
-		/** Called just before the chunk generation is started,
-		to verify that it hasn't been generated in the meantime.
-		If this callback returns true, the chunk is not generated. */
-		virtual bool IsChunkValid(int a_ChunkX, int a_ChunkZ) = 0;
-
-		/** Called when the generator is overloaded to skip chunks that are no longer needed.
-		If this callback returns false, the chunk is not generated. */
-		virtual bool HasChunkAnyClients(int a_ChunkX, int a_ChunkZ) = 0;
-
-		/** Called to check whether the specified chunk is in the queued state.
-		Currently used only in Debug-mode asserts. */
-		virtual bool IsChunkQueued(int a_ChunkX, int a_ChunkZ) = 0;
-	} ;
-
-
-	cChunkGenerator (void);
-	virtual ~cChunkGenerator() override;
-
-	/** Read settings from the ini file and initialize in preperation for being started. */
-	bool Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile);
-
-	void Stop(void);
-
-	/** Queues the chunk for generation
-	If a-ForceGenerate is set, the chunk is regenerated even if the data is already present in the chunksink.
-	a_Callback is called after the chunk is generated. If the chunk was already present, the callback is still called, even if not regenerating.
-	It is legal to set the callback to nullptr, no callback is called then.
-	If the generator becomes overloaded and skips this chunk, the callback is still called. */
-	void QueueGenerateChunk(int a_ChunkX, int a_ChunkZ, bool a_ForceGenerate, cChunkCoordCallback * a_Callback = nullptr);
-
-	/** Generates the biomes for the specified chunk (directly, not in a separate thread). Used by the world loader if biomes failed loading. */
-	void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap);
-
-	void WaitForQueueEmpty(void);
-
-	int GetQueueLength(void);
-
+	/** Returns the seed that was read from the INI file. */
 	int GetSeed(void) const { return m_Seed; }
 
-	/** Returns the biome at the specified coords. Used by ChunkMap if an invalid chunk is queried for biome */
-	EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ);
-
-	/** Reads a block type from the ini file; returns the blocktype on success, emits a warning and returns a_Default's representation on failure. */
-	static BLOCKTYPE GetIniBlock(cIniFile & a_IniFile, const AString & a_SectionName, const AString & a_ValueName, const AString & a_Default);
-
-private:
-
-	struct cQueueItem
-	{
-		/** The chunk coords */
-		int m_ChunkX, m_ChunkZ;
-
-		/** Force the regeneration of an already existing chunk */
-		bool m_ForceGenerate;
-
-		/** Callback to call after generating. */
-		cChunkCoordCallback * m_Callback;
-	};
-
-	typedef std::list<cQueueItem> cGenQueue;
+	/** Creates and initializes the entire generator based on the settings in the INI file.
+	Initializes the generator, so that it can be used immediately after this call returns. */
+	static std::unique_ptr<cChunkGenerator> CreateFromIniFile(cIniFile & a_IniFile);
 
 
-	/** Seed used for the generator. */
+protected:
+
+	/** The main seed, read from the INI file, used for the entire generator. */
 	int m_Seed;
-
-	/** CS protecting access to the queue. */
-	cCriticalSection m_CS;
-
-	/** Queue of the chunks to be generated. Protected against multithreaded access by m_CS. */
-	cGenQueue m_Queue;
-
-	/** Set when an item is added to the queue or the thread should terminate. */
-	cEvent m_Event;
-
-	/** Set when an item is removed from the queue. */
-	cEvent m_evtRemoved;
-
-	/** The actual generator engine used to generate chunks. */
-	cGenerator * m_Generator;
-
-	/** The plugin interface that may modify the generated chunks */
-	cPluginInterface * m_PluginInterface;
-
-	/** The destination where the generated chunks are sent */
-	cChunkSink * m_ChunkSink;
-
-
-	// cIsThread override:
-	virtual void Execute(void) override;
-
-	/** Generates the specified chunk and sets it into the chunksink. */
-	void DoGenerate(int a_ChunkX, int a_ChunkZ);
 };
 
 

--- a/src/Generating/CompoGenBiomal.cpp
+++ b/src/Generating/CompoGenBiomal.cpp
@@ -413,13 +413,15 @@ protected:
 				return;
 			}
 			case biInvalidBiome:
-			case biHell:
-			case biSky:
+			case biNether:
+			case biEnd:
 			case biNumBiomes:
 			case biVariant:
 			case biNumVariantBiomes:
 			{
-				ASSERT(!"Unhandled biome");
+				// This generator is not supposed to be used for these biomes, but it has to produce *something*
+				// so let's produce stone:
+				FillColumnPattern(a_ChunkDesc, a_RelX, a_RelZ, patStone.Get(), a_ShapeColumn);
 				return;
 			}
 		}  // switch (Biome)

--- a/src/Generating/ComposableGenerator.h
+++ b/src/Generating/ComposableGenerator.h
@@ -183,17 +183,17 @@ typedef std::list<cFinishGenPtr> cFinishGenList;
 
 
 class cComposableGenerator :
-	public cChunkGenerator::cGenerator
+	public cChunkGenerator
 {
-	typedef cChunkGenerator::cGenerator super;
+	typedef cChunkGenerator Super;
 
 public:
-	cComposableGenerator(cChunkGenerator & a_ChunkGenerator);
+	cComposableGenerator();
 
 	// cChunkGenerator::cGenerator overrides:
 	virtual void Initialize(cIniFile & a_IniFile) override;
 	virtual void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap) override;
-	virtual void DoGenerate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) override;
+	virtual void Generate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) override;
 
 protected:
 	// The generator's composition:

--- a/src/Generating/ComposableGenerator.h
+++ b/src/Generating/ComposableGenerator.h
@@ -55,11 +55,16 @@ public:
 	/** Reads parameters from the ini file, prepares generator for use. */
 	virtual void InitializeBiomeGen(cIniFile & a_IniFile) {}
 
-	/** Creates the correct BiomeGen descendant based on the ini file settings and the seed provided.
+	/** Creates the correct BiomeGen descendant based on the ini file settings.
+	a_Seed is the seed read from the INI file.
 	a_CacheOffByDefault gets set to whether the cache should be disabled by default.
 	Used in BiomeVisualiser, too.
 	Implemented in BioGen.cpp! */
-	static cBiomeGenPtr CreateBiomeGen(cIniFile & a_IniFile, int a_Seed, bool & a_CacheOffByDefault);
+	static cBiomeGenPtr CreateBiomeGen(
+		cIniFile & a_IniFile,
+		int a_Seed,
+		bool & a_CacheOffByDefault
+	);
 } ;
 
 
@@ -91,7 +96,12 @@ public:
 	a_CacheOffByDefault gets set to whether the cache should be disabled by default
 	Implemented in ShapeGen.cpp!
 	*/
-	static cTerrainShapeGenPtr CreateShapeGen(cIniFile & a_IniFile, cBiomeGenPtr a_BiomeGen, int a_Seed, bool & a_CacheOffByDefault);
+	static cTerrainShapeGenPtr CreateShapeGen(
+		cIniFile & a_IniFile,
+		cBiomeGenPtr a_BiomeGen,
+		int a_Seed,
+		bool & a_CacheOffByDefault
+	);
 } ;
 
 
@@ -126,7 +136,12 @@ public:
 	}
 
 	/** Creates a cTerrainHeightGen descendant based on the INI file settings. */
-	static cTerrainHeightGenPtr CreateHeightGen(cIniFile & a_IniFile, cBiomeGenPtr a_BiomeGen, int a_Seed, bool & a_CacheOffByDefault);
+	static cTerrainHeightGenPtr CreateHeightGen(
+		cIniFile & a_IniFile,
+		cBiomeGenPtr a_BiomeGen,
+		int a_Seed,
+		bool & a_CacheOffByDefault
+	);
 } ;
 
 
@@ -152,9 +167,13 @@ public:
 
 	/** Creates the correct TerrainCompositionGen descendant based on the ini file settings and the seed provided.
 	a_BiomeGen is the underlying biome generator, some composition generators may depend on it providing additional biomes around the chunk
-	a_ShapeGen is the underlying shape generator, some composition generators may depend on it providing additional shape around the chunk
-	*/
-	static cTerrainCompositionGenPtr CreateCompositionGen(cIniFile & a_IniFile, cBiomeGenPtr a_BiomeGen, cTerrainShapeGenPtr a_ShapeGen, int a_Seed);
+	a_ShapeGen is the underlying shape generator, some composition generators may depend on it providing additional shape around the chunk. */
+	static cTerrainCompositionGenPtr CreateCompositionGen(
+		cIniFile & a_IniFile,
+		cBiomeGenPtr a_BiomeGen,
+		cTerrainShapeGenPtr a_ShapeGen,
+		int a_Seed
+	);
 } ;
 
 
@@ -195,7 +214,13 @@ public:
 	virtual void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap) override;
 	virtual void Generate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) override;
 
+	/** If there's no particular sub-generator set in the INI file,
+	adds the default one, based on the dimension. */
+	static void InitializeGeneratorDefaults(cIniFile & a_IniFile, eDimension a_Dimension);
+
+
 protected:
+
 	// The generator's composition:
 	/** The biome generator. */
 	cBiomeGenPtr m_BiomeGen;

--- a/src/Generating/CompositedHeiGen.h
+++ b/src/Generating/CompositedHeiGen.h
@@ -34,7 +34,7 @@ public:
 	{
 		cChunkDesc::Shape shape;
 		m_ShapeGen->GenShape(a_ChunkX, a_ChunkZ, shape);
-		cChunkDesc desc(a_ChunkX, a_ChunkZ);
+		cChunkDesc desc({a_ChunkX, a_ChunkZ});
 		m_BiomeGen->GenBiomes(a_ChunkX, a_ChunkZ, desc.GetBiomeMap());	  // Need to initialize biomes for the composition gen
 		desc.SetHeightFromShape(shape);
 		m_CompositionGen->ComposeTerrain(desc, shape);

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -12,7 +12,6 @@
 #include "FinishGen.h"
 #include "../Simulator/FluidSimulator.h"  // for cFluidSimulator::CanWashAway()
 #include "../Simulator/FireSimulator.h"
-#include "../World.h"
 #include "../IniFile.h"
 #include "../MobSpawner.h"
 

--- a/src/Generating/Noise3DGenerator.cpp
+++ b/src/Generating/Noise3DGenerator.cpp
@@ -148,8 +148,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // cNoise3DGenerator:
 
-cNoise3DGenerator::cNoise3DGenerator(cChunkGenerator & a_ChunkGenerator) :
-	super(a_ChunkGenerator),
+cNoise3DGenerator::cNoise3DGenerator():
+	Super(),
 	m_Perlin(1000),
 	m_Cubic(1000)
 {
@@ -207,7 +207,7 @@ void cNoise3DGenerator::GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::Bi
 
 
 
-void cNoise3DGenerator::DoGenerate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc)
+void cNoise3DGenerator::Generate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc)
 {
 	NOISE_DATATYPE Noise[17 * 257 * 17];
 	GenerateNoiseArray(a_ChunkX, a_ChunkZ, Noise);

--- a/src/Generating/Noise3DGenerator.h
+++ b/src/Generating/Noise3DGenerator.h
@@ -21,17 +21,17 @@
 
 
 class cNoise3DGenerator :
-	public cChunkGenerator::cGenerator
+	public cChunkGenerator
 {
-	typedef cChunkGenerator::cGenerator super;
+	typedef cChunkGenerator Super;
 
 public:
-	cNoise3DGenerator(cChunkGenerator & a_ChunkGenerator);
+	cNoise3DGenerator();
 	virtual ~cNoise3DGenerator() override;
 
 	virtual void Initialize(cIniFile & a_IniFile) override;
 	virtual void GenerateBiomes(int a_ChunkX, int a_ChunkZ, cChunkDef::BiomeMap & a_BiomeMap) override;
-	virtual void DoGenerate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) override;
+	virtual void Generate(int a_ChunkX, int a_ChunkZ, cChunkDesc & a_ChunkDesc) override;
 
 protected:
 	// Linear interpolation step sizes, must be divisors of cChunkDef::Width and cChunkDef::Height, respectively:

--- a/src/Generating/ShapeGen.cpp
+++ b/src/Generating/ShapeGen.cpp
@@ -75,9 +75,14 @@ typedef std::shared_ptr<cTerrainHeightToShapeGen> cTerrainHeightToShapeGenPtr;
 ////////////////////////////////////////////////////////////////////////////////
 // cTerrainShapeGen:
 
-cTerrainShapeGenPtr cTerrainShapeGen::CreateShapeGen(cIniFile & a_IniFile, cBiomeGenPtr a_BiomeGen, int a_Seed, bool & a_CacheOffByDefault)
+cTerrainShapeGenPtr cTerrainShapeGen::CreateShapeGen(
+	cIniFile & a_IniFile,
+	cBiomeGenPtr a_BiomeGen,
+	int a_Seed,
+	bool & a_CacheOffByDefault
+)
 {
-	AString shapeGenName = a_IniFile.GetValueSet("Generator", "ShapeGen", "");
+	AString shapeGenName = a_IniFile.GetValue("Generator", "ShapeGen");
 	if (shapeGenName.empty())
 	{
 		LOGWARN("[Generator] ShapeGen value not set in world.ini, using \"BiomalNoise3D\".");

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -19,7 +19,7 @@ void cStructGenTrees::GenFinish(cChunkDesc & a_ChunkDesc)
 	int ChunkX = a_ChunkDesc.GetChunkX();
 	int ChunkZ = a_ChunkDesc.GetChunkZ();
 
-	cChunkDesc WorkerDesc(ChunkX, ChunkZ);
+	cChunkDesc WorkerDesc({ChunkX, ChunkZ});
 
 	// Generate trees:
 	for (int x = 0; x <= 2; x++)
@@ -34,7 +34,7 @@ void cStructGenTrees::GenFinish(cChunkDesc & a_ChunkDesc)
 			if ((x != 1) || (z != 1))
 			{
 				Dest = &WorkerDesc;
-				WorkerDesc.SetChunkCoords(BaseX, BaseZ);
+				WorkerDesc.SetChunkCoords({BaseX, BaseZ});
 
 				// TODO: This may cause a lot of wasted calculations, instead of pulling data out of a single (cChunkDesc) cache
 

--- a/src/Generating/Trees.cpp
+++ b/src/Generating/Trees.cpp
@@ -5,7 +5,6 @@
 
 #include "Globals.h"
 #include "Trees.h"
-#include "../World.h"
 
 
 
@@ -1055,90 +1054,4 @@ void GetSmallJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & 
 	// Top plus, all leaves:
 	PushCoordBlocks(a_BlockX, hei, a_BlockZ, a_OtherBlocks, BigO1, ARRAYCOUNT(BigO1), E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE);
 	a_OtherBlocks.push_back(sSetBlock(a_BlockX, hei, a_BlockZ, E_BLOCK_LEAVES, E_META_LEAVES_JUNGLE));
-}
-
-
-
-
-
-bool GetLargeTreeAdjustment(cWorld & a_World, int & a_X, int & a_Y, int & a_Z, NIBBLETYPE a_Meta)
-{
-	bool IsLarge = true;
-	a_Meta = a_Meta & 0x07;
-
-	// Check to see if we are the northwest corner
-	for (int x = 0; x  < 2; ++x)
-	{
-		for (int z = 0; z < 2; ++z)
-		{
-			NIBBLETYPE meta;
-			BLOCKTYPE type;
-			a_World.GetBlockTypeMeta(a_X + x, a_Y, a_Z + z, type, meta);
-			IsLarge = IsLarge && (type == E_BLOCK_SAPLING) && ((a_Meta & meta) == a_Meta);
-		}
-	}
-
-	if (IsLarge)
-	{
-		return true;
-	}
-
-	IsLarge = true;
-	// Check to see if we are the southwest corner
-	for (int x = 0; x  < 2; ++x)
-	{
-		for (int z = 0; z > -2; --z)
-		{
-			NIBBLETYPE meta;
-			BLOCKTYPE type;
-			a_World.GetBlockTypeMeta(a_X + x, a_Y, a_Z + z, type, meta);
-			IsLarge = IsLarge && (type == E_BLOCK_SAPLING) && ((a_Meta & meta) == a_Meta);
-		}
-	}
-
-	if (IsLarge)
-	{
-		--a_Z;
-		return true;
-	}
-
-	IsLarge = true;
-	// Check to see if we are the southeast corner
-	for (int x = 0; x > -2; --x)
-	{
-		for (int z = 0; z > -2; --z)
-		{
-			NIBBLETYPE meta;
-			BLOCKTYPE type;
-			a_World.GetBlockTypeMeta(a_X + x, a_Y, a_Z + z, type, meta);
-			IsLarge = IsLarge && (type == E_BLOCK_SAPLING) && ((a_Meta & meta) == a_Meta);
-		}
-	}
-
-	if (IsLarge)
-	{
-		--a_Z;
-		--a_X;
-		return true;
-	}
-
-	IsLarge = true;
-	// Check to see if we are the northeast corner
-	for (int x = 0; x > -2; --x)
-	{
-		for (int z = 0; z < 2; ++z)
-		{
-			NIBBLETYPE meta;
-			BLOCKTYPE type;
-			a_World.GetBlockTypeMeta(a_X + x, a_Y, a_Z + z, type, meta);
-			IsLarge = IsLarge && (type == E_BLOCK_SAPLING) && ((a_Meta & meta) == a_Meta);
-		}
-	}
-
-	if (IsLarge)
-	{
-		--a_X;
-	}
-
-	return IsLarge;
 }

--- a/src/Generating/Trees.h
+++ b/src/Generating/Trees.h
@@ -19,8 +19,6 @@ logs can overwrite others(leaves), but others shouldn't overwrite logs. This is 
 
 #include "../Noise/Noise.h"
 
-class cWorld;
-
 
 
 
@@ -104,9 +102,3 @@ void GetLargeJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & 
 
 /** Generates an image of a small jungle tree (1x1 trunk) */
 void GetSmallJungleTreeImage(int a_BlockX, int a_BlockY, int a_BlockZ, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
-
-/** Moves the x and z coordinants to the north-west corner of a 2x2 of saplings. Returns true if a 2x2 was found, otherwise it returns false */
-bool GetLargeTreeAdjustment(cWorld & a_World, int & a_X, int & a_Y, int & a_Z, NIBBLETYPE a_Meta);
-
-
-

--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -237,7 +237,7 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 	{
 		if (a_Item.m_CallbackAfter != nullptr)
 		{
-			a_Item.m_CallbackAfter->Call(a_Item.m_ChunkX, a_Item.m_ChunkZ, true);
+			a_Item.m_CallbackAfter->Call({a_Item.m_ChunkX, a_Item.m_ChunkZ}, true);
 		}
 		return;
 	}
@@ -318,7 +318,7 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 
 	if (a_Item.m_CallbackAfter != nullptr)
 	{
-		a_Item.m_CallbackAfter->Call(a_Item.m_ChunkX, a_Item.m_ChunkZ, true);
+		a_Item.m_CallbackAfter->Call({a_Item.m_ChunkX, a_Item.m_ChunkZ}, true);
 	}
 }
 

--- a/src/SpawnPrepare.cpp
+++ b/src/SpawnPrepare.cpp
@@ -21,9 +21,9 @@ protected:
 
 	std::shared_ptr<cSpawnPrepare> m_SpawnPrepare;
 
-	virtual void Call(int a_ChunkX, int a_ChunkZ, bool a_IsSuccess) override
+	virtual void Call(cChunkCoords a_Coords, bool a_IsSuccess) override
 	{
-		m_SpawnPrepare->PreparedChunkCallback(a_ChunkX, a_ChunkZ);
+		m_SpawnPrepare->PreparedChunkCallback(a_Coords.m_ChunkX, a_Coords.m_ChunkZ);
 	}
 };
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -7,6 +7,7 @@
 #include "Root.h"
 #include "IniFile.h"
 #include "Generating/ChunkDesc.h"
+#include "Generating/ComposableGenerator.h"
 #include "SetChunkData.h"
 #include "DeadlockDetect.h"
 #include "LineBlockTracer.h"
@@ -400,8 +401,9 @@ cWorld::cWorld(
 	m_TNTShrapnelLevel = static_cast<eShrapnelLevel>(Clamp<int>(TNTShrapnelLevel, slNone,     slAll));
 	m_Weather          = static_cast<eWeather>      (Clamp<int>(Weather,          wSunny,     wStorm));
 
-	InitialiseGeneratorDefaults(IniFile);
-	InitialiseAndLoadMobSpawningValues(IniFile);
+	cComposableGenerator::InitializeGeneratorDefaults(IniFile, m_Dimension);
+
+	InitializeAndLoadMobSpawningValues(IniFile);
 	SetTimeOfDay(IniFile.GetValueSetI("General", "TimeInTicks", GetTimeOfDay()));
 
 	m_ChunkMap = cpp14::make_unique<cChunkMap>(this);
@@ -881,54 +883,7 @@ eWeather cWorld::ChooseNewWeather()
 
 
 
-void cWorld::InitialiseGeneratorDefaults(cIniFile & a_IniFile)
-{
-	switch (GetDimension())
-	{
-		case dimEnd:
-		{
-			a_IniFile.GetValueSet("Generator", "Generator",      "Composable");
-			a_IniFile.GetValueSet("Generator", "BiomeGen",       "Constant");
-			a_IniFile.GetValueSet("Generator", "ConstantBiome",  "End");
-			a_IniFile.GetValueSet("Generator", "ShapeGen",       "End");
-			a_IniFile.GetValueSet("Generator", "CompositionGen", "End");
-			break;
-		}
-		case dimOverworld:
-		{
-			a_IniFile.GetValueSet("Generator", "Generator",      "Composable");
-			a_IniFile.GetValueSet("Generator", "BiomeGen",       "Grown");
-			a_IniFile.GetValueSet("Generator", "ShapeGen",       "BiomalNoise3D");
-			a_IniFile.GetValueSet("Generator", "CompositionGen", "Biomal");
-			a_IniFile.GetValueSet("Generator", "Finishers",      "RoughRavines, WormNestCaves, WaterLakes, WaterSprings, LavaLakes, LavaSprings, OreNests, Mineshafts, Trees, Villages, TallGrass, SprinkleFoliage, Ice, Snow, Lilypads, BottomLava, DeadBushes, NaturalPatches, PreSimulator, Animals");
-			break;
-		}
-		case dimNether:
-		{
-			a_IniFile.GetValueSet("Generator", "Generator",        "Composable");
-			a_IniFile.GetValueSet("Generator", "BiomeGen",         "Constant");
-			a_IniFile.GetValueSet("Generator", "ConstantBiome",    "Nether");
-			a_IniFile.GetValueSet("Generator", "ShapeGen",         "HeightMap");
-			a_IniFile.GetValueSet("Generator", "HeightGen",        "Flat");
-			a_IniFile.GetValueSet("Generator", "FlatHeight",       "128");
-			a_IniFile.GetValueSet("Generator", "CompositionGen",   "Nether");
-			a_IniFile.GetValueSet("Generator", "Finishers",        "SoulsandRims, WormNestCaves, BottomLava, LavaSprings, NetherClumpFoliage, NetherOreNests, PieceStructures: NetherFort, GlowStone, PreSimulator");
-			a_IniFile.GetValueSet("Generator", "BottomLavaHeight", "30");
-			break;
-		}
-		case dimNotSet:
-		{
-			ASSERT(!"Dimension not set");
-			break;
-		}
-	}
-}
-
-
-
-
-
-void cWorld::InitialiseAndLoadMobSpawningValues(cIniFile & a_IniFile)
+void cWorld::InitializeAndLoadMobSpawningValues(cIniFile & a_IniFile)
 {
 	AString DefaultMonsters;
 	switch (m_Dimension)

--- a/src/World.h
+++ b/src/World.h
@@ -1133,11 +1133,8 @@ private:
 	Assumes it is called from the Tick thread. */
 	void AddQueuedPlayers(void);
 
-	/** Sets generator values to dimension specific defaults, if those values do not exist */
-	void InitialiseGeneratorDefaults(cIniFile & a_IniFile);
-
 	/** Sets mob spawning values if nonexistant to their dimension specific defaults */
-	void InitialiseAndLoadMobSpawningValues(cIniFile & a_IniFile);
+	void InitializeAndLoadMobSpawningValues(cIniFile & a_IniFile);
 
 	/** Sets the specified chunk data into the chunkmap. Called in the tick thread.
 	Modifies the a_SetChunkData - moves the entities contained in it into the chunk. */

--- a/src/WorldStorage/WorldStorage.cpp
+++ b/src/WorldStorage/WorldStorage.cpp
@@ -240,7 +240,7 @@ bool cWorldStorage::LoadOneChunk(void)
 	// Call the callback, if specified:
 	if (ToLoad.m_Callback != nullptr)
 	{
-		ToLoad.m_Callback->Call(ToLoad.m_ChunkX, ToLoad.m_ChunkZ, res);
+		ToLoad.m_Callback->Call({ToLoad.m_ChunkX, ToLoad.m_ChunkZ}, res);
 	}
 	return res;
 }
@@ -274,7 +274,7 @@ bool cWorldStorage::SaveOneChunk(void)
 	// Call the callback, if specified:
 	if (ToSave.m_Callback != nullptr)
 	{
-		ToSave.m_Callback->Call(ToSave.m_ChunkX, ToSave.m_ChunkZ, Status);
+		ToSave.m_Callback->Call({ToSave.m_ChunkX, ToSave.m_ChunkZ}, Status);
 	}
 	return true;
 }

--- a/tests/Generating/BasicGeneratorTest.cpp
+++ b/tests/Generating/BasicGeneratorTest.cpp
@@ -1,0 +1,223 @@
+#include "Globals.h"
+#include "Generating/ChunkGenerator.h"
+#include "Generating/ChunkDesc.h"
+#include "../TestHelpers.h"
+#include "IniFile.h"
+
+
+
+
+
+/** Checks that the chunk's heightmap corresponds to the chunk contents. */
+static void verifyChunkDescHeightmap(const cChunkDesc & a_ChunkDesc)
+{
+	for (int x = 0; x < cChunkDef::Width; x++)
+	{
+		for (int z = 0; z < cChunkDef::Width; z++)
+		{
+			for (int y = cChunkDef::Height - 1; y > 0; y--)
+			{
+				BLOCKTYPE BlockType = a_ChunkDesc.GetBlockType(x, y, z);
+				if (BlockType != E_BLOCK_AIR)
+				{
+					int Height = a_ChunkDesc.GetHeight(x, z);
+					TEST_EQUAL_MSG(Height, y, Printf("Chunk height at <%d, %d>: exp %d, got %d", x, z, y, Height));
+					break;
+				}
+			}  // for y
+		}  // for z
+	}  // for x
+}
+
+
+
+
+
+/** Prints out the entire column from the chunk, one block type per line. */
+static void printChunkColumn(const cChunkDesc & a_ChunkDesc, int a_X, int a_Z)
+{
+	auto prevBlockType = a_ChunkDesc.GetBlockType(a_X, cChunkDef::Height - 1, a_Z);
+	int count = 1;
+	LOG("Column {%d, %d}:", a_X, a_Z);
+	LOG("Yfrom\tYto\tcnt\ttype\ttypeStr");
+	for (int y = cChunkDef::Height - 2; y >= 0; --y)
+	{
+		auto blockType = a_ChunkDesc.GetBlockType(a_X, y, a_Z);
+		if (blockType != prevBlockType)
+		{
+			LOG("%d\t%d\t%d\t%d\t%s", y + 1, y + count, count, prevBlockType, ItemTypeToString(prevBlockType));
+			prevBlockType = blockType;
+			count = 1;
+		}
+		else
+		{
+			count += 1;
+		}
+	}
+	LOG("%d\t%d\t%d\t%s", 0, count, prevBlockType, ItemTypeToString(prevBlockType));
+}
+
+
+
+
+
+/** Tests that the default Overworld generator generates a few chunks that have the Overworld look:
+- bedrock at their bottom
+- a valid overworld block at their height's top
+- air at their top, unless the height at that point is equal to full chunk height.
+- valid heightmap
+Multiple chunks are tested. */
+static void testGenerateOverworld()
+{
+	LOG("Testing Overworld generator...");
+
+	// Create a default Overworld generator:
+	cIniFile ini;
+	ini.AddValue("General", "Dimension", "Overworld");
+	ini.AddValueI("Seed", "Seed", 1);
+	ini.AddValue("Generator", "Finishers", "");  // Use no finishers, so that we don't have to check too many blocktypes
+	auto gen = cChunkGenerator::CreateFromIniFile(ini);
+	TEST_NOTEQUAL(gen, nullptr);
+
+	for (int chunkX = 0; chunkX < 50; ++chunkX)
+	{
+		// Generate a chunk:
+		cChunkDesc chd({chunkX, 0});
+		gen->Generate(chunkX, 0, chd);
+		verifyChunkDescHeightmap(chd);
+
+		// Check that it has bedrock at the bottom:
+		for (int x = 0; x < cChunkDef::Width; ++x)
+		{
+			for (int z = 0; z < cChunkDef::Width; ++z)
+			{
+				TEST_EQUAL_MSG(chd.GetBlockType(x, 0, z), E_BLOCK_BEDROCK, Printf("Bedrock floor at {%d, 0, %d}", x, z));
+			}
+		}
+
+		// Check that the blocks on the top are valid Overworld blocks:
+		static std::set<BLOCKTYPE> validOverworldBlockTypes =
+		{
+			E_BLOCK_STONE,
+			E_BLOCK_GRASS,
+			E_BLOCK_WATER,
+			E_BLOCK_STATIONARY_WATER,
+			E_BLOCK_LAVA,
+			E_BLOCK_STATIONARY_LAVA,
+			E_BLOCK_SAND,
+			E_BLOCK_GRAVEL,
+			E_BLOCK_LEAVES,
+			E_BLOCK_NEW_LEAVES,
+		};
+		for (int x = 0; x < cChunkDef::Width; ++x)
+		{
+			for (int z = 0; z < cChunkDef::Width; ++z)
+			{
+				auto y = chd.GetHeight(x, z);
+				auto blockType = chd.GetBlockType(x, y, z);
+				TEST_EQUAL_MSG(validOverworldBlockTypes.count(blockType), 1,
+					Printf("Block at {%d, %d, %d}: %d", x, y, z, blockType)
+				);
+				if (y < cChunkDef::Height - 1)
+				{
+					TEST_EQUAL_MSG(chd.GetBlockType(x, cChunkDef::Height - 1, z), E_BLOCK_AIR,
+						Printf("Air at {%d, %d, %d}", x, cChunkDef::Height - 1, z)
+					);
+				}
+			}
+		}
+	}
+}
+
+
+
+
+
+/** Tests that the default Nether generator generates a chunk that has the Nether look:
+- bedrock at the bottom
+- bedrock at the height's top
+- netherrack, lava or soulsand anywhere in the middle
+- valid heightmap
+Multiple chunks are tested. */
+static void testGenerateNether()
+{
+	LOG("Testing Nether generator...");
+
+	// Create a default Nether generator:
+	cIniFile ini;
+	ini.AddValue("General", "Dimension", "Nether");
+	ini.AddValueI("Seed", "Seed", 1);
+	auto gen = cChunkGenerator::CreateFromIniFile(ini);
+	TEST_NOTEQUAL(gen, nullptr);
+
+	for (int chunkX = 0; chunkX < 50; ++chunkX)
+	{
+		// Generate a chunk:
+		cChunkDesc chd({chunkX, 0});
+		gen->Generate(chunkX, 0, chd);
+		verifyChunkDescHeightmap(chd);
+
+		// Check that the biome is Nether everywhere:
+		for (int x = 0; x < cChunkDef::Width; ++x)
+		{
+			for (int z = 0; z < cChunkDef::Width; ++z)
+			{
+				TEST_EQUAL_MSG(chd.GetBiome(x, z), biNether, Printf("Nether biome at {%d, %d}", x, z));
+			}
+		}
+
+		// Check that it has bedrock at the bottom and height:
+		int prevHeight = chd.GetHeight(0, 0);
+		for (int x = 0; x < cChunkDef::Width; ++x)
+		{
+			for (int z = 0; z < cChunkDef::Width; ++z)
+			{
+				TEST_EQUAL_MSG(chd.GetBlockType(x, 0, z), E_BLOCK_BEDROCK, Printf("Bedrock floor at {%d, 0, %d}", x, z));
+				auto y = chd.GetHeight(x, z);
+				TEST_EQUAL(y, prevHeight);  // Same height across the entire chunk
+				auto blockType = chd.GetBlockType(x, y, z);
+				TEST_EQUAL_MSG(blockType, E_BLOCK_BEDROCK,
+					Printf("Bedrock ceiling at {%d, %d, %d}: %d", x, y, z, blockType)
+				);
+			}
+		}
+
+		// Check that the blocks on the top are valid Overworld blocks:
+		for (int x = 0; x < cChunkDef::Width; ++x)
+		{
+			for (int z = 0; z < cChunkDef::Width; ++z)
+			{
+				bool hasSuitableBlockType = false;
+				for (int y = chd.GetHeight(x, z); y > 0; --y)
+				{
+					switch (chd.GetBlockType(x, y, z))
+					{
+						case E_BLOCK_NETHERRACK:
+						case E_BLOCK_NETHER_QUARTZ_ORE:
+						case E_BLOCK_LAVA:
+						case E_BLOCK_STATIONARY_LAVA:
+						case E_BLOCK_SOULSAND:
+						{
+							hasSuitableBlockType = true;
+							break;
+						}
+					}
+				}  // for y
+				if (!hasSuitableBlockType)
+				{
+					printChunkColumn(chd, x, z);
+					TEST_FAIL(Printf("!hasSuitableBlockType at column {%d, %d} of chunk [%d, 0]", x, z, chunkX));
+				}
+			}
+		}
+	}
+}
+
+
+
+
+
+IMPLEMENT_TEST_MAIN("BasicGeneratorTest",
+	testGenerateOverworld();
+	testGenerateNether();
+)

--- a/tests/Generating/CMakeLists.txt
+++ b/tests/Generating/CMakeLists.txt
@@ -10,10 +10,16 @@ add_definitions(-DTEST_GLOBALS=1)
 set (SHARED_SRCS
 	${CMAKE_SOURCE_DIR}/src/BiomeDef.cpp
 	${CMAKE_SOURCE_DIR}/src/BlockArea.cpp
+	${CMAKE_SOURCE_DIR}/src/BlockID.cpp
 	${CMAKE_SOURCE_DIR}/src/Cuboid.cpp
 	${CMAKE_SOURCE_DIR}/src/ChunkData.cpp
+	${CMAKE_SOURCE_DIR}/src/Enchantments.cpp
+	${CMAKE_SOURCE_DIR}/src/FastRandom.cpp
+	${CMAKE_SOURCE_DIR}/src/IniFile.cpp
+	${CMAKE_SOURCE_DIR}/src/ProbabDistrib.cpp
 	${CMAKE_SOURCE_DIR}/src/StringCompression.cpp
 	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${CMAKE_SOURCE_DIR}/src/VoronoiMap.cpp
 
 	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.cpp  # Needed for PrefabPiecePool loading
 
@@ -64,11 +70,18 @@ set (GENERATING_SRCS
 set (SHARED_HDRS
 	${CMAKE_SOURCE_DIR}/src/BiomeDef.h
 	${CMAKE_SOURCE_DIR}/src/BlockArea.h
+	${CMAKE_SOURCE_DIR}/src/BlockID.h
 	${CMAKE_SOURCE_DIR}/src/Cuboid.h
 	${CMAKE_SOURCE_DIR}/src/ChunkData.h
+	${CMAKE_SOURCE_DIR}/src/ChunkDef.h
+	${CMAKE_SOURCE_DIR}/src/Enchantments.h
+	${CMAKE_SOURCE_DIR}/src/FastRandom.h
 	${CMAKE_SOURCE_DIR}/src/Globals.h
+	${CMAKE_SOURCE_DIR}/src/IniFile.h
+	${CMAKE_SOURCE_DIR}/src/ProbabDistrib.h
 	${CMAKE_SOURCE_DIR}/src/StringCompression.h
 	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${CMAKE_SOURCE_DIR}/src/VoronoiMap.h
 
 	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.h
 
@@ -151,6 +164,22 @@ source_group("Generating" FILES ${GENERATING_HDRS} ${GENERATING_SRCS})
 
 
 
+# BasicGeneratingTest:
+add_executable(BasicGeneratorTest
+	BasicGeneratorTest.cpp
+	${CMAKE_SOURCE_DIR}/src/IniFile.cpp
+)
+target_link_libraries(BasicGeneratorTest GeneratorTestingSupport)
+file(COPY "${CMAKE_SOURCE_DIR}/Server/items.ini" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+add_test(
+	NAME BasicGeneratorTest
+	COMMAND BasicGeneratorTest
+)
+
+
+
+
+
 # LoadablePieces test:
 source_group("Data files" FILES Test.cubeset Test1.schematic)
 add_executable(LoadablePieces
@@ -201,6 +230,7 @@ add_test(
 
 # Put the projects into solution folders (MSVC):
 set_target_properties(
+	BasicGeneratorTest
 	GeneratorTestingSupport
 	LoadablePieces
 	PieceGeneratorBFSTree

--- a/tests/Generating/CMakeLists.txt
+++ b/tests/Generating/CMakeLists.txt
@@ -15,19 +15,11 @@ set (SHARED_SRCS
 	${CMAKE_SOURCE_DIR}/src/StringCompression.cpp
 	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.cpp
-
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
+	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.cpp  # Needed for PrefabPiecePool loading
 
 	${CMAKE_SOURCE_DIR}/src/Noise/Noise.cpp
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
+	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp  # Needed for LuaState
 	${CMAKE_SOURCE_DIR}/src/OSSupport/File.cpp
 	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
 	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
@@ -35,6 +27,38 @@ set (SHARED_SRCS
 
 	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
 	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
+)
+
+set (GENERATING_SRCS
+	${CMAKE_SOURCE_DIR}/src/Generating/BioGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/Caves.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/ChunkGenerator.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/CompoGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/CompoGenBiomal.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/ComposableGenerator.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/DistortedHeightmap.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/DungeonRoomsFinisher.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/EndGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/FinishGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/GridStructGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/HeiGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/MineShafts.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/Noise3DGenerator.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/PieceStructuresGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/PrefabStructure.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/Ravines.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/RoughRavines.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/StructGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/Trees.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/TwoHeights.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/VillageGen.cpp
 )
 
 set (SHARED_HDRS
@@ -48,13 +72,6 @@ set (SHARED_HDRS
 
 	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.h
 
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.h
-
 	${CMAKE_SOURCE_DIR}/src/Noise/Noise.h
 
 	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.h
@@ -66,6 +83,42 @@ set (SHARED_HDRS
 
 	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.h
 	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
+)
+
+set (GENERATING_HDRS
+	${CMAKE_SOURCE_DIR}/src/Generating/BioGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/Caves.h
+	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.h
+	${CMAKE_SOURCE_DIR}/src/Generating/ChunkGenerator.h
+	${CMAKE_SOURCE_DIR}/src/Generating/CompoGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/CompoGenBiomal.h
+	${CMAKE_SOURCE_DIR}/src/Generating/ComposableGenerator.h
+	${CMAKE_SOURCE_DIR}/src/Generating/CompositedHeiGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/DistortedHeightmap.h
+	${CMAKE_SOURCE_DIR}/src/Generating/DungeonRoomsFinisher.h
+	${CMAKE_SOURCE_DIR}/src/Generating/EndGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/FinishGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/GridStructGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/HeiGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/IntGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/MineShafts.h
+	${CMAKE_SOURCE_DIR}/src/Generating/Noise3DGenerator.h
+	${CMAKE_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.h
+	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.h
+	${CMAKE_SOURCE_DIR}/src/Generating/PieceStructuresGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.h
+	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
+	${CMAKE_SOURCE_DIR}/src/Generating/PrefabStructure.h
+	${CMAKE_SOURCE_DIR}/src/Generating/ProtIntGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/Ravines.h
+	${CMAKE_SOURCE_DIR}/src/Generating/RoughRavines.h
+	${CMAKE_SOURCE_DIR}/src/Generating/ShapeGen.cpp
+	${CMAKE_SOURCE_DIR}/src/Generating/StructGen.h
+	${CMAKE_SOURCE_DIR}/src/Generating/Trees.h
+	${CMAKE_SOURCE_DIR}/src/Generating/TwoHeights.h
+	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.h
+	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.h
+	${CMAKE_SOURCE_DIR}/src/Generating/VillageGen.h
 )
 
 set (STUBS
@@ -83,9 +136,16 @@ endif()
 
 
 
-add_library(GeneratorTestingSupport STATIC ${SHARED_SRCS} ${SHARED_HDRS} ${STUBS})
+add_library(GeneratorTestingSupport STATIC
+	${SHARED_SRCS}
+	${SHARED_HDRS}
+	${GENERATING_SRCS}
+	${GENERATING_HDRS}
+	${STUBS}
+)
 target_link_libraries(GeneratorTestingSupport tolualib zlib fmt::fmt)
 source_group("Stubs" FILES ${STUBS})
+source_group("Generating" FILES ${GENERATING_HDRS} ${GENERATING_SRCS})
 
 
 
@@ -93,18 +153,32 @@ source_group("Stubs" FILES ${STUBS})
 
 # LoadablePieces test:
 source_group("Data files" FILES Test.cubeset Test1.schematic)
-add_executable(LoadablePieces LoadablePieces.cpp Test.cubeset Test1.schematic)
+add_executable(LoadablePieces
+	LoadablePieces.cpp
+	Test.cubeset
+	Test1.schematic
+)
 target_link_libraries(LoadablePieces GeneratorTestingSupport)
-add_test(NAME LoadablePieces-test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND LoadablePieces)
+add_test(
+	NAME LoadablePieces-test
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	COMMAND LoadablePieces
+)
 
 
 
 
 
 # PieceRotation test:
-add_executable(PieceRotation PieceRotationTest.cpp)
+add_executable(PieceRotation
+	PieceRotationTest.cpp
+)
 target_link_libraries(PieceRotation GeneratorTestingSupport)
-add_test(NAME PieceRotation-test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND PieceRotation)
+add_test(
+	NAME PieceRotation-test
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	COMMAND PieceRotation
+)
 
 
 
@@ -113,11 +187,13 @@ add_test(NAME PieceRotation-test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} C
 # PieceGeneratorBFSTree test:
 add_executable(PieceGeneratorBFSTree
 	PieceGeneratorBFSTreeTest.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.h
 )
 target_link_libraries(PieceGeneratorBFSTree GeneratorTestingSupport)
-add_test(NAME PieceGeneratorBFSTree-test WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Server/Prefabs/PieceStructures COMMAND PieceGeneratorBFSTree)
+add_test(
+	NAME PieceGeneratorBFSTree-test
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Server/Prefabs/PieceStructures
+	COMMAND PieceGeneratorBFSTree
+)
 
 
 

--- a/tests/Generating/Stubs.cpp
+++ b/tests/Generating/Stubs.cpp
@@ -16,6 +16,12 @@
 #include "Blocks/BlockHandler.h"
 #include "Generating/ChunkDesc.h"
 #include "DeadlockDetect.h"
+#include "Entities/Entity.h"
+#include "Mobs/Monster.h"
+#include "Simulator/FluidSimulator.h"
+#include "Simulator/FireSimulator.h"
+#include "MobSpawner.h"
+#include "ItemGrid.h"
 
 
 
@@ -106,6 +112,7 @@ cBlockInfo::cBlockInfoArray::cBlockInfoArray()
 		BlockInfos[i].m_Handler.reset(new cBlockHandler(static_cast<BLOCKTYPE>(i)));
 	}
 }
+
 
 
 
@@ -352,3 +359,68 @@ bool cUUID::FromString(const AString&)
 
 
 
+
+void cEntity::SetPosition(const Vector3d & a_Position)
+{
+}
+
+
+
+
+
+void cEntity::SetHealth(float a_NewHealth)
+{
+}
+
+
+
+
+
+cMonster::eFamily cMonster::FamilyFromType(eMonsterType a_Type)
+{
+	return cMonster::mfAmbient;
+}
+
+
+
+
+
+std::unique_ptr<cMonster> cMonster::NewMonsterFromType(eMonsterType a_Type)
+{
+	return nullptr;
+}
+
+
+
+
+
+bool cFluidSimulator::CanWashAway(BLOCKTYPE a_BlockType)
+{
+	return false;
+}
+
+
+
+
+
+bool cFireSimulator::DoesBurnForever(BLOCKTYPE a_BlockType)
+{
+	return false;
+}
+
+
+
+
+
+void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, size_t a_CountLootProbabs, int a_NumSlots, int a_Seed)
+{
+}
+
+
+
+
+
+std::set<eMonsterType> cMobSpawner::GetAllowedMobTypes(EMCSBiome a_Biome)
+{
+	return {};
+}

--- a/tests/TestHelpers.h
+++ b/tests/TestHelpers.h
@@ -172,6 +172,14 @@ public:
 
 
 
+/** Fails the test unconditionally, with the specified message. */
+#define TEST_FAIL(MSG) \
+	throw TestException(__FILE__, __LINE__, __FUNCTION__, MSG);
+
+
+
+
+
 /** Checks that the statement causes an ASSERT trigger. */
 #ifdef _DEBUG
 	#define TEST_ASSERTS(Stmt) TEST_THROWS(Stmt, cAssertFailure)
@@ -210,7 +218,9 @@ int main() \
 	} \
 	catch (const cAssertFailure & exc) \
 	{ \
-		LOGERROR("Test has failed, an unexpected ASSERT was triggered at %s:%d", exc.fileName().c_str(), exc.lineNumber()); \
+		LOGERROR("Test has failed, an unexpected ASSERT was triggered at %s:%d: %s", \
+			exc.fileName().c_str(), exc.lineNumber(), exc.expression().c_str() \
+		); \
 		return 1; \
 	} \
 	catch (...) \


### PR DESCRIPTION
The generator now doesn't depend on any `cChunkSink` or `cPluginInterface`, its sole responsibility is to generate a single chunk on request.
Moved the generator defaults into the `cComposableGenerator`, rather than `cWorld`.
Added a basic test that checks the default Overworld and Nether generator.