### PR TITLE
cChunk::CanUnload no longer returns true when chunk holds player entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ ReleaseProfile/
 *.dir/
 CPackConfig.cmake
 CPackSourceConfig.cmake
+cmake-build-debug
 
 # APIDump-generated status files:
 Server/cuberite_api.lua

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ cloc.xsl
 *.sqlite
 /EveryNight.cmd
 /UploadLuaAPI.cmd
+GPUCache
 AllFiles.lst
 
 # IDE Stuff

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -973,10 +973,18 @@ cItems cChunk::PickupsFromBlock(Vector3i a_RelPos, const cEntity * a_Digger, con
 	NIBBLETYPE blockMeta;
 	GetBlockTypeMeta(a_RelPos, blockType, blockMeta);
 	auto blockHandler = cBlockInfo::GetHandler(blockType);
-	auto toolHandler = a_Tool->GetHandler();
-	auto canHarvestBlock = toolHandler->CanHarvestBlock(blockType);
 	auto blockEntity = GetBlockEntityRel(a_RelPos);
 	cItems pickups (0);
+	bool canHarvestBlock;
+	if (a_Tool)
+	{
+		auto toolHandler = a_Tool->GetHandler();
+		canHarvestBlock = toolHandler->CanHarvestBlock(blockType);
+	}
+	else
+	{
+		canHarvestBlock = false;
+	}
 	if (canHarvestBlock)
 	{
 		pickups = blockHandler->ConvertToPickups(blockMeta, blockEntity, a_Digger, a_Tool);

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -973,8 +973,14 @@ cItems cChunk::PickupsFromBlock(Vector3i a_RelPos, const cEntity * a_Digger, con
 	NIBBLETYPE blockMeta;
 	GetBlockTypeMeta(a_RelPos, blockType, blockMeta);
 	auto blockHandler = cBlockInfo::GetHandler(blockType);
+	auto toolHandler = a_Tool->GetHandler();
+	auto canHarvestBlock = toolHandler->CanHarvestBlock(blockType);
 	auto blockEntity = GetBlockEntityRel(a_RelPos);
-	auto pickups = blockHandler->ConvertToPickups(blockMeta, blockEntity, a_Digger, a_Tool);
+	cItems pickups (0);
+	if (canHarvestBlock)
+	{
+		pickups = blockHandler->ConvertToPickups(blockMeta, blockEntity, a_Digger, a_Tool);
+	}
 	auto absPos = RelativeToAbsolute(a_RelPos);
 	cRoot::Get()->GetPluginManager()->CallHookBlockToPickups(*m_World, absPos, blockType, blockMeta, blockEntity, a_Digger, a_Tool, pickups);
 	return pickups;

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -683,6 +683,10 @@ private:
 
 	/** Called by Tick() when an entity moves out of this chunk into a neighbor; moves the entity and sends spawn / despawn packet to clients */
 	void MoveEntityToNewChunk(OwnedEntity a_Entity);
+
+	/** Check m_Entities for cPlayer objects. */
+	bool HasPlayerEntities();
+
 };
 
 typedef cChunk * cChunkPtr;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2201,8 +2201,7 @@ bool cWorld::DigBlock(Vector3i a_BlockPos)
 bool cWorld::DropBlockAsPickups(Vector3i a_BlockPos, const cEntity * a_Digger, const cItem * a_Tool)
 {
 	auto pickups = PickupsFromBlock(a_BlockPos, a_Digger, a_Tool);
-	bool CanHarvestBlock {a_Tool->GetHandler()->CanHarvestBlock(GetBlock(a_BlockPos))};
-	if (!CanHarvestBlock || !DigBlock(a_BlockPos))
+	if (!DigBlock(a_BlockPos))
 	{
 		return false;
 	}

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2201,7 +2201,8 @@ bool cWorld::DigBlock(Vector3i a_BlockPos)
 bool cWorld::DropBlockAsPickups(Vector3i a_BlockPos, const cEntity * a_Digger, const cItem * a_Tool)
 {
 	auto pickups = PickupsFromBlock(a_BlockPos, a_Digger, a_Tool);
-	if (!DigBlock(a_BlockPos))
+	bool CanHarvestBlock {a_Tool->GetHandler()->CanHarvestBlock(GetBlock(a_BlockPos))};
+	if (!CanHarvestBlock || !DigBlock(a_BlockPos))
 	{
 		return false;
 	}


### PR DESCRIPTION
Fixes #4497 

When chunks are loaded rapidly, cChunk::RemoveClient doesn't remove the corresponding entities fast enough.
This has lead to the unloading of chunks that still hold PlayerEntities, because their ClientHandlers were already removed, calling the Player objects destructor.