### PR TITLE
Disable ticking if player leaves the server

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -213,6 +213,7 @@ cPlayer::~cPlayer(void)
 	SaveToDisk();
 
 	m_ClientHandle = nullptr;
+	SetIsTicking(false);
 
 	delete m_InventoryWindow;
 	m_InventoryWindow = nullptr;


### PR DESCRIPTION
This fixes an assertion error.
I guess something like that happens:
1) Chunk is removed
2) Destructor of player class is called
3) Destructor of entity class is called, that checks if the entity is still being ticked
4) m_IsTicking is true and server crashes
https://github.com/cuberite/cuberite/blob/5a2163d7e6ffa0c5c568be41257fb726d452b3b9/src/Entities/Entity.cpp#L86
