### PR TITLE
Don't call player movement hook if nothing changed

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -842,6 +842,11 @@ void cClientHandle::HandlePlayerPos(double a_PosX, double a_PosY, double a_PosZ,
 	double OldStance = GetPlayer()->GetStance();
 	auto PreviousIsOnGround = GetPlayer()->IsOnGround();
 
+	#ifdef __clang__
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wfloat-equal"
+	#endif
+
 	if (
 	    (OldPosition == NewPosition) &&
 	    (OldStance == a_Stance) &&
@@ -851,6 +856,10 @@ void cClientHandle::HandlePlayerPos(double a_PosX, double a_PosY, double a_PosZ,
 		// Nothing changed, no need to do anything
 		return;
 	}
+
+	#ifdef __clang__
+		#pragma clang diagnostic pop
+	#endif
 
 	// If the player has moved too far, "repair" them:
 	if ((OldPosition - NewPosition).SqrLength() > 100 * 100)

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -839,6 +839,7 @@ void cClientHandle::HandlePlayerPos(double a_PosX, double a_PosY, double a_PosZ,
 
 	Vector3d NewPosition(a_PosX, a_PosY, a_PosZ);
 	Vector3d OldPosition = GetPlayer()->GetPosition();
+	double OldStance = GetPlayer()->GetStance();
 	auto PreviousIsOnGround = GetPlayer()->IsOnGround();
 
 	if ((OldPosition == NewPosition) && (OldStance == a_Stance))

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -848,9 +848,9 @@ void cClientHandle::HandlePlayerPos(double a_PosX, double a_PosY, double a_PosZ,
 	#endif
 
 	if (
-	    (OldPosition == NewPosition) &&
-	    (OldStance == a_Stance) &&
-	    (PreviousIsOnGround == a_IsOnGround)
+		(OldPosition == NewPosition) &&
+		(OldStance == a_Stance) &&
+		(PreviousIsOnGround == a_IsOnGround)
 	)
 	{
 		// Nothing changed, no need to do anything

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -841,6 +841,12 @@ void cClientHandle::HandlePlayerPos(double a_PosX, double a_PosY, double a_PosZ,
 	Vector3d OldPosition = GetPlayer()->GetPosition();
 	auto PreviousIsOnGround = GetPlayer()->IsOnGround();
 
+	if ((OldPosition == NewPosition) && (OldStance == a_Stance))
+	{
+		// Nothing changed, no need to do anything
+		return;
+	}
+
 	// If the player has moved too far, "repair" them:
 	if ((OldPosition - NewPosition).SqrLength() > 100 * 100)
 	{

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -842,7 +842,11 @@ void cClientHandle::HandlePlayerPos(double a_PosX, double a_PosY, double a_PosZ,
 	double OldStance = GetPlayer()->GetStance();
 	auto PreviousIsOnGround = GetPlayer()->IsOnGround();
 
-	if ((OldPosition == NewPosition) && (OldStance == a_Stance))
+	if (
+	    (OldPosition == NewPosition) &&
+	    (OldStance == a_Stance) &&
+	    (PreviousIsOnGround == a_IsOnGround)
+	)
 	{
 		// Nothing changed, no need to do anything
 		return;


### PR DESCRIPTION
The client seems to send a position packet every second or so, even if the position didn't change. Does it make sense to call HOOK_PLAYER_MOVING every time?