### PR TITLE
TNT position fixes

### DIFF
--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -3548,6 +3548,10 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 							Name = "InitialVelocityCoeff",
 							Type = "number",
 						},
+						{
+							Name = "ShouldPlayFuseSound",
+							Type = "boolean",
+						},
 					},
 					Returns =
 					{

--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -126,6 +126,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 			// Spawn a primed TNT entity, if space allows:
 			if (!cBlockInfo::IsSolid(dispBlock))
 			{
+				a_World->BroadcastSoundEffect("entity.tnt.primed", dispAbsCoord, 1.0f, 1.0f);
 				m_World->SpawnPrimedTNT(Vector3d(0.5, 0.5, 0.5) + dispAbsCoord, 80, 0);  // 80 ticks fuse, no initial velocity
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}

--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -126,7 +126,6 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 			// Spawn a primed TNT entity, if space allows:
 			if (!cBlockInfo::IsSolid(dispBlock))
 			{
-				a_World->BroadcastSoundEffect("entity.tnt.primed", dispAbsCoord, 1.0f, 1.0f);
 				m_World->SpawnPrimedTNT(Vector3d(0.5, 0.5, 0.5) + dispAbsCoord, 80, 0);  // 80 ticks fuse, no initial velocity
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1199,7 +1199,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 						{
 							// Activate the TNT, with a random fuse between 10 to 30 game ticks
 							int FuseTime = GetRandomProvider().RandInt(10, 30);
-							m_World->SpawnPrimedTNT({a_BlockX + x + 0.5, a_BlockY + y + 0.5, a_BlockZ + z + 0.5}, FuseTime);
+							m_World->SpawnPrimedTNT({a_BlockX + x + 0.5, a_BlockY + y + 0.5, a_BlockZ + z + 0.5}, FuseTime, 1, false); // Initial velocity, no fuse sound
 							area.SetBlockTypeMeta(bx + x, by + y, bz + z, E_BLOCK_AIR, 0);
 							a_BlocksAffected.push_back(Vector3i(bx + x, by + y, bz + z));
 							break;

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1199,7 +1199,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 						{
 							// Activate the TNT, with a random fuse between 10 to 30 game ticks
 							int FuseTime = GetRandomProvider().RandInt(10, 30);
-							m_World->SpawnPrimedTNT({a_BlockX + x + 0.5, a_BlockY + y + 0.5, a_BlockZ + z + 0.5}, FuseTime, 1, false); // Initial velocity, no fuse sound
+							m_World->SpawnPrimedTNT({a_BlockX + x + 0.5, a_BlockY + y + 0.5, a_BlockZ + z + 0.5}, FuseTime, 1, false);  // Initial velocity, no fuse sound
 							area.SetBlockTypeMeta(bx + x, by + y, bz + z, E_BLOCK_AIR, 0);
 							a_BlocksAffected.push_back(Vector3i(bx + x, by + y, bz + z));
 							break;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -965,7 +965,7 @@ void cEntity::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			}
 		}
 	}
-	else
+	else if (!(IsMinecart() || IsTNT()))
 	{
 		// Push out entity.
 		BLOCKTYPE GotBlock;

--- a/src/Entities/TNTEntity.cpp
+++ b/src/Entities/TNTEntity.cpp
@@ -36,7 +36,7 @@ void cTNTEntity::Explode(void)
 	m_FuseTicks = 0;
 	Destroy();
 	FLOGD("BOOM at {0}", GetPosition());
-	m_World->DoExplosionAt(4.0, GetPosX() + 0.49, GetPosY() + 0.49, GetPosZ() + 0.49, true, esPrimedTNT, this);
+	m_World->DoExplosionAt(4.0, GetPosX(), GetPosY(), GetPosZ(), true, esPrimedTNT, this);
 }
 
 

--- a/src/Items/ItemLighter.h
+++ b/src/Items/ItemLighter.h
@@ -56,7 +56,6 @@ public:
 			case E_BLOCK_TNT:
 			{
 				// Activate the TNT:
-				a_World->BroadcastSoundEffect("entity.tnt.primed", Vector3d(a_BlockX, a_BlockY, a_BlockZ), 1.0f, 1.0f);
 				a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, E_BLOCK_AIR, 0);
 				a_World->SpawnPrimedTNT({a_BlockX + 0.5, a_BlockY + 0.5, a_BlockZ + 0.5});  // 80 ticks to boom
 				break;

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -385,7 +385,7 @@ void cFireSimulator::RemoveFuelNeighbors(cChunk * a_Chunk, Vector3i a_RelPos)
 		if (BlockType == E_BLOCK_TNT)
 		{
 			neighbor->SetBlock(relPos, E_BLOCK_AIR, 0);
-			m_World.SpawnPrimedTNT(Vector3d(absPos.x + 0.5, absPos.y + 0.5, absPos.z + 0.5));  // 80 ticks to boom
+			m_World.SpawnPrimedTNT(Vector3d(absPos) + Vector3d(0.5, 0.5, 0.5));  // 80 ticks to boom
 			return;
 		}
 

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -385,7 +385,8 @@ void cFireSimulator::RemoveFuelNeighbors(cChunk * a_Chunk, Vector3i a_RelPos)
 		if (BlockType == E_BLOCK_TNT)
 		{
 			neighbor->SetBlock(relPos, E_BLOCK_AIR, 0);
-			m_World.SpawnPrimedTNT(absPos, 0);
+			m_World.BroadcastSoundEffect("entity.tnt.primed", absPos, 1.0f, 1.0f);
+			m_World.SpawnPrimedTNT(Vector3d(absPos.x + 0.5, absPos.y + 0.5, absPos.z + 0.5));  // 80 ticks to boom
 			return;
 		}
 

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -385,7 +385,6 @@ void cFireSimulator::RemoveFuelNeighbors(cChunk * a_Chunk, Vector3i a_RelPos)
 		if (BlockType == E_BLOCK_TNT)
 		{
 			neighbor->SetBlock(relPos, E_BLOCK_AIR, 0);
-			m_World.BroadcastSoundEffect("entity.tnt.primed", absPos, 1.0f, 1.0f);
 			m_World.SpawnPrimedTNT(Vector3d(absPos.x + 0.5, absPos.y + 0.5, absPos.z + 0.5));  // 80 ticks to boom
 			return;
 		}

--- a/src/Simulator/IncrementalRedstoneSimulator/TNTHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/TNTHandler.h
@@ -39,7 +39,7 @@ public:
 		{
 			a_World.BroadcastSoundEffect("entity.tnt.primed", a_Position, 0.5f, 0.6f);
 			a_World.SetBlock(a_Position.x, a_Position.y, a_Position.z, E_BLOCK_AIR, 0);
-			a_World.SpawnPrimedTNT(Vector3d(a_Position.x + 0.5, a_Position.y + 0.5, a_Position.z + 0.5));  // 80 ticks to boom
+			a_World.SpawnPrimedTNT(Vector3d(a_Position) + Vector3d(0.5, 0.5, 0.5));  // 80 ticks to boom
 		}
 		return {};
 	}

--- a/src/Simulator/IncrementalRedstoneSimulator/TNTHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/TNTHandler.h
@@ -39,7 +39,7 @@ public:
 		{
 			a_World.BroadcastSoundEffect("entity.tnt.primed", a_Position, 0.5f, 0.6f);
 			a_World.SetBlock(a_Position.x, a_Position.y, a_Position.z, E_BLOCK_AIR, 0);
-			a_World.SpawnPrimedTNT(a_Position + Vector3d(0.5, 0.5, 0.5));  // 80 ticks to boom
+			a_World.SpawnPrimedTNT(Vector3d(a_Position.x + 0.5, a_Position.y + 0.5, a_Position.z + 0.5));  // 80 ticks to boom
 		}
 		return {};
 	}

--- a/src/Simulator/IncrementalRedstoneSimulator/TNTHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/TNTHandler.h
@@ -37,7 +37,6 @@ public:
 		// LOGD("Evaluating explodinator the trinitrotoluene (%d %d %d)", a_Position.x, a_Position.y, a_Position.z);
 		if (a_PoweringData.PowerLevel != 0)
 		{
-			a_World.BroadcastSoundEffect("entity.tnt.primed", a_Position, 0.5f, 0.6f);
 			a_World.SetBlock(a_Position.x, a_Position.y, a_Position.z, E_BLOCK_AIR, 0);
 			a_World.SpawnPrimedTNT(Vector3d(a_Position) + Vector3d(0.5, 0.5, 0.5));  // 80 ticks to boom
 		}

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2153,7 +2153,7 @@ UInt32 cWorld::SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTicks, double a_InitialV
 	{
 		return cEntity::INVALID_ID;
 	}
-	
+
 	if (a_ShouldPlayFuseSound)
 	{
 		BroadcastSoundEffect("entity.tnt.primed", a_Pos, 1.0f, 1.0f);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2160,7 +2160,7 @@ UInt32 cWorld::SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTicks, double a_InitialV
 	}
 
 	auto & Random = GetRandomProvider();
-	TNTPtr->AddSpeed(
+	TNTPtr->SetSpeed(
 		a_InitialVelocityCoeff * Random.RandReal(-0.5f, 0.5f),
 		a_InitialVelocityCoeff * 2,
 		a_InitialVelocityCoeff * Random.RandReal(-0.5f, 0.5f)

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2156,9 +2156,9 @@ UInt32 cWorld::SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTicks, double a_InitialV
 
 	auto & Random = GetRandomProvider();
 	TNTPtr->SetSpeed(
-		a_InitialVelocityCoeff * Random.RandInt(-1, 1),
+		a_InitialVelocityCoeff * Random.RandReal(-0.5f, 0.5f),
 		a_InitialVelocityCoeff * 2,
-		a_InitialVelocityCoeff * Random.RandInt(-1, 1)
+		a_InitialVelocityCoeff * Random.RandReal(-0.5f, 0.5f)
 	);
 	return TNTPtr->GetUniqueID();
 }

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2145,7 +2145,7 @@ UInt32 cWorld::SpawnBoat(Vector3d a_Pos, cBoat::eMaterial a_Material)
 
 
 
-UInt32 cWorld::SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTicks, double a_InitialVelocityCoeff)
+UInt32 cWorld::SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTicks, double a_InitialVelocityCoeff, bool a_ShouldPlayFuseSound)
 {
 	auto TNT = cpp14::make_unique<cTNTEntity>(a_Pos, a_FuseTicks);
 	auto TNTPtr = TNT.get();
@@ -2153,9 +2153,14 @@ UInt32 cWorld::SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTicks, double a_InitialV
 	{
 		return cEntity::INVALID_ID;
 	}
+	
+	if (a_ShouldPlayFuseSound)
+	{
+		BroadcastSoundEffect("entity.tnt.primed", a_Pos, 1.0f, 1.0f);
+	}
 
 	auto & Random = GetRandomProvider();
-	TNTPtr->SetSpeed(
+	TNTPtr->AddSpeed(
 		a_InitialVelocityCoeff * Random.RandReal(-0.5f, 0.5f),
 		a_InitialVelocityCoeff * 2,
 		a_InitialVelocityCoeff * Random.RandReal(-0.5f, 0.5f)

--- a/src/World.h
+++ b/src/World.h
@@ -625,16 +625,16 @@ public:
 	// tolua_begin
 
 	// DEPRECATED, use the vector-parametered version instead.
-	UInt32 SpawnPrimedTNT(double a_X, double a_Y, double a_Z, int a_FuseTimeInSec = 80, double a_InitialVelocityCoeff = 1)
+	UInt32 SpawnPrimedTNT(double a_X, double a_Y, double a_Z, int a_FuseTimeInSec = 80, double a_InitialVelocityCoeff = 1, bool a_ShouldPlayFuseSound = true)
 	{
 		LOGWARNING("cWorld::SpawnPrimedTNT(double, double, double) is deprecated, use cWorld::SpawnPrimedTNT(Vector3d) instead.");
-		return SpawnPrimedTNT({a_X, a_Y, a_Z}, a_FuseTimeInSec, a_InitialVelocityCoeff);
+		return SpawnPrimedTNT({a_X, a_Y, a_Z}, a_FuseTimeInSec, a_InitialVelocityCoeff, a_ShouldPlayFuseSound);
 	}
 
 	/** Spawns a new primed TNT entity at the specified block coords and specified fuse duration.
 	Initial velocity is given based on the relative coefficient provided.
 	Returns the UniqueID of the created entity, or cEntity::INVALID_ID on failure. */
-	UInt32 SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTimeInSec = 80, double a_InitialVelocityCoeff = 1);
+	UInt32 SpawnPrimedTNT(Vector3d a_Pos, int a_FuseTimeInSec = 80, double a_InitialVelocityCoeff = 1, bool a_ShouldPlayFuseSound = true);
 
 	// tolua_end
 


### PR DESCRIPTION
- Position offset didn't apply properly to TNT ignited by redstone, and was missing from TNT ignited by fire. Fixes #2093
- In some cases, TNT destroyed blocks despite being in water, due to an offset applied to the explosion position. Fixes #4462
- TNT ignited by fire had incorrect fuse ticks
- Added missing TNT ignition sounds in a few cases