### PR TITLE
BlockTypePalette: Improved loading speed in MSVC Debug builds.

### DIFF
--- a/tests/BlockTypeRegistry/BlockTypePaletteTest.cpp
+++ b/tests/BlockTypeRegistry/BlockTypePaletteTest.cpp
@@ -229,8 +229,8 @@ static void testLoadTsvRegular(void)
 	auto str = "\
 BlockTypePalette\r\n\
 FileVersion\t1\n\
-CommonPrefix\tminecraft:\r\n\
-\n\
+CommonPrefix\tminecraft:\n\
+\r\n\
 0\tair\r\n\
 1\tstone\n\
 2\tgrass\tsnow_covered\t0\n\


### PR DESCRIPTION
#4455 alternative, not using state machine, but searching for separators instead. The load time is slightly worse than the state machine's (1.8 sec here vs 1.7 sec with state machine), but still much better than before.

@peterbell10 Please choose which one you like better.