### PR TITLE
Inventory changes

### DIFF
--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1630,7 +1630,7 @@ void cProtocol_1_8_0::SendWholeInventory(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowItems);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Window.GetNumSlots()));
 	cItems Slots;
 	a_Window.GetSlots(*(m_Client->GetPlayer()), Slots);
@@ -1649,7 +1649,7 @@ void cProtocol_1_8_0::SendWindowClose(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowClose);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 }
 
 
@@ -1667,7 +1667,7 @@ void cProtocol_1_8_0::SendWindowOpen(const cWindow & a_Window)
 	}
 
 	cPacketizer Pkt(*this, pktWindowOpen);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 	Pkt.WriteString(a_Window.GetWindowTypeName());
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", a_Window.GetWindowTitle().c_str()));
 
@@ -1677,12 +1677,12 @@ void cProtocol_1_8_0::SendWindowOpen(const cWindow & a_Window)
 		case cWindow::wtEnchantment:
 		case cWindow::wtAnvil:
 		{
-			Pkt.WriteBEInt8(0);
+			Pkt.WriteBEUInt8(0);
 			break;
 		}
 		default:
 		{
-			Pkt.WriteBEInt8(static_cast<Int8>(a_Window.GetNumNonInventorySlots()));
+			Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetNumNonInventorySlots()));
 			break;
 		}
 	}
@@ -1703,7 +1703,7 @@ void cProtocol_1_8_0::SendWindowProperty(const cWindow & a_Window, short a_Prope
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowProperty);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(a_Property);
 	Pkt.WriteBEInt16(a_Value);
 }

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -1686,7 +1686,7 @@ void cProtocol_1_9_0::SendWholeInventory(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowItems);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Window.GetNumSlots()));
 	cItems Slots;
 	a_Window.GetSlots(*(m_Client->GetPlayer()), Slots);
@@ -1705,7 +1705,7 @@ void cProtocol_1_9_0::SendWindowClose(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowClose);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 }
 
 
@@ -1723,7 +1723,7 @@ void cProtocol_1_9_0::SendWindowOpen(const cWindow & a_Window)
 	}
 
 	cPacketizer Pkt(*this, pktWindowOpen);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 	Pkt.WriteString(a_Window.GetWindowTypeName());
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", a_Window.GetWindowTitle().c_str()));
 
@@ -1733,12 +1733,12 @@ void cProtocol_1_9_0::SendWindowOpen(const cWindow & a_Window)
 		case cWindow::wtEnchantment:
 		case cWindow::wtAnvil:
 		{
-			Pkt.WriteBEInt8(0);
+			Pkt.WriteBEUInt8(0);
 			break;
 		}
 		default:
 		{
-			Pkt.WriteBEInt8(static_cast<Int8>(a_Window.GetNumNonInventorySlots()));
+			Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetNumNonInventorySlots()));
 			break;
 		}
 	}
@@ -1759,7 +1759,7 @@ void cProtocol_1_9_0::SendWindowProperty(const cWindow & a_Window, short a_Prope
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowProperty);
-	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(a_Window.GetWindowID());
 	Pkt.WriteBEInt16(a_Property);
 	Pkt.WriteBEInt16(a_Value);
 }

--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -21,7 +21,7 @@
 
 
 
-Byte cWindow::m_WindowIDCounter = 1;
+Byte cWindow::m_WindowIDCounter = 0;
 
 
 
@@ -34,6 +34,8 @@ cWindow::cWindow(WindowType a_WindowType, const AString & a_WindowTitle) :
 	m_IsDestroyed(false),
 	m_Owner(nullptr)
 {
+	ASSERT((m_WindowID > 0) && (m_WindowID < 127));
+
 	if (a_WindowType == wtInventory)
 	{
 		m_WindowID = 0;

--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -21,23 +21,19 @@
 
 
 
-Byte cWindow::m_WindowIDCounter = 0;
+char cWindow::m_WindowIDCounter = 1;
 
 
 
 
 
 cWindow::cWindow(WindowType a_WindowType, const AString & a_WindowTitle) :
-	m_WindowID(static_cast<char>((++m_WindowIDCounter) % 127)),
+	m_WindowID((++m_WindowIDCounter) % 127),
 	m_WindowType(a_WindowType),
 	m_WindowTitle(a_WindowTitle),
 	m_IsDestroyed(false),
 	m_Owner(nullptr)
 {
-	// The window ID is signed in protocol 1.7, unsigned in protocol 1.8. Keep out of trouble by using only 7 bits:
-	// Ref.: https://forum.cuberite.org/thread-1876.html
-	ASSERT((m_WindowID >= 0) && (m_WindowID < 127));
-
 	if (a_WindowType == wtInventory)
 	{
 		m_WindowID = 0;

--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -21,7 +21,7 @@
 
 
 
-char cWindow::m_WindowIDCounter = 1;
+Byte cWindow::m_WindowIDCounter = 1;
 
 
 

--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -34,7 +34,7 @@ cWindow::cWindow(WindowType a_WindowType, const AString & a_WindowTitle) :
 	m_IsDestroyed(false),
 	m_Owner(nullptr)
 {
-	ASSERT((m_WindowID > 0) && (m_WindowID < 127));
+	ASSERT((m_WindowID > 0) && (m_WindowID <= 127));
 
 	if (a_WindowType == wtInventory)
 	{
@@ -763,7 +763,6 @@ void cWindow::SetProperty(short a_Property, short a_Value, cPlayer & a_Player)
 {
 	a_Player.GetClientHandle()->SendWindowProperty(*this, a_Property, a_Value);
 }
-
 
 
 

--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -28,7 +28,7 @@ Byte cWindow::m_WindowIDCounter = 0;
 
 
 cWindow::cWindow(WindowType a_WindowType, const AString & a_WindowTitle) :
-	m_WindowID((++m_WindowIDCounter) % 127),
+	m_WindowID(((++m_WindowIDCounter) % 127) + 1),
 	m_WindowType(a_WindowType),
 	m_WindowTitle(a_WindowTitle),
 	m_IsDestroyed(false),

--- a/src/UI/Window.h
+++ b/src/UI/Window.h
@@ -192,7 +192,7 @@ protected:
 
 	cWindowOwner * m_Owner;
 
-	static char m_WindowIDCounter;
+	static Byte m_WindowIDCounter;
 
 	/** Sets the internal flag as "destroyed"; notifies the owner that the window is destroying */
 	virtual void Destroy(void);

--- a/src/UI/Window.h
+++ b/src/UI/Window.h
@@ -192,7 +192,7 @@ protected:
 
 	cWindowOwner * m_Owner;
 
-	static Byte m_WindowIDCounter;
+	static char m_WindowIDCounter;
 
 	/** Sets the internal flag as "destroyed"; notifies the owner that the window is destroying */
 	virtual void Destroy(void);


### PR DESCRIPTION
Possibly fixes #4092

https://github.com/cuberite/cuberite/pull/1883 changed the window ID counter to start from 0 instead of 1. Wouldn't this potentially conflict with player inventories, which are always ID 0?