### PR TITLE
Explosions move primed TNT and blocks

### DIFF
--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1315,7 +1315,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 				EntityExposure = EntityExposure * (1.0f - a_Entity.GetEnchantmentBlastKnockbackReduction());
 
 				double Impact = (1 - ((Length / ExplosionSizeInt) / 2)) * EntityExposure;
-				
+
 				if (a_Entity.IsTNT() || a_Entity.IsFallingBlock())
 				{
 					// Larger impact for primed TNT and falling blocks, to make them move

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1315,6 +1315,12 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 				EntityExposure = EntityExposure * (1.0f - a_Entity.GetEnchantmentBlastKnockbackReduction());
 
 				double Impact = (1 - ((Length / ExplosionSizeInt) / 2)) * EntityExposure;
+				
+				if (a_Entity.IsTNT() || a_Entity.IsFallingBlock())
+				{
+					// Larger impact for primed TNT and falling blocks, to make them move
+					Impact = ExplosionSizeInt * ExplosionSizeInt;
+				}
 
 				DistanceFromExplosion.Normalize();
 				DistanceFromExplosion *= Impact;


### PR DESCRIPTION
https://github.com/cuberite/cuberite/pull/4251 improved explosion knockback for players, but broke knockback for primed TNT and falling blocks in the process. Currently, primed TNT and falling blocks are "glued" to their spawn positions. This PR brings back behavior prior to https://github.com/cuberite/cuberite/pull/4251 for these cases.