### PR TITLE
Prevent player from being destroyed by plugins

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3138,12 +3138,12 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					Params =
 					{
 						{
-							Name = "ShouldBroadcast",
+							Name = "ShouldBroadcast <B>(DEPRECATED)</b>",
 							Type = "boolean",
 							IsOptional = true,
 						},
 					},
-					Notes = "Schedules the entity to be destroyed; if ShouldBroadcast is not present or set to true, broadcasts the DestroyEntity packet",
+					Notes = "Schedules the entity to be destroyed; broadcasts the DestroyEntity packet",
 				},
 				DoesPreventBlockPlacement =
 				{

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3138,7 +3138,7 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					Params =
 					{
 						{
-							Name = "ShouldBroadcast <B>(DEPRECATED)</b>",
+							Name = "ShouldBroadcast <b>(DEPRECATED)</b>",
 							Type = "boolean",
 							IsOptional = true,
 						},

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -4094,9 +4094,14 @@ static int tolua_cEntity_Destroy(lua_State * tolua_S)
 	cEntity * self = nullptr;
 	L.GetStackValue(1, self);
 
+	if (lua_gettop(L) == 2)
+	{
+		LOGWARNING("cEntity:Destroy(bool) is deprecated, use cEntity:Destroy() instead.");
+	}
+
 	if (self->IsPlayer())
 	{
-		return L.ApiParamError("Cannot destroy a player");
+		return L.ApiParamError("Cannot call cEntity:Destroy() on a cPlayer, use cClientHandle:Kick() instead.");
 	}
 
 	self->Destroy();

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -4081,6 +4081,32 @@ static int tolua_cCuboid_Move(lua_State * tolua_S)
 
 
 
+static int tolua_cEntity_Destroy(lua_State * tolua_S)
+{
+	// Check the params:
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("cEntity"))
+	{
+		return 0;
+	}
+
+	// Get the params:
+	cEntity * self = nullptr;
+	L.GetStackValue(1, self);
+
+	if (self->IsPlayer())
+	{
+		return L.ApiParamError("Cannot destroy a player");
+	}
+
+	self->Destroy();
+	return 0;
+}
+
+
+
+
+
 static int tolua_cEntity_IsSubmerged(lua_State * tolua_S)
 {
 	// Check the params:
@@ -4256,6 +4282,7 @@ void cManualBindings::Bind(lua_State * tolua_S)
 
 		tolua_beginmodule(tolua_S, "cEntity");
 			tolua_constant(tolua_S, "INVALID_ID", cEntity::INVALID_ID);
+			tolua_function(tolua_S, "Destroy", tolua_cEntity_Destroy);
 			tolua_function(tolua_S, "IsSubmerged", tolua_cEntity_IsSubmerged);
 			tolua_function(tolua_S, "IsSwimming", tolua_cEntity_IsSwimming);
 			tolua_function(tolua_S, "GetPosition", tolua_cEntity_GetPosition);

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -289,14 +289,16 @@ public:
 	If this returns false, you must stop using the cEntity pointer you have. */
 	bool IsTicking(void) const;
 
+	// tolua_end
 	/** Destroys the entity, schedules it for memory freeing and broadcasts the DestroyEntity packet */
 	virtual void Destroy();
 
 	OBSOLETE void Destroy(bool a_ShouldBroadcast)
 	{
-		LOGWARNING("cEntity:Destory(bool) is deprecated, use cEntity:Destroy() instead.");
+		LOGWARNING("cEntity:Destroy(bool) is deprecated, use cEntity:Destroy() instead.");
 		Destroy();
 	}
+	// tolua_begin
 
 	/** Makes this pawn take damage from an attack by a_Attacker. Damage values are calculated automatically and DoTakeDamage() called */
 	void TakeDamage(cEntity & a_Attacker);

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -292,12 +292,6 @@ public:
 	// tolua_end
 	/** Destroys the entity, schedules it for memory freeing and broadcasts the DestroyEntity packet */
 	virtual void Destroy();
-
-	OBSOLETE void Destroy(bool a_ShouldBroadcast)
-	{
-		LOGWARNING("cEntity:Destroy(bool) is deprecated, use cEntity:Destroy() instead.");
-		Destroy();
-	}
 	// tolua_begin
 
 	/** Makes this pawn take damage from an attack by a_Attacker. Damage values are calculated automatically and DoTakeDamage() called */


### PR DESCRIPTION
Add manual binding, bails out with error message if attempted
entity to destroy is player.

Fix as suggested by @peterbell10 