### PR TITLE
Remove golden apple after eating

### DIFF
--- a/src/Items/ItemFood.h
+++ b/src/Items/ItemFood.h
@@ -98,10 +98,7 @@ public:
 
 	virtual bool EatItem(cPlayer * a_Player, cItem * a_Item) override
 	{
-		if (!super::EatItem(a_Player, a_Item))
-		{
-			return false;
-		}
+		super::EatItem(a_Player, a_Item);
 
 		if (!a_Player->IsGameModeCreative())
 		{


### PR DESCRIPTION
Golden apples weren't removed from the inventory if the player's health was maxed out.