### PR TITLE
Fix clang 8.0 build

### DIFF
--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -32,10 +32,12 @@ Implements the 1.13 protocol classes:
 
 #define HANDLE_READ(ByteBuf, Proc, Type, Var) \
 	Type Var; \
-	if (!ByteBuf.Proc(Var))\
-	{\
-		return;\
-	}
+	do { \
+		if (!ByteBuf.Proc(Var))\
+		{\
+			return;\
+		} \
+	} while (false)
 
 
 
@@ -43,14 +45,16 @@ Implements the 1.13 protocol classes:
 
 #define HANDLE_PACKET_READ(ByteBuf, Proc, Type, Var) \
 	Type Var; \
-	{ \
-		if (!ByteBuf.Proc(Var)) \
+	do { \
 		{ \
+			if (!ByteBuf.Proc(Var)) \
+			{ \
+				ByteBuf.CheckValid(); \
+				return false; \
+			} \
 			ByteBuf.CheckValid(); \
-			return false; \
 		} \
-		ByteBuf.CheckValid(); \
-	}
+	} while (false)
 
 
 


### PR DESCRIPTION
The protocol 13.0 PR broke clang 8.0 builds.