### PR TITLE
Strip debug symbols from Android builds

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(SYSTEM
 )
 
 # Disable some compiler warnings (the lazy way out)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-double-promotion -Wno-sign-conversion")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-double-promotion -Wno-sign-conversion -Wno-unused-command-line-argument -s")
 
 # Build the rest of the server
 add_subdirectory(../ Cuberite)


### PR DESCRIPTION
The Android binaries are currently massive (100MB each), compared to 10MB in 2018.

If someone has a better solution/knows what's going on, let me know.