### PR TITLE
Fix android builds

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,1 +1,2 @@
 /Cuberite/
+Server

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(SYSTEM
 )
 
 # Disable some compiler warnings (the lazy way out)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-double-promotion")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-double-promotion -Wno-sign-conversion")
 
 # Build the rest of the server
 add_subdirectory(../ Cuberite)

--- a/android/compile.sh
+++ b/android/compile.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script cross-compiles cuberite for the android platform. It uses
 # the following enviroment variables
 #   CMAKE: Should be the path to a cmake executable of version 3.7+

--- a/android/compile.sh
+++ b/android/compile.sh
@@ -43,32 +43,21 @@ fi
 cd $BASEDIR
 
 case "$1" in
-	armeabi)
-		APILEVEL=16
-	;;
 
 	armeabi-v7a)
-		APILEVEL=16
+		APILEVEL=29
 	;;
 
 	arm64-v8a)
-		APILEVEL=21
-	;;
-
-	mips)
-		APILEVEL=16
-	;;
-
-	mips64)
-		APILEVEL=21
+		APILEVEL=29
 	;;
 
 	x86)
-		APILEVEL=16
+		APILEVEL=29
 	;;
 
 	x86_64)
-		APILEVEL=21
+		APILEVEL=29
 	;;
 
 	all)
@@ -77,7 +66,7 @@ case "$1" in
 		cd $BASEDIR/../Server
 		zip -r $BASEDIR/Server/server.zip *
 
-		for arch in armeabi armeabi-v7a arm64-v8a mips mips64 x86 x86_64; do
+		for arch in armeabi-v7a arm64-v8a x86 x86_64; do
 			echo "Doing ... $arch ..." && \
 			cd $BASEDIR && \
 			"$SELF" clean && \
@@ -88,7 +77,7 @@ case "$1" in
 		done
 
 		cd $BASEDIR/Server
-		for file in server.zip armeabi.zip armeabi-v7a.zip arm64-v8a.zip mips.zip mips64.zip x86.zip x86_64.zip; do
+		for file in server.zip armeabi-v7a.zip arm64-v8a.zip x86.zip x86_64.zip; do
 			echo "Generating sha1 sum for ... $file ..." && \
 			sha1sum "$file" > "$file".sha1
 		done

--- a/android/compile.sh
+++ b/android/compile.sh
@@ -45,19 +45,19 @@ cd $BASEDIR
 case "$1" in
 
 	armeabi-v7a)
-		APILEVEL=29
+		APILEVEL=14
 	;;
 
 	arm64-v8a)
-		APILEVEL=29
+		APILEVEL=21
 	;;
 
 	x86)
-		APILEVEL=29
+		APILEVEL=14
 	;;
 
 	x86_64)
-		APILEVEL=29
+		APILEVEL=21
 	;;
 
 	all)

--- a/android/compile.sh
+++ b/android/compile.sh
@@ -15,16 +15,16 @@ function usage() {
 }
 
 BASEDIR="$(realpath $(dirname $0))"
+BUILDDIR="$BASEDIR/../android-build"
 SELF="./$(basename $0)"
 
 # Clean doesn't need CMAKE and NDK, so it's handled here
 if [ "$1" == "clean" ]; then
-	cd $BASEDIR
-	rm -rf ../android-build/
+	rm -rf $BUILDDIR
 	exit 0
 fi
 
-if [ -z "$CMAKE" -o -z "$NDK" ];then
+if [ -z "$CMAKE" -o -z "$NDK" ]; then
 	usage;
 fi
 
@@ -62,6 +62,7 @@ case "$1" in
 
 	all)
 		echo "Packing server.zip ..."
+		rm -rf Server
 		mkdir -p Server
 		cd $BASEDIR/../Server
 		zip -r $BASEDIR/Server/server.zip *
@@ -71,9 +72,8 @@ case "$1" in
 			cd $BASEDIR && \
 			"$SELF" clean && \
 			"$SELF" "$arch" && \
-			cd Server && \
-			zip "$arch".zip Cuberite && \
-			rm Cuberite
+			cd $BUILDDIR/Server && \
+			zip $BASEDIR/Server/"$arch".zip Cuberite
 		done
 
 		cd $BASEDIR/Server
@@ -91,8 +91,8 @@ case "$1" in
 	;;
 esac
 
-mkdir -p $BASEDIR/../android-build
-cd $BASEDIR/../android-build
+mkdir -p $BUILDDIR
+cd $BUILDDIR
 "$CMAKE" $BASEDIR/../android -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="$1" \
     -DANDROID_NATIVE_API_LEVEL="$APILEVEL" \

--- a/android/compile.sh
+++ b/android/compile.sh
@@ -93,5 +93,9 @@ esac
 
 mkdir -p $BASEDIR/../android-build
 cd $BASEDIR/../android-build
-"$CMAKE" $BASEDIR/../android -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION="$APILEVEL" -DCMAKE_BUILD_TYPE="$TYPE" -DCMAKE_ANDROID_ARCH_ABI="$1" -DCMAKE_ANDROID_NDK="$NDK"
+"$CMAKE" $BASEDIR/../android -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
+    -DANDROID_ABI="$1" \
+    -DANDROID_NATIVE_API_LEVEL="$APILEVEL" \
+    -DCMAKE_BUILD_TYPE="$TYPE"
+
 make -j "$THREADS"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -358,7 +358,7 @@ function(make_symlink orig link)
 	# Create the symlink (platform-dependent):
 	message("Creating symlink, orig = ${orig}; link = ${link}")
 	if (CMAKE_HOST_UNIX)
-		set(command ln -fs ${orig} ${link})
+		set(command ln -s ${orig} ${link})
 	else()
 		file(TO_NATIVE_PATH "${orig}" orig)
 		file(TO_NATIVE_PATH "${link}" link)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -358,7 +358,7 @@ function(make_symlink orig link)
 	# Create the symlink (platform-dependent):
 	message("Creating symlink, orig = ${orig}; link = ${link}")
 	if (CMAKE_HOST_UNIX)
-		set(command ln -s ${orig} ${link})
+		set(command ln -fs ${orig} ${link})
 	else()
 		file(TO_NATIVE_PATH "${orig}" orig)
 		file(TO_NATIVE_PATH "${link}" link)

--- a/src/OSSupport/Errors.cpp
+++ b/src/OSSupport/Errors.cpp
@@ -22,7 +22,7 @@ AString GetOSErrorString( int a_ErrNo)
 
 	// According to https://linux.die.net/man/3/strerror_r there are two versions of strerror_r():
 
-	#if defined(__GLIBC__) && defined( _GNU_SOURCE) && !defined(ANDROID)  // GNU version of strerror_r()
+	#if defined(__GLIBC__) && defined( _GNU_SOURCE)  // GNU version of strerror_r()
 
 	char * res = strerror_r( errno, buffer, ARRAYCOUNT(buffer));
 	if (res != nullptr)

--- a/src/OSSupport/Errors.cpp
+++ b/src/OSSupport/Errors.cpp
@@ -22,7 +22,7 @@ AString GetOSErrorString( int a_ErrNo)
 
 	// According to https://linux.die.net/man/3/strerror_r there are two versions of strerror_r():
 
-	#if (defined(__GLIBC__) && defined( _GNU_SOURCE)) || defined(ANDROID)  // GNU version of strerror_r()
+	#if defined(__GLIBC__) && defined( _GNU_SOURCE)  // GNU version of strerror_r()
 
 	char * res = strerror_r( errno, buffer, ARRAYCOUNT(buffer));
 	if (res != nullptr)

--- a/src/OSSupport/Errors.cpp
+++ b/src/OSSupport/Errors.cpp
@@ -22,7 +22,7 @@ AString GetOSErrorString( int a_ErrNo)
 
 	// According to https://linux.die.net/man/3/strerror_r there are two versions of strerror_r():
 
-	#if defined(__GLIBC__) && defined( _GNU_SOURCE)  // GNU version of strerror_r()
+	#if defined(__GLIBC__) && defined( _GNU_SOURCE) || defined(ANDROID)  // GNU version of strerror_r()
 
 	char * res = strerror_r( errno, buffer, ARRAYCOUNT(buffer));
 	if (res != nullptr)

--- a/src/OSSupport/Errors.cpp
+++ b/src/OSSupport/Errors.cpp
@@ -22,7 +22,7 @@ AString GetOSErrorString( int a_ErrNo)
 
 	// According to https://linux.die.net/man/3/strerror_r there are two versions of strerror_r():
 
-	#if defined(__GLIBC__) && defined( _GNU_SOURCE) || defined(ANDROID)  // GNU version of strerror_r()
+	#if (defined(__GLIBC__) && defined( _GNU_SOURCE)) || defined(ANDROID)  // GNU version of strerror_r()
 
 	char * res = strerror_r( errno, buffer, ARRAYCOUNT(buffer));
 	if (res != nullptr)


### PR DESCRIPTION
Currently compilation errors don't stop the build, and it generates corrupt output files.