### PR TITLE
Use UpgradeBlockTypePalette

### DIFF
--- a/Server/Install/UnixExecutables.list
+++ b/Server/Install/UnixExecutables.list
@@ -1,6 +1,7 @@
 Cuberite
 Plugins
 Prefabs
+Protocol
 webadmin
 BACKERS
 brewing.txt

--- a/Server/Install/WindowsExecutables.list
+++ b/Server/Install/WindowsExecutables.list
@@ -2,6 +2,7 @@ Cuberite.exe
 *.dll
 Plugins
 Prefabs
+Protocol
 webadmin
 BACKERS
 brewing.txt

--- a/Server/Protocol/UpgradeBlockTypePalette.txt
+++ b/Server/Protocol/UpgradeBlockTypePalette.txt
@@ -10,7 +10,7 @@ CommonPrefix	minecraft:
 1	4	polished_diorite
 1	5	andesite
 1	6	polished_andesite
-2	0	grass_block
+2	0	grass_block	snowy	false
 3	0	dirt
 3	1	coarse_dirt
 3	2	podzol
@@ -38,14 +38,26 @@ CommonPrefix	minecraft:
 14	0	gold_ore
 15	0	iron_ore
 16	0	coal_ore
-17	0	oak_log
-17	1	spruce_log
-17	2	birch_log
-17	3	jungle_log
-18	0	oak_leaves
-18	1	spruce_leaves
-18	2	birch_leaves
-18	3	jungle_leaves
+17	0	oak_log	axis	y
+17	1	spruce_log	axis	y
+17	2	birch_log	axis	y
+17	3	jungle_log	axis	y
+17	4	oak_log	axis	x
+17	5	spruce_log	axis	x
+17	6	birch_log	axis	x
+17	7	jungle_log	axis	x
+17	8	oak_log	axis	z
+17	9	spruce_log	axis	z
+17	10	birch_log	axis	z
+17	11	jungle_log	axis	z
+17	12	oak_wood	axis	y
+17	13	spruce_wood	axis	y
+17	14	birch_wood	axis	y
+17	15	jungle_wood	axis	y
+18	0	oak_leaves	persistent	false	distance	7
+18	1	spruce_leaves	persistent	false	distance	7
+18	2	birch_leaves	persistent	false	distance	7
+18	3	jungle_leaves	persistent	false	distance	7
 19	0	sponge
 19	1	wet_sponge
 20	0	glass

--- a/src/Protocol/CMakeLists.txt
+++ b/src/Protocol/CMakeLists.txt
@@ -12,6 +12,7 @@ SET (SRCS
 	Protocol_1_11.cpp
 	Protocol_1_12.cpp
 	Protocol_1_13.cpp
+	ProtocolPalettes.cpp
 	ProtocolRecognizer.cpp
 )
 
@@ -28,6 +29,7 @@ SET (HDRS
 	Protocol_1_11.h
 	Protocol_1_12.h
 	Protocol_1_13.h
+	ProtocolPalettes.h
 	ProtocolRecognizer.h
 )
 

--- a/src/Protocol/ChunkDataSerializer.h
+++ b/src/Protocol/ChunkDataSerializer.h
@@ -1,31 +1,16 @@
-
-// ChunkDataSerializer.h
-
-// Interfaces to the cChunkDataSerializer class representing the object that can:
-//  - serialize chunk data to different protocol versions
-//  - cache such serialized data for multiple clients
+#pragma once
 
 #include "../ChunkData.h"
 
 
 
 
+
+/** Serializes one chunk's data to (possibly multiple) protocol versions.
+Caches the serialized data for as long as this object lives, so that the same data can be sent to
+other clients using the same protocol. */
 class cChunkDataSerializer
 {
-protected:
-	const cChunkData & m_Data;
-	const unsigned char * m_BiomeData;
-	const eDimension m_Dimension;
-
-	typedef std::map<int, AString> Serializations;
-
-	Serializations m_Serializations;
-
-	void Serialize47 (AString & a_Data, int a_ChunkX, int a_ChunkZ);  // Release 1.8
-	void Serialize107(AString & a_Data, int a_ChunkX, int a_ChunkZ);  // Release 1.9
-	void Serialize110(AString & a_Data, int a_ChunkX, int a_ChunkZ);  // Release 1.9.4
-	void Serialize393(AString & a_Data, int a_ChunkX, int a_ChunkZ);  // Release 1.13
-
 public:
 	enum
 	{
@@ -41,7 +26,34 @@ public:
 		const eDimension      a_Dimension
 	);
 
-	const AString & Serialize(int a_Version, int a_ChunkX, int a_ChunkZ);  // Returns one of the internal m_Serializations[]
+	/** Serializes the contained chunk data into the specified protocol version.
+	TEMPORARY: a_BlockTypeMap is used for the 1.13+ protocols to map from BLOCKTYPE#META to NetBlockID.
+	a_BlockTypeMap is ignored for pre-1.13 protocols. */
+	const AString & Serialize(int a_Version, int a_ChunkX, int a_ChunkZ, const std::map<UInt32, UInt32> & a_BlockTypeMap);
+
+
+protected:
+
+	using Serializations = std::map<int, AString>;
+
+
+	/** The data read from the chunk, to be serialized. */
+	const cChunkData & m_Data;
+
+	/** The biomes in the chunk, to be serialized. */
+	const unsigned char * m_BiomeData;
+
+	/** The dimension where the chunk resides. */
+	const eDimension m_Dimension;
+
+	/** The per-protocol serialized data, cached for reuse for other clients. */
+	Serializations m_Serializations;
+
+
+	void Serialize47 (AString & a_Data, int a_ChunkX, int a_ChunkZ);  // Release 1.8
+	void Serialize107(AString & a_Data, int a_ChunkX, int a_ChunkZ);  // Release 1.9
+	void Serialize110(AString & a_Data, int a_ChunkX, int a_ChunkZ);  // Release 1.9.4
+	void Serialize393(AString & a_Data, int a_ChunkX, int a_ChunkZ, const std::map<UInt32, UInt32> & a_BlockTypeMap);  // Release 1.13
 } ;
 
 

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -57,6 +57,11 @@ public:
 	virtual ~cProtocol() {}
 
 
+	/** Called after construction so that the protocol class can initialize itself.
+	Throws a std::exception descendant on failure; the client is kicked
+	with the exception's message as a result. */
+	virtual void Initialize(cClientHandle & a_Client) {}
+
 	/** Logical types of outgoing packets.
 	These values get translated to on-wire packet IDs in GetPacketID(), specific for each protocol.
 	This is mainly useful for protocol sub-versions that re-number the packets while using mostly the same packet layout. */

--- a/src/Protocol/ProtocolPalettes.cpp
+++ b/src/Protocol/ProtocolPalettes.cpp
@@ -1,0 +1,107 @@
+#include "Globals.h"
+#include "ProtocolPalettes.h"
+#include "../BlockTypePalette.h"
+
+
+
+
+
+void ProtocolPalettes::load(const AString & aProtocolFolder)
+{
+	auto contents = cFile::GetFolderContents(aProtocolFolder);
+	for (const auto & c: contents)
+	{
+		auto fullName = aProtocolFolder + cFile::PathSeparator() + c;
+		if (cFile::IsFolder(fullName))
+		{
+			loadSingleVersion(c, fullName);
+		}
+	}
+}
+
+
+
+
+
+std::shared_ptr<const BlockTypePalette> ProtocolPalettes::blockTypePalette(const AString & aProtocolVersion) const
+{
+	cCSLock lock(mCS);
+	auto itr = mPalettes.find(aProtocolVersion);
+	if (itr == mPalettes.end())
+	{
+		return nullptr;
+	}
+	return itr->second.mBlockTypePalette;
+}
+
+
+
+
+
+std::vector<AString> ProtocolPalettes::protocolVersions() const
+{
+	cCSLock lock(mCS);
+
+	std::vector<AString> res;
+	for (const auto & p: mPalettes)
+	{
+		res.push_back(p.first);
+	}
+	return res;
+}
+
+
+
+
+
+void ProtocolPalettes::loadSingleVersion(const AString & aProtocolVersion, const AString & aFolder)
+{
+	// Get the file list, sort by name
+	auto contents = cFile::GetFolderContents(aFolder);
+	std::sort(contents.begin(), contents.end());
+
+	// Load files into the palettes:
+	cCSLock lock(mCS);
+	auto & pal = mPalettes[aProtocolVersion];
+	for (const auto & c: contents)
+	{
+		if (c.length() < 8)
+		{
+			// Name too short, can't have the ".btp.txt" etc. suffix
+			continue;
+		}
+		auto fnam = aFolder + cFile::PathSeparator() + c;
+		if (!cFile::IsFile(fnam))
+		{
+			continue;
+		}
+		auto fileType = c.substr(c.length() - 8);
+		if ((fileType == ".btp.txt") || (c == "blocks.json"))
+		{
+			try
+			{
+				pal.mBlockTypePalette->loadFromString(cFile::ReadWholeFile(fnam));
+			}
+			catch (...)
+			{
+				// Ignore silently
+			}
+		}
+		else if ((fileType == ".itp.txt") || (c == "items.json"))
+		{
+			// TODO: Load item type palette
+		}
+	}
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// ProtocolPalettes::Palettes:
+
+ProtocolPalettes::Palettes::Palettes():
+	mBlockTypePalette(new BlockTypePalette)
+{
+}

--- a/src/Protocol/ProtocolPalettes.h
+++ b/src/Protocol/ProtocolPalettes.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "../OSSupport/CriticalSection.h"
+
+
+
+
+
+// fwd:
+class BlockTypePalette;
+
+
+
+
+
+/** Loads the protocol-specific palettes on startup and provides them to the individual protocol
+instances when they are created.
+Uses the data in the $/Server/Protocol folder. Each protocol version has a subfolder there,
+containing possibly multiple palette files. All the files are loaded in sequence (alpha-sorted),
+into the palette corresponding to the file's extension (*.btp.txt -> BlockTypePalette).
+Provides thread safety for the data properly. */
+class ProtocolPalettes
+{
+public:
+
+	/** Loads all the per-protocol palettes.
+	aProtocolFolder is the folder that contains a subfolder for each protocol version;
+	each subfolder contains the protocol-specific palettes (as in $/Server/Protocol)
+	If a protocol version is already loaded, yet present in the folder, the newly loaded data is merged
+	into the current data.
+	Always succeeds (even when there are no palettes). */
+	void load(const AString & aProtocolFolder);
+
+	/** Returns the BlockTypePalette for the specified protocol.
+	Returns nullptr if no such palette has been loaded. */
+	std::shared_ptr<const BlockTypePalette> blockTypePalette(const AString & aProtocolVersion) const;
+
+	/** Returns the version names of all protocols that have been loaded. */
+	std::vector<AString> protocolVersions() const;
+
+
+protected:
+
+	/** Container for all palettes for a single protocol. */
+	struct Palettes
+	{
+		std::shared_ptr<BlockTypePalette> mBlockTypePalette;
+		// TODO: ItemTypePalette
+
+		Palettes();
+	};
+
+
+	/** The CS protecting all members against multithreaded access. */
+	mutable cCriticalSection mCS;
+
+	/** The map of protocol version -> all its palettes. */
+	std::map<AString, Palettes> mPalettes;
+
+
+	/** Loads all the palettes from the specified folder into mPalettes under the aProtocolVersion key. */
+	void loadSingleVersion(const AString & aProtocolVersion, const AString & aFolder);
+};

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -27,20 +27,9 @@
 
 cProtocolRecognizer::cProtocolRecognizer(cClientHandle * a_Client) :
 	super(a_Client),
-	m_Protocol(nullptr),
 	m_Buffer(8192),  // We need a larger buffer to support BungeeCord - it sends one huge packet at the start
 	m_InPingForUnrecognizedVersion(false)
 {
-}
-
-
-
-
-
-cProtocolRecognizer::~cProtocolRecognizer()
-{
-	delete m_Protocol;
-	m_Protocol = nullptr;
 }
 
 
@@ -61,6 +50,7 @@ AString cProtocolRecognizer::GetVersionTextFromInt(int a_ProtocolVersion)
 		case PROTO_VERSION_1_11_1:  return "1.11.1";
 		case PROTO_VERSION_1_12:    return "1.12";
 		case PROTO_VERSION_1_12_1:  return "1.12.1";
+		case PROTO_VERSION_1_13:    return "1.13";
 	}
 	ASSERT(!"Unknown protocol version");
 	return Printf("Unknown protocol (%d)", a_ProtocolVersion);
@@ -1098,62 +1088,62 @@ bool cProtocolRecognizer::TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRema
 		case PROTO_VERSION_1_8_0:
 		{
 			m_Buffer.CommitRead();
-			m_Protocol = new cProtocol_1_8_0(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_8_0(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_9_0:
 		{
-			m_Protocol = new cProtocol_1_9_0(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_9_0(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_9_1:
 		{
-			m_Protocol = new cProtocol_1_9_1(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_9_1(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_9_2:
 		{
-			m_Protocol = new cProtocol_1_9_2(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_9_2(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_9_4:
 		{
-			m_Protocol = new cProtocol_1_9_4(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_9_4(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_10_0:
 		{
-			m_Protocol = new cProtocol_1_10_0(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_10_0(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_11_0:
 		{
-			m_Protocol = new cProtocol_1_11_0(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_11_0(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_11_1:
 		{
-			m_Protocol = new cProtocol_1_11_1(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_11_1(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_12:
 		{
-			m_Protocol = new cProtocol_1_12(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_12(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_12_1:
 		{
-			m_Protocol = new cProtocol_1_12_1(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_12_1(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_12_2:
 		{
-			m_Protocol = new cProtocol_1_12_2(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_12_2(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		case PROTO_VERSION_1_13:
 		{
-			m_Protocol = new cProtocol_1_13(m_Client, ServerAddress, ServerPort, NextState);
+			m_Protocol.reset(new cProtocol_1_13(m_Client, ServerAddress, ServerPort, NextState));
 			return true;
 		}
 		default:

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -1038,7 +1038,24 @@ bool cProtocolRecognizer::TryRecognizeProtocol(void)
 		// Not enough bytes for the packet, keep waiting
 		return false;
 	}
-	return TryRecognizeLengthedProtocol(PacketLen - ReadSoFar);
+	if (!TryRecognizeLengthedProtocol(PacketLen - ReadSoFar))
+	{
+		return false;
+	}
+
+	// The protocol has been recognized, initialize it:
+	ASSERT(m_Protocol != nullptr);
+	try
+	{
+		m_Protocol->Initialize(*m_Client);
+	}
+	catch (const std::exception & exc)
+	{
+		m_Client->Kick(exc.what());
+		m_Protocol.reset();
+		return false;
+	}
+	return true;
 }
 
 

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -1,13 +1,3 @@
-
-// ProtocolRecognizer.h
-
-// Interfaces to the cProtocolRecognizer class representing the meta-protocol that recognizes possibly multiple
-// protocol versions and redirects everything to them
-
-
-
-
-
 #pragma once
 
 #include "Protocol.h"
@@ -26,7 +16,9 @@
 
 
 
-class cProtocolRecognizer :
+/** Meta-protocol that recognizes multiple protocol versions, creates the specific
+protocol version instance and redirects everything to it. */
+class cProtocolRecognizer:
 	public cProtocol
 {
 	typedef cProtocol super;
@@ -49,7 +41,7 @@ public:
 	};
 
 	cProtocolRecognizer(cClientHandle * a_Client);
-	virtual ~cProtocolRecognizer() override;
+	virtual ~cProtocolRecognizer() override {}
 
 	/** Translates protocol version number into protocol version text: 49 -> "1.4.4" */
 	static AString GetVersionTextFromInt(int a_ProtocolVersion);
@@ -149,9 +141,11 @@ public:
 
 	virtual void SendData(const char * a_Data, size_t a_Size) override;
 
+
 protected:
+
 	/** The recognized protocol */
-	cProtocol * m_Protocol;
+	std::unique_ptr<cProtocol> m_Protocol;
 
 	/** Buffer for the incoming data until we recognize the protocol */
 	cByteBuffer m_Buffer;

--- a/src/Protocol/Protocol_1_13.h
+++ b/src/Protocol/Protocol_1_13.h
@@ -20,6 +20,13 @@ Declares the 1.13 protocol classes:
 
 
 
+// fwd:
+class BlockTypePalette;
+
+
+
+
+
 class cProtocol_1_13 :
 	public cProtocol_1_12_2
 {
@@ -28,8 +35,24 @@ class cProtocol_1_13 :
 public:
 	cProtocol_1_13(cClientHandle * a_Client, const AString & a_ServerAddress, UInt16 a_ServerPort, UInt32 a_State);
 
+	virtual void Initialize(cClientHandle & a_Client) override;
+
+
 protected:
 
+	/** The palette used to transform internal block type palette into the protocol-specific ID. */
+	std::shared_ptr<const BlockTypePalette> m_BlockTypePalette;
+
+	/** Temporary hack for initial 1.13+ support while keeping BLOCKTYPE data:
+	Map of the BLOCKTYPE#META to the protocol-specific NetBlockID. */
+	std::map<UInt32, UInt32> m_BlockTypeMap;
+
+
+	/** Returns the string identifying the palettes' version, such as "1.13" or "1.14.4".
+	The palettes for that version are loaded into m_BlockTypePalette and m_ItemTypePalette. */
+	virtual AString GetPaletteVersion() const;
+
+	// Outgoing packet type translation:
 	virtual UInt32 GetPacketID(ePacketType a_PacketType) override;
 
 	// Packet receiving:

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -307,7 +307,7 @@ void cProtocol_1_8_0::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerial
 
 	// Serialize first, before creating the Packetizer (the packetizer locks a CS)
 	// This contains the flags and bitmasks, too
-	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_8_0, a_ChunkX, a_ChunkZ);
+	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_8_0, a_ChunkX, a_ChunkZ, {});
 
 	cCSLock Lock(m_CSPacket);
 	SendData(ChunkData.data(), ChunkData.size());

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -351,7 +351,7 @@ void cProtocol_1_9_0::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerial
 
 	// Serialize first, before creating the Packetizer (the packetizer locks a CS)
 	// This contains the flags and bitmasks, too
-	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_0, a_ChunkX, a_ChunkZ);
+	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_0, a_ChunkX, a_ChunkZ, {});
 
 	cCSLock Lock(m_CSPacket);
 	SendData(ChunkData.data(), ChunkData.size());
@@ -4513,7 +4513,7 @@ void cProtocol_1_9_4::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerial
 
 	// Serialize first, before creating the Packetizer (the packetizer locks a CS)
 	// This contains the flags and bitmasks, too
-	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_4, a_ChunkX, a_ChunkZ);
+	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_9_4, a_ChunkX, a_ChunkZ, {});
 
 	cCSLock Lock(m_CSPacket);
 	SendData(ChunkData.data(), ChunkData.size());

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -39,6 +39,7 @@
 #include "OverridesSettingsRepository.h"
 #include "Logger.h"
 #include "ClientHandle.h"
+#include "BlockTypePalette.h"
 
 
 
@@ -191,6 +192,24 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 
 	// cClientHandle::FASTBREAK_PERCENTAGE = settingsRepo->GetValueSetI("AntiCheat", "FastBreakPercentage", 97) / 100.0f;
 	cClientHandle::FASTBREAK_PERCENTAGE = 0;  // AntiCheat disabled due to bugs. We will enabled it once they are fixed. See #3506.
+
+	// Load the UpgradeBlockTypePalette:
+	LOG("Loading UpgradeBlockTypePalette...");
+	try
+	{
+		auto paletteStr = cFile::ReadWholeFile("Protocol/UpgradeBlockTypePalette.txt");
+		if (paletteStr.empty())
+		{
+			throw std::runtime_error("File is empty");
+		}
+		m_UpgradeBlockTypePalette.reset(new BlockTypePalette);
+		m_UpgradeBlockTypePalette->loadFromString(paletteStr);
+	}
+	catch (const std::exception & exc)
+	{
+		LOGERROR("Failed to load the Upgrade block type palette from Protocol/UpgradeBlockTypePalette.txt: %s\nAborting", exc.what());
+		throw;
+	}
 
 	m_MojangAPI = new cMojangAPI;
 	bool ShouldAuthenticate = settingsRepo->GetValueSetB("Authentication", "Authenticate", true);

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -40,6 +40,7 @@
 #include "Logger.h"
 #include "ClientHandle.h"
 #include "BlockTypePalette.h"
+#include "Protocol/ProtocolPalettes.h"
 
 
 
@@ -193,23 +194,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> a_OverridesRepo)
 	// cClientHandle::FASTBREAK_PERCENTAGE = settingsRepo->GetValueSetI("AntiCheat", "FastBreakPercentage", 97) / 100.0f;
 	cClientHandle::FASTBREAK_PERCENTAGE = 0;  // AntiCheat disabled due to bugs. We will enabled it once they are fixed. See #3506.
 
-	// Load the UpgradeBlockTypePalette:
-	LOG("Loading UpgradeBlockTypePalette...");
-	try
-	{
-		auto paletteStr = cFile::ReadWholeFile("Protocol/UpgradeBlockTypePalette.txt");
-		if (paletteStr.empty())
-		{
-			throw std::runtime_error("File is empty");
-		}
-		m_UpgradeBlockTypePalette.reset(new BlockTypePalette);
-		m_UpgradeBlockTypePalette->loadFromString(paletteStr);
-	}
-	catch (const std::exception & exc)
-	{
-		LOGERROR("Failed to load the Upgrade block type palette from Protocol/UpgradeBlockTypePalette.txt: %s\nAborting", exc.what());
-		throw;
-	}
+	LoadPalettes(settingsRepo->GetValueSet("Folders", "ProtocolPalettes", "Protocol"));
 
 	m_MojangAPI = new cMojangAPI;
 	bool ShouldAuthenticate = settingsRepo->GetValueSetB("Authentication", "Authenticate", true);
@@ -410,6 +395,48 @@ void cRoot::StopServer()
 void cRoot::LoadGlobalSettings()
 {
 	// Nothing needed yet
+}
+
+
+
+
+
+void cRoot::LoadPalettes(const AString & aProtocolFolder)
+{
+	LOG("Loading UpgradeBlockTypePalette...");
+	try
+	{
+		auto paletteStr = cFile::ReadWholeFile(aProtocolFolder + cFile::PathSeparator() + "UpgradeBlockTypePalette.txt");
+		if (paletteStr.empty())
+		{
+			throw std::runtime_error("File is empty");
+		}
+		m_UpgradeBlockTypePalette.reset(new BlockTypePalette);
+		m_UpgradeBlockTypePalette->loadFromString(paletteStr);
+	}
+	catch (const std::exception & exc)
+	{
+		LOGERROR("Failed to load the Upgrade block type palette from %s/UpgradeBlockTypePalette.txt: %s\nAborting",
+			aProtocolFolder, exc.what()
+		);
+		throw;
+	}
+
+	// Note: This can take a lot of time in MSVC debug builds
+	// If impatient, edit the settings.ini: [Folders] ProtocolPalettes=DummyDir; copy only one palette to DummyDir
+	LOG("Loading per-protocol palettes...");
+	m_ProtocolPalettes.reset(new ProtocolPalettes);
+	m_ProtocolPalettes->load(aProtocolFolder);
+	auto versions = m_ProtocolPalettes->protocolVersions();
+	if (versions.empty())
+	{
+		LOGWARNING("No per-protocol palettes were loaded");
+	}
+	else
+	{
+		std::sort(versions.begin(), versions.end());
+		LOG("Loaded palettes for protocol versions: %s", StringJoin(versions, ", "));
+	}
 }
 
 

--- a/src/Root.h
+++ b/src/Root.h
@@ -28,6 +28,7 @@ class cCompositeChat;
 class cSettingsRepositoryInterface;
 class cDeadlockDetect;
 class cUUID;
+class BlockTypePalette;
 
 using cPlayerListCallback =  cFunctionRef<bool(cPlayer &)>;
 using cWorldListCallback  =  cFunctionRef<bool(cWorld  &)>;
@@ -91,6 +92,9 @@ public:
 
 	/** Returns the (read-write) storage for registered block types. */
 	BlockTypeRegistry & GetBlockTypeRegistry() { return m_BlockTypeRegistry; }
+
+	/** Returns the block type palette used for upgrading blocks from pre-1.13 data. */
+	const BlockTypePalette & GetUpgradeBlockTypePalette() const { return *m_UpgradeBlockTypePalette; }
 
 	/** Returns the number of ticks for how long the item would fuel a furnace. Returns zero if not a fuel */
 	static int GetFurnaceFuelBurnTime(const cItem & a_Fuel);  // tolua_export
@@ -233,6 +237,9 @@ private:
 
 	/** The storage for all registered block types. */
 	BlockTypeRegistry m_BlockTypeRegistry;
+
+	/** The upgrade palette for pre-1.13 blocks. */
+	std::unique_ptr<BlockTypePalette> m_UpgradeBlockTypePalette;
 
 
 	void LoadGlobalSettings();

--- a/src/Root.h
+++ b/src/Root.h
@@ -29,6 +29,7 @@ class cSettingsRepositoryInterface;
 class cDeadlockDetect;
 class cUUID;
 class BlockTypePalette;
+class ProtocolPalettes;
 
 using cPlayerListCallback =  cFunctionRef<bool(cPlayer &)>;
 using cWorldListCallback  =  cFunctionRef<bool(cWorld  &)>;
@@ -95,6 +96,9 @@ public:
 
 	/** Returns the block type palette used for upgrading blocks from pre-1.13 data. */
 	const BlockTypePalette & GetUpgradeBlockTypePalette() const { return *m_UpgradeBlockTypePalette; }
+
+	/** Returns the per-protocol palettes manager. */
+	ProtocolPalettes & GetProtocolPalettes() const { return *m_ProtocolPalettes; }
 
 	/** Returns the number of ticks for how long the item would fuel a furnace. Returns zero if not a fuel */
 	static int GetFurnaceFuelBurnTime(const cItem & a_Fuel);  // tolua_export
@@ -241,8 +245,15 @@ private:
 	/** The upgrade palette for pre-1.13 blocks. */
 	std::unique_ptr<BlockTypePalette> m_UpgradeBlockTypePalette;
 
+	/** The per-protocol palettes manager. */
+	std::unique_ptr<ProtocolPalettes> m_ProtocolPalettes;
+
 
 	void LoadGlobalSettings();
+
+	/** Loads the upgrade palette and the per-protocol palettes.
+	The aProtocolFolder is the path to the folder containing the per-protocol palettes. */
+	void LoadPalettes(const AString & aProtocolFolder);
 
 	/** Loads the worlds from settings.ini, creates the worldmap */
 	void LoadWorlds(cDeadlockDetect & a_dd, cSettingsRepositoryInterface & a_Settings, bool a_IsNewIniFile);

--- a/src/StringUtils.h
+++ b/src/StringUtils.h
@@ -142,7 +142,8 @@ The order of items doesn't change, only the duplicates are removed.
 If a_Strings1 contains duplicates, the result will still contain those duplicates. */
 extern AStringVector MergeStringVectors(const AStringVector & a_Strings1, const AStringVector & a_Strings2);
 
-/** Concatenates the specified strings into a single string, separated by the specified separator. */
+/** Concatenates the specified strings into a single string, separated by the specified separator character.
+Use StringJoin() if you need multiple separator characters. */
 extern AString StringsConcat(const AStringVector & a_Strings, char a_Separator);
 
 /** Converts a string into a float. Returns false if the conversion fails. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -235,16 +235,19 @@ static void UniversalMain(std::unique_ptr<cSettingsRepositoryInterface> a_Overri
 		cRoot Root;
 		Root.Start(std::move(a_OverridesRepo));
 	}
-	catch (fmt::FormatError & f)
+	catch (const fmt::FormatError & exc)
 	{
-		FLOGERROR("Formatting exception: {0}", f.what());
+		cRoot::m_TerminateEventRaised = true;
+		FLOGERROR("Formatting exception: {0}", exc.what());
 	}
-	catch (std::exception & e)
+	catch (const std::exception & exc)
 	{
-		LOGERROR("Standard exception: %s", e.what());
+		cRoot::m_TerminateEventRaised = true;
+		LOGERROR("Standard exception: %s", exc.what());
 	}
 	catch (...)
 	{
+		cRoot::m_TerminateEventRaised = true;
 		LOGERROR("Unknown exception!");
 	}
 


### PR DESCRIPTION
Implemented temporary block type mapping for 1.13+ clients, using the UpgradeBlockTypePalette and per-protocol BlockTypePalettes.

This allows 1.13+ clients to connect and see most of the terrain in proper block types, as long as the UpgradeBlockTypePalette is correct (it's very bad at this time):
![image](https://user-images.githubusercontent.com/4388386/71735725-7517a780-2e4f-11ea-82ed-b4e1af320c54.png)
