### PR TITLE
Updated plugin list format

### DIFF
--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -1736,7 +1736,8 @@ AStringVector cPluginManager::GetFoldersToLoad(cSettingsRepositoryInterface & a_
 
 	AStringVector res;
 
-	// Get the old format plugin list, and migrate it:
+	// Get the old format plugin list, and migrate it.
+	// Upgrade path added on 27/03/2020
 	auto OldValues = a_Settings.GetValues("Plugins");
 	for (auto NameValue : OldValues)
 	{
@@ -1744,7 +1745,11 @@ AStringVector cPluginManager::GetFoldersToLoad(cSettingsRepositoryInterface & a_
 		if (ValueName.compare("Plugin") == 0)
 		{
 			AString PluginFile = NameValue.second;
-			if (!PluginFile.empty())
+			if (
+				!PluginFile.empty() &&
+				(PluginFile != "0") &&
+				(PluginFile != "1")
+			)
 			{
 				a_Settings.DeleteValue("Plugins", ValueName);
 				a_Settings.SetValue("Plugins", PluginFile, "1");

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -154,8 +154,9 @@ void cPluginManager::ReloadPluginsNow(cSettingsRepositoryInterface & a_Settings)
 void cPluginManager::InsertDefaultPlugins(cSettingsRepositoryInterface & a_Settings)
 {
 	a_Settings.AddKeyName("Plugins");
-	a_Settings.AddValue("Plugins", "Plugin", "Core");
-	a_Settings.AddValue("Plugins", "Plugin", "ChatLog");
+	a_Settings.AddValue("Plugins", "Core", "1");
+	a_Settings.AddValue("Plugins", "ChatLog", "1");
+	a_Settings.AddValue("Plugins", "ProtectionAreas", "0");
 }
 
 
@@ -1733,10 +1734,11 @@ AStringVector cPluginManager::GetFoldersToLoad(cSettingsRepositoryInterface & a_
 		InsertDefaultPlugins(a_Settings);
 	}
 
-	// Get the list of plugins to load:
 	AStringVector res;
-	auto Values = a_Settings.GetValues("Plugins");
-	for (auto NameValue : Values)
+
+	// Get the old format plugin list, and migrate it:
+	auto OldValues = a_Settings.GetValues("Plugins");
+	for (auto NameValue : OldValues)
 	{
 		AString ValueName = NameValue.first;
 		if (ValueName.compare("Plugin") == 0)
@@ -1744,8 +1746,20 @@ AStringVector cPluginManager::GetFoldersToLoad(cSettingsRepositoryInterface & a_
 			AString PluginFile = NameValue.second;
 			if (!PluginFile.empty())
 			{
-				res.push_back(PluginFile);
+				a_Settings.DeleteValue("Plugins", ValueName);
+				a_Settings.SetValue("Plugins", PluginFile, "1");
 			}
+		}
+	}  // for i - ini values
+
+	// Get the list of plugins to load:
+	auto Values = a_Settings.GetValues("Plugins");
+	for (auto NameValue : Values)
+	{
+		AString Enabled = NameValue.second;
+		if (Enabled == "1")
+		{
+			res.push_back(NameValue.first);
 		}
 	}  // for i - ini values
 

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -1737,7 +1737,7 @@ AStringVector cPluginManager::GetFoldersToLoad(cSettingsRepositoryInterface & a_
 	AStringVector res;
 
 	// Get the old format plugin list, and migrate it.
-	// Upgrade path added on 27/03/2020
+	// Upgrade path added on 2020-03-27
 	auto OldValues = a_Settings.GetValues("Plugins");
 	for (auto NameValue : OldValues)
 	{


### PR DESCRIPTION
One potential solution for issues where an ini parser removes duplicate keys when the plugin list is loaded.

```
[Plugins]
WorldEdit=1
Core=1
ChatLog=1
ProtectionAreas=0
```

1 enables a plugin, 0 disables it. Commenting out a line can also be used to disable a plugin. I also thought about having a single line listing all enabled plugins with commas, but it would be harder to quickly disable a plugin.
