### PR TITLE
Pickup spawn improvements

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -965,7 +965,7 @@ void cEntity::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			}
 		}
 	}
-	else
+	else if (!(IsMinecart() || IsTNT() || (IsPickup() && (m_TicksAlive < 15))))
 	{
 		// Push out entity.
 		BLOCKTYPE GotBlock;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1965,7 +1965,6 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3i a_BlockPos, dou
 void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, double a_FlyAwaySpeed, bool a_IsPlayerCreated)
 {
 	auto & Random = GetRandomProvider();
-	a_FlyAwaySpeed /= 100;  // Pre-divide, so that we don't have to divide each time inside the loop
 	for (cItems::const_iterator itr = a_Pickups.begin(); itr != a_Pickups.end(); ++itr)
 	{
 		if (!IsValidItem(itr->m_ItemType) || (itr->m_ItemType == E_BLOCK_AIR))
@@ -1974,9 +1973,9 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, double a
 			continue;
 		}
 
-		float SpeedX = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(-5, 5));
-		float SpeedY = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(50));
-		float SpeedZ = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(-5, 5));
+		float SpeedX = static_cast<float>(a_FlyAwaySpeed * Random.RandReal(-2.0, 2.0));
+		float SpeedY = static_cast<float>(a_FlyAwaySpeed * 5.0);
+		float SpeedZ = static_cast<float>(a_FlyAwaySpeed * Random.RandReal(-2.0, 2.0));
 
 		auto Pickup = cpp14::make_unique<cPickup>(a_Pos, *itr, a_IsPlayerCreated, Vector3f{SpeedX, SpeedY, SpeedZ});
 		auto PickupPtr = Pickup.get();

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1965,6 +1965,7 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3i a_BlockPos, dou
 void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, double a_FlyAwaySpeed, bool a_IsPlayerCreated)
 {
 	auto & Random = GetRandomProvider();
+	a_FlyAwaySpeed /= 100;  // Pre-divide, so that we don't have to divide each time inside the loop
 	for (cItems::const_iterator itr = a_Pickups.begin(); itr != a_Pickups.end(); ++itr)
 	{
 		if (!IsValidItem(itr->m_ItemType) || (itr->m_ItemType == E_BLOCK_AIR))
@@ -1973,9 +1974,9 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, double a
 			continue;
 		}
 
-		float SpeedX = static_cast<float>(a_FlyAwaySpeed * Random.RandReal(-2.0, 2.0));
-		float SpeedY = static_cast<float>(a_FlyAwaySpeed * 5.0);
-		float SpeedZ = static_cast<float>(a_FlyAwaySpeed * Random.RandReal(-2.0, 2.0));
+		float SpeedX = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(-10, 10));
+		float SpeedY = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(40, 50));
+		float SpeedZ = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(-10, 10));
 
 		auto Pickup = cpp14::make_unique<cPickup>(a_Pos, *itr, a_IsPlayerCreated, Vector3f{SpeedX, SpeedY, SpeedZ});
 		auto PickupPtr = Pickup.get();
@@ -2220,7 +2221,7 @@ bool cWorld::DropBlockAsPickups(Vector3i a_BlockPos, const cEntity * a_Digger, c
 	{
 		return false;
 	}
-	SpawnItemPickups(pickups, Vector3d(0.5, 0.5, 0.5) + a_BlockPos);
+	SpawnItemPickups(pickups, Vector3d(0.5, 0.5, 0.5) + a_BlockPos, 10);
 	return true;
 }
 


### PR DESCRIPTION
Pickups are now thrown around when spawned, like in vanilla. Pickups also bail out of the collision detection checks while being created, to prevent them from blasting too far off in e.g. cobblestone generators.