### PR TITLE
Improvements to knockback

### DIFF
--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1319,7 +1319,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 				DistanceFromExplosion.Normalize();
 				DistanceFromExplosion *= Impact;
 
-				a_Entity.AddSpeed(DistanceFromExplosion);
+				a_Entity.SetSpeed(DistanceFromExplosion);
 			}
 
 			return false;

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -116,7 +116,7 @@ void cArrowEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos)
 	}
 
 	unsigned int PunchLevel = m_CreatorData.m_Enchantments.GetLevel(cEnchantments::enchPunch);
-	double KnockbackAmount = 11 + 10 * PunchLevel;
+	double KnockbackAmount = 10 + 8 * PunchLevel;
 	a_EntityHit.TakeDamage(dtRangedAttack, GetCreatorUniqueID(), Damage, KnockbackAmount);
 
 	if (IsOnFire() && !a_EntityHit.IsInWater())

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -118,7 +118,7 @@ void cArrowEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos)
 	double Knockback = 10;
 
 	unsigned int PunchLevel = m_CreatorData.m_Enchantments.GetLevel(cEnchantments::enchPunch);
-	int PunchLevelMultiplier = 8;
+	unsigned int PunchLevelMultiplier = 8;
 
 	Knockback += PunchLevelMultiplier * PunchLevel;
 	a_EntityHit.TakeDamage(dtRangedAttack, GetCreatorUniqueID(), Damage, Knockback);

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -115,9 +115,13 @@ void cArrowEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos)
 		Damage += ExtraDamage;
 	}
 
+	double Knockback = 10;
+
 	unsigned int PunchLevel = m_CreatorData.m_Enchantments.GetLevel(cEnchantments::enchPunch);
-	double KnockbackAmount = 10 + 8 * PunchLevel;
-	a_EntityHit.TakeDamage(dtRangedAttack, GetCreatorUniqueID(), Damage, KnockbackAmount);
+	int PunchLevelMultiplier = 8;
+
+	Knockback += PunchLevelMultiplier * PunchLevel;
+	a_EntityHit.TakeDamage(dtRangedAttack, GetCreatorUniqueID(), Damage, Knockback);
 
 	if (IsOnFire() && !a_EntityHit.IsInWater())
 	{

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -783,18 +783,12 @@ int cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_Dama
 double cEntity::GetKnockbackAmountAgainst(const cEntity & a_Receiver)
 {
 	// Default knockback for entities
-	double Knockback = 8;
+	double Knockback = 10;
 
 	// If we're sprinting, bump up the knockback
 	if (IsSprinting())
 	{
-		Knockback = 13;
-	}
-
-	// Apply more knockback for players
-	if (a_Receiver.IsPlayer())
-	{
-		Knockback += 2;
+		Knockback = 15;
 	}
 
 	// Check for knockback enchantments (punch only applies to shot arrows)

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -344,7 +344,17 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 		Heading = a_Attacker->GetLookVector();
 	}
 
-	TDI.Knockback = Heading * a_KnockbackAmount;
+	int KnockbackHeight = 3;
+	
+	if (IsPlayer())
+	{
+		KnockbackHeight = 8;
+	}
+	
+	// Apply slight height to knockback
+	Vector3d FinalKnockback = Vector3d(Heading.x * a_KnockbackAmount, Heading.y + KnockbackHeight, Heading.z * a_KnockbackAmount);
+
+	TDI.Knockback = FinalKnockback;
 	DoTakeDamage(TDI);
 }
 
@@ -535,7 +545,7 @@ bool cEntity::DoTakeDamage(TakeDamageInfo & a_TDI)
 	// Add knockback:
 	if ((IsMob() || IsPlayer()) && (a_TDI.Attacker != nullptr))
 	{
-		AddSpeed(a_TDI.Knockback);
+		SetSpeed(a_TDI.Knockback);
 	}
 
 	m_World->BroadcastEntityStatus(*this, esGenericHurt);
@@ -772,18 +782,24 @@ int cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_Dama
 
 double cEntity::GetKnockbackAmountAgainst(const cEntity & a_Receiver)
 {
-	// Returns the knockback amount that the currently equipped items would cause to a_Receiver on a hit
-	double Knockback = 11;
-
+	// Default knockback for entities
+	double Knockback = 8;
+	
 	// If we're sprinting, bump up the knockback
 	if (IsSprinting())
 	{
-		Knockback = 16;
+		Knockback = 13;
+	}
+
+	// Apply more knockback for players
+	if (a_Receiver.IsPlayer())
+	{
+		Knockback += 2;
 	}
 
 	// Check for knockback enchantments (punch only applies to shot arrows)
 	unsigned int KnockbackLevel = GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchKnockback);
-	Knockback += 10 * KnockbackLevel;
+	Knockback += 8 * KnockbackLevel;
 
 	return Knockback;
 }

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -345,12 +345,12 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 	}
 
 	int KnockbackHeight = 3;
-	
+
 	if (IsPlayer())
 	{
 		KnockbackHeight = 8;
 	}
-	
+
 	// Apply slight height to knockback
 	Vector3d FinalKnockback = Vector3d(Heading.x * a_KnockbackAmount, Heading.y + KnockbackHeight, Heading.z * a_KnockbackAmount);
 
@@ -784,7 +784,7 @@ double cEntity::GetKnockbackAmountAgainst(const cEntity & a_Receiver)
 {
 	// Default knockback for entities
 	double Knockback = 8;
-	
+
 	// If we're sprinting, bump up the knockback
 	if (IsSprinting())
 	{

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -793,7 +793,9 @@ double cEntity::GetKnockbackAmountAgainst(const cEntity & a_Receiver)
 
 	// Check for knockback enchantments (punch only applies to shot arrows)
 	unsigned int KnockbackLevel = GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchKnockback);
-	Knockback += 8 * KnockbackLevel;
+	int KnockbackLevelMultiplier = 8;
+
+	Knockback += KnockbackLevelMultiplier * KnockbackLevel;
 
 	return Knockback;
 }

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -793,7 +793,7 @@ double cEntity::GetKnockbackAmountAgainst(const cEntity & a_Receiver)
 
 	// Check for knockback enchantments (punch only applies to shot arrows)
 	unsigned int KnockbackLevel = GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchKnockback);
-	int KnockbackLevelMultiplier = 8;
+	unsigned int KnockbackLevelMultiplier = 8;
 
 	Knockback += KnockbackLevelMultiplier * KnockbackLevel;
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1000,10 +1000,6 @@ void cPlayer::ApplyArmorDamage(int a_DamageBlocked)
 
 bool cPlayer::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
-	SetSpeed(0, 0, 0);
-	// Prevents knocking the player in the wrong direction due to
-	// the speed vector problems, see #2865
-	// In the future, the speed vector should be fixed
 	if ((a_TDI.DamageType != dtInVoid) && (a_TDI.DamageType != dtPlugin))
 	{
 		if (IsGameModeCreative() || IsGameModeSpectator())

--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -102,7 +102,7 @@ bool cAggressiveMonster::Attack(std::chrono::milliseconds a_Dt)
 
 	// Setting this higher gives us more wiggle room for attackrate
 	ResetAttackCooldown();
-	
+
 	double KnockbackAmount = 9;
 	GetTarget()->TakeDamage(dtMobAttack, this, m_AttackDamage, KnockbackAmount);
 

--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -102,7 +102,9 @@ bool cAggressiveMonster::Attack(std::chrono::milliseconds a_Dt)
 
 	// Setting this higher gives us more wiggle room for attackrate
 	ResetAttackCooldown();
-	GetTarget()->TakeDamage(dtMobAttack, this, m_AttackDamage, 0);
+	
+	double KnockbackAmount = 9;
+	GetTarget()->TakeDamage(dtMobAttack, this, m_AttackDamage, KnockbackAmount);
 
 	return true;
 }


### PR DESCRIPTION
- Small tweaks to knockback values to make knockback feel closer to vanilla.
- Added slight height to knockback, like in vanilla.
- Monsters now apply knockback to target.
- Fixes #4062. I haven't encountered the issue the original workaround tried to solve (wrong knockback direction) or any other issues with knockback, when using setspeed instead of addspeed (are there any side effects?)
- Closes #4300

I don't play PVP a lot, so the values and calculations can probably be tweaked further if necessary. Mob knockback still feel too "floaty" and slow compared to players, not sure why.