### PR TITLE
Fixed unloading of chunks that contain player entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ cloc.xsl
 /EveryNight.cmd
 /UploadLuaAPI.cmd
 AllFiles.lst
+GPUCache
 
 # IDE Stuff
 ## Sublime Text
@@ -104,6 +105,7 @@ ReleaseProfile/
 *.dir/
 CPackConfig.cmake
 CPackSourceConfig.cmake
+cmake-build-debug
 
 # APIDump-generated status files:
 Server/cuberite_api.lua

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -196,15 +196,11 @@ void cChunk::MarkRegenerating(void)
 
 bool cChunk::HasPlayerEntities()
 {
-	bool hasPlayerEntities {false};
-	for (auto & Entity: m_Entities)
-	{
-		if (Entity->IsPlayer())
-		{
-			hasPlayerEntities = true;
+	return std::any_of(m_Entities.begin(), m_Entities.end(),
+		[](cEntitiy * Entity) {
+			return Entity->IsPlayer();
 		}
-	}
-	return hasPlayerEntities;
+	);
 }
 
 

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -194,10 +194,28 @@ void cChunk::MarkRegenerating(void)
 
 
 
+bool cChunk::HasPlayerEntities()
+{
+	bool hasPlayerEntities {false};
+	for (auto & Entity: m_Entities)
+	{
+		if (Entity->IsPlayer())
+		{
+			hasPlayerEntities = true;
+		}
+	}
+	return hasPlayerEntities;
+}
+
+
+
+
+
 bool cChunk::CanUnload(void)
 {
 	return
 		m_LoadedByClient.empty() &&  // The chunk is not used by any client
+		!HasPlayerEntities() &&      // Ensure not only the absence of ClientHandlers, but also of cPlayer objects
 		!m_IsDirty &&                // The chunk has been saved properly or hasn't been touched since the load / gen
 		(m_StayCount == 0) &&        // The chunk is not in a ChunkStay
 		(m_Presence != cpQueued) ;   // The chunk is not queued for loading / generating (otherwise multi-load / multi-gen could occur)

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -197,7 +197,7 @@ void cChunk::MarkRegenerating(void)
 bool cChunk::HasPlayerEntities()
 {
 	return std::any_of(m_Entities.begin(), m_Entities.end(),
-		[](cEntity * Entity)
+		[](std::unique_ptr<cEntity>& Entity)
 		{
 			return Entity->IsPlayer();
 		}

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -197,7 +197,8 @@ void cChunk::MarkRegenerating(void)
 bool cChunk::HasPlayerEntities()
 {
 	return std::any_of(m_Entities.begin(), m_Entities.end(),
-		[](cEntitiy * Entity) {
+		[](cEntity * Entity)
+		{
 			return Entity->IsPlayer();
 		}
 	);
@@ -225,6 +226,7 @@ bool cChunk::CanUnloadAfterSaving(void)
 {
 	return
 		m_LoadedByClient.empty() &&  // The chunk is not used by any client
+		!HasPlayerEntities() &&      // Ensure not only the absence of ClientHandlers, but also of cPlayer objects
 		m_IsDirty &&                 // The chunk is dirty
 		(m_StayCount == 0) &&        // The chunk is not in a ChunkStay
 		(m_Presence != cpQueued) ;   // The chunk is not queued for loading / generating (otherwise multi-load / multi-gen could occur)

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -683,6 +683,9 @@ private:
 
 	/** Called by Tick() when an entity moves out of this chunk into a neighbor; moves the entity and sends spawn / despawn packet to clients */
 	void MoveEntityToNewChunk(OwnedEntity a_Entity);
+
+	/** Check m_Entities for cPlayer objects. */
+	bool HasPlayerEntities();
 };
 
 typedef cChunk * cChunkPtr;


### PR DESCRIPTION
Fixes #4497

When chunks are loaded rapidly, cChunk::RemoveClient doesn't remove the corresponding entities fast enough.
This has lead to the unloading of chunks that still hold PlayerEntities, because their ClientHandlers were already removed, calling the Player objects destructor.