### PR TITLE
Ender chest is not affected by piston

### DIFF
--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -141,7 +141,7 @@ private:
 			case E_BLOCK_END_GATEWAY:
 			case E_BLOCK_END_PORTAL:
 			case E_BLOCK_END_PORTAL_FRAME:
-			// Notice the lack of an E_BLOCK_ENDER_CHEST here; its because ender chests can totally be pushed / pulled in MCS :)
+			case E_BLOCK_ENDER_CHEST:
 			case E_BLOCK_FURNACE:
 			case E_BLOCK_LIT_FURNACE:
 			case E_BLOCK_INVERTED_DAYLIGHT_SENSOR:


### PR DESCRIPTION
This has been discussed in #2612. I don't think we should stray away from vanilla in this regard. A piston animation for ender chests doesn't exist either, as @tigerw mentioned.