### PR TITLE
Attached entities can't enter portals

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1534,7 +1534,7 @@ void cEntity::DoMoveToWorld(const sWorldChangeInfo & a_WorldChangeInfo)
 		m_World->GetName(), a_WorldChangeInfo.m_NewWorld->GetName(),
 		GetChunkX(), GetChunkZ()
 	);
-  
+
 	// If entity is attached to another entity, detach, to prevent client side effects
 	Detach();
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1368,6 +1368,12 @@ bool cEntity::DetectPortal()
 					return false;
 				}
 
+				if ((m_AttachedTo != nullptr) || (m_Attachee != nullptr))
+				{
+					// Don't let attached entities change worlds, like players riding a minecart
+					return false;
+				}
+
 				if (IsPlayer() && !(static_cast<cPlayer *>(this))->IsGameModeCreative() && (m_PortalCooldownData.m_TicksDelayed != 80))
 				{
 					// Delay teleportation for four seconds if the entity is a non-creative player
@@ -1441,6 +1447,12 @@ bool cEntity::DetectPortal()
 			{
 				if (m_PortalCooldownData.m_ShouldPreventTeleportation)
 				{
+					return false;
+				}
+
+				if ((m_AttachedTo != nullptr) || (m_Attachee != nullptr))
+				{
+					// Don't let attached entities change worlds, like players riding a minecart
 					return false;
 				}
 
@@ -1536,6 +1548,9 @@ bool cEntity::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 		// A Plugin doesn't allow the entity to changing the world
 		return false;
 	}
+
+	// If entity is attached to another entity, detach, to prevent client side effects
+	Detach();
 
 	// Stop ticking, in preperation for detaching from this world.
 	SetIsTicking(false);

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2026,6 +2026,9 @@ bool cPlayer::DoMoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d
 		// The clienthandle caches the coords of the chunk we're standing at. Invalidate this.
 		GetClientHandle()->InvalidateCachedSentChunk();
 
+		// If player is attached to entity, detach, to prevent client side effects
+		Detach();
+
 		// Prevent further ticking in this world
 		SetIsTicking(false);
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2028,7 +2028,7 @@ void cPlayer::DoMoveToWorld(const cEntity::sWorldChangeInfo & a_WorldChangeInfo)
 
 	// Stop all mobs from targeting this player
 	StopEveryoneFromTargetingMe();
-	
+
 	// If player is attached to entity, detach, to prevent client side effects
 	Detach();
 


### PR DESCRIPTION
Prevents attached entities from entering portals, like in vanilla.
Detaches entities when calling MoveToWorld, which prevents client side effects, such as not being able to break blocks.