### PR TITLE
Added a /boom command to Debuggers.

### DIFF
--- a/Server/Plugins/Debuggers/Debuggers.lua
+++ b/Server/Plugins/Debuggers/Debuggers.lua
@@ -2679,6 +2679,18 @@ end
 
 
 
+function HandleBoomCmd(a_Split, a_Player)
+	local playerPos = a_Player:GetPosition()
+	a_Player:GetWorld():BroadcastParticleEffect("smoke", Vector3f(playerPos), Vector3f(), 0, 900)
+	a_Player:GetWorld():BroadcastSoundEffect("entity.firework.large_blast", playerPos, 1, 1)
+	a_Player:SendMessage("BOOM!")
+	return true
+end
+
+
+
+
+
 function HandleTeamsCmd(a_Split, a_Player)
 	local Scoreboard = a_Player:GetWorld():GetScoreBoard()
 

--- a/Server/Plugins/Debuggers/Info.lua
+++ b/Server/Plugins/Debuggers/Info.lua
@@ -22,12 +22,21 @@ g_PluginInfo =
 			Handler = HandleArrowCmd,
 			HelpString = "Creates an arrow going away from the player"
 		},
+
 		["/blk"] =
 		{
 			Permission = "debuggers",
 			Handler = HandleBlkCmd,
 			HelpString = "Gets info about the block you are looking at"
 		},
+
+		["/boom"] =
+		{
+			Permission = "debuggers",
+			Handler = HandleBoomCmd,
+			HelpString = "Playes a sound and displays an effect at the player's position",
+		},
+
 		["/clientversion"] =
 		{
 			Permission = "debuggers",


### PR DESCRIPTION
This is a simple addition to the Debuggers plugin, mainly to show off how to send effects / sounds to clients.

[ci skip]