### PR TITLE
Fix armor protection

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -283,7 +283,7 @@ void cEntity::TakeDamage(cEntity & a_Attacker)
 void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_RawDamage, double a_KnockbackAmount)
 {
 	float FinalDamage = a_RawDamage;
-	double ArmorCover = GetArmorCoverAgainst(a_Attacker, a_DamageType, a_RawDamage);
+	float ArmorCover = GetArmorCoverAgainst(a_Attacker, a_DamageType, a_RawDamage);
 
 	ApplyArmorDamage(static_cast<int>(ArmorCover));
 
@@ -651,7 +651,7 @@ bool cEntity::ArmorCoversAgainst(eDamageType a_DamageType)
 
 
 
-double cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
+float cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
 {
 	int TotalEPF = 0;
 
@@ -719,7 +719,7 @@ float cEntity::GetEnchantmentBlastKnockbackReduction()
 
 
 
-double cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
+float cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
 {
 	// Returns the hitpoints out of a_RawDamage that the currently equipped armor would cover
 
@@ -769,8 +769,8 @@ double cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_D
 	// TODO: Special armor cases, such as wool, saddles, dog's collar
 	// Ref.: https://minecraft.gamepedia.com/Armor#Mob_armor as of 2012_12_20
 
-	double Reduction = std::max(ArmorValue / 5.0, ArmorValue - a_Damage / (2 + Toughness / 4.0));
-	return (a_Damage * std::min(20.0, Reduction) / 25.0);
+	float Reduction = std::max(ArmorValue / 5.0, ArmorValue - a_Damage / (2 + Toughness / 4.0));
+	return (a_Damage * std::min(20.0f, Reduction) / 25.0);
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -282,17 +282,12 @@ void cEntity::TakeDamage(cEntity & a_Attacker)
 
 void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_RawDamage, double a_KnockbackAmount)
 {
-	int ArmorCover = GetArmorCoverAgainst(a_Attacker, a_DamageType, a_RawDamage);
-	int EnchantmentCover = GetEnchantmentCoverAgainst(a_Attacker, a_DamageType, a_RawDamage);
-	int FinalDamage = a_RawDamage - ArmorCover - EnchantmentCover;
-	if ((FinalDamage == 0) && (a_RawDamage > 0))
-	{
-		// Nobody's invincible
-		FinalDamage = 1;
-	}
+	float FinalDamage = a_RawDamage;
+	double ArmorCover = GetArmorCoverAgainst(a_Attacker, a_DamageType, a_RawDamage);
+
 	ApplyArmorDamage(ArmorCover);
 
-	cEntity::TakeDamage(a_DamageType, a_Attacker, a_RawDamage, static_cast<float>(FinalDamage), a_KnockbackAmount);
+	cEntity::TakeDamage(a_DamageType, a_Attacker, a_RawDamage, FinalDamage, a_KnockbackAmount);
 }
 
 
@@ -644,7 +639,7 @@ bool cEntity::ArmorCoversAgainst(eDamageType a_DamageType)
 
 
 
-int cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
+double cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
 {
 	int TotalEPF = 0;
 
@@ -680,7 +675,7 @@ int cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType 
 		}
 	}
 	int CappedEPF = std::min(20, TotalEPF);
-	return static_cast<int>(a_Damage * CappedEPF / 25.0);
+	return (a_Damage * CappedEPF / 25.0);
 }
 
 
@@ -712,7 +707,7 @@ float cEntity::GetEnchantmentBlastKnockbackReduction()
 
 
 
-int cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
+double cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage)
 {
 	// Returns the hitpoints out of a_RawDamage that the currently equipped armor would cover
 
@@ -763,7 +758,7 @@ int cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_Dama
 	// Ref.: https://minecraft.gamepedia.com/Armor#Mob_armor as of 2012_12_20
 
 	double Reduction = std::max(ArmorValue / 5.0, ArmorValue - a_Damage / (2 + Toughness / 4.0));
-	return static_cast<int>(a_Damage * std::min(20.0, Reduction) / 25.0);
+	return (a_Damage * std::min(20.0, Reduction) / 25.0);
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -330,11 +330,17 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 	{
 		TDI.Attacker = nullptr;
 	}
-	TDI.RawDamage = a_RawDamage;
 
+	if (a_RawDamage <= 0)
+	{
+		a_RawDamage = 0;
+	}
+
+	TDI.RawDamage = a_RawDamage;
+	
 	if (a_FinalDamage <= 0)
 	{
-		a_FinalDamage = 1;
+		a_FinalDamage = 0;
 	}
 
 	TDI.FinalDamage = a_FinalDamage;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -285,7 +285,7 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 	float FinalDamage = a_RawDamage;
 	double ArmorCover = GetArmorCoverAgainst(a_Attacker, a_DamageType, a_RawDamage);
 
-	ApplyArmorDamage(ArmorCover);
+	ApplyArmorDamage(static_cast<int>(ArmorCover));
 
 	cEntity::TakeDamage(a_DamageType, a_Attacker, a_RawDamage, FinalDamage, a_KnockbackAmount);
 }

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -331,6 +331,12 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 		TDI.Attacker = nullptr;
 	}
 	TDI.RawDamage = a_RawDamage;
+
+	if (a_FinalDamage <= 0)
+	{
+		a_FinalDamage = 1;
+	}
+
 	TDI.FinalDamage = a_FinalDamage;
 
 	Vector3d Heading(0, 0, 0);

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -337,7 +337,7 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 	}
 
 	TDI.RawDamage = a_RawDamage;
-	
+
 	if (a_FinalDamage <= 0)
 	{
 		a_FinalDamage = 0;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -687,7 +687,7 @@ float cEntity::GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageTyp
 		}
 	}
 	int CappedEPF = std::min(20, TotalEPF);
-	return (a_Damage * CappedEPF / 25.0);
+	return (a_Damage * CappedEPF / 25.0f);
 }
 
 
@@ -769,8 +769,8 @@ float cEntity::GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_Da
 	// TODO: Special armor cases, such as wool, saddles, dog's collar
 	// Ref.: https://minecraft.gamepedia.com/Armor#Mob_armor as of 2012_12_20
 
-	float Reduction = std::max(ArmorValue / 5.0, ArmorValue - a_Damage / (2 + Toughness / 4.0));
-	return (a_Damage * std::min(20.0f, Reduction) / 25.0);
+	float Reduction = std::max(ArmorValue / 5.0f, ArmorValue - a_Damage / (2.0f + Toughness / 4.0f));
+	return (a_Damage * std::min(20.0f, Reduction) / 25.0f);
 }
 
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -357,10 +357,10 @@ public:
 	virtual bool ArmorCoversAgainst(eDamageType a_DamageType);
 
 	/** Returns the hitpoints out of a_RawDamage that the currently equipped armor would cover */
-	virtual int GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_RawDamage);
+	virtual double GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_RawDamage);
 
 	/** Returns the hitpoints that the currently equipped armor's enchantments would cover */
-	virtual int GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage);
+	virtual double GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage);
 
 	/** Returns explosion knock back reduction percent from blast protection level
 	@return knock back reduce percent */

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -357,10 +357,10 @@ public:
 	virtual bool ArmorCoversAgainst(eDamageType a_DamageType);
 
 	/** Returns the hitpoints out of a_RawDamage that the currently equipped armor would cover */
-	virtual double GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_RawDamage);
+	virtual float GetArmorCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_RawDamage);
 
 	/** Returns the hitpoints that the currently equipped armor's enchantments would cover */
-	virtual double GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage);
+	virtual float GetEnchantmentCoverAgainst(const cEntity * a_Attacker, eDamageType a_DamageType, int a_Damage);
 
 	/** Returns explosion knock back reduction percent from blast protection level
 	@return knock back reduce percent */


### PR DESCRIPTION
Precision was lost when returning GetArmorCoverAgainst's value as int. Since the Core plugin handles world difficulty, it reverted all FinalDamage changes from the armor checks. Armor calculation has been moved to Core. https://github.com/cuberite/Core/pull/218