### PR TITLE
Quick fix to make spawn eggs work

### DIFF
--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -3238,7 +3238,7 @@ void cProtocol_1_9_0::ParseItemMetadata(cItem & a_Item, const AString & a_Metada
 							AString NBTName = NBT.GetString(entitytag);
 							ReplaceString(NBTName, "minecraft:", "");
 							eMonsterType MonsterType = cMonster::StringToMobType(NBTName);
-							a_Item.m_ItemDamage = static_cast<short>(MonsterType);
+							a_Item.m_ItemDamage = static_cast<short>(GetProtocolMobType(MonsterType));
 
 						}
 					}


### PR DESCRIPTION
Mob type values changed in https://github.com/cuberite/cuberite/commit/01b8ed5295875262a91b60af878bf2a18c1b7aae, which broke spawn eggs. In the long run, we should really rework how spawn eggs are handled.