### PR TITLE
Refactored more of Entities and BlockEntities to use Vector3.

### DIFF
--- a/Server/Plugins/APIDump/Classes/BlockEntities.lua
+++ b/Server/Plugins/APIDump/Classes/BlockEntities.lua
@@ -275,6 +275,16 @@ return
 				},
 				Notes = "Returns the block Z-coord of the block entity's block",
 			},
+			GetRelPos =
+			{
+				Returns =
+				{
+					{
+						Type = "Vector3i",
+					},
+				},
+				Notes = "Returns the relative coords of the block entity's block within its chunk",
+			},
 			GetRelX =
 			{
 				Returns =

--- a/Server/Plugins/APIDump/Classes/Geometry.lua
+++ b/Server/Plugins/APIDump/Classes/Geometry.lua
@@ -1150,23 +1150,6 @@ end
 			{
 				Notes = "<b>OBSOLETE</b>, use Abs() instead.",
 			},
-			added =
-			{
-				Params =
-				{
-					{
-						Name = "ofs",
-						Type = "Vector3d",
-					},
-				},
-				Returns =
-				{
-					{
-						Type = "Vector3d",
-					},
-				},
-				Notes = "Returns a copy of the vector, moved by the specified offsets on each of the axes",
-			},
 			addedX =
 			{
 				Params =
@@ -1731,23 +1714,6 @@ end
 			abs =
 			{
 				Notes = "<b>OBSOLETE</b>, use Abs() instead.",
-			},
-			added =
-			{
-				Params =
-				{
-					{
-						Name = "ofs",
-						Type = "Vector3f",
-					},
-				},
-				Returns =
-				{
-					{
-						Type = "Vector3f",
-					},
-				},
-				Notes = "Returns a copy of the vector, moved by the specified offsets on each of the axes",
 			},
 			addedX =
 			{
@@ -2345,23 +2311,6 @@ end
 			abs =
 			{
 				Notes = "<b>OBSOLETE</b>, use Abs() instead.",
-			},
-			added =
-			{
-				Params =
-				{
-					{
-						Name = "ofs",
-						Type = "Vector3i",
-					},
-				},
-				Returns =
-				{
-					{
-						Type = "Vector3i",
-					},
-				},
-				Notes = "Returns a copy of the vector, moved by the specified offsets on each of the axes",
 			},
 			addedX =
 			{

--- a/Server/Plugins/APIDump/Classes/Geometry.lua
+++ b/Server/Plugins/APIDump/Classes/Geometry.lua
@@ -1150,6 +1150,95 @@ end
 			{
 				Notes = "<b>OBSOLETE</b>, use Abs() instead.",
 			},
+			added =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "Vector3d",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3d",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offsets on each of the axes",
+			},
+			addedX =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3d",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the X axis",
+			},
+			addedXZ =
+			{
+				Params =
+				{
+					{
+						Name = "ofsX",
+						Type = "number",
+					},
+					{
+						Name = "ofsZ",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3d",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offsets on the X and Z axes",
+			},
+			addedY =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3d",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the Y axis",
+			},
+			addedZ =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3d",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the Z axis",
+			},
 			Clamp =
 			{
 				Params =
@@ -1642,6 +1731,95 @@ end
 			abs =
 			{
 				Notes = "<b>OBSOLETE</b>, use Abs() instead.",
+			},
+			added =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "Vector3f",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3f",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offsets on each of the axes",
+			},
+			addedX =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3f",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the X axis",
+			},
+			addedXZ =
+			{
+				Params =
+				{
+					{
+						Name = "ofsX",
+						Type = "number",
+					},
+					{
+						Name = "ofsZ",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3f",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offsets on the X and Z axes",
+			},
+			addedY =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3f",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the Y axis",
+			},
+			addedZ =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3f",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the Z axis",
 			},
 			Clamp =
 			{
@@ -2167,6 +2345,95 @@ end
 			abs =
 			{
 				Notes = "<b>OBSOLETE</b>, use Abs() instead.",
+			},
+			added =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "Vector3i",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3i",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offsets on each of the axes",
+			},
+			addedX =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3i",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the X axis",
+			},
+			addedXZ =
+			{
+				Params =
+				{
+					{
+						Name = "ofsX",
+						Type = "number",
+					},
+					{
+						Name = "ofsZ",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3i",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offsets on the X and Z axes",
+			},
+			addedY =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3i",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the Y axis",
+			},
+			addedZ =
+			{
+				Params =
+				{
+					{
+						Name = "ofs",
+						Type = "number",
+					},
+				},
+				Returns =
+				{
+					{
+						Type = "Vector3i",
+					},
+				},
+				Notes = "Returns a copy of the vector, moved by the specified offset on the Z axis",
 			},
 			Clamp =
 			{

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -3477,14 +3477,13 @@ static int tolua_cHopperEntity_GetOutputBlockPos(lua_State * tolua_S)
 	}
 
 	NIBBLETYPE a_BlockMeta = static_cast<NIBBLETYPE>(tolua_tonumber(tolua_S, 2, 0));
-	int a_OutputX, a_OutputY, a_OutputZ;
-	bool res = self->GetOutputBlockPos(a_BlockMeta, a_OutputX, a_OutputY, a_OutputZ);
-	tolua_pushboolean(tolua_S, res);
-	if (res)
+	auto res = self->GetOutputBlockPos(a_BlockMeta);
+	tolua_pushboolean(tolua_S, res.first);
+	if (res.first)
 	{
-		tolua_pushnumber(tolua_S, static_cast<lua_Number>(a_OutputX));
-		tolua_pushnumber(tolua_S, static_cast<lua_Number>(a_OutputY));
-		tolua_pushnumber(tolua_S, static_cast<lua_Number>(a_OutputZ));
+		tolua_pushnumber(tolua_S, static_cast<lua_Number>(res.second.x));
+		tolua_pushnumber(tolua_S, static_cast<lua_Number>(res.second.y));
+		tolua_pushnumber(tolua_S, static_cast<lua_Number>(res.second.z));
 		return 4;
 	}
 	return 1;

--- a/src/BlockArea.cpp
+++ b/src/BlockArea.cpp
@@ -572,7 +572,7 @@ void cBlockArea::CopyTo(cBlockArea & a_Into) const
 		for (const auto & keyPair: *m_BlockEntities)
 		{
 			const auto & pos = keyPair.second->GetPos();
-			a_Into.m_BlockEntities->insert({keyPair.first, keyPair.second->Clone(pos.x, pos.y, pos.z)});
+			a_Into.m_BlockEntities->insert({keyPair.first, keyPair.second->Clone(pos)});
 		}
 	}
 }
@@ -690,7 +690,7 @@ void cBlockArea::Crop(int a_AddMinX, int a_SubMaxX, int a_AddMinY, int a_SubMaxY
 				posX -= a_AddMinX;
 				posY -= a_AddMinY;
 				posZ -= a_AddMinZ;
-				be->SetPos(posX, posY, posZ);
+				be->SetPos({posX, posY, posZ});
 				m_BlockEntities->insert({MakeIndex(posX, posY, posZ), std::move(be)});
 			}
 		}
@@ -735,7 +735,7 @@ void cBlockArea::Expand(int a_SubMinX, int a_AddMaxX, int a_SubMinY, int a_AddMa
 			auto posX = be->GetPosX() + a_SubMinX;
 			auto posY = be->GetPosY() + a_SubMinY;
 			auto posZ = be->GetPosZ() + a_SubMinZ;
-			be->SetPos(posX, posY, posZ);
+			be->SetPos({posX, posY, posZ});
 			m_BlockEntities->insert({MakeIndex(posX, posY, posZ), std::move(be)});
 		}
 	}
@@ -1097,7 +1097,7 @@ void cBlockArea::RotateCCW(void)
 			auto newY = be->GetPosY();
 			auto newZ = m_Size.x - be->GetPosX() - 1;
 			auto newIdx = newX + newZ * m_Size.z + newY * m_Size.x * m_Size.z;
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1157,7 +1157,7 @@ void cBlockArea::RotateCW(void)
 			auto newY = be->GetPosY();
 			auto newZ = be->GetPosX();
 			auto newIdx = newX + newZ * m_Size.z + newY * m_Size.x * m_Size.z;
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1216,7 +1216,7 @@ void cBlockArea::MirrorXY(void)
 			auto newY = be->GetPosY();
 			auto newZ = MaxZ - be->GetPosZ();
 			auto newIdx = MakeIndex(newX, newY, newZ);
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1273,7 +1273,7 @@ void cBlockArea::MirrorXZ(void)
 			auto newY = MaxY - be->GetPosY();
 			auto newZ = be->GetPosZ();
 			auto newIdx = MakeIndex(newX, newY, newZ);
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1330,7 +1330,7 @@ void cBlockArea::MirrorYZ(void)
 			auto newY = be->GetPosY();
 			auto newZ = be->GetPosZ();
 			auto newIdx = MakeIndex(newX, newY, newZ);
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1389,7 +1389,7 @@ void cBlockArea::RotateCCWNoMeta(void)
 			auto newY = be->GetPosY();
 			auto newZ = m_Size.x - be->GetPosX() - 1;
 			auto newIdx = newX + newZ * m_Size.z + newY * m_Size.x * m_Size.z;
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1450,7 +1450,7 @@ void cBlockArea::RotateCWNoMeta(void)
 			auto newY = be->GetPosY();
 			auto newZ = be->GetPosX();
 			auto newIdx = newX + newZ * m_Size.z + newY * m_Size.x * m_Size.z;
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1506,7 +1506,7 @@ void cBlockArea::MirrorXYNoMeta(void)
 			auto newY = be->GetPosY();
 			auto newZ = MaxZ - be->GetPosZ();
 			auto newIdx = MakeIndex(newX, newY, newZ);
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1560,7 +1560,7 @@ void cBlockArea::MirrorXZNoMeta(void)
 			auto newY = MaxY - be->GetPosY();
 			auto newZ = be->GetPosZ();
 			auto newIdx = MakeIndex(newX, newY, newZ);
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1614,7 +1614,7 @@ void cBlockArea::MirrorYZNoMeta(void)
 			auto newY = be->GetPosY();
 			auto newZ = be->GetPosZ();
 			auto newIdx = MakeIndex(newX, newY, newZ);
-			be->SetPos(newX, newY, newZ);
+			be->SetPos({newX, newY, newZ});
 			m_BlockEntities->insert({newIdx, std::move(be)});
 		}
 	}
@@ -1646,7 +1646,7 @@ void cBlockArea::SetRelBlockType(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a
 		if (cBlockEntity::IsBlockEntityBlockType(a_BlockType))
 		{
 			NIBBLETYPE meta = HasBlockMetas() ? m_BlockMetas[idx] : 0;
-			m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(a_BlockType, meta, a_RelX, a_RelY, a_RelZ)});
+			m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(a_BlockType, meta, {a_RelX, a_RelY, a_RelZ})});
 		}
 	}
 }
@@ -1839,7 +1839,7 @@ void cBlockArea::SetRelBlockTypeMeta(int a_RelX,   int a_RelY,   int a_RelZ,   B
 		}
 		if (cBlockEntity::IsBlockEntityBlockType(a_BlockType))
 		{
-			m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(a_BlockType, a_BlockMeta, a_RelX, a_RelY, a_RelZ)});
+			m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(a_BlockType, a_BlockMeta, {a_RelX, a_RelY, a_RelZ})});
 		}
 	}
 }
@@ -2414,7 +2414,7 @@ void cBlockArea::RelSetData(
 		if (cBlockEntity::IsBlockEntityBlockType(a_BlockType))
 		{
 			// The block type should have a block entity attached to it, create an empty one:
-			m_BlockEntities->insert({Index, cBlockEntity::CreateByBlockType(a_BlockType, a_BlockMeta, a_RelX, a_RelY, a_RelZ)});
+			m_BlockEntities->insert({Index, cBlockEntity::CreateByBlockType(a_BlockType, a_BlockMeta, {a_RelX, a_RelY, a_RelZ})});
 		}
 	}
 }
@@ -2634,13 +2634,13 @@ void cBlockArea::MergeBlockEntities(int a_RelX, int a_RelY, int a_RelZ, const cB
 			auto itrSrc = a_Src.m_BlockEntities->find(srcIdx);
 			if (itrSrc != a_Src.m_BlockEntities->end())
 			{
-				m_BlockEntities->insert({idx, itrSrc->second->Clone(x, y, z)});
+				m_BlockEntities->insert({idx, itrSrc->second->Clone({x, y, z})});
 				continue;
 			}
 		}
 		// No BE found in a_Src, insert a new empty one:
 		NIBBLETYPE meta = HasBlockMetas() ? m_BlockMetas[idx] : 0;
-		m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(type, meta, x, y, z)});
+		m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(type, meta, {x, y, z})});
 	}  // for x, z, y
 }
 
@@ -2676,7 +2676,7 @@ void cBlockArea::RescanBlockEntities(void)
 		}
 		// Create a new BE for this block:
 		NIBBLETYPE meta = HasBlockMetas() ? m_BlockMetas[idx] : 0;
-		m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(type, meta, x, y, z)});
+		m_BlockEntities->insert({idx, cBlockEntity::CreateByBlockType(type, meta, {x, y, z})});
 	}  // for x, z, y
 }
 
@@ -2962,11 +2962,9 @@ void cBlockArea::cChunkReader::BlockEntity(cBlockEntity * a_BlockEntity)
 	{
 		return;
 	}
-	auto areaX = a_BlockEntity->GetPosX() - m_Area.m_Origin.x;
-	auto areaY = a_BlockEntity->GetPosY() - m_Area.m_Origin.y;
-	auto areaZ = a_BlockEntity->GetPosZ() - m_Area.m_Origin.z;
-	auto Idx = m_Area.MakeIndex(areaX, areaY, areaZ);
-	m_Area.m_BlockEntities->insert({Idx, a_BlockEntity->Clone(areaX, areaY, areaZ)});
+	auto areaPos = a_BlockEntity->GetPos() - m_Area.m_Origin;
+	auto Idx = m_Area.MakeIndex(areaPos);
+	m_Area.m_BlockEntities->insert({Idx, a_BlockEntity->Clone(areaPos)});
 }
 
 

--- a/src/BlockArea.h
+++ b/src/BlockArea.h
@@ -388,6 +388,15 @@ public:
 	NIBBLETYPE * GetBlockSkyLight(void) const { return m_BlockSkyLight.get(); }  // NOTE: one byte per block!
 	size_t       GetBlockCount(void) const { return static_cast<size_t>(m_Size.x * m_Size.y * m_Size.z); }
 	static size_t MakeIndexForSize(Vector3i a_RelPos, Vector3i a_Size);
+
+	/** Returns the index into the internal arrays for the specified coords */
+	size_t MakeIndex(Vector3i a_RelPos) const
+	{
+		return MakeIndexForSize(a_RelPos, m_Size);
+	}
+
+	/** OBSOLETE, use the Vector3i-based overload instead.
+	Returns the index into the internal arrays for the specified coords */
 	size_t MakeIndex(int a_RelX, int a_RelY, int a_RelZ) const
 	{
 		return MakeIndexForSize({ a_RelX, a_RelY, a_RelZ }, m_Size);

--- a/src/BlockEntities/BeaconEntity.cpp
+++ b/src/BlockEntities/BeaconEntity.cpp
@@ -11,8 +11,8 @@
 
 
 
-cBeaconEntity::cBeaconEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, 1, 1, a_World),
+cBeaconEntity::cBeaconEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, 1, 1, a_World),
 	m_IsActive(false),
 	m_BeaconLevel(0),
 	m_PrimaryEffect(cEntityEffect::effNoEffect),
@@ -138,9 +138,9 @@ bool cBeaconEntity::SetSecondaryEffect(cEntityEffect::eType a_Effect)
 
 bool cBeaconEntity::IsBeaconBlocked(void)
 {
-	for (int Y = m_PosY; Y < cChunkDef::Height; ++Y)
+	for (int Y = m_Pos.y; Y < cChunkDef::Height; ++Y)
 	{
-		BLOCKTYPE Block = m_World->GetBlock(m_PosX, Y, m_PosZ);
+		BLOCKTYPE Block = m_World->GetBlock({m_Pos.x, Y, m_Pos.z});
 		if (!cBlockInfo::IsTransparent(Block))
 		{
 			return true;
@@ -195,7 +195,7 @@ void cBeaconEntity::UpdateBeacon(void)
 			GetWindow()->SetProperty(0, m_BeaconLevel);
 		}
 
-		Vector3d BeaconPosition(m_PosX, m_PosY, m_PosZ);
+		Vector3d BeaconPosition(m_Pos);
 		GetWorld()->ForEachPlayer([=](cPlayer & a_Player)
 			{
 				Vector3d Distance = BeaconPosition - a_Player.GetPosition();
@@ -233,7 +233,7 @@ void cBeaconEntity::GiveEffects(void)
 
 	bool HasSecondaryEffect = (m_BeaconLevel >= 4) && (m_PrimaryEffect != m_SecondaryEffect) && (m_SecondaryEffect > 0);
 
-	Vector3d BeaconPosition(m_PosX, m_PosY, m_PosZ);
+	Vector3d BeaconPosition(m_Pos);
 	GetWorld()->ForEachPlayer([=](cPlayer & a_Player)
 		{
 			auto PlayerPosition = a_Player.GetPosition();
@@ -263,7 +263,7 @@ void cBeaconEntity::GiveEffects(void)
 
 void cBeaconEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cBeaconEntity &>(a_Src);
 	m_BeaconLevel = src.m_BeaconLevel;
 	m_Contents.CopyFrom(src.m_Contents);
@@ -305,7 +305,7 @@ bool cBeaconEntity::UsedBy(cPlayer * a_Player)
 	cWindow * Window = GetWindow();
 	if (Window == nullptr)
 	{
-		OpenWindow(new cBeaconWindow(m_PosX, m_PosY, m_PosZ, this));
+		OpenWindow(new cBeaconWindow(this));
 		Window = GetWindow();
 	}
 

--- a/src/BlockEntities/BeaconEntity.h
+++ b/src/BlockEntities/BeaconEntity.h
@@ -19,14 +19,16 @@
 class cBeaconEntity :
 	public cBlockEntityWithItems
 {
-	typedef cBlockEntityWithItems Super;
-
-public:
 	// tolua_end
+
+	using super = cBlockEntityWithItems;
+
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cBeaconEntity)
 
-	cBeaconEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cBeaconEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;

--- a/src/BlockEntities/BedEntity.cpp
+++ b/src/BlockEntities/BedEntity.cpp
@@ -9,8 +9,12 @@
 #include "../ClientHandle.h"
 #include "../Blocks/BlockBed.h"
 
-cBedEntity::cBedEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, short a_Color):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+
+
+
+
+cBedEntity::cBedEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, short a_Color):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	m_Color(a_Color)
 {
 	ASSERT(a_BlockType == E_BLOCK_BED);
@@ -22,7 +26,7 @@ cBedEntity::cBedEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_Bloc
 
 void cBedEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cBedEntity &>(a_Src);
 	m_Color = src.m_Color;
 }

--- a/src/BlockEntities/BedEntity.h
+++ b/src/BlockEntities/BedEntity.h
@@ -14,13 +14,14 @@
 class cBedEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-public:
 	// tolua_end
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cBedEntity)
 
-	cBedEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World, short a_Color = E_META_WOOL_RED);
+	cBedEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, short a_Color = E_META_WOOL_RED);
 
 	// tolua_begin
 

--- a/src/BlockEntities/BlockEntity.cpp
+++ b/src/BlockEntities/BlockEntity.cpp
@@ -26,12 +26,10 @@
 
 
 
-void cBlockEntity::SetPos(int a_NewBlockX, int a_NewBlockY, int a_NewBlockZ)
+void cBlockEntity::SetPos(Vector3i a_NewPos)
 {
 	ASSERT(m_World == nullptr);  // Cannot move block entities that represent world blocks (only use this for cBlockArea's BEs)
-	m_PosX = a_NewBlockX;
-	m_PosY = a_NewBlockY;
-	m_PosZ = a_NewBlockZ;
+	m_Pos = a_NewPos;
 }
 
 
@@ -75,29 +73,29 @@ bool cBlockEntity::IsBlockEntityBlockType(BLOCKTYPE a_BlockType)
 
 
 
-cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World)
+cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World)
 {
 	switch (a_BlockType)
 	{
-		case E_BLOCK_BEACON:        return new cBeaconEntity      (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_BED:           return new cBedEntity         (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_BREWING_STAND: return new cBrewingstandEntity(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_CHEST:         return new cChestEntity       (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_COMMAND_BLOCK: return new cCommandBlockEntity(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_DISPENSER:     return new cDispenserEntity   (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_DROPPER:       return new cDropperEntity     (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_ENDER_CHEST:   return new cEnderChestEntity  (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_FLOWER_POT:    return new cFlowerPotEntity   (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_FURNACE:       return new cFurnaceEntity     (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_HEAD:          return new cMobHeadEntity     (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_HOPPER:        return new cHopperEntity      (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_JUKEBOX:       return new cJukeboxEntity     (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_LIT_FURNACE:   return new cFurnaceEntity     (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_MOB_SPAWNER:   return new cMobSpawnerEntity  (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_NOTE_BLOCK:    return new cNoteEntity        (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_SIGN_POST:     return new cSignEntity        (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_TRAPPED_CHEST: return new cChestEntity       (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
-		case E_BLOCK_WALLSIGN:      return new cSignEntity        (a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World);
+		case E_BLOCK_BEACON:        return new cBeaconEntity      (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_BED:           return new cBedEntity         (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_BREWING_STAND: return new cBrewingstandEntity(a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_CHEST:         return new cChestEntity       (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_COMMAND_BLOCK: return new cCommandBlockEntity(a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_DISPENSER:     return new cDispenserEntity   (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_DROPPER:       return new cDropperEntity     (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_ENDER_CHEST:   return new cEnderChestEntity  (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_FLOWER_POT:    return new cFlowerPotEntity   (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_FURNACE:       return new cFurnaceEntity     (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_HEAD:          return new cMobHeadEntity     (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_HOPPER:        return new cHopperEntity      (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_JUKEBOX:       return new cJukeboxEntity     (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_LIT_FURNACE:   return new cFurnaceEntity     (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_MOB_SPAWNER:   return new cMobSpawnerEntity  (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_NOTE_BLOCK:    return new cNoteEntity        (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_SIGN_POST:     return new cSignEntity        (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_TRAPPED_CHEST: return new cChestEntity       (a_BlockType, a_BlockMeta, a_Pos, a_World);
+		case E_BLOCK_WALLSIGN:      return new cSignEntity        (a_BlockType, a_BlockMeta, a_Pos, a_World);
 		default:
 		{
 			LOGD("%s: Requesting creation of an unknown block entity - block type %d (%s)",
@@ -113,9 +111,9 @@ cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE
 
 
 
-cBlockEntity * cBlockEntity::Clone(int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cBlockEntity::Clone(Vector3i a_Pos)
 {
-	auto res = std::unique_ptr<cBlockEntity>(CreateByBlockType(m_BlockType, m_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, nullptr));
+	auto res = std::unique_ptr<cBlockEntity>(CreateByBlockType(m_BlockType, m_BlockMeta, a_Pos, nullptr));
 	res->CopyFrom(*this);
 	return res.release();
 }

--- a/src/BlockEntities/BlockEntity.h
+++ b/src/BlockEntities/BlockEntity.h
@@ -9,19 +9,19 @@
 #define BLOCKENTITY_PROTODEF(classname) \
 	virtual bool IsA(const char * a_ClassName) const override \
 	{ \
-		return ((a_ClassName != nullptr) && ((strcmp(a_ClassName, #classname) == 0) || Super::IsA(a_ClassName))); \
+		return ((a_ClassName != nullptr) && ((strcmp(a_ClassName, #classname) == 0) || super::IsA(a_ClassName))); \
 	} \
-	virtual const char * GetClass(void) const override \
+	virtual const char * GetClass() const override \
 	{ \
 		return #classname; \
 	} \
-	static const char * GetClassStatic(void) \
+	static const char * GetClassStatic() \
 	{ \
 		return #classname; \
 	} \
-	virtual const char * GetParentClass(void) const override \
+	virtual const char * GetParentClass() const override \
 	{ \
-		return Super::GetClass(); \
+		return super::GetClass(); \
 	}
 
 
@@ -40,12 +40,10 @@ class cWorld;
 class cBlockEntity
 {
 protected:
-	cBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World) :
-		m_PosX(a_BlockX),
-		m_PosY(a_BlockY),
-		m_PosZ(a_BlockZ),
-		m_RelX(a_BlockX - cChunkDef::Width * FAST_FLOOR_DIV(a_BlockX, cChunkDef::Width)),
-		m_RelZ(a_BlockZ - cChunkDef::Width * FAST_FLOOR_DIV(a_BlockZ, cChunkDef::Width)),
+	cBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World) :
+		m_Pos(a_Pos),
+		m_RelX(a_Pos.x - cChunkDef::Width * FAST_FLOOR_DIV(a_Pos.x, cChunkDef::Width)),
+		m_RelZ(a_Pos.z - cChunkDef::Width * FAST_FLOOR_DIV(a_Pos.z, cChunkDef::Width)),
 		m_BlockType(a_BlockType),
 		m_BlockMeta(a_BlockMeta),
 		m_World(a_World)
@@ -57,7 +55,7 @@ public:
 
 	virtual ~cBlockEntity() {}  // force a virtual destructor in all descendants
 
-	virtual void Destroy(void) {}
+	virtual void Destroy() {}
 
 	void SetWorld(cWorld * a_World)
 	{
@@ -66,27 +64,27 @@ public:
 
 	/** Updates the internally stored position.
 	Note that this should not ever be used for world-contained block entities, it is meant only for when BEs in a cBlockArea are manipulated.
-	Asserts when the block entity is assigned to a world. */
-	void SetPos(int a_NewBlockX, int a_NewBlockY, int a_NewBlockZ);
+	Asserts that the block entity is not assigned to a world. */
+	void SetPos(Vector3i a_NewPos);
 
 	/** Returns true if the specified blocktype is supposed to have an associated block entity. */
 	static bool IsBlockEntityBlockType(BLOCKTYPE a_BlockType);
 
-	/** Creates a new block entity for the specified block type
+	/** Creates a new block entity for the specified block type at the specified absolute pos.
 	If a_World is valid, then the entity is created bound to that world
 	Returns nullptr for unknown block types. */
-	static cBlockEntity * CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World = nullptr);
+	static cBlockEntity * CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World = nullptr);
 
 	/** Makes an exact copy of this block entity, except for its m_World (set to nullptr), and at a new position.
 	Uses CopyFrom() to copy the properties. */
-	cBlockEntity * Clone(int a_BlockX, int a_BlockY, int a_BlockZ);
+	cBlockEntity * Clone(Vector3i a_Pos);
 
 	/** Copies all properties of a_Src into this entity, except for its m_World and location.
 	Each non-abstract descendant should override to copy its specific properties, and call
 	Super::CopyFrom(a_Src) to copy the common ones. */
 	virtual void CopyFrom(const cBlockEntity & a_Src);
 
-	static const char * GetClassStatic(void)  // Needed for ManualBindings's ForEach templates
+	static const char * GetClassStatic()  // Needed for ManualBindings's ForEach templates
 	{
 		return "cBlockEntity";
 	}
@@ -94,29 +92,31 @@ public:
 	/** Returns true if the object is the specified class, or its descendant. */
 	virtual bool IsA(const char * a_ClassName) const { return (strcmp(a_ClassName, "cBlockEntity") == 0); }
 
-	/** Returns the name of the tompost class (the most descendant). Used for Lua bindings to push the correct object type. */
-	virtual const char * GetClass(void) const { return GetClassStatic(); }
+	/** Returns the name of the topmost class (the most descendant). Used for Lua bindings to push the correct object type. */
+	virtual const char * GetClass() const { return GetClassStatic(); }
 
 	/** Returns the name of the parent class, or empty string if no parent class. */
-	virtual const char * GetParentClass(void) const { return ""; }
+	virtual const char * GetParentClass() const { return ""; }
 
 	// tolua_begin
 
 	// Position, in absolute block coordinates:
-	Vector3i GetPos(void) const { return Vector3i{m_PosX, m_PosY, m_PosZ}; }
-	int GetPosX(void) const { return m_PosX; }
-	int GetPosY(void) const { return m_PosY; }
-	int GetPosZ(void) const { return m_PosZ; }
+	Vector3i GetPos() const { return m_Pos; }
+	int GetPosX() const { return m_Pos.x; }
+	int GetPosY() const { return m_Pos.y; }
+	int GetPosZ() const { return m_Pos.z; }
 
-	BLOCKTYPE GetBlockType(void) const { return m_BlockType; }
+	Vector3i GetRelPos() const { return Vector3i(m_RelX, m_Pos.y, m_RelZ); }
 
-	cWorld * GetWorld(void) const { return m_World; }
+	BLOCKTYPE GetBlockType() const { return m_BlockType; }
 
-	int GetChunkX(void) const { return FAST_FLOOR_DIV(m_PosX, cChunkDef::Width); }
-	int GetChunkZ(void) const { return FAST_FLOOR_DIV(m_PosZ, cChunkDef::Width); }
+	cWorld * GetWorld() const { return m_World; }
 
-	int GetRelX(void) const { return m_RelX; }
-	int GetRelZ(void) const { return m_RelZ; }
+	int GetChunkX() const { return FAST_FLOOR_DIV(m_Pos.x, cChunkDef::Width); }
+	int GetChunkZ() const { return FAST_FLOOR_DIV(m_Pos.y, cChunkDef::Width); }
+
+	int GetRelX() const { return m_RelX; }
+	int GetRelZ() const { return m_RelZ; }
 
 	// tolua_end
 
@@ -135,9 +135,11 @@ public:
 		return false;
 	}
 
+
 protected:
+
 	/** Position in absolute block coordinates */
-	int m_PosX, m_PosY, m_PosZ;
+	Vector3i m_Pos;
 
 	/** Position relative to the chunk, used to speed up ticking */
 	int m_RelX, m_RelZ;

--- a/src/BlockEntities/BlockEntityWithItems.cpp
+++ b/src/BlockEntities/BlockEntityWithItems.cpp
@@ -1,11 +1,5 @@
 // BlockEntityWithItems.cpp
 
-// Implements the cBlockEntityWithItems class representing a common ancestor for all block entities that have an ItemGrid
-
-
-
-
-
 #include "Globals.h"
 #include "BlockEntityWithItems.h"
 #include "../Simulator/RedstoneSimulator.h"
@@ -17,11 +11,11 @@
 cBlockEntityWithItems::cBlockEntityWithItems(
 	BLOCKTYPE a_BlockType,
 	NIBBLETYPE a_BlockMeta,
-	int a_BlockX, int a_BlockY, int a_BlockZ,
+	Vector3i a_Pos,
 	int a_ItemGridWidth, int a_ItemGridHeight,
 	cWorld * a_World
 ):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	cBlockEntityWindowOwner(this),
 	m_Contents(a_ItemGridWidth, a_ItemGridHeight)
 {
@@ -39,7 +33,7 @@ void cBlockEntityWithItems::Destroy(void)
 	cItems Pickups;
 	m_Contents.CopyToItems(Pickups);
 	m_Contents.Clear();
-	m_World->SpawnItemPickups(Pickups, m_PosX + 0.5, m_PosY + 0.5, m_PosZ + 0.5);  // Spawn in centre of block
+	m_World->SpawnItemPickups(Pickups, m_Pos.x + 0.5, m_Pos.y + 0.5, m_Pos.z + 0.5);  // Spawn in centre of block
 }
 
 
@@ -48,7 +42,7 @@ void cBlockEntityWithItems::Destroy(void)
 
 void cBlockEntityWithItems::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cBlockEntityWithItems &>(a_Src);
 	m_Contents.CopyFrom(src.m_Contents);
 }
@@ -69,10 +63,9 @@ void cBlockEntityWithItems::OnSlotChanged(cItemGrid * a_Grid, int a_SlotNum)
 		}
 
 		m_World->MarkChunkDirty(GetChunkX(), GetChunkZ());
-		auto Pos = Vector3i(m_PosX, m_PosY, m_PosZ);
-		m_World->DoWithChunkAt(Pos, [&](cChunk & a_Chunk)
+		m_World->DoWithChunkAt(m_Pos, [&](cChunk & a_Chunk)
 			{
-				m_World->GetRedstoneSimulator()->WakeUp(Pos, &a_Chunk);
+				m_World->GetRedstoneSimulator()->WakeUp(m_Pos, &a_Chunk);
 				return true;
 			}
 		);

--- a/src/BlockEntities/BlockEntityWithItems.h
+++ b/src/BlockEntities/BlockEntityWithItems.h
@@ -26,10 +26,11 @@ class cBlockEntityWithItems :
 	// tolua_begin
 	public cBlockEntityWindowOwner
 {
-	typedef cBlockEntity Super;
-
-public:
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cBlockEntityWithItems)
 
@@ -37,7 +38,7 @@ public:
 	cBlockEntityWithItems(
 		BLOCKTYPE a_BlockType,                      // Type of the block that the entity represents
 		NIBBLETYPE a_BlockMeta,                     // Meta of the block that the entity represents
-		int a_BlockX, int a_BlockY, int a_BlockZ,   // Position of the block entity
+		Vector3i a_Pos,                             // Abs position of the block entity
 		int a_ItemGridWidth, int a_ItemGridHeight,  // Dimensions of the ItemGrid
 		cWorld * a_World                            // Optional world to assign to the entity
 	);

--- a/src/BlockEntities/BrewingstandEntity.cpp
+++ b/src/BlockEntities/BrewingstandEntity.cpp
@@ -11,8 +11,8 @@
 
 
 
-cBrewingstandEntity::cBrewingstandEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, ContentsWidth, ContentsHeight, a_World),
+cBrewingstandEntity::cBrewingstandEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, ContentsWidth, ContentsHeight, a_World),
 	m_IsDestroyed(false),
 	m_IsBrewing(false),
 	m_TimeBrewed(0),
@@ -42,7 +42,7 @@ cBrewingstandEntity::~cBrewingstandEntity()
 void cBrewingstandEntity::Destroy()
 {
 	m_IsDestroyed = true;
-	Super::Destroy();
+	super::Destroy();
 }
 
 
@@ -51,7 +51,7 @@ void cBrewingstandEntity::Destroy()
 
 void cBrewingstandEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cBrewingstandEntity &>(a_Src);
 	m_IsBrewing = src.m_IsBrewing;
 	for (size_t i = 0; i < ARRAYCOUNT(m_CurrentBrewingRecipes); ++i)
@@ -158,7 +158,7 @@ bool cBrewingstandEntity::UsedBy(cPlayer * a_Player)
 	cWindow * Window = GetWindow();
 	if (Window == nullptr)
 	{
-		OpenWindow(new cBrewingstandWindow(m_PosX, m_PosY, m_PosZ, this));
+		OpenWindow(new cBrewingstandWindow(this));
 		Window = GetWindow();
 	}
 
@@ -201,7 +201,7 @@ void cBrewingstandEntity::BroadcastProgress(short a_ProgressbarID, short a_Value
 
 void cBrewingstandEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 {
-	Super::OnSlotChanged(a_ItemGrid, a_SlotNum);
+	super::OnSlotChanged(a_ItemGrid, a_SlotNum);
 
 	if (m_IsDestroyed)
 	{

--- a/src/BlockEntities/BrewingstandEntity.h
+++ b/src/BlockEntities/BrewingstandEntity.h
@@ -18,9 +18,14 @@ class cClientHandle;
 class cBrewingstandEntity :
 	public cBlockEntityWithItems
 {
-	typedef cBlockEntityWithItems Super;
+	// tolua_end
+
+	using super = cBlockEntityWithItems;
+
+	// tolua_begin
 
 public:
+
 	enum
 	{
 		bsLeftBottle        = 0,  // Left bottle slot number
@@ -38,7 +43,7 @@ public:
 	BLOCKENTITY_PROTODEF(cBrewingstandEntity)
 
 	/** Constructor used for normal operation */
-	cBrewingstandEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cBrewingstandEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	virtual ~cBrewingstandEntity() override;
 

--- a/src/BlockEntities/ChestEntity.h
+++ b/src/BlockEntities/ChestEntity.h
@@ -18,9 +18,14 @@ class cClientHandle;
 class cChestEntity :
 	public cBlockEntityWithItems
 {
-	typedef cBlockEntityWithItems Super;
+	// tolua_end
+
+	using super = cBlockEntityWithItems;
+
+	// tolua_begin
 
 public:
+
 	enum
 	{
 		ContentsHeight = 3,
@@ -32,7 +37,7 @@ public:
 	BLOCKENTITY_PROTODEF(cChestEntity)
 
 	/** Constructor used for normal operation */
-	cChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	virtual ~cChestEntity() override;
 
@@ -58,6 +63,7 @@ public:
 
 	/** Sets the number of players who currently have this chest open */
 	void SetNumberOfPlayers(int a_NumActivePlayers) { m_NumActivePlayers = a_NumActivePlayers; }
+
 
 private:
 
@@ -90,10 +96,9 @@ private:
 			}
 
 			m_World->MarkChunkDirty(GetChunkX(), GetChunkZ());
-			auto Pos = Vector3i(m_PosX, m_PosY, m_PosZ);
-			m_World->DoWithChunkAt(Pos, [&](cChunk & a_Chunk)
+			m_World->DoWithChunkAt(m_Pos, [&](cChunk & a_Chunk)
 				{
-					m_World->GetRedstoneSimulator()->WakeUp(Pos, &a_Chunk);
+					m_World->GetRedstoneSimulator()->WakeUp(m_Pos, &a_Chunk);
 					return true;
 				}
 			);

--- a/src/BlockEntities/CommandBlockEntity.cpp
+++ b/src/BlockEntities/CommandBlockEntity.cpp
@@ -17,8 +17,8 @@
 
 
 
-cCommandBlockEntity::cCommandBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+cCommandBlockEntity::cCommandBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	m_ShouldExecute(false),
 	m_Result(0)
 {
@@ -115,7 +115,7 @@ void cCommandBlockEntity::Activate(void)
 
 void cCommandBlockEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cCommandBlockEntity &>(a_Src);
 	m_Command = src.m_Command;
 	m_LastOutput = src.m_LastOutput;

--- a/src/BlockEntities/CommandBlockEntity.h
+++ b/src/BlockEntities/CommandBlockEntity.h
@@ -20,16 +20,16 @@
 class cCommandBlockEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-
-public:
-
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cCommandBlockEntity)
 
 	/** Creates a new empty command block entity */
-	cCommandBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cCommandBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;

--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -13,8 +13,8 @@
 
 
 
-cDispenserEntity::cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World)
+cDispenserEntity::cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World)
 {
 	ASSERT(a_BlockType == E_BLOCK_DISPENSER);
 }
@@ -25,27 +25,24 @@ cDispenserEntity::cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta
 
 void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 {
-	int DispX = m_RelX;
-	int DispY = m_PosY;
-	int DispZ = m_RelZ;
-	NIBBLETYPE Meta = a_Chunk.GetMeta(m_RelX, m_PosY, m_RelZ);
-	AddDropSpenserDir(DispX, DispY, DispZ, Meta);
-	cChunk * DispChunk = a_Chunk.GetRelNeighborChunkAdjustCoords(DispX, DispZ);
-	if (DispChunk == nullptr)
+	Vector3i dispRelCoord(GetRelPos());
+	auto meta = a_Chunk.GetMeta(dispRelCoord);
+	AddDropSpenserDir(dispRelCoord, meta);
+	auto dispChunk = a_Chunk.GetRelNeighborChunkAdjustCoords(dispRelCoord.x, dispRelCoord.z);
+	if (dispChunk == nullptr)
 	{
 		// Would dispense into / interact with a non-loaded chunk, ignore the tick
 		return;
 	}
 
-	BLOCKTYPE DispBlock = DispChunk->GetBlock(DispX, DispY, DispZ);
-	int BlockX = (DispX + DispChunk->GetPosX() * cChunkDef::Width);
-	int BlockZ = (DispZ + DispChunk->GetPosZ() * cChunkDef::Width);
+	BLOCKTYPE dispBlock = dispChunk->GetBlock(dispRelCoord);
+	auto dispAbsCoord = dispChunk->RelativeToAbsolute(dispRelCoord);
 
 	// Dispense the item:
 	const cItem & SlotItem = m_Contents.GetSlot(a_SlotNum);
-	if (ItemCategory::IsMinecart(SlotItem.m_ItemType) && IsBlockRail(DispBlock))  // only actually place the minecart if there are rails!
+	if (ItemCategory::IsMinecart(SlotItem.m_ItemType) && IsBlockRail(dispBlock))  // only actually place the minecart if there are rails!
 	{
-		if (m_World->SpawnMinecart(BlockX + 0.5, DispY + 0.5, BlockZ + 0.5, SlotItem.m_ItemType) != cEntity::INVALID_ID)
+		if (m_World->SpawnMinecart(dispAbsCoord.x + 0.5, dispAbsCoord.y + 0.5, dispAbsCoord.z + 0.5, SlotItem.m_ItemType) != cEntity::INVALID_ID)
 		{
 			m_Contents.ChangeSlotCount(a_SlotNum, -1);
 		}
@@ -55,15 +52,15 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 	{
 		case E_ITEM_BUCKET:
 		{
-			LOGD("Dispensing empty bucket in slot %d; DispBlock is \"%s\" (%d).", a_SlotNum, ItemTypeToString(DispBlock).c_str(), DispBlock);
-			switch (DispBlock)
+			LOGD("Dispensing empty bucket in slot %d; dispBlock is \"%s\" (%d).", a_SlotNum, ItemTypeToString(dispBlock).c_str(), dispBlock);
+			switch (dispBlock)
 			{
 				case E_BLOCK_STATIONARY_WATER:
 				case E_BLOCK_WATER:
 				{
 					if (ScoopUpLiquid(a_SlotNum, E_ITEM_WATER_BUCKET))
 					{
-						DispChunk->SetBlock(DispX, DispY, DispZ, E_BLOCK_AIR, 0);
+						dispChunk->SetBlock(dispRelCoord, E_BLOCK_AIR, 0);
 					}
 					break;
 				}
@@ -72,7 +69,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 				{
 					if (ScoopUpLiquid(a_SlotNum, E_ITEM_LAVA_BUCKET))
 					{
-						DispChunk->SetBlock(DispX, DispY, DispZ, E_BLOCK_AIR, 0);
+						dispChunk->SetBlock(dispRelCoord, E_BLOCK_AIR, 0);
 					}
 					break;
 				}
@@ -87,10 +84,10 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_WATER_BUCKET:
 		{
-			LOGD("Dispensing water bucket in slot %d; DispBlock is \"%s\" (%d).", a_SlotNum, ItemTypeToString(DispBlock).c_str(), DispBlock);
-			if (EmptyLiquidBucket(DispBlock, a_SlotNum))
+			LOGD("Dispensing water bucket in slot %d; dispBlock is \"%s\" (%d).", a_SlotNum, ItemTypeToString(dispBlock).c_str(), dispBlock);
+			if (EmptyLiquidBucket(dispBlock, a_SlotNum))
 			{
-				DispChunk->SetBlock(DispX, DispY, DispZ, E_BLOCK_WATER, 0);
+				dispChunk->SetBlock(dispRelCoord, E_BLOCK_WATER, 0);
 			}
 			else
 			{
@@ -101,10 +98,10 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_LAVA_BUCKET:
 		{
-			LOGD("Dispensing lava bucket in slot %d; DispBlock is \"%s\" (%d).", a_SlotNum, ItemTypeToString(DispBlock).c_str(), DispBlock);
-			if (EmptyLiquidBucket(DispBlock, a_SlotNum))
+			LOGD("Dispensing lava bucket in slot %d; dispBlock is \"%s\" (%d).", a_SlotNum, ItemTypeToString(dispBlock).c_str(), dispBlock);
+			if (EmptyLiquidBucket(dispBlock, a_SlotNum))
 			{
-				DispChunk->SetBlock(DispX, DispY, DispZ, E_BLOCK_LAVA, 0);
+				dispChunk->SetBlock(dispRelCoord, E_BLOCK_LAVA, 0);
 			}
 			else
 			{
@@ -115,9 +112,9 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_SPAWN_EGG:
 		{
-			double MobX = 0.5 + (DispX + DispChunk->GetPosX() * cChunkDef::Width);
-			double MobZ = 0.5 + (DispZ + DispChunk->GetPosZ() * cChunkDef::Width);
-			if (m_World->SpawnMob(MobX, DispY, MobZ, static_cast<eMonsterType>(m_Contents.GetSlot(a_SlotNum).m_ItemDamage), false) != cEntity::INVALID_ID)
+			double MobX = 0.5 + dispAbsCoord.x;
+			double MobZ = 0.5 + dispAbsCoord.z;
+			if (m_World->SpawnMob(MobX, dispAbsCoord.y, MobZ, static_cast<eMonsterType>(m_Contents.GetSlot(a_SlotNum).m_ItemDamage), false) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -127,11 +124,9 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 		case E_BLOCK_TNT:
 		{
 			// Spawn a primed TNT entity, if space allows:
-			if (!cBlockInfo::IsSolid(DispBlock))
+			if (!cBlockInfo::IsSolid(dispBlock))
 			{
-				double TNTX = 0.5 + (DispX + DispChunk->GetPosX() * cChunkDef::Width);
-				double TNTZ = 0.5 + (DispZ + DispChunk->GetPosZ() * cChunkDef::Width);
-				m_World->SpawnPrimedTNT({TNTX, DispY + 0.5, TNTZ}, 80, 0);  // 80 ticks fuse, no initial velocity
+				m_World->SpawnPrimedTNT(Vector3d(0.5, 0.5, 0.5) + dispAbsCoord, 80, 0);  // 80 ticks fuse, no initial velocity
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
 			break;
@@ -140,9 +135,9 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 		case E_ITEM_FLINT_AND_STEEL:
 		{
 			// Spawn fire if the block in front is air.
-			if (DispBlock == E_BLOCK_AIR)
+			if (dispBlock == E_BLOCK_AIR)
 			{
-				DispChunk->SetBlock(DispX, DispY, DispZ, E_BLOCK_FIRE, 0);
+				dispChunk->SetBlock(dispRelCoord, E_BLOCK_FIRE, 0);
 
 				bool ItemBroke = m_Contents.DamageItem(a_SlotNum, 1);
 
@@ -156,7 +151,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_FIRE_CHARGE:
 		{
-			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkFireCharge, GetShootVector(Meta) * 20) != cEntity::INVALID_ID)
+			if (SpawnProjectileFromDispenser(dispAbsCoord, cProjectileEntity::pkFireCharge, GetShootVector(meta) * 20) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -165,7 +160,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_ARROW:
 		{
-			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkArrow, GetShootVector(Meta) * 30 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
+			if (SpawnProjectileFromDispenser(dispAbsCoord, cProjectileEntity::pkArrow, GetShootVector(meta) * 30 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -174,7 +169,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_SNOWBALL:
 		{
-			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkSnowball, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
+			if (SpawnProjectileFromDispenser(dispAbsCoord, cProjectileEntity::pkSnowball, GetShootVector(meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -183,7 +178,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_EGG:
 		{
-			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkEgg, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
+			if (SpawnProjectileFromDispenser(dispAbsCoord, cProjectileEntity::pkEgg, GetShootVector(meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -192,7 +187,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_BOTTLE_O_ENCHANTING:
 		{
-			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkExpBottle, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
+			if (SpawnProjectileFromDispenser(dispAbsCoord, cProjectileEntity::pkExpBottle, GetShootVector(meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -201,7 +196,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_POTION:
 		{
-			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkSplashPotion, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0), &SlotItem) != cEntity::INVALID_ID)
+			if (SpawnProjectileFromDispenser(dispAbsCoord, cProjectileEntity::pkSplashPotion, GetShootVector(meta) * 20 + Vector3d(0, 1, 0), &SlotItem) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -215,7 +210,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 				DropFromSlot(a_Chunk, a_SlotNum);
 				break;
 			}
-			if (m_World->GrowRipePlant(BlockX, DispY, BlockZ, true))
+			if (m_World->GrowRipePlant(dispAbsCoord.x, dispAbsCoord.y, dispAbsCoord.z, true))
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -229,16 +224,16 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 		case E_ITEM_ACACIA_BOAT:
 		case E_ITEM_DARK_OAK_BOAT:
 		{
-			Vector3d SpawnPos;
-			if (IsBlockWater(DispBlock))
+			Vector3d spawnPos = dispAbsCoord;
+			if (IsBlockWater(dispBlock))
 			{
 				// Water next to the dispenser, spawn a boat above the water block
-				SpawnPos.Set(BlockX, DispY + 1, BlockZ);
+				spawnPos.y += 1;
 			}
-			else if (IsBlockWater(DispChunk->GetBlock(DispX, DispY - 1, DispZ)))
+			else if (IsBlockWater(dispChunk->GetBlock(dispRelCoord.addedY(-1))))
 			{
 				// Water one block below the dispenser, spawn a boat at the dispenser's Y level
-				SpawnPos.Set(BlockX, DispY, BlockZ);
+				// No adjustment needed
 			}
 			else
 			{
@@ -247,10 +242,10 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 				break;
 			}
 
-			SpawnPos += GetShootVector(Meta) * 0.8;  // A boat is bigger than one block. Add the shoot vector to put it outside the dispenser.
-			SpawnPos += Vector3d(0.5, 0.5, 0.5);
+			spawnPos += GetShootVector(meta) * 0.8;  // A boat is bigger than one block. Add the shoot vector to put it outside the dispenser.
+			spawnPos += Vector3d(0.5, 0.5, 0.5);
 
-			if (m_World->SpawnBoat(SpawnPos, cBoat::ItemToMaterial(SlotItem)))
+			if (m_World->SpawnBoat(spawnPos, cBoat::ItemToMaterial(SlotItem)))
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -259,7 +254,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_FIREWORK_ROCKET:
 		{
-			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkFirework, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0), &SlotItem) != cEntity::INVALID_ID)
+			if (SpawnProjectileFromDispenser(dispAbsCoord, cProjectileEntity::pkFirework, GetShootVector(meta) * 20 + Vector3d(0, 1, 0), &SlotItem) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -278,12 +273,9 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 
 
-UInt32 cDispenserEntity::SpawnProjectileFromDispenser(int a_BlockX, int a_BlockY, int a_BlockZ, cProjectileEntity::eKind a_Kind, const Vector3d & a_ShootVector, const cItem * a_Item)
+UInt32 cDispenserEntity::SpawnProjectileFromDispenser(Vector3i a_BlockPos, cProjectileEntity::eKind a_Kind, const Vector3d & a_ShootVector, const cItem * a_Item)
 {
-	return m_World->CreateProjectile(
-		static_cast<double>(a_BlockX + 0.5),
-		static_cast<double>(a_BlockY + 0.5),
-		static_cast<double>(a_BlockZ + 0.5),
+	return m_World->CreateProjectile(Vector3d(0.5, 0.5, 0.5) + a_BlockPos,
 		a_Kind, nullptr, a_Item, &a_ShootVector
 	);
 }

--- a/src/BlockEntities/DispenserEntity.h
+++ b/src/BlockEntities/DispenserEntity.h
@@ -11,22 +11,42 @@
 class cDispenserEntity :
 	public cDropSpenserEntity
 {
-	typedef cDropSpenserEntity Super;
-
-public:
-
 	// tolua_end
+
+	using super = cDropSpenserEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cDispenserEntity)
 
 	/** Constructor used for normal operation */
-	cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	// tolua_begin
 
 	/** Spawns a projectile of the given kind in front of the dispenser with the specified speed.
+	a_Item is the item from the internal storage from which the projectile originated.
 	Returns the UniqueID of the spawned projectile, or cEntity::INVALID_ID on failure. */
-	UInt32 SpawnProjectileFromDispenser(int a_BlockX, int a_BlockY, int a_BlockZ, cProjectileEntity::eKind a_Kind, const Vector3d & a_Speed, const cItem * a_Item = nullptr);
+	UInt32 SpawnProjectileFromDispenser(
+		Vector3i a_BlockPos,
+		cProjectileEntity::eKind a_Kind,
+		const Vector3d & a_Speed,
+		const cItem * a_Item = nullptr
+	);
+
+	/** OBSOLETE, use the Vector3i-based overload instead.
+	Spawns a projectile of the given kind in front of the dispenser with the specified speed.
+	a_Item is the item from the internal storage from which the projectile originated.
+	Returns the UniqueID of the spawned projectile, or cEntity::INVALID_ID on failure. */
+	UInt32 SpawnProjectileFromDispenser(
+		int a_BlockX, int a_BlockY, int a_BlockZ,
+		cProjectileEntity::eKind a_Kind,
+		const Vector3d & a_Speed,
+		const cItem * a_Item = nullptr
+	)
+	{
+		return SpawnProjectileFromDispenser({a_BlockX, a_BlockY, a_BlockZ}, a_Kind, a_Speed, a_Item);
+	}
 
 	/** Returns a unit vector in the cardinal direction of where the dispenser with the specified meta would be facing. */
 	static Vector3d GetShootVector(NIBBLETYPE a_BlockMeta);

--- a/src/BlockEntities/DropSpenserEntity.h
+++ b/src/BlockEntities/DropSpenserEntity.h
@@ -26,9 +26,14 @@ class cClientHandle;
 class cDropSpenserEntity :
 	public cBlockEntityWithItems
 {
-	typedef cBlockEntityWithItems Super;
+	// tolua_end
+
+	using super = cBlockEntityWithItems;
+
+	// tolua_begin
 
 public:
+
 	enum
 	{
 		ContentsHeight = 3,
@@ -39,7 +44,7 @@ public:
 
 	BLOCKENTITY_PROTODEF(cDropSpenserEntity)
 
-	cDropSpenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cDropSpenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 	virtual ~cDropSpenserEntity() override;
 
 	// cBlockEntity overrides:
@@ -51,7 +56,7 @@ public:
 	// tolua_begin
 
 	/** Modifies the block coords to match the dropspenser direction given (where the dropspensed pickups should materialize) */
-	void AddDropSpenserDir(int & a_BlockX, int & a_BlockY, int & a_BlockZ, NIBBLETYPE a_Direction);
+	void AddDropSpenserDir(Vector3i & a_RelCoord, NIBBLETYPE a_Direction);
 
 	/** Sets the dropspenser to dropspense an item in the next tick */
 	void Activate(void);

--- a/src/BlockEntities/DropperEntity.cpp
+++ b/src/BlockEntities/DropperEntity.cpp
@@ -10,8 +10,8 @@
 
 
 
-cDropperEntity::cDropperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World)
+cDropperEntity::cDropperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World)
 {
 	ASSERT(a_BlockType == E_BLOCK_DROPPER);
 }

--- a/src/BlockEntities/DropperEntity.h
+++ b/src/BlockEntities/DropperEntity.h
@@ -19,25 +19,22 @@
 class cDropperEntity :
 	public cDropSpenserEntity
 {
-	typedef cDropSpenserEntity Super;
-
-public:
-
 	// tolua_end
+
+	using super = cDropSpenserEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cDropperEntity)
 
 	/** Constructor used for normal operation */
-	cDropperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cDropperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
+
 
 protected:
+
 	// cDropSpenserEntity overrides:
 	virtual void DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum) override;
-
-	/** Takes an item from slot a_SlotNum and puts it into the container in front of the dropper.
-	Called when there's a container directly in front of the dropper,
-	so the dropper should store items there, rather than dropping. */
-	void PutIntoContainer(cChunk & a_Chunk, int a_SlotNum, BLOCKTYPE a_ContainerBlock, int a_ContainerX, int a_ContainerY, int a_ContainerZ);
 } ;  // tolua_export
 
 

--- a/src/BlockEntities/EnderChestEntity.cpp
+++ b/src/BlockEntities/EnderChestEntity.cpp
@@ -13,8 +13,8 @@
 
 
 
-cEnderChestEntity::cEnderChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+cEnderChestEntity::cEnderChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	cBlockEntityWindowOwner(this)
 {
 	ASSERT(a_BlockType == E_BLOCK_ENDER_CHEST);
@@ -40,7 +40,7 @@ cEnderChestEntity::~cEnderChestEntity()
 void cEnderChestEntity::SendTo(cClientHandle & a_Client)
 {
 	// Send a dummy "number of players with chest open" packet to make the chest visible:
-	a_Client.SendBlockAction(m_PosX, m_PosY, m_PosZ, 1, 0, m_BlockType);
+	a_Client.SendBlockAction(m_Pos.x, m_Pos.y, m_Pos.z, 1, 0, m_BlockType);
 }
 
 

--- a/src/BlockEntities/EnderChestEntity.h
+++ b/src/BlockEntities/EnderChestEntity.h
@@ -13,14 +13,15 @@ class cEnderChestEntity :
 	public cBlockEntity,
 	public cBlockEntityWindowOwner
 {
-	typedef cBlockEntity Super;
-
-public:
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cEnderChestEntity)
 
-	cEnderChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cEnderChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 	virtual ~cEnderChestEntity() override;
 
 	// cBlockEntity overrides:

--- a/src/BlockEntities/FlowerPotEntity.cpp
+++ b/src/BlockEntities/FlowerPotEntity.cpp
@@ -13,8 +13,8 @@
 
 
 
-cFlowerPotEntity::cFlowerPotEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World)
+cFlowerPotEntity::cFlowerPotEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World)
 {
 	ASSERT(a_BlockType == E_BLOCK_FLOWER_POT);
 }
@@ -31,7 +31,7 @@ void cFlowerPotEntity::Destroy(void)
 		ASSERT(m_World != nullptr);
 		cItems Pickups;
 		Pickups.Add(m_Item);
-		m_World->SpawnItemPickups(Pickups, m_PosX + 0.5, m_PosY + 0.5, m_PosZ + 0.5);
+		m_World->SpawnItemPickups(Pickups, Vector3d(0.5, 0.5, 0.5) + m_Pos);
 
 		m_Item.Empty();
 	}
@@ -43,7 +43,7 @@ void cFlowerPotEntity::Destroy(void)
 
 void cFlowerPotEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cFlowerPotEntity &>(a_Src);
 	m_Item = src.m_Item;
 }

--- a/src/BlockEntities/FlowerPotEntity.h
+++ b/src/BlockEntities/FlowerPotEntity.h
@@ -20,16 +20,16 @@
 class cFlowerPotEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-
-public:
-
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cFlowerPotEntity)
 
 	/** Creates a new flowerpot entity at the specified block coords. a_World may be nullptr */
-	cFlowerPotEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cFlowerPotEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 
 	// tolua_begin

--- a/src/BlockEntities/FurnaceEntity.cpp
+++ b/src/BlockEntities/FurnaceEntity.cpp
@@ -22,8 +22,8 @@ enum
 
 
 
-cFurnaceEntity::cFurnaceEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, ContentsWidth, ContentsHeight, a_World),
+cFurnaceEntity::cFurnaceEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, ContentsWidth, ContentsHeight, a_World),
 	m_CurrentRecipe(nullptr),
 	m_IsDestroyed(false),
 	m_IsCooking(a_BlockType == E_BLOCK_LIT_FURNACE),
@@ -58,7 +58,7 @@ cFurnaceEntity::~cFurnaceEntity()
 void cFurnaceEntity::Destroy()
 {
 	m_IsDestroyed = true;
-	Super::Destroy();
+	super::Destroy();
 }
 
 
@@ -67,7 +67,7 @@ void cFurnaceEntity::Destroy()
 
 void cFurnaceEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cFurnaceEntity &>(a_Src);
 	m_Contents.CopyFrom(src.m_Contents);
 	m_CurrentRecipe = src.m_CurrentRecipe;
@@ -106,7 +106,7 @@ bool cFurnaceEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 		// Reset progressbars, block type, and bail out
 		m_BlockType = E_BLOCK_FURNACE;
-		a_Chunk.FastSetBlock(GetRelX(), m_PosY, GetRelZ(), E_BLOCK_FURNACE, m_BlockMeta);
+		a_Chunk.FastSetBlock(GetRelPos(), E_BLOCK_FURNACE, m_BlockMeta);
 		UpdateProgressBars();
 		return false;
 	}
@@ -142,7 +142,7 @@ bool cFurnaceEntity::UsedBy(cPlayer * a_Player)
 	cWindow * Window = GetWindow();
 	if (Window == nullptr)
 	{
-		OpenWindow(new cFurnaceWindow(m_PosX, m_PosY, m_PosZ, this));
+		OpenWindow(new cFurnaceWindow(this));
 		Window = GetWindow();
 	}
 
@@ -255,7 +255,7 @@ void cFurnaceEntity::BurnNewFuel(void)
 
 void cFurnaceEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 {
-	Super::OnSlotChanged(a_ItemGrid, a_SlotNum);
+	super::OnSlotChanged(a_ItemGrid, a_SlotNum);
 
 	if (m_IsDestroyed)
 	{
@@ -433,6 +433,6 @@ void cFurnaceEntity::SetIsCooking(bool a_IsCooking)
 	if (m_IsCooking)
 	{
 		m_BlockType = E_BLOCK_LIT_FURNACE;
-		m_World->FastSetBlock(m_PosX, m_PosY, m_PosZ, E_BLOCK_LIT_FURNACE, m_BlockMeta);
+		m_World->FastSetBlock(m_Pos, E_BLOCK_LIT_FURNACE, m_BlockMeta);
 	}
 }

--- a/src/BlockEntities/FurnaceEntity.h
+++ b/src/BlockEntities/FurnaceEntity.h
@@ -18,9 +18,14 @@ class cClientHandle;
 class cFurnaceEntity :
 	public cBlockEntityWithItems
 {
-	typedef cBlockEntityWithItems Super;
+	// tolua_end
+
+	using super = cBlockEntityWithItems;
+
+	// tolua_begin
 
 public:
+
 	enum
 	{
 		fsInput  = 0,  // Input slot number
@@ -36,7 +41,7 @@ public:
 	BLOCKENTITY_PROTODEF(cFurnaceEntity)
 
 	/** Constructor used for normal operation */
-	cFurnaceEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cFurnaceEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	virtual ~cFurnaceEntity() override;
 

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -556,7 +556,7 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords)
 			continue;
 		}
 
-		auto chest = static_cast<cChestEntity *>(neighbor->GetBlockEntity(a_Coords + ofs)));
+		auto chest = static_cast<cChestEntity *>(neighbor->GetBlockEntity(a_Coords + ofs));
 		if (chest == nullptr)
 		{
 			FLOGWARNING("{0}: A chest entity was not found where expected, at {1} ({2}, {3}})", __FUNCTION__, a_Coords + ofs, ofs.x, ofs.z);

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -556,7 +556,7 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords)
 			continue;
 		}
 
-		auto chest = static_cast<cChestEntity *>(neighbor->GetBlockEntity(a_Coords.addedXZ(ofs.x, ofs.z)));
+		auto chest = static_cast<cChestEntity *>(neighbor->GetBlockEntity(a_Coords + ofs)));
 		if (chest == nullptr)
 		{
 			FLOGWARNING("{0}: A chest entity was not found where expected, at {1} ({2}, {3}})", __FUNCTION__, a_Coords.addedXZ(ofs.x, ofs.z), ofs.x, ofs.z);

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -17,8 +17,8 @@
 
 
 
-cHopperEntity::cHopperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, ContentsWidth, ContentsHeight, a_World),
+cHopperEntity::cHopperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, ContentsWidth, ContentsHeight, a_World),
 	m_LastMoveItemsInTick(0),
 	m_LastMoveItemsOutTick(0)
 {
@@ -29,22 +29,20 @@ cHopperEntity::cHopperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int 
 
 
 
-bool cHopperEntity::GetOutputBlockPos(NIBBLETYPE a_BlockMeta, int & a_OutputX, int & a_OutputY, int & a_OutputZ)
+std::pair<bool, Vector3i> cHopperEntity::GetOutputBlockPos(NIBBLETYPE a_BlockMeta)
 {
-	a_OutputX = m_PosX;
-	a_OutputY = m_PosY;
-	a_OutputZ = m_PosZ;
+	auto pos = GetPos();
 	switch (a_BlockMeta)
 	{
-		case E_META_HOPPER_FACING_XM: a_OutputX--; return true;
-		case E_META_HOPPER_FACING_XP: a_OutputX++; return true;
-		case E_META_HOPPER_FACING_YM: a_OutputY--; return true;
-		case E_META_HOPPER_FACING_ZM: a_OutputZ--; return true;
-		case E_META_HOPPER_FACING_ZP: a_OutputZ++; return true;
+		case E_META_HOPPER_FACING_XM: return {true, pos.addedX(-1)};
+		case E_META_HOPPER_FACING_XP: return {true, pos.addedX( 1)};
+		case E_META_HOPPER_FACING_YM: return {true, pos.addedY(-1)};
+		case E_META_HOPPER_FACING_ZM: return {true, pos.addedZ(-1)};
+		case E_META_HOPPER_FACING_ZP: return {true, pos.addedZ( 1)};
 		default:
 		{
 			// Not attached
-			return false;
+			return {false, pos};
 		}
 	}
 }
@@ -55,7 +53,7 @@ bool cHopperEntity::GetOutputBlockPos(NIBBLETYPE a_BlockMeta, int & a_OutputX, i
 
 void cHopperEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cHopperEntity &>(a_Src);
 	m_LastMoveItemsInTick = src.m_LastMoveItemsInTick;
 	m_LastMoveItemsOutTick = src.m_LastMoveItemsOutTick;
@@ -127,7 +125,7 @@ bool cHopperEntity::UsedBy(cPlayer * a_Player)
 
 void cHopperEntity::OpenNewWindow(void)
 {
-	OpenWindow(new cHopperWindow(m_PosX, m_PosY, m_PosZ, this));
+	OpenWindow(new cHopperWindow(this));
 }
 
 
@@ -136,7 +134,7 @@ void cHopperEntity::OpenNewWindow(void)
 
 bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 {
-	if (m_PosY >= cChunkDef::Height)
+	if (m_Pos.y >= cChunkDef::Height)
 	{
 		// This hopper is at the top of the world, no more blocks above
 		return false;
@@ -150,7 +148,7 @@ bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 
 	// Try moving an item in:
 	bool res = false;
-	switch (a_Chunk.GetBlock(m_RelX, m_PosY + 1, m_RelZ))
+	switch (a_Chunk.GetBlock(GetRelPos()))
 	{
 		case E_BLOCK_TRAPPED_CHEST:
 		case E_BLOCK_CHEST:
@@ -170,7 +168,7 @@ bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 		case E_BLOCK_DROPPER:
 		case E_BLOCK_HOPPER:
 		{
-			res = MoveItemsFromGrid(*static_cast<cBlockEntityWithItems *>(a_Chunk.GetBlockEntity(m_PosX, m_PosY + 1, m_PosZ)));
+			res = MoveItemsFromGrid(*static_cast<cBlockEntityWithItems *>(a_Chunk.GetBlockEntity(GetRelPos().addedY(1))));
 			break;
 		}
 	}
@@ -286,24 +284,23 @@ bool cHopperEntity::MoveItemsOut(cChunk & a_Chunk, Int64 a_CurrentTick)
 	}
 
 	// Get the coords of the block where to output items:
-	int OutX, OutY, OutZ;
-	NIBBLETYPE Meta = a_Chunk.GetMeta(m_RelX, m_PosY, m_RelZ);
-	if (!GetOutputBlockPos(Meta, OutX, OutY, OutZ))
+	auto meta = a_Chunk.GetMeta(GetRelPos());
+	auto out = GetOutputBlockPos(meta);
+	if (!out.first)
 	{
 		// Not attached to another container
 		return false;
 	}
-	if (OutY < 0)
+	if (out.second.y < 0)
 	{
 		// Cannot output below the zero-th block level
 		return false;
 	}
 
 	// Convert coords to relative:
-	int OutRelX = OutX - a_Chunk.GetPosX() * cChunkDef::Width;
-	int OutRelZ = OutZ - a_Chunk.GetPosZ() * cChunkDef::Width;
-	cChunk * DestChunk = a_Chunk.GetRelNeighborChunkAdjustCoords(OutRelX, OutRelZ);
-	if (DestChunk == nullptr)
+	auto relCoord = a_Chunk.AbsoluteToRelative(out.second);
+	auto destChunk = a_Chunk.GetRelNeighborChunkAdjustCoords(relCoord.x, relCoord.z);
+	if (destChunk == nullptr)
 	{
 		// The destination chunk has been unloaded, don't tick
 		return false;
@@ -311,33 +308,34 @@ bool cHopperEntity::MoveItemsOut(cChunk & a_Chunk, Int64 a_CurrentTick)
 
 	// Call proper moving function, based on the blocktype present at the coords:
 	bool res = false;
-	switch (DestChunk->GetBlock(OutRelX, OutY, OutRelZ))
+	auto absCoord = destChunk->RelativeToAbsolute(relCoord);
+	switch (destChunk->GetBlock(relCoord))
 	{
 		case E_BLOCK_TRAPPED_CHEST:
 		case E_BLOCK_CHEST:
 		{
 			// Chests have special handling because of double-chests
-			res = MoveItemsToChest(*DestChunk, OutX, OutY, OutZ);
+			res = MoveItemsToChest(*destChunk, absCoord);
 			break;
 		}
 		case E_BLOCK_LIT_FURNACE:
 		case E_BLOCK_FURNACE:
 		{
 			// Furnaces have special handling because of the direction-to-slot relation
-			res = MoveItemsToFurnace(*DestChunk, OutX, OutY, OutZ, Meta);
+			res = MoveItemsToFurnace(*destChunk, absCoord, meta);
 			break;
 		}
 		case E_BLOCK_DISPENSER:
 		case E_BLOCK_DROPPER:
 		case E_BLOCK_HOPPER:
 		{
-			cBlockEntityWithItems * BlockEntity = static_cast<cBlockEntityWithItems *>(DestChunk->GetBlockEntity(OutX, OutY, OutZ));
-			if (BlockEntity == nullptr)
+			auto blockEntity = static_cast<cBlockEntityWithItems *>(destChunk->GetBlockEntity(absCoord));
+			if (blockEntity == nullptr)
 			{
-				FLOGWARNING("{0}: A block entity was not found where expected at {1}", __FUNCTION__, Vector3i{OutX, OutY, OutZ});
+				FLOGWARNING("{0}: A block entity was not found where expected at {1}", __FUNCTION__, absCoord);
 				return false;
 			}
-			res = MoveItemsToGrid(*BlockEntity);
+			res = MoveItemsToGrid(*blockEntity);
 			break;
 		}
 	}
@@ -357,55 +355,52 @@ bool cHopperEntity::MoveItemsOut(cChunk & a_Chunk, Int64 a_CurrentTick)
 
 bool cHopperEntity::MoveItemsFromChest(cChunk & a_Chunk)
 {
-	cChestEntity * MainChest = static_cast<cChestEntity *>(a_Chunk.GetBlockEntity(m_PosX, m_PosY + 1, m_PosZ));
-	if (MainChest == nullptr)
+	auto chestPos = GetPos().addedY(1);
+	auto mainChest = static_cast<cChestEntity *>(a_Chunk.GetBlockEntity(chestPos));
+	if (mainChest == nullptr)
 	{
-		FLOGWARNING("{0}: A chest entity was not found where expected, at {1}", __FUNCTION__, GetPos() + Vector3i{0, 1, 0});
+		FLOGWARNING("{0}: A chest entity was not found where expected, at {1}", __FUNCTION__, chestPos);
 		return false;
 	}
-	if (MoveItemsFromGrid(*MainChest))
+	if (MoveItemsFromGrid(*mainChest))
 	{
 		// Moved the item from the chest directly above the hopper
 		return true;
 	}
 
 	// Check if the chest is a double-chest (chest directly above was empty), if so, try to move from there:
-	static const struct
+	static const Vector3i neighborOfs[] =
 	{
-		int x, z;
-	}
-	Coords [] =
-	{
-		{1, 0},
-		{-1, 0},
-		{0, 1},
-		{0, -1},
+		{ 1, 1,  0},
+		{-1, 1,  0},
+		{ 0, 1,  1},
+		{ 0, 1, -1},
 	} ;
-	for (size_t i = 0; i < ARRAYCOUNT(Coords); i++)
+	for (const auto & ofs: neighborOfs)
 	{
-		int x = m_RelX + Coords[i].x;
-		int z = m_RelZ + Coords[i].z;
-		cChunk * Neighbor = a_Chunk.GetRelNeighborChunkAdjustCoords(x, z);
-		if (Neighbor == nullptr)
+		auto neighborRelCoord = ofs.addedXZ(m_RelX, m_RelZ);
+		auto neighbor = a_Chunk.GetRelNeighborChunkAdjustCoords(neighborRelCoord.x, neighborRelCoord.z);
+		if (neighbor == nullptr)
 		{
 			continue;
 		}
 
-		BLOCKTYPE Block = Neighbor->GetBlock(x, m_PosY + 1, z);
-		if (Block != MainChest->GetBlockType())
+		BLOCKTYPE Block = neighbor->GetBlock(neighborRelCoord);
+		if (Block != mainChest->GetBlockType())
 		{
 			// Not the same kind of chest
 			continue;
 		}
 
-		cChestEntity * SideChest = static_cast<cChestEntity *>(Neighbor->GetBlockEntity(m_PosX + Coords[i].x, m_PosY + 1, m_PosZ + Coords[i].z));
-		if (SideChest == nullptr)
+		auto neighborAbsCoord = neighbor->RelativeToAbsolute(neighborRelCoord);
+		auto sideChest = static_cast<cChestEntity *>(neighbor->GetBlockEntity(neighborAbsCoord));
+		if (sideChest == nullptr)
 		{
-			FLOGWARNING("{0}: A chest entity was not found where expected, at {1}", __FUNCTION__, GetPos() + Vector3i{Coords[i].x, 1, Coords[i].z});
+			FLOGWARNING("{0}: A chest entity was not found where expected, at {1}", __FUNCTION__, neighborAbsCoord);
 		}
 		else
 		{
-			if (MoveItemsFromGrid(*SideChest))
+			if (MoveItemsFromGrid(*sideChest))
 			{
 				return true;
 			}
@@ -413,7 +408,7 @@ bool cHopperEntity::MoveItemsFromChest(cChunk & a_Chunk)
 		return false;
 	}
 
-	// The chest was single and nothing could be moved
+	// The chest was empty
 	return false;
 }
 
@@ -423,27 +418,27 @@ bool cHopperEntity::MoveItemsFromChest(cChunk & a_Chunk)
 
 bool cHopperEntity::MoveItemsFromFurnace(cChunk & a_Chunk)
 {
-	cFurnaceEntity * Furnace = static_cast<cFurnaceEntity *>(a_Chunk.GetBlockEntity(m_PosX, m_PosY + 1, m_PosZ));
-	if (Furnace == nullptr)
+	auto furnace = static_cast<cFurnaceEntity *>(a_Chunk.GetBlockEntity(m_Pos.addedY(1)));
+	if (furnace == nullptr)
 	{
-		FLOGWARNING("{0}: A furnace entity was not found where expected, at {1}", __FUNCTION__, GetPos() + Vector3i{0, 1, 0});
+		FLOGWARNING("{0}: A furnace entity was not found where expected, at {1}", __FUNCTION__, m_Pos.addedY(1));
 		return false;
 	}
 
 	// Try move from the output slot:
-	if (MoveItemsFromSlot(*Furnace, cFurnaceEntity::fsOutput))
+	if (MoveItemsFromSlot(*furnace, cFurnaceEntity::fsOutput))
 	{
-		cItem NewOutput(Furnace->GetOutputSlot());
-		Furnace->SetOutputSlot(NewOutput.AddCount(-1));
+		cItem NewOutput(furnace->GetOutputSlot());
+		furnace->SetOutputSlot(NewOutput.AddCount(-1));
 		return true;
 	}
 
 	// No output moved, check if we can move an empty bucket out of the fuel slot:
-	if (Furnace->GetFuelSlot().m_ItemType == E_ITEM_BUCKET)
+	if (furnace->GetFuelSlot().m_ItemType == E_ITEM_BUCKET)
 	{
-		if (MoveItemsFromSlot(*Furnace, cFurnaceEntity::fsFuel))
+		if (MoveItemsFromSlot(*furnace, cFurnaceEntity::fsFuel))
 		{
-			Furnace->SetFuelSlot(cItem());
+			furnace->SetFuelSlot(cItem());
 			return true;
 		}
 	}
@@ -458,7 +453,7 @@ bool cHopperEntity::MoveItemsFromFurnace(cChunk & a_Chunk)
 
 bool cHopperEntity::MoveItemsFromGrid(cBlockEntityWithItems & a_Entity)
 {
-	cItemGrid & Grid = a_Entity.GetContents();
+	auto & Grid = a_Entity.GetContents();
 	int NumSlots = Grid.GetNumSlots();
 
 	for (int i = 0; i < NumSlots; i++)
@@ -521,13 +516,13 @@ bool cHopperEntity::MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, int a_Sl
 
 
 
-bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, int a_BlockX, int a_BlockY, int a_BlockZ)
+bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords)
 {
 	// Try the chest directly connected to the hopper:
-	cChestEntity * ConnectedChest = static_cast<cChestEntity *>(a_Chunk.GetBlockEntity(a_BlockX, a_BlockY, a_BlockZ));
+	auto ConnectedChest = static_cast<cChestEntity *>(a_Chunk.GetBlockEntity(a_Coords));
 	if (ConnectedChest == nullptr)
 	{
-		FLOGWARNING("{0}: A chest entity was not found where expected, at {1}", __FUNCTION__, Vector3i{a_BlockX, a_BlockY, a_BlockZ});
+		FLOGWARNING("{0}: A chest entity was not found where expected, at {1}", __FUNCTION__, a_Coords);
 		return false;
 	}
 	if (MoveItemsToGrid(*ConnectedChest))
@@ -537,43 +532,37 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, int a_BlockX, int a_Block
 	}
 
 	// Check if the chest is a double-chest (chest block directly connected was full), if so, try to move into the other half:
-	static const struct
+	static const Vector3i neighborOfs [] =
 	{
-		int x, z;
-	}
-	Coords [] =
-	{
-		{1, 0},
-		{-1, 0},
-		{0, 1},
-		{0, -1},
+		{ 1, 0,  0},
+		{-1, 0,  0},
+		{ 0, 0,  1},
+		{ 0, 0, -1},
 	} ;
-	int RelX = a_BlockX - a_Chunk.GetPosX() * cChunkDef::Width;
-	int RelZ = a_BlockZ - a_Chunk.GetPosZ() * cChunkDef::Width;
-	for (size_t i = 0; i < ARRAYCOUNT(Coords); i++)
+	auto relCoord = a_Chunk.AbsoluteToRelative(a_Coords);
+	for (const auto & ofs: neighborOfs)
 	{
-		int x = RelX + Coords[i].x;
-		int z = RelZ + Coords[i].z;
-		cChunk * Neighbor = a_Chunk.GetRelNeighborChunkAdjustCoords(x, z);
-		if (Neighbor == nullptr)
+		auto otherHalfRelCoord = relCoord.addedXZ(ofs.x, ofs.z);
+		auto neighbor = a_Chunk.GetRelNeighborChunkAdjustCoords(otherHalfRelCoord.x, otherHalfRelCoord.z);
+		if (neighbor == nullptr)
 		{
 			continue;
 		}
 
-		BLOCKTYPE Block = Neighbor->GetBlock(x, a_BlockY, z);
+		auto Block = neighbor->GetBlock(otherHalfRelCoord);
 		if (Block != ConnectedChest->GetBlockType())
 		{
 			// Not the same kind of chest
 			continue;
 		}
 
-		cChestEntity * Chest = static_cast<cChestEntity *>(Neighbor->GetBlockEntity(a_BlockX + Coords[i].x, a_BlockY, a_BlockZ + Coords[i].z));
-		if (Chest == nullptr)
+		auto chest = static_cast<cChestEntity *>(neighbor->GetBlockEntity(a_Coords.addedXZ(ofs.x, ofs.z)));
+		if (chest == nullptr)
 		{
-			FLOGWARNING("{0}: A chest entity was not found where expected, at {1} ({2}, {3}})", __FUNCTION__, Vector3i{a_BlockX + Coords[i].x, a_BlockY, a_BlockZ + Coords[i].z}, x, z);
+			FLOGWARNING("{0}: A chest entity was not found where expected, at {1} ({2}, {3}})", __FUNCTION__, a_Coords.addedXZ(ofs.x, ofs.z), ofs.x, ofs.z);
 			continue;
 		}
-		if (MoveItemsToGrid(*Chest))
+		if (MoveItemsToGrid(*chest))
 		{
 			return true;
 		}
@@ -588,18 +577,18 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, int a_BlockX, int a_Block
 
 
 
-bool cHopperEntity::MoveItemsToFurnace(cChunk & a_Chunk, int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_HopperMeta)
+bool cHopperEntity::MoveItemsToFurnace(cChunk & a_Chunk, Vector3i a_Coords, NIBBLETYPE a_HopperMeta)
 {
-	cFurnaceEntity * Furnace = static_cast<cFurnaceEntity *>(a_Chunk.GetBlockEntity(a_BlockX, a_BlockY, a_BlockZ));
+	auto furnace = static_cast<cFurnaceEntity *>(a_Chunk.GetBlockEntity(a_Coords));
 	if (a_HopperMeta == E_META_HOPPER_FACING_YM)
 	{
 		// Feed the input slot of the furnace
-		return MoveItemsToSlot(*Furnace, cFurnaceEntity::fsInput);
+		return MoveItemsToSlot(*furnace, cFurnaceEntity::fsInput);
 	}
 	else
 	{
 		// Feed the fuel slot of the furnace
-		return MoveItemsToSlot(*Furnace, cFurnaceEntity::fsFuel);
+		return MoveItemsToSlot(*furnace, cFurnaceEntity::fsFuel);
 	}
 }
 

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -559,7 +559,7 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords)
 		auto chest = static_cast<cChestEntity *>(neighbor->GetBlockEntity(a_Coords + ofs)));
 		if (chest == nullptr)
 		{
-			FLOGWARNING("{0}: A chest entity was not found where expected, at {1} ({2}, {3}})", __FUNCTION__, a_Coords.addedXZ(ofs.x, ofs.z), ofs.x, ofs.z);
+			FLOGWARNING("{0}: A chest entity was not found where expected, at {1} ({2}, {3}})", __FUNCTION__, a_Coords + ofs, ofs.x, ofs.z);
 			continue;
 		}
 		if (MoveItemsToGrid(*chest))

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -542,7 +542,7 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords)
 	auto relCoord = a_Chunk.AbsoluteToRelative(a_Coords);
 	for (const auto & ofs: neighborOfs)
 	{
-		auto otherHalfRelCoord = relCoord.addedXZ(ofs.x, ofs.z);
+		auto otherHalfRelCoord = relCoord + ofs;
 		auto neighbor = a_Chunk.GetRelNeighborChunkAdjustCoords(otherHalfRelCoord.x, otherHalfRelCoord.z);
 		if (neighbor == nullptr)
 		{

--- a/src/BlockEntities/HopperEntity.h
+++ b/src/BlockEntities/HopperEntity.h
@@ -19,7 +19,11 @@
 class cHopperEntity :
 	public cBlockEntityWithItems
 {
-	typedef cBlockEntityWithItems Super;
+	// tolua_end
+
+	using super = cBlockEntityWithItems;
+
+	// tolua_begin
 
 public:
 	enum
@@ -34,12 +38,12 @@ public:
 	BLOCKENTITY_PROTODEF(cHopperEntity)
 
 	/** Constructor used for normal operation */
-	cHopperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cHopperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	/** Returns the block coords of the block receiving the output items, based on the meta
-	Returns false if unattached.
+	Returns <false, undefined> if unattached.
 	Exported in ManualBindings.cpp. */
-	bool GetOutputBlockPos(NIBBLETYPE a_BlockMeta, int & a_OutputX, int & a_OutputY, int & a_OutputZ);
+	std::pair<bool, Vector3i> GetOutputBlockPos(NIBBLETYPE a_BlockMeta);
 
 protected:
 
@@ -76,11 +80,11 @@ protected:
 	/** Moves one piece from the specified itemstack into this hopper. Returns true if contents have changed. Doesn't change the itemstack. */
 	bool MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, int a_SrcSlotNum);
 
-	/** Moves items to the chest at the specified coords. Returns true if contents have changed */
-	bool MoveItemsToChest(cChunk & a_Chunk, int a_BlockX, int a_BlockY, int a_BlockZ);
+	/** Moves items to the chest at the specified absolute coords. Returns true if contents have changed */
+	bool MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords);
 
-	/** Moves items to the furnace at the specified coords. Returns true if contents have changed */
-	bool MoveItemsToFurnace(cChunk & a_Chunk, int a_BlockX, int a_BlockY, int a_BlockZ, NIBBLETYPE a_HopperMeta);
+	/** Moves items to the furnace at the specified absolute coords. Returns true if contents have changed */
+	bool MoveItemsToFurnace(cChunk & a_Chunk, Vector3i a_Coords, NIBBLETYPE a_HopperMeta);
 
 	/** Moves items to the specified ItemGrid. Returns true if contents have changed */
 	bool MoveItemsToGrid(cBlockEntityWithItems & a_Entity);

--- a/src/BlockEntities/JukeboxEntity.cpp
+++ b/src/BlockEntities/JukeboxEntity.cpp
@@ -10,8 +10,8 @@
 
 
 
-cJukeboxEntity::cJukeboxEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+cJukeboxEntity::cJukeboxEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	m_Record(0)
 {
 	ASSERT(a_BlockType == E_BLOCK_JUKEBOX);
@@ -31,7 +31,7 @@ cJukeboxEntity::~cJukeboxEntity()
 
 void cJukeboxEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cJukeboxEntity &>(a_Src);
 	m_Record = src.m_Record;
 }
@@ -77,7 +77,7 @@ bool cJukeboxEntity::PlayRecord(int a_Record)
 	}
 	m_Record = a_Record;
 	m_World->BroadcastSoundParticleEffect(EffectID::SFX_RANDOM_PLAY_MUSIC_DISC, GetPos(), m_Record);
-	m_World->SetBlockMeta(m_PosX, m_PosY, m_PosZ, E_META_JUKEBOX_ON);
+	m_World->SetBlockMeta(m_Pos, E_META_JUKEBOX_ON);
 	return true;
 }
 
@@ -96,9 +96,9 @@ bool cJukeboxEntity::EjectRecord(void)
 	cItems Drops;
 	Drops.push_back(cItem(static_cast<short>(m_Record), 1, 0));
 	m_Record = 0;
-	m_World->SpawnItemPickups(Drops, m_PosX + 0.5, m_PosY + 1, m_PosZ + 0.5, 8);
+	m_World->SpawnItemPickups(Drops, Vector3d(0.5, 1, 0.5) + m_Pos, 8);
 	m_World->BroadcastSoundParticleEffect(EffectID::SFX_RANDOM_PLAY_MUSIC_DISC, GetPos(), 0);
-	m_World->SetBlockMeta(m_PosX, m_PosY, m_PosZ, E_META_JUKEBOX_OFF);
+	m_World->SetBlockMeta(m_Pos, E_META_JUKEBOX_OFF);
 	return true;
 }
 

--- a/src/BlockEntities/JukeboxEntity.h
+++ b/src/BlockEntities/JukeboxEntity.h
@@ -12,15 +12,15 @@
 class cJukeboxEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-
-public:
-
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cJukeboxEntity)
 
-	cJukeboxEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cJukeboxEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 	virtual ~cJukeboxEntity() override;
 
 	// tolua_begin

--- a/src/BlockEntities/MobHeadEntity.cpp
+++ b/src/BlockEntities/MobHeadEntity.cpp
@@ -13,8 +13,8 @@
 
 
 
-cMobHeadEntity::cMobHeadEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+cMobHeadEntity::cMobHeadEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	m_Type(SKULL_TYPE_SKELETON),
 	m_Rotation(SKULL_ROTATION_NORTH)
 {
@@ -27,7 +27,7 @@ cMobHeadEntity::cMobHeadEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, in
 
 void cMobHeadEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cMobHeadEntity &>(a_Src);
 	m_OwnerName = src.m_OwnerName;
 	m_OwnerTexture = src.m_OwnerTexture;
@@ -125,7 +125,7 @@ void cMobHeadEntity::SetOwner(const cUUID & a_OwnerUUID, const AString & a_Owner
 void cMobHeadEntity::SendTo(cClientHandle & a_Client)
 {
 	cWorld * World = a_Client.GetPlayer()->GetWorld();
-	a_Client.SendBlockChange(m_PosX, m_PosY, m_PosZ, m_BlockType, World->GetBlockMeta(GetPos()));
+	a_Client.SendBlockChange(m_Pos.x, m_Pos.y, m_Pos.z, m_BlockType, World->GetBlockMeta(GetPos()));
 	a_Client.SendUpdateBlockEntity(*this);
 }
 

--- a/src/BlockEntities/MobHeadEntity.h
+++ b/src/BlockEntities/MobHeadEntity.h
@@ -21,16 +21,16 @@
 class cMobHeadEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-
-public:
-
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cMobHeadEntity)
 
 	/** Creates a new mob head entity at the specified block coords. a_World may be nullptr */
-	cMobHeadEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cMobHeadEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	// tolua_begin
 

--- a/src/BlockEntities/MobSpawnerEntity.cpp
+++ b/src/BlockEntities/MobSpawnerEntity.cpp
@@ -13,8 +13,8 @@
 
 
 
-cMobSpawnerEntity::cMobSpawnerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+cMobSpawnerEntity::cMobSpawnerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	m_Entity(mtPig),
 	m_SpawnDelay(100),
 	m_IsActive(false)
@@ -28,7 +28,7 @@ cMobSpawnerEntity::cMobSpawnerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMe
 
 void cMobSpawnerEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cMobSpawnerEntity &>(a_Src);
 	m_Entity = src.m_Entity;
 	m_IsActive = src.m_IsActive;
@@ -152,7 +152,7 @@ void cMobSpawnerEntity::SpawnEntity(void)
 				}
 
 				int RelX = m_RelX + static_cast<int>((Random.RandReal<double>() - Random.RandReal<double>()) * 4.0);
-				int RelY = m_PosY + Random.RandInt(-1, 1);
+				int RelY = m_Pos.y + Random.RandInt(-1, 1);
 				int RelZ = m_RelZ + static_cast<int>((Random.RandReal<double>() - Random.RandReal<double>()) * 4.0);
 
 				cChunk * Chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(RelX, RelZ);
@@ -203,7 +203,7 @@ void cMobSpawnerEntity::SpawnEntity(void)
 
 int cMobSpawnerEntity::GetNearbyPlayersNum(void)
 {
-	Vector3d SpawnerPos(m_PosX + 0.5, m_PosY + 0.5, m_PosZ + 0.5);
+	auto SpawnerPos = Vector3d(0.5, 0.5, 0.5) + m_Pos;
 	int NumPlayers = 0;
 
 	class cCallback : public cChunkDataCallback
@@ -246,7 +246,7 @@ int cMobSpawnerEntity::GetNearbyPlayersNum(void)
 
 int cMobSpawnerEntity::GetNearbyMonsterNum(eMonsterType a_EntityType)
 {
-	Vector3d SpawnerPos(m_PosX + 0.5, m_PosY + 0.5, m_PosZ + 0.5);
+	auto SpawnerPos = Vector3d(0.5, 0.5, 0.5) + m_Pos;
 	int NumEntities = 0;
 
 	class cCallback : public cChunkDataCallback

--- a/src/BlockEntities/MobSpawnerEntity.h
+++ b/src/BlockEntities/MobSpawnerEntity.h
@@ -16,16 +16,16 @@
 
 
 // tolua_begin
-
 class cMobSpawnerEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-public:
-
 	// tolua_end
 
-	cMobSpawnerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	using super = cBlockEntity;
+
+public:  // tolua_export
+
+	cMobSpawnerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;

--- a/src/BlockEntities/NoteEntity.cpp
+++ b/src/BlockEntities/NoteEntity.cpp
@@ -9,8 +9,8 @@
 
 
 
-cNoteEntity::cNoteEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World),
+cNoteEntity::cNoteEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World),
 	m_Pitch(0)
 {
 	ASSERT(a_BlockType == E_BLOCK_NOTE_BLOCK);
@@ -22,7 +22,7 @@ cNoteEntity::cNoteEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_Bl
 
 void cNoteEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cNoteEntity &>(a_Src);
 	m_Pitch = src.m_Pitch;
 }
@@ -48,7 +48,7 @@ void cNoteEntity::MakeSound(void)
 	char instrument;
 	AString sampleName;
 
-	switch (m_World->GetBlock(m_PosX, m_PosY - 1, m_PosZ))
+	switch (m_World->GetBlock(m_Pos.addedY(-1)))
 	{
 		case E_BLOCK_ACACIA_DOOR:
 		case E_BLOCK_ACACIA_FENCE:
@@ -243,13 +243,13 @@ void cNoteEntity::MakeSound(void)
 		}
 	}
 
-	m_World->BroadcastBlockAction({m_PosX, m_PosY, m_PosZ}, static_cast<Byte>(instrument), static_cast<Byte>(m_Pitch), E_BLOCK_NOTE_BLOCK);
+	m_World->BroadcastBlockAction(m_Pos, static_cast<Byte>(instrument), static_cast<Byte>(m_Pitch), E_BLOCK_NOTE_BLOCK);
 
 	// TODO: instead of calculating the power function over and over, make a precalculated table - there's only 24 pitches after all
 	float calcPitch = static_cast<float>(pow(2.0f, static_cast<float>(m_Pitch - 12.0f) / 12.0f));
 	m_World->BroadcastSoundEffect(
 		sampleName,
-		Vector3d(m_PosX, m_PosY, m_PosZ),
+		m_Pos,
 		3.0f,
 		calcPitch
 	);

--- a/src/BlockEntities/NoteEntity.h
+++ b/src/BlockEntities/NoteEntity.h
@@ -30,15 +30,16 @@ enum ENUM_NOTE_INSTRUMENTS
 class cNoteEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-public:
-
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cNoteEntity)
 
 	/** Creates a new note entity. a_World may be nullptr */
-	cNoteEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cNoteEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 	virtual ~cNoteEntity() override {}
 
 	// tolua_begin

--- a/src/BlockEntities/SignEntity.cpp
+++ b/src/BlockEntities/SignEntity.cpp
@@ -12,11 +12,11 @@
 
 
 
-cSignEntity::cSignEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World):
-	Super(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, a_World)
+cSignEntity::cSignEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
+	super(a_BlockType, a_BlockMeta, a_Pos, a_World)
 {
 	ASSERT((a_BlockType ==  E_BLOCK_WALLSIGN) || (a_BlockType == E_BLOCK_SIGN_POST));
-	ASSERT(cChunkDef::IsValidHeight(a_BlockY));
+	ASSERT(cChunkDef::IsValidHeight(a_Pos.y));
 }
 
 
@@ -25,7 +25,7 @@ cSignEntity::cSignEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_Bl
 
 void cSignEntity::CopyFrom(const cBlockEntity & a_Src)
 {
-	Super::CopyFrom(a_Src);
+	super::CopyFrom(a_Src);
 	auto & src = static_cast<const cSignEntity &>(a_Src);
 	for (size_t i = 0; i < ARRAYCOUNT(m_Line); ++i)
 	{
@@ -89,5 +89,5 @@ AString cSignEntity::GetLine(int a_Index) const
 
 void cSignEntity::SendTo(cClientHandle & a_Client)
 {
-	a_Client.SendUpdateSign(m_PosX, m_PosY, m_PosZ, m_Line[0], m_Line[1], m_Line[2], m_Line[3]);
+	a_Client.SendUpdateSign(m_Pos.x, m_Pos.y, m_Pos.z, m_Line[0], m_Line[1], m_Line[2], m_Line[3]);
 }

--- a/src/BlockEntities/SignEntity.h
+++ b/src/BlockEntities/SignEntity.h
@@ -19,16 +19,16 @@
 class cSignEntity :
 	public cBlockEntity
 {
-	typedef cBlockEntity Super;
-
-public:
-
 	// tolua_end
+
+	using super = cBlockEntity;
+
+public:  // tolua_export
 
 	BLOCKENTITY_PROTODEF(cSignEntity)
 
 	/** Creates a new empty sign entity at the specified block coords and block type (wall or standing). a_World may be nullptr */
-	cSignEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World);
+	cSignEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 	// tolua_begin
 

--- a/src/Blocks/BlockFence.h
+++ b/src/Blocks/BlockFence.h
@@ -89,7 +89,7 @@ public:
 		// New knot? needs to init and produce sound effect
 		else
 		{
-			auto NewLeashKnot = cpp14::make_unique<cLeashKnot>(a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
+			auto NewLeashKnot = cpp14::make_unique<cLeashKnot>(a_BlockFace, Vector3i{a_BlockX, a_BlockY, a_BlockZ});
 			auto NewLeashKnotPtr = NewLeashKnot.get();
 
 			NewLeashKnotPtr->TiePlayersLeashedMobs(a_Player, KnotAlreadyExists);

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -464,7 +464,7 @@ void cChunk::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlock
 			{
 				m_BlockEntities.erase(itr);
 			}
-			auto clone = be->Clone(posX, posY, posZ);
+			auto clone = be->Clone({posX, posY, posZ});
 			clone->SetWorld(m_World);
 			AddBlockEntityClean(clone);
 			m_World->BroadcastBlockEntity({posX, posY, posZ});
@@ -1047,7 +1047,7 @@ bool cChunk::GrowMelonPumpkin(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Bl
 				Meta
 			);
 			VERIFY(UnboundedRelFastSetBlock(a_RelX + x, a_RelY, a_RelZ + z, ProduceType, Meta));
-			auto Absolute = RelativeToAbsolute(Vector3i{a_RelX + x, a_RelY, a_RelZ + z}, m_PosX, m_PosZ);
+			auto Absolute = RelativeToAbsolute(Vector3i{a_RelX + x, a_RelY, a_RelZ + z});
 			cChunkInterface ChunkInterface(this->GetWorld()->GetChunkMap());
 			cBlockHandler::NeighborChanged(ChunkInterface, Absolute.x, Absolute.y - 1, Absolute.z, BLOCK_FACE_YP);
 			break;
@@ -1422,12 +1422,12 @@ void cChunk::CreateBlockEntities(void)
 			{
 				auto RelPos = IndexToCoordinate(BlockIdx);
 				RelPos.y += static_cast<int>(SectionIdx * cChunkData::SectionHeight);
-				auto WorldPos = RelativeToAbsolute(RelPos, m_PosX, m_PosZ);
+				auto WorldPos = RelativeToAbsolute(RelPos);
 
 				if (!HasBlockEntityAt(WorldPos))
 				{
 					AddBlockEntityClean(cBlockEntity::CreateByBlockType(
-						BlockType, GetMeta(RelPos), WorldPos.x, WorldPos.y, WorldPos.z, m_World
+						BlockType, GetMeta(RelPos), WorldPos, m_World
 					));
 				}
 			}
@@ -1462,7 +1462,7 @@ void cChunk::WakeUpSimulators(void)
 			{
 				auto RelPos = IndexToCoordinate(BlockIdx);
 				RelPos.y += static_cast<int>(SectionIdx * cChunkData::SectionHeight);
-				return RelativeToAbsolute(RelPos, m_PosX, m_PosZ);
+				return RelativeToAbsolute(RelPos);
 			};
 
 			// The redstone sim takes multiple blocks, use the inbuilt checker
@@ -1563,7 +1563,7 @@ void cChunk::SetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockType,
 		case E_BLOCK_BREWING_STAND:
 		{
 			// Fast set block has already marked dirty
-			AddBlockEntityClean(cBlockEntity::CreateByBlockType(a_BlockType, a_BlockMeta, WorldPos.x, WorldPos.y, WorldPos.z, m_World));
+			AddBlockEntityClean(cBlockEntity::CreateByBlockType(a_BlockType, a_BlockMeta, WorldPos, m_World));
 			break;
 		}
 	}  // switch (a_BlockType)

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -479,6 +479,14 @@ public:
 		return cChunkClientHandles(m_LoadedByClient);
 	}
 
+	/** Converts the coord relative to this chunk into an absolute coord.
+	Doesn't check relative coord validity. */
+	Vector3i RelativeToAbsolute(Vector3i a_RelBlockPosition)
+	{
+		return cChunkDef::RelativeToAbsolute(a_RelBlockPosition, m_PosX, m_PosZ);
+	}
+
+
 private:
 
 	friend class cChunkMap;

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -245,6 +245,14 @@ public:
 	}
 
 
+
+	inline static int MakeIndexNoCheck(Vector3i a_RelPos)
+	{
+		return MakeIndexNoCheck(a_RelPos.x, a_RelPos.y, a_RelPos.z);
+	}
+
+
+
 	inline static Vector3i IndexToCoordinate(size_t index)
 	{
 		#if AXIS_ORDER == AXIS_ORDER_XZY
@@ -276,6 +284,13 @@ public:
 	{
 		ASSERT((a_Index >= 0) && (a_Index <= NumBlocks));
 		a_BlockTypes[a_Index] = a_Type;
+	}
+
+
+	inline static BLOCKTYPE GetBlock(const BLOCKTYPE * a_BlockTypes, Vector3i a_RelPos)
+	{
+		ASSERT(IsValidRelPos(a_RelPos));
+		return a_BlockTypes[MakeIndexNoCheck(a_RelPos)];
 	}
 
 
@@ -354,6 +369,18 @@ public:
 			return ExpandNibble(a_Buffer, Index);
 		}
 		ASSERT(!"cChunkDef::GetNibble(): coords out of chunk range!");
+		return 0;
+	}
+
+
+	static NIBBLETYPE GetNibble(const NIBBLETYPE * a_Buffer, Vector3i a_RelPos)
+	{
+		if (IsValidRelPos(a_RelPos))
+		{
+			auto Index = MakeIndexNoCheck(a_RelPos);
+			return (a_Buffer[static_cast<size_t>(Index / 2)] >> ((Index & 1) * 4)) & 0x0f;
+		}
+		ASSERT(!"Coords out of chunk range!");
 		return 0;
 	}
 

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -8,8 +8,8 @@
 
 
 
-cArrowEntity::cArrowEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed) :
-	super(pkArrow, a_Creator, a_X, a_Y, a_Z, 0.5, 0.5),
+cArrowEntity::cArrowEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
+	super(pkArrow, a_Creator, a_Pos, 0.5, 0.5),
 	m_PickupState(psNoPickup),
 	m_DamageCoeff(2),
 	m_IsCritical(false),

--- a/src/Entities/ArrowEntity.h
+++ b/src/Entities/ArrowEntity.h
@@ -20,9 +20,15 @@
 class cArrowEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
+	// tolua_end
+
+	using super = cProjectileEntity;
+
+	// tolua_begin
+
 
 public:
+
 	/** Determines when the arrow can be picked up (depending on player gamemode). Corresponds to the MCA file "pickup" field */
 	enum ePickupState
 	{
@@ -36,7 +42,7 @@ public:
 	CLASS_PROTODEF(cArrowEntity)
 
 	/** Creates a new arrow with psNoPickup state and default damage modifier coeff */
-	cArrowEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed);
+	cArrowEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
 	/** Creates a new arrow as shot by a player, initializes it from the player object */
 	cArrowEntity(cPlayer & a_Player, double a_Force);

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -14,7 +14,7 @@
 
 
 cBoat::cBoat(Vector3d a_Pos, eMaterial a_Material) :
-	super(etBoat, a_Pos.x, a_Pos.y, a_Pos.z, 0.98, 0.7),
+	super(etBoat, a_Pos, 0.98, 0.7),
 	m_LastDamage(0), m_ForwardDirection(0),
 	m_DamageTaken(0.0f), m_Material(a_Material),
 	m_RightPaddleUsed(false), m_LeftPaddleUsed(false)

--- a/src/Entities/Boat.h
+++ b/src/Entities/Boat.h
@@ -35,14 +35,14 @@ public:
 
 	CLASS_PROTODEF(cBoat)
 
+	cBoat(Vector3d a_Pos, eMaterial a_Material);
+
 	// cEntity overrides:
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways) override;
-
-	cBoat(Vector3d a_Pos, eMaterial a_Material);
 
 	int GetLastDamage(void) const { return m_LastDamage; }
 	int GetForwardDirection(void) const { return m_ForwardDirection; }

--- a/src/Entities/EnderCrystal.cpp
+++ b/src/Entities/EnderCrystal.cpp
@@ -10,8 +10,8 @@
 
 
 
-cEnderCrystal::cEnderCrystal(double a_X, double a_Y, double a_Z)
-	: cEntity(etEnderCrystal, a_X, a_Y, a_Z, 1.0, 1.0)
+cEnderCrystal::cEnderCrystal(Vector3d a_Pos):
+	super(etEnderCrystal, a_Pos, 1.0, 1.0)
 {
 	SetMaxHealth(5);
 }

--- a/src/Entities/EnderCrystal.h
+++ b/src/Entities/EnderCrystal.h
@@ -12,12 +12,13 @@ class cEnderCrystal :
 	public cEntity
 {
 	// tolua_end
-	typedef cEntity super;
+	using super = cEntity;
 
 public:
+
 	CLASS_PROTODEF(cEnderCrystal)
 
-	cEnderCrystal(double a_X, double a_Y, double a_Z);
+	cEnderCrystal(Vector3d a_Pos);
 
 private:
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -32,7 +32,7 @@ static UInt32 GetNextUniqueID(void)
 ////////////////////////////////////////////////////////////////////////////////
 // cEntity:
 
-cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, double a_Width, double a_Height):
+cEntity::cEntity(eEntityType a_EntityType, Vector3d a_Pos, double a_Width, double a_Height):
 	m_UniqueID(GetNextUniqueID()),
 	m_Health(1),
 	m_MaxHealth(1),
@@ -44,7 +44,7 @@ cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, d
 	m_bOnGround(false),
 	m_Gravity(-9.81f),
 	m_AirDrag(0.02f),
-	m_LastPosition(a_X, a_Y, a_Z),
+	m_LastPosition(a_Pos),
 	m_EntityType(a_EntityType),
 	m_World(nullptr),
 	m_IsWorldChangeScheduled(false),
@@ -65,8 +65,8 @@ cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, d
 	m_ParentChunk(nullptr),
 	m_HeadYaw(0.0),
 	m_Rot(0.0, 0.0, 0.0),
-	m_Position(a_X, a_Y, a_Z),
-	m_LastSentPosition(a_X, a_Y, a_Z),
+	m_Position(a_Pos),
+	m_LastSentPosition(a_Pos),
 	m_WaterSpeed(0, 0, 0),
 	m_Mass (0.001),  // Default 1g
 	m_Width(a_Width),

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -156,7 +156,7 @@ public:
 	static const UInt32 INVALID_ID = 0;  // Exported to Lua in ManualBindings.cpp, ToLua doesn't parse initialized constants.
 
 
-	cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, double a_Width, double a_Height);
+	cEntity(eEntityType a_EntityType, Vector3d a_Pos, double a_Width, double a_Height);
 	virtual ~cEntity();
 
 	/** Spawns the entity in the world; returns true if spawned, false if not (plugin disallowed).
@@ -558,7 +558,9 @@ public:
 	@return exposure rate */
 	virtual float GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_ExlosionPower);
 
+
 protected:
+
 	/** Structure storing the portal delay timer and cooldown boolean */
 	struct sPortalCooldownData
 	{
@@ -569,6 +571,7 @@ protected:
 		This prevents teleportation loops, and is reset when the entity has moved out of the portal. */
 		bool m_ShouldPreventTeleportation;
 	};
+
 
 	/** Measured in meters / second (m / s) */
 	Vector3d m_Speed;
@@ -685,6 +688,7 @@ protected:
 	/** Set the entities position and last sent position.
 	Only to be used when the caller will broadcast a teleport or equivalent to clients. */
 	virtual void ResetPosition(Vector3d a_NewPos);
+
 
 private:
 

--- a/src/Entities/ExpBottleEntity.cpp
+++ b/src/Entities/ExpBottleEntity.cpp
@@ -8,18 +8,8 @@
 
 
 
-cExpBottleEntity::cExpBottleEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, Vector3d a_Speed) :
-	super(pkExpBottle, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25)
-{
-	SetSpeed(a_Speed);
-}
-
-
-
-
-
 cExpBottleEntity::cExpBottleEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed) :
-	super(pkExpBottle, a_Creator, a_Pos.x, a_Pos.y, a_Pos.z, 0.25, 0.25)
+	super(pkExpBottle, a_Creator, a_Pos, 0.25, 0.25)
 {
 	SetSpeed(a_Speed);
 }

--- a/src/Entities/ExpBottleEntity.h
+++ b/src/Entities/ExpBottleEntity.h
@@ -20,15 +20,13 @@
 class cExpBottleEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
 
-	CLASS_PROTODEF(cExpBottleEntity)
+	using super = cProjectileEntity;
 
-	cExpBottleEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, Vector3d a_Speed);
+public:  // tolua_export
+
+	CLASS_PROTODEF(cExpBottleEntity)
 
 	cExpBottleEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 

--- a/src/Entities/ExpOrb.cpp
+++ b/src/Entities/ExpOrb.cpp
@@ -5,25 +5,10 @@
 #include "../ClientHandle.h"
 
 
-cExpOrb::cExpOrb(double a_X, double a_Y, double a_Z, int a_Reward)
-	: cEntity(etExpOrb, a_X, a_Y, a_Z, 0.98, 0.98)
-	, m_Reward(a_Reward)
-	, m_Timer(0)
-{
-	SetMaxHealth(5);
-	SetHealth(5);
-	SetGravity(-16);
-	SetAirDrag(0.02f);
-}
-
-
-
-
-
-cExpOrb::cExpOrb(const Vector3d & a_Pos, int a_Reward)
-	: cEntity(etExpOrb, a_Pos.x, a_Pos.y, a_Pos.z, 0.98, 0.98)
-	, m_Reward(a_Reward)
-	, m_Timer(0)
+cExpOrb::cExpOrb(Vector3d a_Pos, int a_Reward):
+	super(etExpOrb, a_Pos, 0.98, 0.98),  // TODO: Check size
+	m_Reward(a_Reward),
+	m_Timer(0)
 {
 	SetMaxHealth(5);
 	SetHealth(5);

--- a/src/Entities/ExpOrb.h
+++ b/src/Entities/ExpOrb.h
@@ -18,8 +18,7 @@ public:
 
 	CLASS_PROTODEF(cExpOrb)
 
-	cExpOrb(double a_X, double a_Y, double a_Z, int a_Reward);
-	cExpOrb(const Vector3d & a_Pos, int a_Reward);
+	cExpOrb(Vector3d a_Pos, int a_Reward);
 
 	// Override functions
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;

--- a/src/Entities/FallingBlock.cpp
+++ b/src/Entities/FallingBlock.cpp
@@ -10,8 +10,8 @@
 
 
 
-cFallingBlock::cFallingBlock(const Vector3i & a_BlockPosition, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) :
-	super(etFallingBlock, a_BlockPosition.x + 0.5f, a_BlockPosition.y, a_BlockPosition.z + 0.5f, 0.98, 0.98),
+cFallingBlock::cFallingBlock(Vector3i a_BlockPosition, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) :
+	super(etFallingBlock, Vector3d(0.5, 0, 0.5) + a_BlockPosition, 0.98, 0.98),
 	m_BlockType(a_BlockType),
 	m_BlockMeta(a_BlockMeta),
 	m_OriginalPosition(a_BlockPosition)

--- a/src/Entities/FallingBlock.h
+++ b/src/Entities/FallingBlock.h
@@ -8,19 +8,20 @@
 
 
 // tolua_begin
-
 class cFallingBlock :
 	public cEntity
 {
-	typedef cEntity super;
-
-public:
 	// tolua_end
+
+	using super = cEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cFallingBlock)
 
-	/** Creates a new falling block. a_BlockPosition is expected in world coords */
-	cFallingBlock(const Vector3i & a_BlockPosition, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
+	/** Creates a new falling block.
+	a_BlockPosition is expected in world coords */
+	cFallingBlock(Vector3i a_BlockPosition, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 
 	// tolua_begin
 

--- a/src/Entities/FireChargeEntity.cpp
+++ b/src/Entities/FireChargeEntity.cpp
@@ -7,8 +7,8 @@
 
 
 
-cFireChargeEntity::cFireChargeEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed) :
-	super(pkFireCharge, a_Creator, a_X, a_Y, a_Z, 0.3125, 0.3125)
+cFireChargeEntity::cFireChargeEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
+	super(pkFireCharge, a_Creator, a_Pos, 0.3125, 0.3125)
 {
 	SetSpeed(a_Speed);
 	SetGravity(0);

--- a/src/Entities/FireChargeEntity.h
+++ b/src/Entities/FireChargeEntity.h
@@ -20,15 +20,15 @@
 class cFireChargeEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cFireChargeEntity)
 
-	cFireChargeEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed);
+	cFireChargeEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
 protected:
 

--- a/src/Entities/FireworkEntity.cpp
+++ b/src/Entities/FireworkEntity.cpp
@@ -8,8 +8,8 @@
 
 
 
-cFireworkEntity::cFireworkEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem & a_Item) :
-	super(pkFirework, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25),
+cFireworkEntity::cFireworkEntity(cEntity * a_Creator, Vector3d a_Pos, const cItem & a_Item) :
+	super(pkFirework, a_Creator, a_Pos, 0.25, 0.25),
 	m_TicksToExplosion(a_Item.m_FireworkItem.m_FlightTimeInTicks),
 	m_FireworkItem(a_Item)
 {

--- a/src/Entities/FireworkEntity.h
+++ b/src/Entities/FireworkEntity.h
@@ -20,15 +20,15 @@
 class cFireworkEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cFireworkEntity)
 
-	cFireworkEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem & a_Item);
+	cFireworkEntity(cEntity * a_Creator, Vector3d a_Pos, const cItem & a_Item);
 
 	// tolua_begin
 

--- a/src/Entities/Floater.cpp
+++ b/src/Entities/Floater.cpp
@@ -73,9 +73,9 @@ protected:
 
 
 
-cFloater::cFloater(double a_X, double a_Y, double a_Z, Vector3d a_Speed, UInt32 a_PlayerID, int a_CountDownTime) :
-	cEntity(etFloater, a_X, a_Y, a_Z, 0.2, 0.2),
-	m_BitePos(Vector3d(a_X, a_Y, a_Z)),
+cFloater::cFloater(Vector3d a_Pos, Vector3d a_Speed, UInt32 a_PlayerID, int a_CountDownTime) :
+	super(etFloater, a_Pos, 0.2, 0.2),
+	m_BitePos(a_Pos),
 	m_CanPickupItem(false),
 	m_PickupCountDown(0),
 	m_CountDownTime(a_CountDownTime),

--- a/src/Entities/Floater.h
+++ b/src/Entities/Floater.h
@@ -11,14 +11,15 @@
 class cFloater :
 	public cEntity
 {
-	typedef cEntity super;
-
-public:
 	// tolua_end
+
+	using super = cEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cFloater)
 
-	cFloater(double a_X, double a_Y, double a_Z, Vector3d a_Speed, UInt32 a_PlayerID, int a_CountDownTime);
+	cFloater(Vector3d a_Pos, Vector3d a_Speed, UInt32 a_PlayerID, int a_CountDownTime);
 
 	virtual void SpawnOn(cClientHandle & a_Client) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;

--- a/src/Entities/GhastFireballEntity.cpp
+++ b/src/Entities/GhastFireballEntity.cpp
@@ -7,8 +7,8 @@
 
 
 
-cGhastFireballEntity::cGhastFireballEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed) :
-	super(pkGhastFireball, a_Creator, a_X, a_Y, a_Z, 1, 1)
+cGhastFireballEntity::cGhastFireballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
+	super(pkGhastFireball, a_Creator, a_Pos, 1, 1)
 {
 	SetSpeed(a_Speed);
 	SetGravity(0);

--- a/src/Entities/GhastFireballEntity.h
+++ b/src/Entities/GhastFireballEntity.h
@@ -20,15 +20,15 @@
 class cGhastFireballEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cGhastFireballEntity)
 
-	cGhastFireballEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed);
+	cGhastFireballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
 protected:
 

--- a/src/Entities/HangingEntity.cpp
+++ b/src/Entities/HangingEntity.cpp
@@ -9,8 +9,8 @@
 
 
 
-cHangingEntity::cHangingEntity(eEntityType a_EntityType, eBlockFace a_Facing, double a_X, double a_Y, double a_Z) :
-	cEntity(a_EntityType, a_X, a_Y, a_Z, 0.8, 0.8),
+cHangingEntity::cHangingEntity(eEntityType a_EntityType, eBlockFace a_Facing, Vector3d a_Pos) :
+	super(a_EntityType, a_Pos, 0.8, 0.8),
 	m_Facing(cHangingEntity::BlockFaceToProtocolFace(a_Facing))
 {
 	SetMaxHealth(1);

--- a/src/Entities/HangingEntity.h
+++ b/src/Entities/HangingEntity.h
@@ -11,15 +11,15 @@
 class cHangingEntity :
 	public cEntity
 {
-	typedef cEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cHangingEntity)
 
-	cHangingEntity(eEntityType a_EntityType, eBlockFace a_BlockFace, double a_X, double a_Y, double a_Z);
+	cHangingEntity(eEntityType a_EntityType, eBlockFace a_BlockFace, Vector3d a_Pos);
 
 	// tolua_begin
 

--- a/src/Entities/ItemFrame.cpp
+++ b/src/Entities/ItemFrame.cpp
@@ -9,8 +9,8 @@
 
 
 
-cItemFrame::cItemFrame(eBlockFace a_BlockFace, double a_X, double a_Y, double a_Z) :
-	cHangingEntity(etItemFrame, a_BlockFace, a_X, a_Y, a_Z),
+cItemFrame::cItemFrame(eBlockFace a_BlockFace, Vector3d a_Pos):
+	super(etItemFrame, a_BlockFace, a_Pos),
 	m_Item(E_BLOCK_AIR),
 	m_ItemRotation(0)
 {

--- a/src/Entities/ItemFrame.h
+++ b/src/Entities/ItemFrame.h
@@ -11,15 +11,15 @@
 class cItemFrame :
 	public cHangingEntity
 {
-	typedef cHangingEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cHangingEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cItemFrame)
 
-	cItemFrame(eBlockFace a_BlockFace, double a_X, double a_Y, double a_Z);
+	cItemFrame(eBlockFace a_BlockFace, Vector3d a_Pos);
 
 	// tolua_begin
 

--- a/src/Entities/LeashKnot.cpp
+++ b/src/Entities/LeashKnot.cpp
@@ -14,8 +14,8 @@
 
 
 
-cLeashKnot::cLeashKnot(eBlockFace a_BlockFace, double a_X, double a_Y, double a_Z) :
-	cHangingEntity(etLeashKnot, a_BlockFace, a_X, a_Y, a_Z),
+cLeashKnot::cLeashKnot(eBlockFace a_BlockFace, Vector3d a_Pos) :
+	super(etLeashKnot, a_BlockFace, a_Pos),
 	m_ShouldSelfDestroy(false),
 	m_TicksToSelfDestroy(20 * 1)
 {

--- a/src/Entities/LeashKnot.h
+++ b/src/Entities/LeashKnot.h
@@ -13,15 +13,14 @@ class cWorldInterface;
 class cLeashKnot :
 	public cHangingEntity
 {
-	typedef cHangingEntity super;
-
-public:
-
 	// tolua_end
+	using super = cHangingEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cLeashKnot)
 
-	cLeashKnot(eBlockFace a_BlockFace, double a_X, double a_Y, double a_Z);
+	cLeashKnot(eBlockFace a_BlockFace, Vector3d a_Pos);
 
 	/** Looks for mobs leashed to a player and ties them to this knot */
 	void TiePlayersLeashedMobs(cPlayer & a_Player, bool a_ShouldBroadCast);

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -90,8 +90,11 @@ protected:
 
 
 
-cMinecart::cMinecart(ePayload a_Payload, double a_X, double a_Y, double a_Z) :
-	super(etMinecart, a_X, a_Y, a_Z, 0.98, 0.7),
+////////////////////////////////////////////////////////////////////////////////
+// cMinecart:
+
+cMinecart::cMinecart(ePayload a_Payload, Vector3d a_Pos):
+	super(etMinecart, a_Pos, 0.98, 0.7),
 	m_Payload(a_Payload),
 	m_LastDamage(0),
 	m_DetectorRailPosition(0, 0, 0),
@@ -1164,8 +1167,8 @@ void cMinecart::Destroyed()
 ////////////////////////////////////////////////////////////////////////////////
 // cRideableMinecart:
 
-cRideableMinecart::cRideableMinecart(double a_X, double a_Y, double a_Z, const cItem & a_Content, int a_Height) :
-	super(mpNone, a_X, a_Y, a_Z),
+cRideableMinecart::cRideableMinecart(Vector3d a_Pos, const cItem & a_Content, int a_Height):
+	super(mpNone, a_Pos),
 	m_Content(a_Content),
 	m_Height(a_Height)
 {
@@ -1209,8 +1212,8 @@ void cRideableMinecart::OnRightClicked(cPlayer & a_Player)
 ////////////////////////////////////////////////////////////////////////////////
 // cMinecartWithChest:
 
-cMinecartWithChest::cMinecartWithChest(double a_X, double a_Y, double a_Z) :
-	super(mpChest, a_X, a_Y, a_Z),
+cMinecartWithChest::cMinecartWithChest(Vector3d a_Pos):
+	super(mpChest, a_Pos),
 	cEntityWindowOwner(this),
 	m_Contents(ContentsWidth, ContentsHeight)
 {
@@ -1283,8 +1286,8 @@ void cMinecartWithChest::Destroyed()
 ////////////////////////////////////////////////////////////////////////////////
 // cMinecartWithFurnace:
 
-cMinecartWithFurnace::cMinecartWithFurnace(double a_X, double a_Y, double a_Z) :
-	super(mpFurnace, a_X, a_Y, a_Z),
+cMinecartWithFurnace::cMinecartWithFurnace(Vector3d a_Pos):
+	super(mpFurnace, a_Pos),
 	m_FueledTimeLeft(-1),
 	m_IsFueled(false)
 {
@@ -1350,8 +1353,8 @@ void cMinecartWithFurnace::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk
 ////////////////////////////////////////////////////////////////////////////////
 // cMinecartWithTNT:
 
-cMinecartWithTNT::cMinecartWithTNT(double a_X, double a_Y, double a_Z) :
-	super(mpTNT, a_X, a_Y, a_Z)
+cMinecartWithTNT::cMinecartWithTNT(Vector3d a_Pos):
+	super(mpTNT, a_Pos)
 {
 }
 
@@ -1364,8 +1367,8 @@ cMinecartWithTNT::cMinecartWithTNT(double a_X, double a_Y, double a_Z) :
 ////////////////////////////////////////////////////////////////////////////////
 // cMinecartWithHopper:
 
-cMinecartWithHopper::cMinecartWithHopper(double a_X, double a_Y, double a_Z) :
-	super(mpHopper, a_X, a_Y, a_Z)
+cMinecartWithHopper::cMinecartWithHopper(Vector3d a_Pos):
+	super(mpHopper, a_Pos)
 {
 }
 

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -20,7 +20,7 @@
 class cMinecart :
 	public cEntity
 {
-	typedef cEntity super;
+	using super = cEntity;
 
 public:
 	CLASS_PROTODEF(cMinecart)
@@ -45,7 +45,9 @@ public:
 	int LastDamage(void) const { return m_LastDamage; }
 	ePayload GetPayload(void) const { return m_Payload; }
 
+
 protected:
+
 	ePayload m_Payload;
 	int m_LastDamage;
 	Vector3i m_DetectorRailPosition;
@@ -57,7 +59,7 @@ protected:
 	// Overwrite to enforce speed limit
 	virtual void DoSetSpeed(double a_SpeedX, double a_SpeedY, double a_SpeedZ) override;
 
-	cMinecart(ePayload a_Payload, double a_X, double a_Y, double a_Z);
+	cMinecart(ePayload a_Payload, Vector3d a_Pos);
 
 	/** Handles physics on normal rails
 	For each tick, slow down on flat rails, speed up or slow down on ascending / descending rails (depending on direction), and turn on curved rails. */
@@ -95,18 +97,22 @@ protected:
 class cRideableMinecart :
 	public cMinecart
 {
-	typedef cMinecart super;
+	using super = cMinecart;
 
 public:
+
 	CLASS_PROTODEF(cRideableMinecart)
 
-	cRideableMinecart(double a_X, double a_Y, double a_Z, const cItem & a_Content, int a_Height);
+	cRideableMinecart(Vector3d a_Pos, const cItem & a_Content, int a_Height);
 
 	const cItem & GetContent(void) const {return m_Content;}
 	int GetBlockHeight(void) const {return m_Height;}
+
 	// cEntity overrides:
 	virtual void OnRightClicked(cPlayer & a_Player) override;
+
 protected:
+
 
 	cItem m_Content;
 	int m_Height;
@@ -121,12 +127,13 @@ class cMinecartWithChest :
 	public cItemGrid::cListener,
 	public cEntityWindowOwner
 {
-	typedef cMinecart super;
+	using super = cMinecart;
 
 public:
+
 	CLASS_PROTODEF(cMinecartWithChest)
 
-	cMinecartWithChest(double a_X, double a_Y, double a_Z);
+	cMinecartWithChest(Vector3d a_Pos);
 
 	enum
 	{
@@ -137,7 +144,9 @@ public:
 	const cItem & GetSlot(int a_Idx) const { return m_Contents.GetSlot(a_Idx); }
 	void SetSlot(int a_Idx, const cItem & a_Item) { m_Contents.SetSlot(a_Idx, a_Item); }
 
+
 protected:
+
 	cItemGrid m_Contents;
 	void OpenNewWindow(void);
 	virtual void Destroyed() override;
@@ -169,12 +178,13 @@ protected:
 class cMinecartWithFurnace :
 	public cMinecart
 {
-	typedef cMinecart super;
+	using super = cMinecart;
 
 public:
+
 	CLASS_PROTODEF(cMinecartWithFurnace)
 
-	cMinecartWithFurnace(double a_X, double a_Y, double a_Z);
+	cMinecartWithFurnace(Vector3d a_Pos);
 
 	// cEntity overrides:
 	virtual void OnRightClicked(cPlayer & a_Player) override;
@@ -201,12 +211,12 @@ private:
 class cMinecartWithTNT :
 	public cMinecart
 {
-	typedef cMinecart super;
+	using super = cMinecart;
 
 public:
 	CLASS_PROTODEF(cMinecartWithTNT)
 
-	cMinecartWithTNT(double a_X, double a_Y, double a_Z);
+	cMinecartWithTNT(Vector3d a_Pos);
 } ;
 
 
@@ -216,10 +226,11 @@ public:
 class cMinecartWithHopper :
 	public cMinecart
 {
-	typedef cMinecart super;
+	using super = cMinecart;
 
 public:
+
 	CLASS_PROTODEF(cMinecartWithHopper)
 
-	cMinecartWithHopper(double a_X, double a_Y, double a_Z);
+	cMinecartWithHopper(Vector3d a_Pos);
 } ;

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -10,8 +10,8 @@
 
 
 
-cPainting::cPainting(const AString & a_Name, eBlockFace a_Direction, double a_X, double a_Y, double a_Z)
-	: cHangingEntity(etPainting, a_Direction, a_X, a_Y, a_Z),
+cPainting::cPainting(const AString & a_Name, eBlockFace a_Direction, Vector3d a_Pos):
+	super(etPainting, a_Direction, a_Pos),
 	m_Name(a_Name)
 {
 }

--- a/src/Entities/Painting.h
+++ b/src/Entities/Painting.h
@@ -11,15 +11,15 @@
 class cPainting :
 	public cHangingEntity
 {
-	typedef cHangingEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cHangingEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cPainting)
 
-	cPainting(const AString & a_Name, eBlockFace a_Direction, double a_X, double a_Y, double a_Z);
+	cPainting(const AString & a_Name, eBlockFace a_Direction, Vector3d a_Pos);
 
 	/** Returns the protocol name of the painting */
 	const AString & GetName(void) const { return m_Name; }  // tolua_export

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -14,7 +14,7 @@
 
 
 cPawn::cPawn(eEntityType a_EntityType, double a_Width, double a_Height) :
-	super(a_EntityType, 0, 0, 0, a_Width, a_Height),
+	super(a_EntityType, Vector3d(), a_Width, a_Height),
 	m_EntityEffects(tEffectMap()),
 	m_LastGroundHeight(0),
 	m_bTouchGround(false)

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -93,20 +93,23 @@ protected:
 
 
 
-cPickup::cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX, float a_SpeedY, float a_SpeedZ, int a_LifetimeTicks, bool a_CanCombine)
-	: cEntity(etPickup, a_PosX, a_PosY, a_PosZ, 0.2, 0.2)
-	, m_Timer(0)
-	, m_Item(a_Item)
-	, m_bCollected(false)
-	, m_bIsPlayerCreated(IsPlayerCreated)
-	, m_bCanCombine(a_CanCombine)
-	, m_Lifetime(cTickTime(a_LifetimeTicks))
+////////////////////////////////////////////////////////////////////////////////
+// cPickup:
+
+cPickup::cPickup(Vector3d a_Pos, const cItem & a_Item, bool IsPlayerCreated, Vector3f a_Speed, int a_LifetimeTicks, bool a_CanCombine):
+	super(etPickup, a_Pos, 0.2, 0.2),
+	m_Timer(0),
+	m_Item(a_Item),
+	m_bCollected(false),
+	m_bIsPlayerCreated(IsPlayerCreated),
+	m_bCanCombine(a_CanCombine),
+	m_Lifetime(cTickTime(a_LifetimeTicks))
 {
 	SetGravity(-16.0f);
 	SetAirDrag(0.02f);
 	SetMaxHealth(5);
 	SetHealth(5);
-	SetSpeed(a_SpeedX, a_SpeedY, a_SpeedZ);
+	SetSpeed(a_Speed);
 }
 
 

--- a/src/Entities/Pickup.h
+++ b/src/Entities/Pickup.h
@@ -18,14 +18,15 @@ class cPlayer;
 class cPickup :
 	public cEntity
 {
-	typedef cEntity super;
-
-public:
 	// tolua_end
+
+	using super = cEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cPickup)
 
-	cPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, bool IsPlayerCreated, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true);
+	cPickup(Vector3d a_Pos, const cItem & a_Item, bool IsPlayerCreated, Vector3f a_Speed = Vector3d(), int a_LifetimeTicks = 6000, bool a_CanCombine = true);
 
 	cItem &       GetItem(void)       {return m_Item; }  // tolua_export
 	const cItem & GetItem(void) const {return m_Item; }

--- a/src/Entities/Pickup.h
+++ b/src/Entities/Pickup.h
@@ -26,7 +26,7 @@ public:  // tolua_export
 
 	CLASS_PROTODEF(cPickup)
 
-	cPickup(Vector3d a_Pos, const cItem & a_Item, bool IsPlayerCreated, Vector3f a_Speed = Vector3d(), int a_LifetimeTicks = 6000, bool a_CanCombine = true);
+	cPickup(Vector3d a_Pos, const cItem & a_Item, bool IsPlayerCreated, Vector3f a_Speed = Vector3f(), int a_LifetimeTicks = 6000, bool a_CanCombine = true);
 
 	cItem &       GetItem(void)       {return m_Item; }  // tolua_export
 	const cItem & GetItem(void) const {return m_Item; }

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -224,8 +224,8 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 // cProjectileEntity:
 
-cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, double a_Width, double a_Height) :
-	super(etProjectile, a_X, a_Y, a_Z, a_Width, a_Height),
+cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, double a_Width, double a_Height):
+	super(etProjectile, a_Pos, a_Width, a_Height),
 	m_ProjectileKind(a_Kind),
 	m_CreatorData(
 		((a_Creator != nullptr) ? a_Creator->GetUniqueID() : cEntity::INVALID_ID),
@@ -242,8 +242,8 @@ cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, double a
 
 
 
-cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, const Vector3d & a_Pos, const Vector3d & a_Speed, double a_Width, double a_Height) :
-	super(etProjectile, a_Pos.x, a_Pos.y, a_Pos.z, a_Width, a_Height),
+cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed, double a_Width, double a_Height):
+	super(etProjectile, a_Pos, a_Width, a_Height),
 	m_ProjectileKind(a_Kind),
 	m_CreatorData(a_Creator->GetUniqueID(), a_Creator->IsPlayer() ? static_cast<cPlayer *>(a_Creator)->GetName() : "", a_Creator->GetEquippedWeapon().m_Enchantments),
 	m_IsInGround(false)
@@ -259,7 +259,13 @@ cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, const Ve
 
 
 
-std::unique_ptr<cProjectileEntity> cProjectileEntity::Create(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem * a_Item, const Vector3d * a_Speed)
+std::unique_ptr<cProjectileEntity> cProjectileEntity::Create(
+	eKind a_Kind,
+	cEntity * a_Creator,
+	Vector3d a_Pos,
+	const cItem * a_Item,
+	const Vector3d * a_Speed
+)
 {
 	Vector3d Speed;
 	if (a_Speed != nullptr)
@@ -269,15 +275,15 @@ std::unique_ptr<cProjectileEntity> cProjectileEntity::Create(eKind a_Kind, cEnti
 
 	switch (a_Kind)
 	{
-		case pkArrow:         return cpp14::make_unique<cArrowEntity>           (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkEgg:           return cpp14::make_unique<cThrownEggEntity>       (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkEnderPearl:    return cpp14::make_unique<cThrownEnderPearlEntity>(a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkSnowball:      return cpp14::make_unique<cThrownSnowballEntity>  (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkGhastFireball: return cpp14::make_unique<cGhastFireballEntity>   (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkFireCharge:    return cpp14::make_unique<cFireChargeEntity>      (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkExpBottle:     return cpp14::make_unique<cExpBottleEntity>       (a_Creator, a_X, a_Y, a_Z, Speed);
-		case pkSplashPotion:  return cpp14::make_unique<cSplashPotionEntity>    (a_Creator, a_X, a_Y, a_Z, Speed, *a_Item);
-		case pkWitherSkull:   return cpp14::make_unique<cWitherSkullEntity>     (a_Creator, a_X, a_Y, a_Z, Speed);
+		case pkArrow:         return cpp14::make_unique<cArrowEntity>           (a_Creator, a_Pos, Speed);
+		case pkEgg:           return cpp14::make_unique<cThrownEggEntity>       (a_Creator, a_Pos, Speed);
+		case pkEnderPearl:    return cpp14::make_unique<cThrownEnderPearlEntity>(a_Creator, a_Pos, Speed);
+		case pkSnowball:      return cpp14::make_unique<cThrownSnowballEntity>  (a_Creator, a_Pos, Speed);
+		case pkGhastFireball: return cpp14::make_unique<cGhastFireballEntity>   (a_Creator, a_Pos, Speed);
+		case pkFireCharge:    return cpp14::make_unique<cFireChargeEntity>      (a_Creator, a_Pos, Speed);
+		case pkExpBottle:     return cpp14::make_unique<cExpBottleEntity>       (a_Creator, a_Pos, Speed);
+		case pkSplashPotion:  return cpp14::make_unique<cSplashPotionEntity>    (a_Creator, a_Pos, Speed, *a_Item);
+		case pkWitherSkull:   return cpp14::make_unique<cWitherSkullEntity>     (a_Creator, a_Pos, Speed);
 		case pkFirework:
 		{
 			ASSERT(a_Item != nullptr);
@@ -286,7 +292,7 @@ std::unique_ptr<cProjectileEntity> cProjectileEntity::Create(eKind a_Kind, cEnti
 				return nullptr;
 			}
 
-			return cpp14::make_unique<cFireworkEntity>(a_Creator, a_X, a_Y, a_Z, *a_Item);
+			return cpp14::make_unique<cFireworkEntity>(a_Creator, a_Pos, *a_Item);
 		}
 		case pkFishingFloat: break;
 	}

--- a/src/Entities/ProjectileEntity.h
+++ b/src/Entities/ProjectileEntity.h
@@ -20,9 +20,15 @@
 class cProjectileEntity :
 	public cEntity
 {
-	typedef cEntity super;
+	// tolua_end
+
+	using super = cEntity;
+
+	// tolua_begin
+
 
 public:
+
 	/** The kind of the projectile. The numbers correspond to the network type ID used for spawning them in the protocol. */
 	enum eKind
 	{
@@ -43,10 +49,32 @@ public:
 
 	CLASS_PROTODEF(cProjectileEntity)
 
-	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, double a_Width, double a_Height);
-	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, const Vector3d & a_Pos, const Vector3d & a_Speed, double a_Width, double a_Height);
+	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, double a_Width, double a_Height);
+	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed, double a_Width, double a_Height);
 
-	static std::unique_ptr<cProjectileEntity> Create(eKind a_Kind, cEntity * a_Creator, double a_X, double a_Y, double a_Z, const cItem * a_Item, const Vector3d * a_Speed = nullptr);
+	/** Creates a new instance of the specified projectile entity.
+	a_Item is the item from which the projectile originated (such as firework or arrow). */
+	static std::unique_ptr<cProjectileEntity> Create(
+		eKind a_Kind,
+		cEntity * a_Creator,
+		Vector3d a_Pos,
+		const cItem * a_Item,
+		const Vector3d * a_Speed = nullptr
+	);
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Creates a new instance of the specified projectile entity.
+	a_Item is the item from which the projectile originated (such as firework or arrow). */
+	static std::unique_ptr<cProjectileEntity> Create(
+		eKind a_Kind,
+		cEntity * a_Creator,
+		double a_PosX, double a_PosY, double a_PosZ,
+		const cItem * a_Item,
+		const Vector3d * a_Speed = nullptr
+	)
+	{
+		return Create(a_Kind, a_Creator, {a_PosX, a_PosY, a_PosZ}, a_Item, a_Speed);
+	}
 
 	/** Called by the physics blocktracer when the entity hits a solid block, the hit position and the face hit (BLOCK_FACE_) is given */
 	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace);

--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -21,11 +21,11 @@
 
 cSplashPotionEntity::cSplashPotionEntity(
 	cEntity * a_Creator,
-	double a_X, double a_Y, double a_Z,
-	const Vector3d & a_Speed,
+	Vector3d a_Pos,
+	Vector3d a_Speed,
 	const cItem & a_Item
-) :
-	super(pkSplashPotion, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25),
+):
+	super(pkSplashPotion, a_Creator, a_Pos, 0.25, 0.25),
 	m_Item(a_Item),
 	m_DestroyTimer(-1)
 {

--- a/src/Entities/SplashPotionEntity.h
+++ b/src/Entities/SplashPotionEntity.h
@@ -24,18 +24,18 @@ class cEntity;
 class cSplashPotionEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cSplashPotionEntity)
 
 	cSplashPotionEntity(
 		cEntity * a_Creator,
-		double a_X, double a_Y, double a_Z,
-		const Vector3d & a_Speed,
+		Vector3d a_Pos,
+		Vector3d a_Speed,
 		const cItem & a_Item
 	);
 

--- a/src/Entities/TNTEntity.cpp
+++ b/src/Entities/TNTEntity.cpp
@@ -9,7 +9,7 @@
 
 
 cTNTEntity::cTNTEntity(Vector3d a_Pos, int a_FuseTicks) :
-	super(etTNT, a_Pos.x, a_Pos.y, a_Pos.z, 0.98, 0.98),
+	super(etTNT, a_Pos, 0.98, 0.98),
 	m_FuseTicks(a_FuseTicks)
 {
 	SetGravity(-16.0f);

--- a/src/Entities/ThrownEggEntity.cpp
+++ b/src/Entities/ThrownEggEntity.cpp
@@ -7,8 +7,8 @@
 
 
 
-cThrownEggEntity::cThrownEggEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed) :
-	super(pkEgg, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25),
+cThrownEggEntity::cThrownEggEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
+	super(pkEgg, a_Creator, a_Pos, 0.25, 0.25),
 	m_DestroyTimer(-1)
 {
 	SetSpeed(a_Speed);

--- a/src/Entities/ThrownEggEntity.h
+++ b/src/Entities/ThrownEggEntity.h
@@ -20,15 +20,15 @@
 class cThrownEggEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cThrownEggEntity)
 
-	cThrownEggEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed);
+	cThrownEggEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
 protected:
 

--- a/src/Entities/ThrownEnderPearlEntity.cpp
+++ b/src/Entities/ThrownEnderPearlEntity.cpp
@@ -8,8 +8,8 @@
 
 
 
-cThrownEnderPearlEntity::cThrownEnderPearlEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed) :
-	super(pkEnderPearl, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25),
+cThrownEnderPearlEntity::cThrownEnderPearlEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
+	super(pkEnderPearl, a_Creator, a_Pos, 0.25, 0.25),
 	m_DestroyTimer(-1)
 {
 	SetSpeed(a_Speed);

--- a/src/Entities/ThrownEnderPearlEntity.h
+++ b/src/Entities/ThrownEnderPearlEntity.h
@@ -20,15 +20,15 @@
 class cThrownEnderPearlEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cThrownEnderPearlEntity)
 
-	cThrownEnderPearlEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed);
+	cThrownEnderPearlEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
 protected:
 

--- a/src/Entities/ThrownSnowballEntity.cpp
+++ b/src/Entities/ThrownSnowballEntity.cpp
@@ -7,8 +7,8 @@
 
 
 
-cThrownSnowballEntity::cThrownSnowballEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed) :
-	super(pkSnowball, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25),
+cThrownSnowballEntity::cThrownSnowballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
+	super(pkSnowball, a_Creator, a_Pos, 0.25, 0.25),
 	m_DestroyTimer(-1)
 {
 	SetSpeed(a_Speed);

--- a/src/Entities/ThrownSnowballEntity.h
+++ b/src/Entities/ThrownSnowballEntity.h
@@ -20,15 +20,15 @@
 class cThrownSnowballEntity :
 	public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cThrownSnowballEntity)
 
-	cThrownSnowballEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed);
+	cThrownSnowballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
 protected:
 

--- a/src/Entities/WitherSkullEntity.cpp
+++ b/src/Entities/WitherSkullEntity.cpp
@@ -12,8 +12,8 @@
 
 
 
-cWitherSkullEntity::cWitherSkullEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed) :
-	super(pkWitherSkull, a_Creator, a_X, a_Y, a_Z, 0.25, 0.25)
+cWitherSkullEntity::cWitherSkullEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
+	super(pkWitherSkull, a_Creator, a_Pos, 0.25, 0.25)
 {
 	SetSpeed(a_Speed);
 	SetGravity(0);

--- a/src/Entities/WitherSkullEntity.h
+++ b/src/Entities/WitherSkullEntity.h
@@ -20,15 +20,15 @@
 class cWitherSkullEntity :
 public cProjectileEntity
 {
-	typedef cProjectileEntity super;
-
-public:
-
 	// tolua_end
+
+	using super = cProjectileEntity;
+
+public:  // tolua_export
 
 	CLASS_PROTODEF(cWitherSkullEntity)
 
-	cWitherSkullEntity(cEntity * a_Creator, double a_X, double a_Y, double a_Z, const Vector3d & a_Speed);
+	cWitherSkullEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
 protected:
 

--- a/src/Generating/ChunkDesc.cpp
+++ b/src/Generating/ChunkDesc.cpp
@@ -595,7 +595,7 @@ cBlockEntity * cChunkDesc::GetBlockEntity(int a_RelX, int a_RelY, int a_RelZ)
 	int AbsZ = a_RelZ + m_Coords.m_ChunkZ * cChunkDef::Width;
 
 	// The block entity is not created yet, try to create it and add to list:
-	cBlockEntity * be = cBlockEntity::CreateByBlockType(GetBlockType(a_RelX, a_RelY, a_RelZ), GetBlockMeta(a_RelX, a_RelY, a_RelZ), AbsX, a_RelY, AbsZ);
+	cBlockEntity * be = cBlockEntity::CreateByBlockType(GetBlockType(a_RelX, a_RelY, a_RelZ), GetBlockMeta(a_RelX, a_RelY, a_RelZ), {AbsX, a_RelY, AbsZ});
 	if (be == nullptr)
 	{
 		// No block entity for this block type

--- a/src/Items/ItemFishingRod.h
+++ b/src/Items/ItemFishingRod.h
@@ -228,9 +228,9 @@ public:
 				FloaterPos.y += 0.5f;
 				const float FISH_SPEED_MULT = 2.25f;
 
-				Vector3d FlyDirection = a_Player->GetEyePosition() - FloaterPos;
-				a_World->SpawnItemPickups(Drops, FloaterPos.x, FloaterPos.y, FloaterPos.z, FlyDirection.x * FISH_SPEED_MULT, (FlyDirection.y + 1.0f) * FISH_SPEED_MULT, FlyDirection.z * FISH_SPEED_MULT);
-				a_World->SpawnExperienceOrb(a_Player->GetPosX(), a_Player->GetPosY(), a_Player->GetPosZ(), Random.RandInt(1, 6));
+				Vector3d FlyDirection = (a_Player->GetEyePosition() - FloaterPos).addedY(1.0f) * FISH_SPEED_MULT;
+				a_World->SpawnItemPickups(Drops, FloaterPos, FlyDirection);
+				a_World->SpawnExperienceOrb(a_Player->GetPosition(), Random.RandInt(1, 6));
 				a_Player->UseEquippedItem(1);
 				cRoot::Get()->GetPluginManager()->CallHookPlayerFished(*a_Player, Drops);
 			}
@@ -245,7 +245,7 @@ public:
 		}
 		else
 		{
-			auto Floater = cpp14::make_unique<cFloater>(a_Player->GetPosition().addedY(1.5), a_Player->GetLookVector() * 15, a_Player->GetUniqueID(), (Random.RandInt(100, 900) - static_cast<int>(a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100)));
+			auto Floater = cpp14::make_unique<cFloater>(a_Player->GetEyePosition(), a_Player->GetLookVector() * 15, a_Player->GetUniqueID(), (Random.RandInt(100, 900) - static_cast<int>(a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100)));
 			auto FloaterPtr = Floater.get();
 			if (!FloaterPtr->Initialize(std::move(Floater), *a_World))
 			{

--- a/src/Items/ItemFishingRod.h
+++ b/src/Items/ItemFishingRod.h
@@ -245,7 +245,7 @@ public:
 		}
 		else
 		{
-			auto Floater = cpp14::make_unique<cFloater>(a_Player->GetPosX(), a_Player->GetStance(), a_Player->GetPosZ(), a_Player->GetLookVector() * 15, a_Player->GetUniqueID(), (Random.RandInt(100, 900) - static_cast<int>(a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100)));
+			auto Floater = cpp14::make_unique<cFloater>(a_Player->GetPosition().addedY(1.5), a_Player->GetLookVector() * 15, a_Player->GetUniqueID(), (Random.RandInt(100, 900) - static_cast<int>(a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100)));
 			auto FloaterPtr = Floater.get();
 			if (!FloaterPtr->Initialize(std::move(Floater), *a_World))
 			{

--- a/src/Items/ItemItemFrame.h
+++ b/src/Items/ItemItemFrame.h
@@ -38,7 +38,7 @@ public:
 
 		if (Block == E_BLOCK_AIR)
 		{
-			auto ItemFrame = cpp14::make_unique<cItemFrame>(a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
+			auto ItemFrame = cpp14::make_unique<cItemFrame>(a_BlockFace, Vector3i{a_BlockX, a_BlockY, a_BlockZ});
 			auto ItemFramePtr = ItemFrame.get();
 			if (!ItemFramePtr->Initialize(std::move(ItemFrame), *a_World))
 			{

--- a/src/Items/ItemPainting.h
+++ b/src/Items/ItemPainting.h
@@ -70,7 +70,7 @@ public:
 				{ "BurningSkull" }
 			};
 
-			auto Painting = cpp14::make_unique<cPainting>(gPaintingTitlesList[a_World->GetTickRandomNumber(ARRAYCOUNT(gPaintingTitlesList) - 1)].Title, a_BlockFace, a_BlockX, a_BlockY, a_BlockZ);
+			auto Painting = cpp14::make_unique<cPainting>(gPaintingTitlesList[a_World->GetTickRandomNumber(ARRAYCOUNT(gPaintingTitlesList) - 1)].Title, a_BlockFace, Vector3i{a_BlockX, a_BlockY, a_BlockZ});
 			auto PaintingPtr = Painting.get();
 			if (!PaintingPtr->Initialize(std::move(Painting), *a_World))
 			{

--- a/src/Mobs/Blaze.cpp
+++ b/src/Mobs/Blaze.cpp
@@ -40,7 +40,7 @@ bool cBlaze::Attack(std::chrono::milliseconds a_Dt)
 		Vector3d Speed = GetLookVector() * 20;
 		Speed.y = Speed.y + 1;
 
-		auto FireCharge = cpp14::make_unique<cFireChargeEntity>(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
+		auto FireCharge = cpp14::make_unique<cFireChargeEntity>(this, GetPosition().addedY(1), Speed);
 		auto FireChargePtr = FireCharge.get();
 		if (!FireChargePtr->Initialize(std::move(FireCharge), *m_World))
 		{

--- a/src/Mobs/Ghast.cpp
+++ b/src/Mobs/Ghast.cpp
@@ -40,7 +40,7 @@ bool cGhast::Attack(std::chrono::milliseconds a_Dt)
 		Vector3d Speed = GetLookVector() * 20;
 		Speed.y = Speed.y + 1;
 
-		auto GhastBall = cpp14::make_unique<cGhastFireballEntity>(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
+		auto GhastBall = cpp14::make_unique<cGhastFireballEntity>(this, GetPosition().addedY(1), Speed);
 		auto GhastBallPtr = GhastBall.get();
 		if (!GhastBallPtr->Initialize(std::move(GhastBall), *m_World))
 		{

--- a/src/Mobs/Skeleton.cpp
+++ b/src/Mobs/Skeleton.cpp
@@ -57,7 +57,7 @@ bool cSkeleton::Attack(std::chrono::milliseconds a_Dt)
 		Vector3d Speed = (GetTarget()->GetPosition() + Inaccuracy - GetPosition()) * 5;
 		Speed.y += Random.RandInt(-1, 1);
 
-		auto Arrow = cpp14::make_unique<cArrowEntity>(this, GetPosX(), GetPosY() + 1, GetPosZ(), Speed);
+		auto Arrow = cpp14::make_unique<cArrowEntity>(this, GetPosition().addedY(1), Speed);
 		auto ArrowPtr = Arrow.get();
 		if (!ArrowPtr->Initialize(std::move(Arrow), *m_World))
 		{

--- a/src/UI/BeaconWindow.cpp
+++ b/src/UI/BeaconWindow.cpp
@@ -13,7 +13,7 @@
 
 
 
-cBeaconWindow::cBeaconWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cBeaconEntity * a_Beacon) :
+cBeaconWindow::cBeaconWindow(cBeaconEntity * a_Beacon):
 	cWindow(wtBeacon, "Beacon"),
 	m_Beacon(a_Beacon)
 {

--- a/src/UI/BeaconWindow.h
+++ b/src/UI/BeaconWindow.h
@@ -19,10 +19,10 @@
 class cBeaconWindow :
 	public cWindow
 {
-	typedef cWindow super;
+	using super = cWindow;
 
 public:
-	cBeaconWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cBeaconEntity * a_Beacon);
+	cBeaconWindow(cBeaconEntity * a_Beacon);
 
 	cBeaconEntity * GetBeaconEntity(void) const { return m_Beacon; }
 

--- a/src/UI/BrewingstandWindow.cpp
+++ b/src/UI/BrewingstandWindow.cpp
@@ -13,8 +13,8 @@
 
 
 
-cBrewingstandWindow::cBrewingstandWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cBrewingstandEntity * a_Brewingstand) :
-	cWindow(wtBrewery, "Brewingstand")
+cBrewingstandWindow::cBrewingstandWindow(cBrewingstandEntity * a_Brewingstand):
+	super(wtBrewery, "Brewingstand")
 {
 	m_SlotAreas.push_back(new cSlotAreaBrewingstand(a_Brewingstand, *this));
 	m_SlotAreas.push_back(new cSlotAreaInventory(*this));

--- a/src/UI/BrewingstandWindow.h
+++ b/src/UI/BrewingstandWindow.h
@@ -18,10 +18,11 @@
 class cBrewingstandWindow :
 	public cWindow
 {
-	typedef cWindow super;
+	using super = cWindow;
 
 public:
-	cBrewingstandWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cBrewingstandEntity * a_Brewingstand);
+
+	cBrewingstandWindow(cBrewingstandEntity * a_Brewingstand);
 
 	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 };

--- a/src/UI/ChestWindow.cpp
+++ b/src/UI/ChestWindow.cpp
@@ -13,7 +13,7 @@
 
 
 
-cChestWindow::cChestWindow(cChestEntity * a_Chest) :
+cChestWindow::cChestWindow(cChestEntity * a_Chest):
 	cWindow(wtChest, (a_Chest->GetBlockType() == E_BLOCK_CHEST) ? "Chest" : "Trapped Chest"),
 	m_World(a_Chest->GetWorld()),
 	m_BlockPos(a_Chest->GetPos()),

--- a/src/UI/DropSpenserWindow.cpp
+++ b/src/UI/DropSpenserWindow.cpp
@@ -11,8 +11,8 @@
 
 
 
-cDropSpenserWindow::cDropSpenserWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cDropSpenserEntity * a_DropSpenser) :
-	cWindow(wtDropSpenser, (a_DropSpenser->GetBlockType() == E_BLOCK_DISPENSER) ? "Dispenser" : "Dropper")
+cDropSpenserWindow::cDropSpenserWindow(cDropSpenserEntity * a_DropSpenser):
+	super(wtDropSpenser, (a_DropSpenser->GetBlockType() == E_BLOCK_DISPENSER) ? "Dispenser" : "Dropper")
 {
 	m_SlotAreas.push_back(new cSlotAreaItemGrid(a_DropSpenser->GetContents(), *this));
 	m_SlotAreas.push_back(new cSlotAreaInventory(*this));

--- a/src/UI/DropSpenserWindow.h
+++ b/src/UI/DropSpenserWindow.h
@@ -19,10 +19,10 @@
 class cDropSpenserWindow :
 	public cWindow
 {
-	typedef cWindow super;
+	using super = cWindow;
 
 public:
-	cDropSpenserWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cDropSpenserEntity * a_DropSpenser);
+	cDropSpenserWindow(cDropSpenserEntity * a_DropSpenser);
 
 	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 };

--- a/src/UI/EnderChestWindow.cpp
+++ b/src/UI/EnderChestWindow.cpp
@@ -12,7 +12,7 @@
 
 
 
-cEnderChestWindow::cEnderChestWindow(cEnderChestEntity * a_EnderChest) :
+cEnderChestWindow::cEnderChestWindow(cEnderChestEntity * a_EnderChest):
 	cWindow(wtChest, "Ender Chest"),
 	m_World(a_EnderChest->GetWorld()),
 	m_BlockPos(a_EnderChest->GetPos())

--- a/src/UI/FurnaceWindow.cpp
+++ b/src/UI/FurnaceWindow.cpp
@@ -13,7 +13,7 @@
 
 
 
-cFurnaceWindow::cFurnaceWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cFurnaceEntity * a_Furnace) :
+cFurnaceWindow::cFurnaceWindow(cFurnaceEntity * a_Furnace):
 	cWindow(wtFurnace, "Furnace")
 {
 	m_SlotAreas.push_back(new cSlotAreaFurnace(a_Furnace, *this));

--- a/src/UI/FurnaceWindow.h
+++ b/src/UI/FurnaceWindow.h
@@ -18,10 +18,10 @@
 class cFurnaceWindow :
 	public cWindow
 {
-	typedef cWindow super;
+	using super = cWindow;
 
 public:
-	cFurnaceWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cFurnaceEntity * a_Furnace);
+	cFurnaceWindow(cFurnaceEntity * a_Furnace);
 
 	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 

--- a/src/UI/HopperWindow.cpp
+++ b/src/UI/HopperWindow.cpp
@@ -13,7 +13,7 @@
 
 
 
-cHopperWindow::cHopperWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cHopperEntity * a_Hopper) :
+cHopperWindow::cHopperWindow(cHopperEntity * a_Hopper):
 	super(wtHopper, "Hopper")
 {
 	m_SlotAreas.push_back(new cSlotAreaItemGrid(a_Hopper->GetContents(), *this));

--- a/src/UI/HopperWindow.h
+++ b/src/UI/HopperWindow.h
@@ -21,7 +21,7 @@ class cHopperWindow :
 	typedef cWindow super;
 
 public:
-	cHopperWindow(int a_BlockX, int a_BlockY, int a_BlockZ, cHopperEntity * a_Hopper);
+	cHopperWindow(cHopperEntity * a_Hopper);
 
 	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -289,12 +289,6 @@ public:
 		);
 	}
 
-	/** Returns a copy of this vector moved by the specified offset on all axes. */
-	inline Vector3<T> added(Vector3<T> a_Offset) const
-	{
-		return Vector3<T>(x + a_Offset.x, y + a_Offset.y, z + a_Offset.z);
-	}
-
 	/** Returns a copy of this vector moved by the specified amount on the X axis. */
 	inline Vector3<T> addedX(T a_AddX) const
 	{

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -289,6 +289,36 @@ public:
 		);
 	}
 
+	/** Returns a copy of this vector moved by the specified offset on all axes. */
+	inline Vector3<T> added(Vector3<T> a_Offset) const
+	{
+		return Vector3<T>(x + a_Offset.x, y + a_Offset.y, z + a_Offset.z);
+	}
+
+	/** Returns a copy of this vector moved by the specified amount on the X axis. */
+	inline Vector3<T> addedX(T a_AddX) const
+	{
+		return Vector3<T>(x + a_AddX, y, z);
+	}
+
+	/** Returns a copy of this vector moved by the specified amount on the y axis. */
+	inline Vector3<T> addedY(T a_AddY) const
+	{
+		return Vector3<T>(x, y + a_AddY, z);
+	}
+
+	/** Returns a copy of this vector moved by the specified amount on the Z axis. */
+	inline Vector3<T> addedZ(T a_AddZ) const
+	{
+		return Vector3<T>(x, y, z + a_AddZ);
+	}
+
+	/** Returns a copy of this vector moved by the specified amount on the X and Z axes. */
+	inline Vector3<T> addedXZ(T a_AddX, T a_AddZ) const
+	{
+		return Vector3<T>(x + a_AddX, y, z + a_AddZ);
+	}
+
 	/** Returns the coefficient for the (a_OtherEnd - this) line to reach the specified Z coord.
 	The result satisfies the following equation:
 	(*this + Result * (a_OtherEnd - *this)).z = a_Z

--- a/src/World.h
+++ b/src/World.h
@@ -436,21 +436,58 @@ public:
 	// tolua_begin
 
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities: */
-	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool IsPlayerCreated = false) override;
+	void SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, double a_FlyAwaySpeed = 1.0, bool a_IsPlayerCreated = false);
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Spawns item pickups for each item in the list. May compress pickups if too many entities: */
+	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool a_IsPlayerCreated = false) override
+	{
+		return SpawnItemPickups(a_Pickups, {a_BlockX, a_BlockY, a_BlockZ}, a_FlyAwaySpeed, a_IsPlayerCreated);
+	}
 
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
-	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) override;
+	void SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, Vector3d a_Speed, bool a_IsPlayerCreated = false);
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
+	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool a_IsPlayerCreated = false) override
+	{
+		return SpawnItemPickups(a_Pickups, {a_BlockX, a_BlockY, a_BlockZ}, {a_SpeedX, a_SpeedY, a_SpeedZ}, a_IsPlayerCreated);
+	}
 
 	/** Spawns a single pickup containing the specified item. */
-	virtual UInt32 SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) override;
+	UInt32 SpawnItemPickup(Vector3d a_Pos, const cItem & a_Item, Vector3f a_Speed, int a_LifetimeTicks = 6000, bool a_CanCombine = true);
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Spawns a single pickup containing the specified item. */
+	virtual UInt32 SpawnItemPickup(double a_PosX, double a_PosY, double a_PosZ, const cItem & a_Item, float a_SpeedX = 0.f, float a_SpeedY = 0.f, float a_SpeedZ = 0.f, int a_LifetimeTicks = 6000, bool a_CanCombine = true) override
+	{
+		return SpawnItemPickup({a_PosX, a_PosY, a_PosZ}, a_Item, {a_SpeedX, a_SpeedY, a_SpeedZ}, a_LifetimeTicks, a_CanCombine);
+	}
 
 	/** Spawns an falling block entity at the given position.
 	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
-	UInt32 SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta);
+	UInt32 SpawnFallingBlock(Vector3i a_Pos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
+
+	/** OBSOLETE, use the Vector3i-based overload instead.
+	Spawns an falling block entity at the given position.
+	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
+	UInt32 SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
+	{
+		return SpawnFallingBlock({a_X, a_Y, a_Z}, a_BlockType, a_BlockMeta);
+	}
 
 	/** Spawns an minecart at the given coordinates.
 	Returns the UniqueID of the spawned minecart, or cEntity::INVALID_ID on failure. */
-	UInt32 SpawnMinecart(double a_X, double a_Y, double a_Z, int a_MinecartType, const cItem & a_Content = cItem(), int a_BlockHeight = 1);
+	UInt32 SpawnMinecart(Vector3d a_Pos, int a_MinecartType, const cItem & a_Content = cItem(), int a_BlockHeight = 1);
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Spawns an minecart at the given coordinates.
+	Returns the UniqueID of the spawned minecart, or cEntity::INVALID_ID on failure. */
+	UInt32 SpawnMinecart(double a_X, double a_Y, double a_Z, int a_MinecartType, const cItem & a_Content = cItem(), int a_BlockHeight = 1)
+	{
+		return SpawnMinecart({a_X, a_Y, a_Z}, a_MinecartType, a_Content, a_BlockHeight);
+	}
 
 	// DEPRECATED, use the vector-parametered version instead.
 	UInt32 SpawnBoat(double a_X, double a_Y, double a_Z, cBoat::eMaterial a_Material)
@@ -465,13 +502,29 @@ public:
 
 	/** Spawns an experience orb at the given location with the given reward.
 	Returns the UniqueID of the spawned experience orb, or cEntity::INVALID_ID on failure. */
-	virtual UInt32 SpawnExperienceOrb(double a_X, double a_Y, double a_Z, int a_Reward) override;
+	UInt32 SpawnExperienceOrb(Vector3d a_Pos, int a_Reward);
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Spawns an experience orb at the given location with the given reward.
+	Returns the UniqueID of the spawned experience orb, or cEntity::INVALID_ID on failure. */
+	virtual UInt32 SpawnExperienceOrb(double a_X, double a_Y, double a_Z, int a_Reward) override
+	{
+		return SpawnExperienceOrb({a_X, a_Y, a_Z}, a_Reward);
+	}
 
 	// tolua_end
 
 	/** Spawns experience orbs of the specified total value at the given location. The orbs' values are split according to regular Minecraft rules.
 	Returns an vector of UniqueID of all the orbs. */
-	virtual std::vector<UInt32> SpawnSplitExperienceOrbs(double a_X, double a_Y, double a_Z, int a_Reward) override;  // Exported in ManualBindings_World.cpp
+	std::vector<UInt32> SpawnSplitExperienceOrbs(Vector3d a_Pos, int a_Reward);  // Exported in ManualBindings_World.cpp
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Spawns experience orbs of the specified total value at the given location. The orbs' values are split according to regular Minecraft rules.
+	Returns an vector of UniqueID of all the orbs. */
+	virtual std::vector<UInt32> SpawnSplitExperienceOrbs(double a_X, double a_Y, double a_Z, int a_Reward) override
+	{
+		return SpawnSplitExperienceOrbs({a_X, a_Y, a_Z}, a_Reward);
+	}
 
 	// tolua_begin
 
@@ -846,6 +899,11 @@ public:
 	UInt32 SpawnMobFinalize(std::unique_ptr<cMonster> a_Monster);
 
 	/** Creates a projectile of the specified type. Returns the projectile's UniqueID if successful, cEntity::INVALID_ID otherwise
+	Item parameter is currently used for Fireworks to correctly set entity metadata based on item metadata. */
+	UInt32 CreateProjectile(Vector3d a_Pos, cProjectileEntity::eKind a_Kind, cEntity * a_Creator, const cItem * a_Item, const Vector3d * a_Speed = nullptr);  // tolua_export
+
+	/** OBSOLETE, use the Vector3d-based overload instead.
+	Creates a projectile of the specified type. Returns the projectile's UniqueID if successful, cEntity::INVALID_ID otherwise
 	Item parameter is currently used for Fireworks to correctly set entity metadata based on item metadata. */
 	UInt32 CreateProjectile(double a_PosX, double a_PosY, double a_PosZ, cProjectileEntity::eKind a_Kind, cEntity * a_Creator, const cItem * a_Item, const Vector3d * a_Speed = nullptr);  // tolua_export
 

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -600,19 +600,18 @@ void cWSSAnvil::LoadBlockEntitiesFromNBT(cBlockEntities & a_BlockEntities, const
 		}
 
 		// Get the BlockEntity's position
-		int x, y, z;
-		if (!GetBlockEntityNBTPos(a_NBT, Child, x, y, z) || (y < 0) || (y >= cChunkDef::Height))
+		Vector3i absPos;
+		if (!GetBlockEntityNBTPos(a_NBT, Child, absPos) || (absPos.y < 0) || (absPos.y >= cChunkDef::Height))
 		{
 			LOGWARNING("Bad block entity, missing the coords. Will be ignored.");
 			continue;
 		}
-		int RelX = x, RelY = y, RelZ = z, ChunkX, ChunkZ;
-		cChunkDef::AbsoluteToRelative(RelX, RelY, RelZ, ChunkX, ChunkZ);
+		auto relPos = cChunkDef::AbsoluteToRelative(absPos);
 
 		// Load the proper BlockEntity type based on the block type:
-		BLOCKTYPE BlockType = cChunkDef::GetBlock(a_BlockTypes, RelX, RelY, RelZ);
-		NIBBLETYPE BlockMeta = cChunkDef::GetNibble(a_BlockMetas, RelX, RelY, RelZ);
-		std::unique_ptr<cBlockEntity> be(LoadBlockEntityFromNBT(a_NBT, Child, x, y, z, BlockType, BlockMeta));
+		BLOCKTYPE BlockType = cChunkDef::GetBlock(a_BlockTypes, relPos);
+		NIBBLETYPE BlockMeta = cChunkDef::GetNibble(a_BlockMetas, relPos);
+		std::unique_ptr<cBlockEntity> be(LoadBlockEntityFromNBT(a_NBT, Child, absPos, BlockType, BlockMeta));
 		if (be.get() == nullptr)
 		{
 			continue;
@@ -630,32 +629,32 @@ void cWSSAnvil::LoadBlockEntitiesFromNBT(cBlockEntities & a_BlockEntities, const
 
 
 
-cBlockEntity * cWSSAnvil::LoadBlockEntityFromNBT(const cParsedNBT & a_NBT, int a_Tag, int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
+cBlockEntity * cWSSAnvil::LoadBlockEntityFromNBT(const cParsedNBT & a_NBT, int a_Tag, Vector3i a_Pos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 {
-	ASSERT((a_BlockY >= 0) && (a_BlockY < cChunkDef::Height));
+	ASSERT((a_Pos.y >= 0) && (a_Pos.y < cChunkDef::Height));
 
 	// Load the specific BlockEntity type:
 	switch (a_BlockType)
 	{
 		// Specific entity loaders:
-		case E_BLOCK_BEACON:        return LoadBeaconFromNBT      (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_BED:           return LoadBedFromNBT         (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_BREWING_STAND: return LoadBrewingstandFromNBT(a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_CHEST:         return LoadChestFromNBT       (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_COMMAND_BLOCK: return LoadCommandBlockFromNBT(a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_DISPENSER:     return LoadDispenserFromNBT   (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_DROPPER:       return LoadDropperFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_FLOWER_POT:    return LoadFlowerPotFromNBT   (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_FURNACE:       return LoadFurnaceFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_HEAD:          return LoadMobHeadFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_HOPPER:        return LoadHopperFromNBT      (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_JUKEBOX:       return LoadJukeboxFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_LIT_FURNACE:   return LoadFurnaceFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_MOB_SPAWNER:   return LoadMobSpawnerFromNBT  (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_NOTE_BLOCK:    return LoadNoteBlockFromNBT   (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_SIGN_POST:     return LoadSignFromNBT        (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_TRAPPED_CHEST: return LoadChestFromNBT       (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
-		case E_BLOCK_WALLSIGN:      return LoadSignFromNBT        (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ);
+		case E_BLOCK_BEACON:        return LoadBeaconFromNBT      (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_BED:           return LoadBedFromNBT         (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_BREWING_STAND: return LoadBrewingstandFromNBT(a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_CHEST:         return LoadChestFromNBT       (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_COMMAND_BLOCK: return LoadCommandBlockFromNBT(a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_DISPENSER:     return LoadDispenserFromNBT   (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_DROPPER:       return LoadDropperFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_FLOWER_POT:    return LoadFlowerPotFromNBT   (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_FURNACE:       return LoadFurnaceFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_HEAD:          return LoadMobHeadFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_HOPPER:        return LoadHopperFromNBT      (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_JUKEBOX:       return LoadJukeboxFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_LIT_FURNACE:   return LoadFurnaceFromNBT     (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_MOB_SPAWNER:   return LoadMobSpawnerFromNBT  (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_NOTE_BLOCK:    return LoadNoteBlockFromNBT   (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_SIGN_POST:     return LoadSignFromNBT        (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_TRAPPED_CHEST: return LoadChestFromNBT       (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
+		case E_BLOCK_WALLSIGN:      return LoadSignFromNBT        (a_NBT, a_Tag, a_BlockType, a_BlockMeta, a_Pos);
 
 		// Blocktypes that have block entities but don't load their contents from disk:
 		case E_BLOCK_ENDER_CHEST:   return nullptr;
@@ -673,7 +672,7 @@ cBlockEntity * cWSSAnvil::LoadBlockEntityFromNBT(const cParsedNBT & a_NBT, int a
 			LOGINFO("WorldLoader({0}): Block entity mismatch: block type {1} ({2}), type \"{3}\", at {4}; the entity will be lost.",
 				m_World->GetName(),
 				ItemTypeToString(a_BlockType), a_BlockType, TypeName,
-				Vector3i{a_BlockX, a_BlockY, a_BlockZ}
+				a_Pos
 			);
 			return nullptr;
 		}
@@ -848,7 +847,7 @@ AString cWSSAnvil::DecodeSignLine(const AString & a_Line)
 
 
 
-bool cWSSAnvil::CheckBlockEntityType(const cParsedNBT & a_NBT, int a_TagIdx, const AStringVector & a_ExpectedTypes, int a_BlockX, int a_BlockY, int a_BlockZ)
+bool cWSSAnvil::CheckBlockEntityType(const cParsedNBT & a_NBT, int a_TagIdx, const AStringVector & a_ExpectedTypes, Vector3i a_Pos)
 {
 	// Check if the given tag is a compound:
 	if (a_NBT.GetType(a_TagIdx) != TAG_Compound)
@@ -883,7 +882,7 @@ bool cWSSAnvil::CheckBlockEntityType(const cParsedNBT & a_NBT, int a_TagIdx, con
 	LOGWARNING("Block entity type mismatch: exp {0}, got \"{1}\". The block entity at {2} will lose all its properties.",
 		expectedTypes.c_str() + 2,  // Skip the first ", " that is extra in the string
 		AString(a_NBT.GetData(TagID), static_cast<size_t>(a_NBT.GetDataLength(TagID))),
-		Vector3i{a_BlockX, a_BlockY, a_BlockZ}
+		a_Pos
 	);
 	return false;
 }
@@ -892,16 +891,16 @@ bool cWSSAnvil::CheckBlockEntityType(const cParsedNBT & a_NBT, int a_TagIdx, con
 
 
 
-cBlockEntity * cWSSAnvil::LoadBeaconFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadBeaconFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({"Beacon", "minecraft:beacon"});
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto Beacon = cpp14::make_unique<cBeaconEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Beacon = cpp14::make_unique<cBeaconEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 
 	int CurrentLine = a_NBT.FindChildByName(a_TagIdx, "Levels");
 	if (CurrentLine >= 0)
@@ -935,11 +934,11 @@ cBlockEntity * cWSSAnvil::LoadBeaconFromNBT(const cParsedNBT & a_NBT, int a_TagI
 
 
 
-cBlockEntity * cWSSAnvil::LoadBedFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadBedFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Bed", "minecraft:bed" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
@@ -953,7 +952,7 @@ cBlockEntity * cWSSAnvil::LoadBedFromNBT(const cParsedNBT & a_NBT, int a_TagIdx,
 		Color = static_cast<short>(a_NBT.GetInt(ColorIDx));
 	}
 
-	auto Bed = cpp14::make_unique<cBedEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World, Color);
+	auto Bed = cpp14::make_unique<cBedEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World, Color);
 	return Bed.release();
 }
 
@@ -961,11 +960,11 @@ cBlockEntity * cWSSAnvil::LoadBedFromNBT(const cParsedNBT & a_NBT, int a_TagIdx,
 
 
 
-cBlockEntity * cWSSAnvil::LoadBrewingstandFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadBrewingstandFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Brewingstand", "minecraft:brewing_stand" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
@@ -976,7 +975,7 @@ cBlockEntity * cWSSAnvil::LoadBrewingstandFromNBT(const cParsedNBT & a_NBT, int 
 		return nullptr;  // Make it an empty brewingstand - the chunk loader will provide an empty cBrewingstandEntity for this
 	}
 
-	auto Brewingstand = cpp14::make_unique<cBrewingstandEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Brewingstand = cpp14::make_unique<cBrewingstandEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 
 	// Fuel has to be loaded at first, because of slot events:
 	int Fuel = a_NBT.FindChildByName(a_TagIdx, "Fuel");
@@ -1019,12 +1018,12 @@ cBlockEntity * cWSSAnvil::LoadBrewingstandFromNBT(const cParsedNBT & a_NBT, int 
 
 
 
-cBlockEntity * cWSSAnvil::LoadChestFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadChestFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	// Note that older Cuberite code used "TrappedChest" for trapped chests; new code mimics vanilla and uses "Chest" throughout, but we allow migration here:
 	static const AStringVector expectedTypes({ "Chest", "TrappedChest", "minecraft:chest" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
@@ -1034,7 +1033,7 @@ cBlockEntity * cWSSAnvil::LoadChestFromNBT(const cParsedNBT & a_NBT, int a_TagId
 	{
 		return nullptr;  // Make it an empty chest - the chunk loader will provide an empty cChestEntity for this
 	}
-	auto Chest = cpp14::make_unique<cChestEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Chest = cpp14::make_unique<cChestEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	LoadItemGridFromNBT(Chest->GetContents(), a_NBT, Items);
 	return Chest.release();
 }
@@ -1043,16 +1042,16 @@ cBlockEntity * cWSSAnvil::LoadChestFromNBT(const cParsedNBT & a_NBT, int a_TagId
 
 
 
-cBlockEntity * cWSSAnvil::LoadCommandBlockFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadCommandBlockFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Control", "minecraft:command_block" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto CmdBlock = cpp14::make_unique<cCommandBlockEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto CmdBlock = cpp14::make_unique<cCommandBlockEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 
 	int currentLine = a_NBT.FindChildByName(a_TagIdx, "Command");
 	if (currentLine >= 0)
@@ -1081,11 +1080,11 @@ cBlockEntity * cWSSAnvil::LoadCommandBlockFromNBT(const cParsedNBT & a_NBT, int 
 
 
 
-cBlockEntity * cWSSAnvil::LoadDispenserFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadDispenserFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Trap", "minecraft:dispenser" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
@@ -1095,7 +1094,7 @@ cBlockEntity * cWSSAnvil::LoadDispenserFromNBT(const cParsedNBT & a_NBT, int a_T
 	{
 		return nullptr;  // Make it an empty dispenser - the chunk loader will provide an empty cDispenserEntity for this
 	}
-	auto Dispenser = cpp14::make_unique<cDispenserEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Dispenser = cpp14::make_unique<cDispenserEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	LoadItemGridFromNBT(Dispenser->GetContents(), a_NBT, Items);
 	return Dispenser.release();
 }
@@ -1104,11 +1103,11 @@ cBlockEntity * cWSSAnvil::LoadDispenserFromNBT(const cParsedNBT & a_NBT, int a_T
 
 
 
-cBlockEntity * cWSSAnvil::LoadDropperFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadDropperFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Dropper", "minecraft:dropper" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
@@ -1118,7 +1117,7 @@ cBlockEntity * cWSSAnvil::LoadDropperFromNBT(const cParsedNBT & a_NBT, int a_Tag
 	{
 		return nullptr;  // Make it an empty dropper - the chunk loader will provide an empty cDropperEntity for this
 	}
-	auto Dropper = cpp14::make_unique<cDropperEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Dropper = cpp14::make_unique<cDropperEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	LoadItemGridFromNBT(Dropper->GetContents(), a_NBT, Items);
 	return Dropper.release();
 }
@@ -1127,16 +1126,16 @@ cBlockEntity * cWSSAnvil::LoadDropperFromNBT(const cParsedNBT & a_NBT, int a_Tag
 
 
 
-cBlockEntity * cWSSAnvil::LoadFlowerPotFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadFlowerPotFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "FlowerPot", "minecraft:flower_pot" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto FlowerPot = cpp14::make_unique<cFlowerPotEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto FlowerPot = cpp14::make_unique<cFlowerPotEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	cItem Item;
 
 	int currentLine = a_NBT.FindChildByName(a_TagIdx, "Item");
@@ -1166,11 +1165,11 @@ cBlockEntity * cWSSAnvil::LoadFlowerPotFromNBT(const cParsedNBT & a_NBT, int a_T
 
 
 
-cBlockEntity * cWSSAnvil::LoadFurnaceFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadFurnaceFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Furnace", "minecraft:furnace" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
@@ -1181,7 +1180,7 @@ cBlockEntity * cWSSAnvil::LoadFurnaceFromNBT(const cParsedNBT & a_NBT, int a_Tag
 		return nullptr;  // Make it an empty furnace - the chunk loader will provide an empty cFurnaceEntity for this
 	}
 
-	auto Furnace = cpp14::make_unique<cFurnaceEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Furnace = cpp14::make_unique<cFurnaceEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	Furnace->SetLoading(true);
 
 	// Load slots:
@@ -1226,11 +1225,11 @@ cBlockEntity * cWSSAnvil::LoadFurnaceFromNBT(const cParsedNBT & a_NBT, int a_Tag
 
 
 
-cBlockEntity * cWSSAnvil::LoadHopperFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadHopperFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Hopper", "minecraft:hopper" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
@@ -1240,7 +1239,7 @@ cBlockEntity * cWSSAnvil::LoadHopperFromNBT(const cParsedNBT & a_NBT, int a_TagI
 	{
 		return nullptr;  // Make it an empty hopper - the chunk loader will provide an empty cHopperEntity for this
 	}
-	auto Hopper = cpp14::make_unique<cHopperEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Hopper = cpp14::make_unique<cHopperEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	LoadItemGridFromNBT(Hopper->GetContents(), a_NBT, Items);
 	return Hopper.release();
 }
@@ -1249,16 +1248,16 @@ cBlockEntity * cWSSAnvil::LoadHopperFromNBT(const cParsedNBT & a_NBT, int a_TagI
 
 
 
-cBlockEntity * cWSSAnvil::LoadJukeboxFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadJukeboxFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "RecordPlayer", "minecraft:jukebox" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto Jukebox = cpp14::make_unique<cJukeboxEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Jukebox = cpp14::make_unique<cJukeboxEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	int Record = a_NBT.FindChildByName(a_TagIdx, "Record");
 	if (Record >= 0)
 	{
@@ -1271,16 +1270,16 @@ cBlockEntity * cWSSAnvil::LoadJukeboxFromNBT(const cParsedNBT & a_NBT, int a_Tag
 
 
 
-cBlockEntity * cWSSAnvil::LoadMobSpawnerFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadMobSpawnerFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "MobSpawner", "minecraft:mob_spawner" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto MobSpawner = cpp14::make_unique<cMobSpawnerEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto MobSpawner = cpp14::make_unique<cMobSpawnerEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 
 	// Load entity (Cuberite worlds):
 	int Type = a_NBT.FindChildByName(a_TagIdx, "Entity");
@@ -1320,16 +1319,16 @@ cBlockEntity * cWSSAnvil::LoadMobSpawnerFromNBT(const cParsedNBT & a_NBT, int a_
 
 
 
-cBlockEntity * cWSSAnvil::LoadMobHeadFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadMobHeadFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Skull", "minecraft:skull" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto MobHead = cpp14::make_unique<cMobHeadEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto MobHead = cpp14::make_unique<cMobHeadEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 
 	int currentLine = a_NBT.FindChildByName(a_TagIdx, "SkullType");
 	if (currentLine >= 0)
@@ -1394,16 +1393,16 @@ cBlockEntity * cWSSAnvil::LoadMobHeadFromNBT(const cParsedNBT & a_NBT, int a_Tag
 
 
 
-cBlockEntity * cWSSAnvil::LoadNoteBlockFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadNoteBlockFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Music", "minecraft:noteblock" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto NoteBlock = cpp14::make_unique<cNoteEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto NoteBlock = cpp14::make_unique<cNoteEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 	int note = a_NBT.FindChildByName(a_TagIdx, "note");
 	if (note >= 0)
 	{
@@ -1416,16 +1415,16 @@ cBlockEntity * cWSSAnvil::LoadNoteBlockFromNBT(const cParsedNBT & a_NBT, int a_T
 
 
 
-cBlockEntity * cWSSAnvil::LoadSignFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cWSSAnvil::LoadSignFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos)
 {
 	// Check if the data has a proper type:
 	static const AStringVector expectedTypes({ "Sign", "minecraft:sign" });
-	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_BlockX, a_BlockY, a_BlockZ))
+	if (!CheckBlockEntityType(a_NBT, a_TagIdx, expectedTypes, a_Pos))
 	{
 		return nullptr;
 	}
 
-	auto Sign = cpp14::make_unique<cSignEntity>(a_BlockType, a_BlockMeta, a_BlockX, a_BlockY, a_BlockZ, m_World);
+	auto Sign = cpp14::make_unique<cSignEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World);
 
 	int currentLine = a_NBT.FindChildByName(a_TagIdx, "Text1");
 	if (currentLine >= 0)
@@ -1609,7 +1608,7 @@ void cWSSAnvil::LoadOldMinecartFromNBT(cEntityList & a_Entities, const cParsedNB
 
 void cWSSAnvil::LoadBoatFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cBoat> Boat = cpp14::make_unique<cBoat>(Vector3d(), cBoat::bmOak);
+	auto Boat = cpp14::make_unique<cBoat>(Vector3d(), cBoat::bmOak);
 	if (!LoadEntityBaseFromNBT(*Boat.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1629,7 +1628,7 @@ void cWSSAnvil::LoadBoatFromNBT(cEntityList & a_Entities, const cParsedNBT & a_N
 
 void cWSSAnvil::LoadEnderCrystalFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cEnderCrystal> EnderCrystal = cpp14::make_unique<cEnderCrystal>(0, 0, 0);
+	auto EnderCrystal = cpp14::make_unique<cEnderCrystal>(Vector3d());
 	if (!LoadEntityBaseFromNBT(*EnderCrystal.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1654,7 +1653,7 @@ void cWSSAnvil::LoadFallingBlockFromNBT(cEntityList & a_Entities, const cParsedN
 	BLOCKTYPE Type = static_cast<BLOCKTYPE>(a_NBT.GetInt(TypeIdx));
 	NIBBLETYPE Meta = static_cast<NIBBLETYPE>(a_NBT.GetByte(MetaIdx));
 
-	std::unique_ptr<cFallingBlock> FallingBlock = cpp14::make_unique<cFallingBlock>(Vector3i(0, 0, 0), Type, Meta);
+	auto FallingBlock = cpp14::make_unique<cFallingBlock>(Vector3i(0, 0, 0), Type, Meta);
 	if (!LoadEntityBaseFromNBT(*FallingBlock.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1668,7 +1667,7 @@ void cWSSAnvil::LoadFallingBlockFromNBT(cEntityList & a_Entities, const cParsedN
 
 void cWSSAnvil::LoadMinecartRFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cRideableMinecart> Minecart = cpp14::make_unique<cRideableMinecart>(0, 0, 0, cItem(), 1);  // TODO: Load the block and the height
+	auto Minecart = cpp14::make_unique<cRideableMinecart>(Vector3d(), cItem(), 1);  // TODO: Load the block and the height
 	if (!LoadEntityBaseFromNBT(*Minecart.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1687,7 +1686,7 @@ void cWSSAnvil::LoadMinecartCFromNBT(cEntityList & a_Entities, const cParsedNBT 
 	{
 		return;  // Make it an empty chest - the chunk loader will provide an empty cChestEntity for this
 	}
-	std::unique_ptr<cMinecartWithChest> Minecart = cpp14::make_unique<cMinecartWithChest>(0, 0, 0);
+	auto Minecart = cpp14::make_unique<cMinecartWithChest>(Vector3d());
 	if (!LoadEntityBaseFromNBT(*Minecart.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1714,7 +1713,7 @@ void cWSSAnvil::LoadMinecartCFromNBT(cEntityList & a_Entities, const cParsedNBT 
 
 void cWSSAnvil::LoadMinecartFFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cMinecartWithFurnace> Minecart = cpp14::make_unique<cMinecartWithFurnace>(0, 0, 0);
+	auto Minecart = cpp14::make_unique<cMinecartWithFurnace>(Vector3d());
 	if (!LoadEntityBaseFromNBT(*Minecart.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1731,7 +1730,7 @@ void cWSSAnvil::LoadMinecartFFromNBT(cEntityList & a_Entities, const cParsedNBT 
 
 void cWSSAnvil::LoadMinecartTFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cMinecartWithTNT> Minecart = cpp14::make_unique<cMinecartWithTNT>(0, 0, 0);
+	auto Minecart = cpp14::make_unique<cMinecartWithTNT>(Vector3d());
 	if (!LoadEntityBaseFromNBT(*Minecart.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1748,7 +1747,7 @@ void cWSSAnvil::LoadMinecartTFromNBT(cEntityList & a_Entities, const cParsedNBT 
 
 void cWSSAnvil::LoadMinecartHFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cMinecartWithHopper> Minecart = cpp14::make_unique<cMinecartWithHopper>(0, 0, 0);
+	auto Minecart = cpp14::make_unique<cMinecartWithHopper>(Vector3d());
 	if (!LoadEntityBaseFromNBT(*Minecart.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1777,7 +1776,7 @@ void cWSSAnvil::LoadPickupFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		return;
 	}
 
-	std::unique_ptr<cPickup> Pickup = cpp14::make_unique<cPickup>(0, 0, 0, Item, false);  // Pickup delay doesn't matter, just say false
+	auto Pickup = cpp14::make_unique<cPickup>(Vector3d(), Item, false);  // Pickup delay doesn't matter, just say false
 	if (!LoadEntityBaseFromNBT(*Pickup.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1799,7 +1798,7 @@ void cWSSAnvil::LoadPickupFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 
 void cWSSAnvil::LoadTNTFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cTNTEntity> TNT = cpp14::make_unique<cTNTEntity>(Vector3d(), 0);
+	auto TNT = cpp14::make_unique<cTNTEntity>(Vector3d(), 0);
 	if (!LoadEntityBaseFromNBT(*TNT.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1821,7 +1820,7 @@ void cWSSAnvil::LoadTNTFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NB
 
 void cWSSAnvil::LoadExpOrbFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cExpOrb> ExpOrb = cpp14::make_unique<cExpOrb>(0.0, 0.0, 0.0, 0);
+	auto ExpOrb = cpp14::make_unique<cExpOrb>(Vector3d(), 0);
 	if (!LoadEntityBaseFromNBT(*ExpOrb.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1890,7 +1889,7 @@ void cWSSAnvil::LoadItemFrameFromNBT(cEntityList & a_Entities, const cParsedNBT 
 		return;
 	}
 
-	std::unique_ptr<cItemFrame> ItemFrame = cpp14::make_unique<cItemFrame>(BLOCK_FACE_NONE, 0.0, 0.0, 0.0);
+	auto ItemFrame = cpp14::make_unique<cItemFrame>(BLOCK_FACE_NONE, Vector3d());
 	if (!LoadEntityBaseFromNBT(*ItemFrame.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1915,7 +1914,7 @@ void cWSSAnvil::LoadItemFrameFromNBT(cEntityList & a_Entities, const cParsedNBT 
 
 void cWSSAnvil::LoadLeashKnotFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	auto LeashKnot = cpp14::make_unique<cLeashKnot>(BLOCK_FACE_NONE, 0.0, 0.0, 0.0);
+	auto LeashKnot = cpp14::make_unique<cLeashKnot>(BLOCK_FACE_NONE, Vector3d());
 
 	if (!LoadEntityBaseFromNBT(*LeashKnot.get(), a_NBT, a_TagIdx))
 	{
@@ -1940,7 +1939,7 @@ void cWSSAnvil::LoadPaintingFromNBT(cEntityList & a_Entities, const cParsedNBT &
 		return;
 	}
 
-	std::unique_ptr<cPainting> Painting = cpp14::make_unique<cPainting>(a_NBT.GetString(MotiveTag), BLOCK_FACE_NONE, 0.0, 0.0, 0.0);
+	auto Painting = cpp14::make_unique<cPainting>(a_NBT.GetString(MotiveTag), BLOCK_FACE_NONE, Vector3d());
 	if (!LoadEntityBaseFromNBT(*Painting.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -1956,7 +1955,7 @@ void cWSSAnvil::LoadPaintingFromNBT(cEntityList & a_Entities, const cParsedNBT &
 
 void cWSSAnvil::LoadArrowFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cArrowEntity> Arrow = cpp14::make_unique<cArrowEntity>(nullptr, 0, 0, 0, Vector3d(0, 0, 0));
+	auto Arrow = cpp14::make_unique<cArrowEntity>(nullptr, Vector3d(), Vector3d());
 	if (!LoadProjectileBaseFromNBT(*Arrow.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -2027,7 +2026,7 @@ void cWSSAnvil::LoadArrowFromNBT(cEntityList & a_Entities, const cParsedNBT & a_
 
 void cWSSAnvil::LoadSplashPotionFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cSplashPotionEntity> SplashPotion = cpp14::make_unique<cSplashPotionEntity>(nullptr, 0, 0, 0, Vector3d(0, 0, 0), cItem());
+	auto SplashPotion = cpp14::make_unique<cSplashPotionEntity>(nullptr, Vector3d(), Vector3d(), cItem());
 	if (!LoadProjectileBaseFromNBT(*SplashPotion.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -2051,7 +2050,7 @@ void cWSSAnvil::LoadSplashPotionFromNBT(cEntityList & a_Entities, const cParsedN
 
 void cWSSAnvil::LoadSnowballFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cThrownSnowballEntity> Snowball = cpp14::make_unique<cThrownSnowballEntity>(nullptr, 0, 0, 0, Vector3d(0, 0, 0));
+	auto Snowball = cpp14::make_unique<cThrownSnowballEntity>(nullptr, Vector3d(), Vector3d());
 	if (!LoadProjectileBaseFromNBT(*Snowball.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -2067,7 +2066,7 @@ void cWSSAnvil::LoadSnowballFromNBT(cEntityList & a_Entities, const cParsedNBT &
 
 void cWSSAnvil::LoadEggFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cThrownEggEntity> Egg = cpp14::make_unique<cThrownEggEntity>(nullptr, 0, 0, 0, Vector3d(0, 0, 0));
+	auto Egg = cpp14::make_unique<cThrownEggEntity>(nullptr, Vector3d(), Vector3d());
 	if (!LoadProjectileBaseFromNBT(*Egg.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -2083,7 +2082,7 @@ void cWSSAnvil::LoadEggFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NB
 
 void cWSSAnvil::LoadFireballFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cGhastFireballEntity> Fireball = cpp14::make_unique<cGhastFireballEntity>(nullptr, 0, 0, 0, Vector3d(0, 0, 0));
+	auto Fireball = cpp14::make_unique<cGhastFireballEntity>(nullptr, Vector3d(), Vector3d());
 	if (!LoadProjectileBaseFromNBT(*Fireball.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -2099,7 +2098,7 @@ void cWSSAnvil::LoadFireballFromNBT(cEntityList & a_Entities, const cParsedNBT &
 
 void cWSSAnvil::LoadFireChargeFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cFireChargeEntity> FireCharge = cpp14::make_unique<cFireChargeEntity>(nullptr, 0, 0, 0, Vector3d(0, 0, 0));
+	auto FireCharge = cpp14::make_unique<cFireChargeEntity>(nullptr, Vector3d(), Vector3d());
 	if (!LoadProjectileBaseFromNBT(*FireCharge.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -2115,7 +2114,7 @@ void cWSSAnvil::LoadFireChargeFromNBT(cEntityList & a_Entities, const cParsedNBT
 
 void cWSSAnvil::LoadThrownEnderpearlFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cThrownEnderPearlEntity> Enderpearl = cpp14::make_unique<cThrownEnderPearlEntity>(nullptr, 0, 0, 0, Vector3d(0, 0, 0));
+	auto Enderpearl = cpp14::make_unique<cThrownEnderPearlEntity>(nullptr, Vector3d(), Vector3d());
 	if (!LoadProjectileBaseFromNBT(*Enderpearl.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -2131,7 +2130,7 @@ void cWSSAnvil::LoadThrownEnderpearlFromNBT(cEntityList & a_Entities, const cPar
 
 void cWSSAnvil::LoadBatFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_TagIdx)
 {
-	std::unique_ptr<cBat> Monster = cpp14::make_unique<cBat>();
+	auto Monster = cpp14::make_unique<cBat>();
 	if (!LoadEntityBaseFromNBT(*Monster.get(), a_NBT, a_TagIdx))
 	{
 		return;
@@ -3291,7 +3290,7 @@ bool cWSSAnvil::LoadFloatsListFromNBT(float * a_Floats, int a_NumFloats, const c
 
 
 
-bool cWSSAnvil::GetBlockEntityNBTPos(const cParsedNBT & a_NBT, int a_TagIdx, int & a_X, int & a_Y, int & a_Z)
+bool cWSSAnvil::GetBlockEntityNBTPos(const cParsedNBT & a_NBT, int a_TagIdx, Vector3i & a_AbsPos)
 {
 	int x = a_NBT.FindChildByName(a_TagIdx, "x");
 	if ((x < 0) || (a_NBT.GetType(x) != TAG_Int))
@@ -3308,9 +3307,11 @@ bool cWSSAnvil::GetBlockEntityNBTPos(const cParsedNBT & a_NBT, int a_TagIdx, int
 	{
 		return false;
 	}
-	a_X = Clamp(a_NBT.GetInt(x), -40000000, 40000000);  // World is limited to 30M blocks in XZ, we clamp to 40M
-	a_Y = Clamp(a_NBT.GetInt(y), -10000,    10000);     // Y is limited to 0 .. 255, we clamp to 10K
-	a_Z = Clamp(a_NBT.GetInt(z), -40000000, 40000000);
+	a_AbsPos.Set(
+		Clamp(a_NBT.GetInt(x), -40000000, 40000000),  // World is limited to 30M blocks in XZ, we clamp to 40M
+		Clamp(a_NBT.GetInt(y), -10000,    10000),     // Y is limited to 0 .. 255, we clamp to 10K
+		Clamp(a_NBT.GetInt(z), -40000000, 40000000)
+	);
 	return true;
 }
 

--- a/src/WorldStorage/WSSAnvil.h
+++ b/src/WorldStorage/WSSAnvil.h
@@ -134,7 +134,7 @@ protected:
 
 	/** Loads the data for a block entity from the specified NBT tag.
 	Returns the loaded block entity, or nullptr upon failure. */
-	cBlockEntity * LoadBlockEntityFromNBT(const cParsedNBT & a_NBT, int a_Tag, int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
+	cBlockEntity * LoadBlockEntityFromNBT(const cParsedNBT & a_NBT, int a_Tag, Vector3i a_Pos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 
 	/** Loads a cItem contents from the specified NBT tag; returns true if successful. Doesn't load the Slot tag */
 	bool LoadItemFromNBT(cItem & a_Item, const cParsedNBT & a_NBT, int a_TagIdx);
@@ -152,23 +152,23 @@ protected:
 	/** Returns true iff the "id" child tag inside the specified tag equals (case-sensitive) any of the specified expected types.
 	Logs a warning to the console on mismatch.
 	The coordinates are used only for the log message. */
-	bool CheckBlockEntityType(const cParsedNBT & a_NBT, int a_TagIdx, const AStringVector & a_ExpectedTypes, int a_BlockX, int a_BlockY, int a_BlockZ);
+	bool CheckBlockEntityType(const cParsedNBT & a_NBT, int a_TagIdx, const AStringVector & a_ExpectedTypes, Vector3i a_Pos);
 
-	cBlockEntity * LoadBeaconFromNBT      (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadBedFromNBT         (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadBrewingstandFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadChestFromNBT       (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadCommandBlockFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadDispenserFromNBT   (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadDropperFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadFlowerPotFromNBT   (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadFurnaceFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadHopperFromNBT      (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadJukeboxFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadMobHeadFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadMobSpawnerFromNBT  (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadNoteBlockFromNBT   (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
-	cBlockEntity * LoadSignFromNBT        (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ);
+	cBlockEntity * LoadBeaconFromNBT      (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadBedFromNBT         (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadBrewingstandFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadChestFromNBT       (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadCommandBlockFromNBT(const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadDispenserFromNBT   (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadDropperFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadFlowerPotFromNBT   (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadFurnaceFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadHopperFromNBT      (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadJukeboxFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadMobHeadFromNBT     (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadMobSpawnerFromNBT  (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadNoteBlockFromNBT   (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
+	cBlockEntity * LoadSignFromNBT        (const cParsedNBT & a_NBT, int a_TagIdx, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos);
 
 	void LoadEntityFromNBT(cEntityList & a_Entities, const cParsedNBT & a_NBT, int a_EntityTagIdx, const char * a_IDTag, size_t a_IDTagLength);
 
@@ -253,7 +253,7 @@ protected:
 	bool LoadFloatsListFromNBT(float * a_Floats, int a_NumFloats, const cParsedNBT & a_NBT, int a_TagIdx);
 
 	/** Helper function for extracting the X, Y, and Z int subtags of a NBT compound; returns true if successful */
-	bool GetBlockEntityNBTPos(const cParsedNBT & a_NBT, int a_TagIdx, int & a_X, int & a_Y, int & a_Z);
+	bool GetBlockEntityNBTPos(const cParsedNBT & a_NBT, int a_TagIdx, Vector3i & a_AbsPos);
 
 	/** Gets the correct MCA file either from cache or from disk, manages the m_MCAFiles cache; assumes m_CS is locked */
 	cMCAFile * LoadMCAFile(const cChunkCoords & a_Chunk);

--- a/tests/Generating/Stubs.cpp
+++ b/tests/Generating/Stubs.cpp
@@ -291,7 +291,7 @@ bool cBlockHandler::IsInsideBlock(Vector3d a_Position, const BLOCKTYPE a_BlockTy
 
 
 
-cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World)
+cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World)
 {
 	return nullptr;
 }
@@ -316,7 +316,7 @@ void cDeadlockDetect::UntrackCriticalSection(cCriticalSection & a_CS)
 
 
 
-void cBlockEntity::SetPos(int a_BlockX, int a_BlockY, int a_BlockZ)
+void cBlockEntity::SetPos(Vector3i a_NewPos)
 {
 }
 
@@ -333,7 +333,7 @@ bool cBlockEntity::IsBlockEntityBlockType(BLOCKTYPE a_BlockType)
 
 
 
-cBlockEntity * cBlockEntity::Clone(int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cBlockEntity::Clone(Vector3i a_Pos)
 {
 	return nullptr;
 }

--- a/tests/LuaThreadStress/Stubs.cpp
+++ b/tests/LuaThreadStress/Stubs.cpp
@@ -284,7 +284,7 @@ bool cBlockHandler::IsInsideBlock(Vector3d a_Position, const BLOCKTYPE a_BlockTy
 
 
 
-cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World)
+cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World)
 {
 	return nullptr;
 }
@@ -309,7 +309,7 @@ void cDeadlockDetect::UntrackCriticalSection(cCriticalSection & a_CS)
 
 
 
-void cBlockEntity::SetPos(int a_BlockX, int a_BlockY, int a_BlockZ)
+void cBlockEntity::SetPos(Vector3i a_NewPos)
 {
 }
 
@@ -326,7 +326,7 @@ bool cBlockEntity::IsBlockEntityBlockType(BLOCKTYPE a_BlockType)
 
 
 
-cBlockEntity * cBlockEntity::Clone(int a_BlockX, int a_BlockY, int a_BlockZ)
+cBlockEntity * cBlockEntity::Clone(Vector3i a_Pos)
 {
 	return nullptr;
 }

--- a/tests/SchematicFileSerializer/Stubs.cpp
+++ b/tests/SchematicFileSerializer/Stubs.cpp
@@ -34,6 +34,9 @@ cBlockInfo::cBlockInfoArray::cBlockInfoArray()
 }
 
 
+
+
+
 cBoundingBox::cBoundingBox(double, double, double, double, double, double)
 {
 }
@@ -217,7 +220,7 @@ bool cBlockEntity::IsBlockEntityBlockType(BLOCKTYPE a_BlockType)
 
 
 
-void cBlockEntity::SetPos(int a_BlockX, int a_BlockY, int a_BlockZ)
+void cBlockEntity::SetPos(Vector3i a_NewPos)
 {
 }
 
@@ -225,16 +228,7 @@ void cBlockEntity::SetPos(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 
 
-cBlockEntity * cBlockEntity::Clone(int a_BlockX, int a_BlockY, int a_BlockZ)
-{
-	return nullptr;
-}
-
-
-
-
-
-cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, int a_BlockX, int a_BlockY, int a_BlockZ, cWorld * a_World)
+cBlockEntity * cBlockEntity::Clone(Vector3i a_Pos)
 {
 	return nullptr;
 }
@@ -242,3 +236,8 @@ cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE
 
 
 
+
+cBlockEntity * cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World)
+{
+	return nullptr;
+}


### PR DESCRIPTION
The BlockEntities use `Vector3i` for position storage.
Both BlockEntities and Entities use `Vector3` in constructor.

Notably, added new utility functions to `Vector3`:
`added(ofs)` returns a copy of the vector moved by the specified offset (3 axes)
`addedX(ofs)` returns a copy of the vector moved by ofs in the X axis
`addedXZ(ofsX, ofsZ)` returns a copy of the vector moved by the specified offsets in X and Z axes.
etc.
These are used when iterating over the neighbors of existing `Vector3` instances.

Despite the looks of it, this *is* a step towards 1.13 :)