### PR TITLE
Remove leading slash from command block commands

### DIFF
--- a/src/BlockEntities/CommandBlockEntity.cpp
+++ b/src/BlockEntities/CommandBlockEntity.cpp
@@ -163,6 +163,11 @@ void cCommandBlockEntity::Execute()
 		return;
 	}
 
+	if (m_Command.empty())
+	{
+		return;
+	}
+
 	class CommandBlockOutCb :
 		public cCommandOutputCallback
 	{
@@ -175,27 +180,29 @@ void cCommandBlockEntity::Execute()
 		{
 			// Overwrite field
 			m_CmdBlock->SetLastOutput(cClientHandle::FormatChatPrefix(m_CmdBlock->GetWorld()->ShouldUseChatPrefixes(), "SUCCESS", cChatColor::Green, cChatColor::White) + a_Text);
+			m_CmdBlock->GetWorld()->BroadcastBlockEntity(m_CmdBlock->GetPos());
 		}
 	} CmdBlockOutCb(this);
 
+	AString RealCommand = m_Command;
+
 	// Remove trailing slash if it exists, since console commands don't use them
-	if (m_Command[0] == '/')
-	{
-		m_Command = m_Command.substr(1, m_Command.length());
+	if (RealCommand[0] == '/') {
+		RealCommand = RealCommand.substr(1, RealCommand.length());
 	}
 
 	// Administrator commands are not executable by command blocks:
 	if (
-		(m_Command != "stop") &&
-		(m_Command != "restart") &&
-		(m_Command != "kick") &&
-		(m_Command != "ban") &&
-		(m_Command != "ipban")
+		(RealCommand != "stop") &&
+		(RealCommand != "restart") &&
+		(RealCommand != "kick") &&
+		(RealCommand != "ban") &&
+		(RealCommand != "ipban")
 	)
 	{
 		cServer * Server = cRoot::Get()->GetServer();
 		LOGD("cCommandBlockEntity: Executing command %s", m_Command.c_str());
-		Server->ExecuteConsoleCommand(m_Command, CmdBlockOutCb);
+		Server->ExecuteConsoleCommand(RealCommand, CmdBlockOutCb);
 	}
 	else
 	{

--- a/src/BlockEntities/CommandBlockEntity.cpp
+++ b/src/BlockEntities/CommandBlockEntity.cpp
@@ -178,6 +178,12 @@ void cCommandBlockEntity::Execute()
 		}
 	} CmdBlockOutCb(this);
 
+	// Remove trailing slash if it exists, since console commands don't use them
+	if (m_Command[0] == '/')
+	{
+		m_Command = m_Command.substr(1, m_Command.length());
+	}
+
 	// Administrator commands are not executable by command blocks:
 	if (
 		(m_Command != "stop") &&

--- a/src/BlockEntities/CommandBlockEntity.cpp
+++ b/src/BlockEntities/CommandBlockEntity.cpp
@@ -186,7 +186,7 @@ void cCommandBlockEntity::Execute()
 
 	AString RealCommand = m_Command;
 
-	// Remove trailing slash if it exists, since console commands don't use them
+	// Remove leading slash if it exists, since console commands don't use them
 	if (RealCommand[0] == '/')
 	{
 		RealCommand = RealCommand.substr(1, RealCommand.length());


### PR DESCRIPTION
Vanilla allows you to include the slash.