### PR TITLE
Fix invisible player issue when changing worlds

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -158,9 +158,6 @@ bool cEntity::Initialize(OwnedEntity a_Self, cWorld & a_EntityWorld)
 
 	cPluginManager::Get()->CallHookSpawnedEntity(a_EntityWorld, *this);
 
-	// Spawn the entity on the clients:
-	a_EntityWorld.BroadcastSpawnEntity(*this);
-
 	// If has any mob leashed broadcast every leashed entity to this
 	if (HasAnyMobLeashed())
 	{

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2069,9 +2069,6 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 			}
 		}
 
-		// Broadcast the player into the new world.
-		a_World->BroadcastSpawnEntity(*this);
-
 		// Queue add to new world and removal from the old one
 
 		// Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value
@@ -2086,6 +2083,9 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 		// New world will take over and announce client at its next tick
 		auto PlayerPtr = static_cast<cPlayer *>(ParentChunk->RemoveEntity(*this).release());
 		a_World->AddPlayer(std::unique_ptr<cPlayer>(PlayerPtr), &a_OldWorld);
+
+		// Broadcast the player into the new world.
+		a_World->BroadcastSpawnEntity(*this);
 	});
 
 	return true;

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -193,9 +193,6 @@ bool cPlayer::Initialize(OwnedEntity a_Self, cWorld & a_World)
 
 	cPluginManager::Get()->CallHookSpawnedEntity(*GetWorld(), *this);
 
-	// Spawn the entity on the clients:
-	GetWorld()->BroadcastSpawnEntity(*this);
-
 	return true;
 }
 
@@ -2069,6 +2066,9 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 			}
 		}
 
+		// Broadcast the player into the new world.
+		//a_World->BroadcastSpawnEntity(*this);
+
 		// Queue add to new world and removal from the old one
 
 		// Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value
@@ -2083,9 +2083,6 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 		// New world will take over and announce client at its next tick
 		auto PlayerPtr = static_cast<cPlayer *>(ParentChunk->RemoveEntity(*this).release());
 		a_World->AddPlayer(std::unique_ptr<cPlayer>(PlayerPtr), &a_OldWorld);
-
-		// Broadcast the player into the new world.
-		a_World->BroadcastSpawnEntity(*this);
 	});
 
 	return true;

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2066,9 +2066,6 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 			}
 		}
 
-		// Broadcast the player into the new world.
-		//a_World->BroadcastSpawnEntity(*this);
-
 		// Queue add to new world and removal from the old one
 
 		// Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2066,8 +2066,6 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 			}
 		}
 
-		// Queue add to new world and removal from the old one
-
 		// Chunks may be streamed before cWorld::AddPlayer() sets the world to the new value
 		cChunk * ParentChunk = this->GetParentChunk();
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1026,6 +1026,7 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 		m_ChunkMap->AddEntity(std::move(Entity));
 		ASSERT(!EntityPtr->IsTicking());
 		EntityPtr->SetIsTicking(true);
+		BroadcastSpawnEntity(*(static_cast <cEntity *>(EntityPtr)));
 	}
 	EntitiesToAdd.clear();
 
@@ -3506,6 +3507,7 @@ void cWorld::AddQueuedPlayers(void)
 			Client->SendHealth();
 			Client->SendWholeInventory(*Player->GetWindow());
 		}
+		BroadcastSpawnEntity(*(static_cast <cEntity *>(Player)));
 	}  // for itr - PlayersToAdd[]
 
 	// Call EntityChangedWorld callback on all eligible clients


### PR DESCRIPTION
Don't broadcast a player into the new world too early, otherwise the player's position will be wrong client side for others in the world (sometimes the player can be hundreds of blocks away from their real position, "invisible").

Also fixes an issue where non-player entities sent through a portal would not spawn client-side for players in the portal world (invisible mob).

Partially fixes() #4049
Should fix() #4082
Potentially fixes() #3696, but we will have to see