### PR TITLE
Send respawn packet by default

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -4097,7 +4097,7 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 							IsOptional  = true,
 						},
 					},
-					Notes = "Schedules a MoveToWorld call to occur on the next Tick of the entity. If ShouldSetPortalCooldown is false (default), doesn't set any portal cooldown, if it is true, the default portal cooldown is applied to the entity. If ShouldSendRespawn is false (default), no respawn packet is sent, if it is true then a respawn packet is sent to the client. <b>OBSOLETE</b>, use MoveToWorld instead.",
+					Notes = "Schedules a MoveToWorld call to occur on the next Tick of the entity. If ShouldSetPortalCooldown is false (default), doesn't set any portal cooldown, if it is true, the default portal cooldown is applied to the entity. If ShouldSendRespawn is false, no respawn packet is sent, if it is true (default) then a respawn packet is sent to the client. <b>OBSOLETE</b>, use MoveToWorld instead.",
 				},
 				SetGravity =
 				{

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -469,13 +469,13 @@ public:
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
 
 	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
-	OBSOLETE void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = false)
+	OBSOLETE void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true)
 	{
 		LOGWARNING("ScheduleMoveToWorld is deprecated, use MoveToWorld instead");
 		MoveToWorld(a_World, a_NewPosition, a_ShouldSetPortalCooldown, a_ShouldSendRespawn);
 	}
 
-	bool MoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = false);
+	bool MoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true);
 
 	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
 	{

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1222,7 +1222,7 @@ void cPlayer::Respawn(void)
 
 	if (GetWorld() != m_SpawnWorld)
 	{
-		MoveToWorld(m_SpawnWorld, GetLastBedPos(), false);
+		MoveToWorld(m_SpawnWorld, GetLastBedPos(), false, false);
 	}
 	else
 	{

--- a/src/NetherPortalScanner.cpp
+++ b/src/NetherPortalScanner.cpp
@@ -296,7 +296,7 @@ void cNetherPortalScanner::OnDisabled(void)
 	}
 
 	FLOGD("Placing player at {0}", Position);
-	m_Entity->MoveToWorld(m_World, Position, true);
+	m_Entity->MoveToWorld(m_World, Position, true, false);
 	delete this;
 }
 


### PR DESCRIPTION
I don't see why the respawn packet is disabled by default. Not sending one breaks the client, and causes confusion for plugin developers.