### PR TITLE
Fix generator repeatability

### DIFF
--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -222,6 +222,10 @@ public:
 	inline cEntityList &             GetEntities              (void) { return m_Entities; }
 	inline cBlockEntities &          GetBlockEntities         (void) { return m_BlockEntities; }
 
+	inline const cChunkDef::BiomeMap &     GetBiomeMap()   const { return m_BiomeMap; }
+	inline const cChunkDef::BlockTypes &   GetBlockTypes() const { return *(reinterpret_cast<cChunkDef::BlockTypes *>(m_BlockArea.GetBlockTypes())); }
+	inline const cChunkDef::HeightMap &    GetHeightMap()  const { return m_HeightMap; }
+
 	/** Compresses the metas from the BlockArea format (1 meta per byte) into regular format (2 metas per byte) */
 	void CompressBlockMetas(cChunkDef::BlockNibbles & a_DestMetas);
 

--- a/src/Generating/CompoGen.cpp
+++ b/src/Generating/CompoGen.cpp
@@ -246,16 +246,12 @@ void cCompoGenNether::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc:
 	// Interpolate the lowest floor:
 	for (int z = 0; z <= 16 / INTERPOL_Z; z++) for (int x = 0; x <= 16 / INTERPOL_X; x++)
 	{
-		//*
-		FloorLo[INTERPOL_X * x + 17 * INTERPOL_Z * z] =
+		// We need to store the intermediate result in a volatile variable, otherwise gcc -O2 optimizes
+		// through the undefined behavior in cNoise and produces different data than the other platforms / build types (#4384)
+		volatile int intermediate =
 			m_Noise1.IntNoise3DInt(BaseX + INTERPOL_X * x, 0, BaseZ + INTERPOL_Z * z) *
-			m_Noise2.IntNoise3DInt(BaseX + INTERPOL_X * x, 0, BaseZ + INTERPOL_Z * z) /
-			256;
-		//*/
-		/*
-		FloorLo[INTERPOL_X * x + 17 * INTERPOL_Z * z] =
-			m_Noise1.IntNoise3DInt(BaseX + INTERPOL_X * x, 0, BaseZ + INTERPOL_Z * z) / 256;
-		//*/
+			m_Noise2.IntNoise3DInt(BaseX + INTERPOL_X * x, 0, BaseZ + INTERPOL_Z * z);
+		FloorLo[INTERPOL_X * x + 17 * INTERPOL_Z * z] = intermediate / 256;
 	}  // for x, z - FloorLo[]
 	LinearUpscale2DArrayInPlace<17, 17, INTERPOL_X, INTERPOL_Z>(FloorLo);
 
@@ -265,16 +261,12 @@ void cCompoGenNether::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc:
 		// First update the high floor:
 		for (int z = 0; z <= 16 / INTERPOL_Z; z++) for (int x = 0; x <= 16 / INTERPOL_X; x++)
 		{
-			//*
-			FloorHi[INTERPOL_X * x + 17 * INTERPOL_Z * z] =
+			// We need to store the intermediate result in a volatile variable, otherwise gcc -O2 optimizes
+			// through the undefined behavior in cNoise and produces different data than the other platforms / build types (#4384)
+			volatile int intermediate =
 				m_Noise1.IntNoise3DInt(BaseX + INTERPOL_X * x, Segment + SEGMENT_HEIGHT, BaseZ + INTERPOL_Z * z) *
-				m_Noise2.IntNoise3DInt(BaseX + INTERPOL_Z * x, Segment + SEGMENT_HEIGHT, BaseZ + INTERPOL_Z * z) /
-				256;
-			//*/
-			/*
-			FloorHi[INTERPOL_X * x + 17 * INTERPOL_Z * z] =
-				m_Noise1.IntNoise3DInt(BaseX + INTERPOL_X * x, Segment + SEGMENT_HEIGHT, BaseZ + INTERPOL_Z * z) / 256;
-			//*/
+				m_Noise2.IntNoise3DInt(BaseX + INTERPOL_Z * x, Segment + SEGMENT_HEIGHT, BaseZ + INTERPOL_Z * z);
+			FloorHi[INTERPOL_X * x + 17 * INTERPOL_Z * z] = intermediate / 256;
 		}  // for x, z - FloorLo[]
 		LinearUpscale2DArrayInPlace<17, 17, INTERPOL_X, INTERPOL_Z>(FloorHi);
 
@@ -287,7 +279,7 @@ void cCompoGenNether::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc:
 			for (int y = 0; y < SEGMENT_HEIGHT; y++)
 			{
 				int Val = Lo + (Hi - Lo) * y / SEGMENT_HEIGHT;
-				if (Val < Threshold)  // Don't calculate if the block should be Netherrack when it's already decided that it's air.
+				if (Val < Threshold)
 				{
 					a_ChunkDesc.SetBlockType(x, y + Segment, z, E_BLOCK_NETHERRACK);
 				}
@@ -298,7 +290,7 @@ void cCompoGenNether::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc:
 		std::swap(FloorLo, FloorHi);
 	}
 
-	// Bedrock at the bottom and at the top:
+	// Bedrock at the bottom and at the top, cover ceiling with netherrack:
 	for (int z = 0; z < 16; z++) for (int x = 0; x < 16; x++)
 	{
 		a_ChunkDesc.SetBlockType(x, 0, z, E_BLOCK_BEDROCK);

--- a/tests/Generating/CMakeLists.txt
+++ b/tests/Generating/CMakeLists.txt
@@ -3,6 +3,7 @@ enable_testing()
 
 include_directories(${CMAKE_SOURCE_DIR}/src/)
 include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/)
+include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/mbedtls/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_definitions(-DTEST_GLOBALS=1)
@@ -168,8 +169,9 @@ source_group("Generating" FILES ${GENERATING_HDRS} ${GENERATING_SRCS})
 add_executable(BasicGeneratorTest
 	BasicGeneratorTest.cpp
 	${CMAKE_SOURCE_DIR}/src/IniFile.cpp
+	${CMAKE_SOURCE_DIR}/src/mbedTLS++/Sha1Checksum.cpp
 )
-target_link_libraries(BasicGeneratorTest GeneratorTestingSupport)
+target_link_libraries(BasicGeneratorTest GeneratorTestingSupport mbedtls)
 file(COPY "${CMAKE_SOURCE_DIR}/Server/items.ini" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 add_test(
 	NAME BasicGeneratorTest


### PR DESCRIPTION
This hot-fixes the Nether generator producing differrent data on Linux Release builds, and adds a check for the default Overworld and Nether generators whether they produce the same output on all platforms.

Fixes #4384.