### PR TITLE
Add pragma to ignore fallthrough warnings within Unicode Inc. code

### DIFF
--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -414,8 +414,10 @@ AString UnicodeCharToUtf8(unsigned a_UnicodeChar)
 
 
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
 // UTF-8 conversion code adapted from:
 //  https://stackoverflow.com/questions/2867123/convert-utf-16-to-utf-8-under-windows-and-linux-in-c
 
@@ -612,7 +614,9 @@ are equivalent to the following loop:
 ////////////////////////////////////////////////////////////////////////////////
 // End of Unicode, Inc.'s code / information
 ////////////////////////////////////////////////////////////////////////////////
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 
 

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -414,6 +414,8 @@ AString UnicodeCharToUtf8(unsigned a_UnicodeChar)
 
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 // UTF-8 conversion code adapted from:
 //  https://stackoverflow.com/questions/2867123/convert-utf-16-to-utf-8-under-windows-and-linux-in-c
 
@@ -610,6 +612,7 @@ are equivalent to the following loop:
 ////////////////////////////////////////////////////////////////////////////////
 // End of Unicode, Inc.'s code / information
 ////////////////////////////////////////////////////////////////////////////////
+#pragma GCC diagnostic pop
 
 
 


### PR DESCRIPTION
While building locally (using GCC) I got a ton of warnings from fallthrough switches within the Unicode code. 
It's better with clang, which only reports once, but GCC throws warnings on every include it seems.

This change should fix this for GCC.
The PR is mostly to verify this does not interfere on the other build systems, merge it if you like.