### PR TITLE
cClientHandle: Only allow m_State to increase

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -163,35 +163,37 @@ void cClientHandle::Destroy(void)
 	m_Self.reset();
 	SetState(csDestroyed);  // Tick thread is allowed to call destructor async at any time after this
 
-	if (player != nullptr)
+	if (player == nullptr)
 	{
-		// Atomically decrement player count (in world or server thread)
-		cRoot::Get()->GetServer()->PlayerDestroyed();
-
-		auto world = player->GetWorld();
-		if (world != nullptr)
-		{
-			player->StopEveryoneFromTargetingMe();
-			player->SetIsTicking(false);
-
-			if (!m_PlayerPtr)
-			{
-				// If our own smart pointer is unset, player has been transferred to world
-        ASSERT(world->IsPlayerReferencedInWorldOrChunk(*player));
-
-				m_PlayerPtr = world->RemovePlayer(*player);
-
-				// And RemovePlayer should have returned a valid smart pointer
-				ASSERT(m_PlayerPtr);
-			}
-			else
-			{
-				// If ownership was not transferred, our own smart pointer should be valid and RemovePlayer's should not
-				ASSERT(!world->IsPlayerReferencedInWorldOrChunk(*player));
-			}
-		}
-		player->RemoveClientHandle();
+		return;
 	}
+
+	// Atomically decrement player count (in world or server thread)
+	cRoot::Get()->GetServer()->PlayerDestroyed();
+
+	auto world = player->GetWorld();
+	if (world != nullptr)
+	{
+		player->StopEveryoneFromTargetingMe();
+		player->SetIsTicking(false);
+
+		if (!m_PlayerPtr)
+		{
+			// If our own smart pointer is unset, player has been transferred to world
+			ASSERT(world->IsPlayerReferencedInWorldOrChunk(*player));
+
+			m_PlayerPtr = world->RemovePlayer(*player);
+
+			// And RemovePlayer should have returned a valid smart pointer
+			ASSERT(m_PlayerPtr);
+		}
+		else
+		{
+			// If ownership was not transferred, our own smart pointer should be valid and RemovePlayer's should not
+			ASSERT(!world->IsPlayerReferencedInWorldOrChunk(*player));
+		}
+	}
+	player->RemoveClientHandle();
 }
 
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -591,6 +591,10 @@ private:
 	/** Called right after the instance is created to store its SharedPtr inside. */
 	void SetSelf(cClientHandlePtr a_Self);
 
+	/** Called to update m_State.
+	Only succeeds if a_NewState > m_State, otherwise returns false. */
+	bool SetState(eState a_NewState);
+
 	/** Processes the data in the network input and output buffers.
 	Called by both Tick() and ServerTick(). */
 	void ProcessProtocolInOut(void);


### PR DESCRIPTION
(Hopefully) Fixes #4494. @Seadragon91 can you test? 

What I think happens is:
1. Client sends chat command and immediately closes connection
1. `cClientHandle::OnRemoteClosed` sets `m_State = csQueuedForDestruction` and resets `m_Link`. 
2. The server processes command and sends a DC to the client, setting `m_State = csKicked`.
3. `cClientHandle::Tick` then tries to shutdown the link after it's already been closed.

The key thing here is that if `m_State` ever goes backwards then things can get messed up. I don't think sending extra protocol messages is ever an issue, they will just not be sent.