### PR TITLE
Faster palette load

### DIFF
--- a/src/BlockTypePalette.h
+++ b/src/BlockTypePalette.h
@@ -126,11 +126,10 @@ protected:
 	void loadFromJsonString(const AString & aJsonPalette);
 
 	/** Loads the palette from the regular or upgrade TSV representation.
-	aIsUpgrade specifies whether the format is an upgrade TSV (true) or a regular one (false)
 	Throws a LoadFailedException if the loading fails hard (bad string format);
 	but still a part of the data may already be loaded at that point.
 	See also: loadFromString(). */
-	void loadFromTsv(const AString & aTsvPalette, bool aIsUpgrade);
+	void loadFromTsv(const AString & aTsvPalette);
 
 	/** Adds a mapping between the numeric and stringular representation into both maps,
 	updates the mMaxIndex, if appropriate.


### PR DESCRIPTION
This improves the loading speed of the `BlockTypePalette` TSV loader by about 30%.

MSVC debug builds take a lot of time to load a single protocol's palette (2.5 seconds on my machine), most of which is caused by `std::map` memory allocations from the debug pool. This change improves the load time to 1.7 seconds, still too much, but much better.
MSVC Release builds, as well as any Linux build, load the same palette really fast (0.03 seconds), so this is purely for better debugging experience.

~Note that this PR is built on top of #4450, I'll rebase it once that gets merged.~ done

Fixes (partially) #4453.