### PR TITLE
Let libevent choose a reasonable backlog value

### DIFF
--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -205,14 +205,14 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 		evutil_closesocket(MainSock);
 		return false;
 	}
-	if (listen(MainSock, 0) != 0)
+	if (listen(MainSock, SOMAXCONN) != 0)
 	{
 		m_ErrorCode = EVUTIL_SOCKET_ERROR();
 		Printf(m_ErrorMsg, "Cannot listen on port %d: %d (%s)", a_Port, m_ErrorCode, evutil_socket_error_to_string(m_ErrorCode));
 		evutil_closesocket(MainSock);
 		return false;
 	}
-	m_ConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1, MainSock);
+	m_ConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, 0, MainSock);
 	m_IsListening = true;
 
 	if (!NeedsTwoSockets)
@@ -263,7 +263,7 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 		return true;  // Report as success, the primary socket is working
 	}
 
-	if (listen(SecondSock, 0) != 0)
+	if (listen(SecondSock, SOMAXCONN) != 0)
 	{
 		err = EVUTIL_SOCKET_ERROR();
 		LOGD("Cannot listen on secondary socket on port %d: %d (%s)", a_Port, err, evutil_socket_error_to_string(err));
@@ -273,7 +273,7 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 
 	UNUSED(err);
 
-	m_SecondaryConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1, SecondSock);
+	m_SecondaryConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, 0, SecondSock);
 	return true;
 }
 

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -205,14 +205,14 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 		evutil_closesocket(MainSock);
 		return false;
 	}
-	if (listen(MainSock, -1) != 0)
+	if (listen(MainSock, 0) != 0)
 	{
 		m_ErrorCode = EVUTIL_SOCKET_ERROR();
 		Printf(m_ErrorMsg, "Cannot listen on port %d: %d (%s)", a_Port, m_ErrorCode, evutil_socket_error_to_string(m_ErrorCode));
 		evutil_closesocket(MainSock);
 		return false;
 	}
-	m_ConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, 0, MainSock);
+	m_ConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1, MainSock);
 	m_IsListening = true;
 
 	if (!NeedsTwoSockets)
@@ -263,7 +263,7 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 		return true;  // Report as success, the primary socket is working
 	}
 
-	if (listen(SecondSock, -1) != 0)
+	if (listen(SecondSock, 0) != 0)
 	{
 		err = EVUTIL_SOCKET_ERROR();
 		LOGD("Cannot listen on secondary socket on port %d: %d (%s)", a_Port, err, evutil_socket_error_to_string(err));
@@ -273,7 +273,7 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 
 	UNUSED(err);
 
-	m_SecondaryConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, 0, SecondSock);
+	m_SecondaryConnListener = evconnlistener_new(cNetworkSingleton::Get().GetEventBase(), Callback, this, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1, SecondSock);
 	return true;
 }
 

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -205,7 +205,7 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 		evutil_closesocket(MainSock);
 		return false;
 	}
-	if (listen(MainSock, 0) != 0)
+	if (listen(MainSock, -1) != 0)
 	{
 		m_ErrorCode = EVUTIL_SOCKET_ERROR();
 		Printf(m_ErrorMsg, "Cannot listen on port %d: %d (%s)", a_Port, m_ErrorCode, evutil_socket_error_to_string(m_ErrorCode));
@@ -263,7 +263,7 @@ bool cServerHandleImpl::Listen(UInt16 a_Port)
 		return true;  // Report as success, the primary socket is working
 	}
 
-	if (listen(SecondSock, 0) != 0)
+	if (listen(SecondSock, -1) != 0)
 	{
 		err = EVUTIL_SOCKET_ERROR();
 		LOGD("Cannot listen on secondary socket on port %d: %d (%s)", a_Port, err, evutil_socket_error_to_string(err));


### PR DESCRIPTION
References: http://www.wangafu.net/~nickm/libevent-book/Ref8_listener.html
https://github.com/libevent/libevent/blob/620a3fa1d514a0020c17a9a1119400dcdbd97d7a/include/event2/listener.h#L124

For some reason this caused issues on Android, but not on other OSes. I suppose this could possibly close other connection issue bug reports if such exist.

Fixes #4457
Fixes https://github.com/cuberite/android/issues/47
Fixes https://github.com/cuberite/cuberite/issues/4596