### PR TITLE
Fixed Clang builds

### DIFF
--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1630,7 +1630,7 @@ void cProtocol_1_8_0::SendWholeInventory(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowItems);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Window.GetNumSlots()));
 	cItems Slots;
 	a_Window.GetSlots(*(m_Client->GetPlayer()), Slots);
@@ -1649,7 +1649,7 @@ void cProtocol_1_8_0::SendWindowClose(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowClose);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 }
 
 
@@ -1667,7 +1667,7 @@ void cProtocol_1_8_0::SendWindowOpen(const cWindow & a_Window)
 	}
 
 	cPacketizer Pkt(*this, pktWindowOpen);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 	Pkt.WriteString(a_Window.GetWindowTypeName());
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", a_Window.GetWindowTitle().c_str()));
 
@@ -1703,7 +1703,7 @@ void cProtocol_1_8_0::SendWindowProperty(const cWindow & a_Window, short a_Prope
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowProperty);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 	Pkt.WriteBEInt16(a_Property);
 	Pkt.WriteBEInt16(a_Value);
 }

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -1686,7 +1686,7 @@ void cProtocol_1_9_0::SendWholeInventory(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowItems);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 	Pkt.WriteBEInt16(static_cast<Int16>(a_Window.GetNumSlots()));
 	cItems Slots;
 	a_Window.GetSlots(*(m_Client->GetPlayer()), Slots);
@@ -1705,7 +1705,7 @@ void cProtocol_1_9_0::SendWindowClose(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowClose);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 }
 
 
@@ -1723,7 +1723,7 @@ void cProtocol_1_9_0::SendWindowOpen(const cWindow & a_Window)
 	}
 
 	cPacketizer Pkt(*this, pktWindowOpen);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 	Pkt.WriteString(a_Window.GetWindowTypeName());
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", a_Window.GetWindowTitle().c_str()));
 
@@ -1759,7 +1759,7 @@ void cProtocol_1_9_0::SendWindowProperty(const cWindow & a_Window, short a_Prope
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktWindowProperty);
-	Pkt.WriteBEUInt8(a_Window.GetWindowID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Window.GetWindowID()));
 	Pkt.WriteBEInt16(a_Property);
 	Pkt.WriteBEInt16(a_Value);
 }


### PR DESCRIPTION
A window id, which was signed was used in an unsigned context. This caused a Clang compilation error.
Since there is one packet (Set Slot, 0x16) that allows negative values, it probably influenced the variable to have a signed value.