### PR TITLE
Revert "Protocol Spawn Position Should Use LastSentPosition"

### DIFF
--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -309,10 +309,6 @@ public:
 	/** Exported in ManualBindings */
 	const Vector3d & GetSpeed(void) const { return m_Speed; }
 
-	/** Returns the last position we sent to all the clients. Use this to
-	initialize clients with our position. */
-	Vector3d GetLastSentPos(void) const { return m_LastSentPosition; }
-
 	/** Destroy the entity without scheduling memory freeing. This should only be used by cChunk or cClientHandle for internal memory management. */
 	void DestroyNoScheduling(bool a_ShouldBroadcast);
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1089,10 +1089,9 @@ void cProtocol_1_8_0::SendPlayerSpawn(const cPlayer & a_Player)
 	cPacketizer Pkt(*this, pktSpawnOtherPlayer);
 	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 	Pkt.WriteUUID(a_Player.GetUUID());
-	Vector3d LastSentPos = a_Player.GetLastSentPos();
-	Pkt.WriteFPInt(LastSentPos.x);
-	Pkt.WriteFPInt(LastSentPos.y + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
-	Pkt.WriteFPInt(LastSentPos.z);
+	Pkt.WriteFPInt(a_Player.GetPosX());
+	Pkt.WriteFPInt(a_Player.GetPosY() + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
+	Pkt.WriteFPInt(a_Player.GetPosZ());
 	Pkt.WriteByteAngle(a_Player.GetYaw());
 	Pkt.WriteByteAngle(a_Player.GetPitch());
 	short ItemType = a_Player.GetEquippedItem().IsEmpty() ? 0 : a_Player.GetEquippedItem().m_ItemType;
@@ -1325,10 +1324,9 @@ void cProtocol_1_8_0::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock
 	cPacketizer Pkt(*this, pktSpawnObject);
 	Pkt.WriteVarInt32(a_FallingBlock.GetUniqueID());
 	Pkt.WriteBEUInt8(70);  // Falling block
-	Vector3d LastSentPos = a_FallingBlock.GetLastSentPos();
-	Pkt.WriteFPInt(LastSentPos.x);
-	Pkt.WriteFPInt(LastSentPos.y);
-	Pkt.WriteFPInt(LastSentPos.z);
+	Pkt.WriteFPInt(a_FallingBlock.GetPosX());
+	Pkt.WriteFPInt(a_FallingBlock.GetPosY());
+	Pkt.WriteFPInt(a_FallingBlock.GetPosZ());
 	Pkt.WriteByteAngle(a_FallingBlock.GetYaw());
 	Pkt.WriteByteAngle(a_FallingBlock.GetPitch());
 	Pkt.WriteBEInt32(static_cast<Int32>(a_FallingBlock.GetBlockType()) | (static_cast<Int32>(a_FallingBlock.GetBlockMeta()) << 12));
@@ -1348,10 +1346,9 @@ void cProtocol_1_8_0::SendSpawnMob(const cMonster & a_Mob)
 	cPacketizer Pkt(*this, pktSpawnMob);
 	Pkt.WriteVarInt32(a_Mob.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<Byte>(a_Mob.GetMobType()));
-	Vector3d LastSentPos = a_Mob.GetLastSentPos();
-	Pkt.WriteFPInt(LastSentPos.x);
-	Pkt.WriteFPInt(LastSentPos.y);
-	Pkt.WriteFPInt(LastSentPos.z);
+	Pkt.WriteFPInt(a_Mob.GetPosX());
+	Pkt.WriteFPInt(a_Mob.GetPosY());
+	Pkt.WriteFPInt(a_Mob.GetPosZ());
 	Pkt.WriteByteAngle(a_Mob.GetPitch());
 	Pkt.WriteByteAngle(a_Mob.GetHeadYaw());
 	Pkt.WriteByteAngle(a_Mob.GetYaw());
@@ -1405,10 +1402,9 @@ void cProtocol_1_8_0::SendSpawnVehicle(const cEntity & a_Vehicle, char a_Vehicle
 	cPacketizer Pkt(*this, pktSpawnObject);
 	Pkt.WriteVarInt32(a_Vehicle.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_VehicleType));
-	Vector3d LastSentPos = a_Vehicle.GetLastSentPos();
-	Pkt.WriteFPInt(LastSentPos.x);
-	Pkt.WriteFPInt(LastSentPos.y);
-	Pkt.WriteFPInt(LastSentPos.z);
+	Pkt.WriteFPInt(a_Vehicle.GetPosX());
+	Pkt.WriteFPInt(a_Vehicle.GetPosY());
+	Pkt.WriteFPInt(a_Vehicle.GetPosZ());
 	Pkt.WriteByteAngle(a_Vehicle.GetPitch());
 	Pkt.WriteByteAngle(a_Vehicle.GetYaw());
 	Pkt.WriteBEInt32(a_VehicleSubType);

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -1180,10 +1180,9 @@ void cProtocol_1_9_0::SendPlayerSpawn(const cPlayer & a_Player)
 	cPacketizer Pkt(*this, pktSpawnOtherPlayer);
 	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 	Pkt.WriteUUID(a_Player.GetUUID());
-	Vector3d LastSentPos = a_Player.GetLastSentPos();
-	Pkt.WriteBEDouble(LastSentPos.x);
-	Pkt.WriteBEDouble(LastSentPos.y + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
-	Pkt.WriteBEDouble(LastSentPos.z);
+	Pkt.WriteBEDouble(a_Player.GetPosX());
+	Pkt.WriteBEDouble(a_Player.GetPosY() + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
+	Pkt.WriteBEDouble(a_Player.GetPosZ());
 	Pkt.WriteByteAngle(a_Player.GetYaw());
 	Pkt.WriteByteAngle(a_Player.GetPitch());
 	WriteEntityMetadata(Pkt, a_Player);
@@ -1383,10 +1382,9 @@ void cProtocol_1_9_0::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock
 	Pkt.WriteBEUInt64(0);
 	Pkt.WriteBEUInt64(a_FallingBlock.GetUniqueID());
 	Pkt.WriteBEUInt8(70);  // Falling block
-	Vector3d LastSentPos = a_FallingBlock.GetLastSentPos();
-	Pkt.WriteBEDouble(LastSentPos.x);
-	Pkt.WriteBEDouble(LastSentPos.y);
-	Pkt.WriteBEDouble(LastSentPos.z);
+	Pkt.WriteBEDouble(a_FallingBlock.GetPosX());
+	Pkt.WriteBEDouble(a_FallingBlock.GetPosY());
+	Pkt.WriteBEDouble(a_FallingBlock.GetPosZ());
 	Pkt.WriteByteAngle(a_FallingBlock.GetYaw());
 	Pkt.WriteByteAngle(a_FallingBlock.GetPitch());
 	Pkt.WriteBEInt32(static_cast<Int32>(a_FallingBlock.GetBlockType()) | (static_cast<Int32>(a_FallingBlock.GetBlockMeta()) << 12));
@@ -1409,10 +1407,9 @@ void cProtocol_1_9_0::SendSpawnMob(const cMonster & a_Mob)
 	Pkt.WriteBEUInt64(0);
 	Pkt.WriteBEUInt64(a_Mob.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<Byte>(a_Mob.GetMobType()));
-	Vector3d LastSentPos = a_Mob.GetLastSentPos();
-	Pkt.WriteBEDouble(LastSentPos.x);
-	Pkt.WriteBEDouble(LastSentPos.y);
-	Pkt.WriteBEDouble(LastSentPos.z);
+	Pkt.WriteBEDouble(a_Mob.GetPosX());
+	Pkt.WriteBEDouble(a_Mob.GetPosY());
+	Pkt.WriteBEDouble(a_Mob.GetPosZ());
 	Pkt.WriteByteAngle(a_Mob.GetPitch());
 	Pkt.WriteByteAngle(a_Mob.GetHeadYaw());
 	Pkt.WriteByteAngle(a_Mob.GetYaw());
@@ -1469,10 +1466,9 @@ void cProtocol_1_9_0::SendSpawnVehicle(const cEntity & a_Vehicle, char a_Vehicle
 	Pkt.WriteBEUInt64(0);
 	Pkt.WriteBEUInt64(a_Vehicle.GetUniqueID());
 	Pkt.WriteBEUInt8(static_cast<UInt8>(a_VehicleType));
-	Vector3d LastSentPos = a_Vehicle.GetLastSentPos();
-	Pkt.WriteBEDouble(LastSentPos.x);
-	Pkt.WriteBEDouble(LastSentPos.y);
-	Pkt.WriteBEDouble(LastSentPos.z);
+	Pkt.WriteBEDouble(a_Vehicle.GetPosX());
+	Pkt.WriteBEDouble(a_Vehicle.GetPosY());
+	Pkt.WriteBEDouble(a_Vehicle.GetPosZ());
 	Pkt.WriteByteAngle(a_Vehicle.GetPitch());
 	Pkt.WriteByteAngle(a_Vehicle.GetYaw());
 	Pkt.WriteBEInt32(a_VehicleSubType);


### PR DESCRIPTION
Reverts cuberite/cuberite#3929

These change cause way more issues than they tried to solve, such as players and boats being "invisible" to others due to being too far away from their server position client-side. The original issue the PR tried to solve should be re-investigated.

Fixes #4082 
Fixes #4049 

Complements #4480