### PR TITLE
Fixed crash in hopper while pulling items from blockentity above itself

### DIFF
--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -148,7 +148,7 @@ bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 
 	// Try moving an item in:
 	bool res = false;
-	switch (a_Chunk.GetBlock(GetRelPos()))
+	switch (a_Chunk.GetBlock(GetRelPos().addedY(1)))
 	{
 		case E_BLOCK_TRAPPED_CHEST:
 		case E_BLOCK_CHEST:
@@ -168,7 +168,7 @@ bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 		case E_BLOCK_DROPPER:
 		case E_BLOCK_HOPPER:
 		{
-			res = MoveItemsFromGrid(*static_cast<cBlockEntityWithItems *>(a_Chunk.GetBlockEntity(GetRelPos().addedY(1))));
+			res = MoveItemsFromGrid(*static_cast<cBlockEntityWithItems *>(a_Chunk.GetBlockEntity(this->GetPos().addedY(1))));
 			break;
 		}
 	}


### PR DESCRIPTION
I compiled Cuberite for the first time in years and wondered why it crashed every time right after I joined. Turns out there was a village with a hopper near spawn which started ticking and crashing.

Fixes #4410