### PR TITLE
Prevent arrows from sinking into the ground

### DIFF
--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -198,7 +198,7 @@ void cArrowEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			}
 		}
 
-		auto relPos = a_Chunk.RelativeToAbsolute(m_HitBlockPos);
+		auto relPos = a_Chunk.AbsoluteToRelative(m_HitBlockPos);
 		auto chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(relPos);
 
 		if (chunk == nullptr)


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/cuberite/cuberite/commit/61904af626b036b6e4e045ca219b2a361aa45a6e