### PR TITLE
Wrong overload of function push() got called when pushing a cEntity*.

### DIFF
--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -951,6 +951,16 @@ void cLuaState::Push(bool a_Value)
 
 void cLuaState::Push(const cEntity * a_Entity)
 {
+	// Once we can make Lua understand constness, this function shall receive a corresponding function body
+	Push(const_cast<cEntity * >(a_Entity));
+}
+
+
+
+
+
+void cLuaState::Push(cEntity * a_Entity)
+{
 	ASSERT(IsValid());
 
 	if (a_Entity == nullptr)
@@ -995,7 +1005,7 @@ void cLuaState::Push(const cEntity * a_Entity)
 				}  // switch (EntityType)
 				UNREACHABLE("Unsupported entity type");
 			}();
-		tolua_pushusertype(m_LuaState, const_cast<void *>(reinterpret_cast<const void *>(a_Entity)), ClassName);
+		tolua_pushusertype(m_LuaState, a_Entity, ClassName);
 	}
 }
 

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -995,7 +995,7 @@ void cLuaState::Push(const cEntity * a_Entity)
 				}  // switch (EntityType)
 				UNREACHABLE("Unsupported entity type");
 			}();
-		tolua_pushusertype(m_LuaState, const_cast<void*>(reinterpret_cast<const void*>(a_Entity)), ClassName);
+		tolua_pushusertype(m_LuaState, const_cast<void *>(reinterpret_cast<const void *>(a_Entity)), ClassName);
 	}
 }
 

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -995,7 +995,7 @@ void cLuaState::Push(const cEntity * a_Entity)
 				}  // switch (EntityType)
 				UNREACHABLE("Unsupported entity type");
 			}();
-		tolua_pushusertype(m_LuaState, (void *) a_Entity, ClassName);
+		tolua_pushusertype(m_LuaState, const_cast<void*>(reinterpret_cast<const void*>(a_Entity)), ClassName);
 	}
 }
 

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -949,7 +949,7 @@ void cLuaState::Push(bool a_Value)
 
 
 
-void cLuaState::Push(cEntity * a_Entity)
+void cLuaState::Push(const cEntity * a_Entity)
 {
 	ASSERT(IsValid());
 
@@ -995,7 +995,7 @@ void cLuaState::Push(cEntity * a_Entity)
 				}  // switch (EntityType)
 				UNREACHABLE("Unsupported entity type");
 			}();
-		tolua_pushusertype(m_LuaState, a_Entity, ClassName);
+		tolua_pushusertype(m_LuaState, (void *) a_Entity, ClassName);
 	}
 }
 

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -295,7 +295,7 @@ public:
 		Returns true if callback has been called.
 		Returns false if the Lua state isn't valid anymore. */
 		template <typename... Args>
-		bool Call(Args &&... args)
+bool Call(Args &&... args)
 		{
 			auto cs = m_CS.load();
 			if (cs == nullptr)
@@ -623,7 +623,7 @@ public:
 
 	// Push a simple value onto the stack (keep alpha-sorted):
 	void Push(bool a_Value);
-	void Push(cEntity * a_Entity);
+	void Push(const cEntity * a_Entity);
 	void Push(cLuaServerHandle * a_ServerHandle);
 	void Push(cLuaTCPLink * a_TCPLink);
 	void Push(cLuaUDPEndpoint * a_UDPEndpoint);

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -295,7 +295,7 @@ public:
 		Returns true if callback has been called.
 		Returns false if the Lua state isn't valid anymore. */
 		template <typename... Args>
-bool Call(Args &&... args)
+		bool Call(Args &&... args)
 		{
 			auto cs = m_CS.load();
 			if (cs == nullptr)

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -623,6 +623,7 @@ public:
 
 	// Push a simple value onto the stack (keep alpha-sorted):
 	void Push(bool a_Value);
+	void Push(cEntity * a_Entity);
 	void Push(const cEntity * a_Entity);
 	void Push(cLuaServerHandle * a_ServerHandle);
 	void Push(cLuaTCPLink * a_TCPLink);


### PR DESCRIPTION
Fixes #4499

When push(cEntity * a_Entity) was called, but a_Entity was _const_ cEntity *,  the overload push(boolean xyz) was called, resulting in errors. 
