### PR TITLE
Prevent container item duplication

### DIFF
--- a/src/BlockEntities/BlockEntityWithItems.cpp
+++ b/src/BlockEntities/BlockEntityWithItems.cpp
@@ -26,20 +26,6 @@ cBlockEntityWithItems::cBlockEntityWithItems(
 
 
 
-void cBlockEntityWithItems::Destroy(void)
-{
-	// Drop the contents as pickups:
-	ASSERT(m_World != nullptr);
-	cItems Pickups;
-	m_Contents.CopyToItems(Pickups);
-	m_Contents.Clear();
-	m_World->SpawnItemPickups(Pickups, m_Pos.x + 0.5, m_Pos.y + 0.5, m_Pos.z + 0.5);  // Spawn in centre of block
-}
-
-
-
-
-
 void cBlockEntityWithItems::CopyFrom(const cBlockEntity & a_Src)
 {
 	super::CopyFrom(a_Src);

--- a/src/BlockEntities/BlockEntityWithItems.h
+++ b/src/BlockEntities/BlockEntityWithItems.h
@@ -44,7 +44,6 @@ public:  // tolua_export
 	);
 
 	// cBlockEntity overrides:
-	virtual void Destroy(void) override;
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 
 	// tolua_begin

--- a/src/Blocks/BlockEntity.h
+++ b/src/Blocks/BlockEntity.h
@@ -68,6 +68,13 @@ public:
 	{
 		// Reset meta to 0
 		cItems res(cItem(Base::m_BlockType, 1, 0));
+
+		// Drop the contents:
+		if (a_BlockEntity != nullptr)
+		{
+			auto container = static_cast<cBlockEntityWithItems *>(a_BlockEntity);
+			res.AddItemGrid(container->GetContents());
+		}
 		return res;
 	}
 };

--- a/src/Blocks/BlockEntity.h
+++ b/src/Blocks/BlockEntity.h
@@ -48,7 +48,7 @@ public:
 
 
 /** Wrapper for blocks that have a cBlockEntityWithItems descendant attached to them.
-When converting to pickups, drops self with meta reset to zero, and adds the container contents. */
+When converting to pickups, drops self with meta reset to zero. */
 template <typename Base = cBlockEntityHandler>
 class cContainerEntityHandler:
 	public Base
@@ -68,13 +68,6 @@ public:
 	{
 		// Reset meta to 0
 		cItems res(cItem(Base::m_BlockType, 1, 0));
-
-		// Drop the contents:
-		if (a_BlockEntity != nullptr)
-		{
-			auto container = static_cast<cBlockEntityWithItems *>(a_BlockEntity);
-			res.AddItemGrid(container->GetContents());
-		}
 		return res;
 	}
 };

--- a/src/Blocks/BlockEntity.h
+++ b/src/Blocks/BlockEntity.h
@@ -48,7 +48,7 @@ public:
 
 
 /** Wrapper for blocks that have a cBlockEntityWithItems descendant attached to them.
-When converting to pickups, drops self with meta reset to zero. */
+When converting to pickups, drops self with meta reset to zero, and adds the container contents. */
 template <typename Base = cBlockEntityHandler>
 class cContainerEntityHandler:
 	public Base


### PR DESCRIPTION
Regression in #4417

I'm not sure what the original intention was, but this PR prevents container items (in chests, hoppers etc) from duplicating when breaking the container block.