### PR TITLE
Fix for piston duplication on retract

### DIFF
--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -640,6 +640,8 @@ void cChunkMap::SetBlock(Vector3i a_BlockPos, BLOCKTYPE a_BlockType, NIBBLETYPE 
 		GetBlockTypeMeta(a_BlockPos, blockType, blockMeta);
 		cChunkInterface ChunkInterface(this);
 		
+		// Hotfix for https://github.com/cuberite/cuberite/issues/4468
+		// Should be removed when a proper fix is found.
 		if ((blockType != E_BLOCK_PISTON) && (blockType != E_BLOCK_STICKY_PISTON) && (blockType != E_BLOCK_PISTON_EXTENSION))
 		{
 			BlockHandler(blockType)->OnBroken(ChunkInterface, *m_World, a_BlockPos, blockType, blockMeta);

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -639,7 +639,12 @@ void cChunkMap::SetBlock(Vector3i a_BlockPos, BLOCKTYPE a_BlockType, NIBBLETYPE 
 		NIBBLETYPE blockMeta;
 		GetBlockTypeMeta(a_BlockPos, blockType, blockMeta);
 		cChunkInterface ChunkInterface(this);
-		BlockHandler(blockType)->OnBroken(ChunkInterface, *m_World, a_BlockPos, blockType, blockMeta);
+		
+		if ((blockType != E_BLOCK_PISTON) && (blockType != E_BLOCK_STICKY_PISTON) && (blockType != E_BLOCK_PISTON_EXTENSION))
+		{
+			BlockHandler(blockType)->OnBroken(ChunkInterface, *m_World, a_BlockPos, blockType, blockMeta);
+		}
+		
 		chunk->SetBlock(relPos, a_BlockType, a_BlockMeta);
 		m_World->GetSimulatorManager()->WakeUp(a_BlockPos, chunk);
 		BlockHandler(a_BlockType)->OnPlaced(ChunkInterface, *m_World, a_BlockPos, a_BlockType, a_BlockMeta);


### PR DESCRIPTION
Stops piston duplication bug and doesn't break water and lava simulation.

I haven't found anything that is broken after doing this, I can still mine and pick it up in survival. 