### PR TITLE
Fixed MSVC warnings

### DIFF
--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -1633,7 +1633,7 @@ void cBlockArea::SetRelBlockType(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a
 	// Update the block entities, if appropriate:
 	if (HasBlockEntities())
 	{
-		auto itr = m_BlockEntities->find(static_cast<int>(idx));
+		auto itr = m_BlockEntities->find(idx);
 		if (itr != m_BlockEntities->end())
 		{
 			if (itr->second->GetBlockType() == a_BlockType)
@@ -1827,7 +1827,7 @@ void cBlockArea::SetRelBlockTypeMeta(int a_RelX,   int a_RelY,   int a_RelZ,   B
 	// Update the block entities, if appropriate:
 	if (HasBlockEntities())
 	{
-		auto itr = m_BlockEntities->find(static_cast<int>(idx));
+		auto itr = m_BlockEntities->find(idx);
 		if (itr != m_BlockEntities->end())
 		{
 			if (itr->second->GetBlockType() == a_BlockType)
@@ -2173,7 +2173,7 @@ bool cBlockArea::DoWithBlockEntityRelAt(int a_RelX, int a_RelY, int a_RelZ, cBlo
 	{
 		return false;
 	}
-	auto idx = static_cast<int>(MakeIndex(a_RelX, a_RelY, a_RelZ));
+	auto idx = MakeIndex(a_RelX, a_RelY, a_RelZ);
 	auto itr = m_BlockEntities->find(idx);
 	if (itr == m_BlockEntities->end())
 	{
@@ -2400,7 +2400,7 @@ void cBlockArea::RelSetData(
 	// Update the block entities, if appropriate:
 	if (HasBlockEntities())
 	{
-		auto itr = m_BlockEntities->find(static_cast<int>(Index));
+		auto itr = m_BlockEntities->find(Index);
 		if (itr != m_BlockEntities->end())
 		{
 			if (itr->second->GetBlockType() == a_BlockType)
@@ -2617,7 +2617,7 @@ void cBlockArea::MergeBlockEntities(int a_RelX, int a_RelY, int a_RelZ, const cB
 		}
 
 		// This block should have a block entity, check that there is one:
-		auto itr = m_BlockEntities->find(static_cast<int>(idx));
+		auto itr = m_BlockEntities->find(idx);
 		if (itr != m_BlockEntities->end())
 		{
 			// There is one already
@@ -2631,7 +2631,7 @@ void cBlockArea::MergeBlockEntities(int a_RelX, int a_RelY, int a_RelZ, const cB
 		if (a_Src.IsValidRelCoords(srcX, srcY, srcZ))
 		{
 			auto srcIdx = a_Src.MakeIndex(srcX, srcY, srcZ);
-			auto itrSrc = a_Src.m_BlockEntities->find(static_cast<int>(srcIdx));
+			auto itrSrc = a_Src.m_BlockEntities->find(srcIdx);
 			if (itrSrc != a_Src.m_BlockEntities->end())
 			{
 				m_BlockEntities->insert({idx, itrSrc->second->Clone(x, y, z)});
@@ -2669,7 +2669,7 @@ void cBlockArea::RescanBlockEntities(void)
 			continue;
 		}
 		// This block should have a block entity, check that there is one:
-		auto itr = m_BlockEntities->find(static_cast<int>(idx));
+		auto itr = m_BlockEntities->find(idx);
 		if (itr != m_BlockEntities->end())
 		{
 			continue;

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -458,7 +458,7 @@ void cChunk::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlock
 				continue;
 			}
 			// This block entity is inside the chunk, clone it (and remove any that is there currently):
-			auto idx = MakeIndex(posX - m_PosX * cChunkDef::Width, posY, posZ - m_PosZ * cChunkDef::Width);
+			auto idx = static_cast<size_t>(MakeIndex(posX - m_PosX * cChunkDef::Width, posY, posZ - m_PosZ * cChunkDef::Width));
 			auto itr = m_BlockEntities.find(idx);
 			if (itr != m_BlockEntities.end())
 			{
@@ -1421,7 +1421,7 @@ void cChunk::CreateBlockEntities(void)
 			if (cBlockEntity::IsBlockEntityBlockType(BlockType))
 			{
 				auto RelPos = IndexToCoordinate(BlockIdx);
-				RelPos.y += SectionIdx * cChunkData::SectionHeight;
+				RelPos.y += static_cast<int>(SectionIdx * cChunkData::SectionHeight);
 				auto WorldPos = RelativeToAbsolute(RelPos, m_PosX, m_PosZ);
 
 				if (!HasBlockEntityAt(WorldPos))
@@ -1461,7 +1461,7 @@ void cChunk::WakeUpSimulators(void)
 			auto WorldPos = [&]
 			{
 				auto RelPos = IndexToCoordinate(BlockIdx);
-				RelPos.y += SectionIdx * cChunkData::SectionHeight;
+				RelPos.y += static_cast<int>(SectionIdx * cChunkData::SectionHeight);
 				return RelativeToAbsolute(RelPos, m_PosX, m_PosZ);
 			};
 
@@ -1761,7 +1761,7 @@ cBlockEntity * cChunk::GetBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ)
 		return nullptr;
 	}
 
-	auto itr = m_BlockEntities.find(MakeIndexNoCheck(RelX, a_BlockY, RelZ));
+	auto itr = m_BlockEntities.find(static_cast<size_t>(MakeIndexNoCheck(RelX, a_BlockY, RelZ)));
 	return (itr == m_BlockEntities.end()) ? nullptr : itr->second;
 }
 
@@ -1921,8 +1921,8 @@ void cChunk::RemoveBlockEntity(cBlockEntity * a_BlockEntity)
 {
 	MarkDirty();
 	ASSERT(a_BlockEntity != nullptr);
-	int Idx = MakeIndex(a_BlockEntity->GetRelX(), a_BlockEntity->GetPosY(), a_BlockEntity->GetRelZ());
-	m_BlockEntities.erase(Idx);
+	auto idx = static_cast<size_t>(MakeIndex(a_BlockEntity->GetRelX(), a_BlockEntity->GetPosY(), a_BlockEntity->GetRelZ()));
+	m_BlockEntities.erase(idx);
 }
 
 

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -29,9 +29,9 @@ class cClientHandle;
 class cBlockEntity;
 class cChunkCoords;
 
-typedef std::unique_ptr<cEntity> OwnedEntity;
-typedef std::vector<OwnedEntity> cEntityList;
-typedef std::map<int, cBlockEntity *> cBlockEntities;
+using OwnedEntity = std::unique_ptr<cEntity>;
+using cEntityList = std::vector<OwnedEntity>;
+using cBlockEntities = std::map<size_t, cBlockEntity *>;
 
 
 

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1370,7 +1370,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 			double Length = DistanceFromExplosion.Length();
 			if (Length <= ExplosionSizeInt)  // Entity is impacted by explosion
 			{
-				float EntityExposure = a_Entity.GetExplosionExposureRate(ExplosionPos, ExplosionSizeInt);
+				float EntityExposure = a_Entity.GetExplosionExposureRate(ExplosionPos, static_cast<float>(a_ExplosionSize));
 
 				// Exposure reduced by armor
 				EntityExposure = EntityExposure * (1.0f - a_Entity.GetEnchantmentBlastKnockbackReduction());

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -288,7 +288,7 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 	}
 	ApplyArmorDamage(ArmorCover);
 
-	cEntity::TakeDamage(a_DamageType, a_Attacker, a_RawDamage, FinalDamage, a_KnockbackAmount);
+	cEntity::TakeDamage(a_DamageType, a_Attacker, a_RawDamage, static_cast<float>(FinalDamage), a_KnockbackAmount);
 }
 
 
@@ -518,7 +518,7 @@ bool cEntity::DoTakeDamage(TakeDamageInfo & a_TDI)
 
 			if (Random.RandBool(Chance / 100.0))
 			{
-				a_TDI.Attacker->TakeDamage(dtAttack, this, 0, Random.RandInt(1, 4), 0);
+				a_TDI.Attacker->TakeDamage(dtAttack, this, 0, Random.RandReal(1.0f, 4.0f), 0);
 			}
 		}
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -425,7 +425,7 @@ void cPawn::HandleFalling(void)
 		auto Damage = static_cast<int>(m_LastGroundHeight - GetPosY() - 3.0);
 		if ((Damage > 0) && !FallDamageAbsorbed)
 		{
-			TakeDamage(dtFalling, nullptr, Damage, Damage, 0);
+			TakeDamage(dtFalling, nullptr, Damage, static_cast<float>(Damage), 0);
 
 			// Fall particles
 			GetWorld()->BroadcastParticleEffect(

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2209,7 +2209,7 @@ bool cPlayer::LoadFromFile(const AString & a_FileName, cWorldPtr & a_World)
 		SetRoll     (static_cast<float>(JSON_PlayerRotation[2].asDouble()));
 	}
 
-	m_Health              = root.get("health",         0).asInt();
+	m_Health              = root.get("health",         0).asFloat();
 	m_AirLevel            = root.get("air",            MAX_AIR_LEVEL).asInt();
 	m_FoodLevel           = root.get("food",           MAX_FOOD_LEVEL).asInt();
 	m_FoodSaturationLevel = root.get("foodSaturation", MAX_FOOD_LEVEL).asDouble();

--- a/src/Generating/ChunkDesc.cpp
+++ b/src/Generating/ChunkDesc.cpp
@@ -572,7 +572,7 @@ void cChunkDesc::RandomFillRelCuboid(
 
 cBlockEntity * cChunkDesc::GetBlockEntity(int a_RelX, int a_RelY, int a_RelZ)
 {
-	auto Idx = cChunkDef::MakeIndex(a_RelX, a_RelY, a_RelZ);
+	auto Idx = static_cast<size_t>(cChunkDef::MakeIndex(a_RelX, a_RelY, a_RelZ));
 	auto itr = m_BlockEntities.find(Idx);
 
 	if (itr != m_BlockEntities.end())

--- a/src/Mobs/Slime.cpp
+++ b/src/Mobs/Slime.cpp
@@ -19,7 +19,7 @@ cSlime::cSlime(int a_Size) :
 	),
 	m_Size(a_Size)
 {
-	SetMaxHealth(a_Size * a_Size);
+	SetMaxHealth(static_cast<float>(a_Size * a_Size));
 	SetAttackDamage(a_Size);
 }
 

--- a/src/MonsterConfig.cpp
+++ b/src/MonsterConfig.cpp
@@ -16,7 +16,7 @@ struct cMonsterConfig::sAttributesStruct
 	int     m_AttackDamage;
 	int     m_AttackRange;
 	double  m_AttackRate;
-	int     m_MaxHealth;
+	double  m_MaxHealth;
 	bool    m_IsFireproof;
 	bool    m_BurnsInDaylight;
 };
@@ -74,7 +74,7 @@ void cMonsterConfig::Initialize()
 		Attributes.m_AttackRange     = MonstersIniFile.GetValueI(Name, "AttackRange",     0);
 		Attributes.m_SightDistance   = MonstersIniFile.GetValueI(Name, "SightDistance",   0);
 		Attributes.m_AttackRate      = MonstersIniFile.GetValueF(Name, "AttackRate",      0);
-		Attributes.m_MaxHealth       = MonstersIniFile.GetValueI(Name, "MaxHealth",       1);
+		Attributes.m_MaxHealth       = MonstersIniFile.GetValueF(Name, "MaxHealth",       1);
 		Attributes.m_IsFireproof     = MonstersIniFile.GetValueB(Name, "IsFireproof",     false);
 		Attributes.m_BurnsInDaylight = MonstersIniFile.GetValueB(Name, "BurnsInDaylight", false);
 		m_pState->AttributesList.push_front(Attributes);
@@ -96,7 +96,7 @@ void cMonsterConfig::AssignAttributes(cMonster * a_Monster, const AString & a_Na
 			a_Monster->SetAttackRange    (itr->m_AttackRange);
 			a_Monster->SetSightDistance  (itr->m_SightDistance);
 			a_Monster->SetAttackRate     (static_cast<float>(itr->m_AttackRate));
-			a_Monster->SetMaxHealth      (itr->m_MaxHealth);
+			a_Monster->SetMaxHealth      (static_cast<float>(itr->m_MaxHealth));
 			a_Monster->SetIsFireproof    (itr->m_IsFireproof);
 			a_Monster->SetBurnsInDaylight(itr->m_BurnsInDaylight);
 			return;

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -712,7 +712,7 @@ int cRoot::GetTotalChunkCount(void)
 	int res = 0;
 	for (WorldMap::iterator itr = m_WorldsByName.begin(); itr != m_WorldsByName.end(); ++itr)
 	{
-		res += itr->second->GetNumChunks();
+		res += static_cast<int>(itr->second->GetNumChunks());
 	}
 	return res;
 }

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2352,7 +2352,7 @@ std::vector<UInt32> cWorld::SpawnSplitExperienceOrbs(double a_X, double a_Y, dou
 	std::vector<int> Rewards = cExpOrb::Split(a_Reward);
 
 	// Check generate number to decide speed limit (distribute range)
-	float SpeedLimit = (Rewards.size() / 2) + 5;
+	float SpeedLimit = static_cast<float>((Rewards.size() / 2) + 5);
 	if (SpeedLimit > 10)
 	{
 		SpeedLimit = 10;


### PR DESCRIPTION
MSVC Win64 build complained a lot about converting from `int` to `float`, and from `size_t` to `int`.