### PR TITLE
Falling blocks can now be spawned at any position.

### DIFF
--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -3319,37 +3319,89 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 			},
 			SpawnFallingBlock =
 			{
-				Params =
 				{
+					Params =
 					{
-						Name = "X",
-						Type = "number",
+						{
+							Name = "X",
+							Type = "number",
+						},
+						{
+							Name = "Y",
+							Type = "number",
+						},
+						{
+							Name = "Z",
+							Type = "number",
+						},
+						{
+							Name = "BlockType",
+							Type = "number",
+						},
+						{
+							Name = "BlockMeta",
+							Type = "number",
+						},
 					},
+					Returns =
 					{
-						Name = "Y",
-						Type = "number",
+						{
+							Name = "EntityID",
+							Type = "number",
+						},
 					},
-					{
-						Name = "Z",
-						Type = "number",
-					},
-					{
-						Name = "BlockType",
-						Type = "number",
-					},
-					{
-						Name = "BlockMeta",
-						Type = "number",
-					},
+					Notes = "OBSOLETE, use the Vector3-based overloads instead. Spawns a {{cFallingBlock|Falling Block}} entity at the specified coords with the given block type/meta. Returns the EntityID of the new falling block, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no falling block was created.",
 				},
-				Returns =
 				{
+					Params =
 					{
-						Name = "EntityID",
-						Type = "number",
+						{
+							Name = "BlockPos",
+							Type = "Vector3i",
+						},
+						{
+							Name = "BlockType",
+							Type = "number",
+						},
+						{
+							Name = "BlockMeta",
+							Type = "number",
+						},
 					},
+					Returns =
+					{
+						{
+							Name = "EntityID",
+							Type = "number",
+						},
+					},
+					Notes = "Spawns a {{cFallingBlock|Falling Block}} entity in the middle of the specified block, with the given block type/meta. Returns the EntityID of the new falling block, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no falling block was created.",
 				},
-				Notes = "Spawns a {{cFallingBlock|Falling Block}} entity at the specified coords with the given block type/meta. Returns the EntityID of the new falling block, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no falling block was created.",
+				{
+					Params =
+					{
+						{
+							Name = "Pos",
+							Type = "Vector3d",
+						},
+						{
+							Name = "BlockType",
+							Type = "number",
+						},
+						{
+							Name = "BlockMeta",
+							Type = "number",
+						},
+					},
+					Returns =
+					{
+						{
+							Name = "EntityID",
+							Type = "number",
+						},
+					},
+					Notes = "Spawns a {{cFallingBlock|Falling Block}} entity at exactly the specified coords, with the given block type/meta. Returns the EntityID of the new falling block, or {{cEntity#INVALID_ID|cEntity#INVALID_ID}} if no falling block was created.",
+				},
 			},
 			SpawnItemPickup =
 			{

--- a/Server/Plugins/Debuggers/Debuggers.lua
+++ b/Server/Plugins/Debuggers/Debuggers.lua
@@ -1567,6 +1567,25 @@ end
 
 
 
+function HandleCakeCmd(a_Split, a_Player)
+	local lookVector = a_Player:GetLookVector()
+	local pos = a_Player:GetEyePosition() + lookVector
+	local world = a_Player:GetWorld()
+	local speed = lookVector * 10
+	local cakeID = world:SpawnFallingBlock(pos, E_BLOCK_CAKE, 0)
+	world:DoWithEntityByID(cakeID,
+		function(a_CBCake)
+			a_CBCake:SetSpeed(speed)
+		end
+	)
+	a_Player:SendMessage("Your cake is served")
+	return true
+end
+
+
+
+
+
 function HandleClientVersionCmd(a_Split, a_Player)
 	a_Player:SendMessage("Your client version number is " .. a_Player:GetClientHandle():GetProtocolVersion() ..".")
 	return true

--- a/Server/Plugins/Debuggers/Info.lua
+++ b/Server/Plugins/Debuggers/Info.lua
@@ -37,6 +37,13 @@ g_PluginInfo =
 			HelpString = "Playes a sound and displays an effect at the player's position",
 		},
 
+		["/cake"] =
+		{
+			Permission = "debuggers",
+			Handler = HandleCakeCmd,
+			HelpString = "Throws a cake in the direction the player's looking, in a slow arc.",
+		},
+
 		["/clientversion"] =
 		{
 			Permission = "debuggers",

--- a/src/Entities/FallingBlock.cpp
+++ b/src/Entities/FallingBlock.cpp
@@ -11,11 +11,10 @@
 
 
 
-cFallingBlock::cFallingBlock(Vector3i a_BlockPosition, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) :
-	super(etFallingBlock, Vector3d(0.5, 0, 0.5) + a_BlockPosition, 0.98, 0.98),
+cFallingBlock::cFallingBlock(Vector3d a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta):
+	super(etFallingBlock, a_Position, 0.98, 0.98),
 	m_BlockType(a_BlockType),
-	m_BlockMeta(a_BlockMeta),
-	m_OriginalPosition(a_BlockPosition)
+	m_BlockMeta(a_BlockMeta)
 {
 	SetGravity(-16.0f);
 	SetAirDrag(0.02f);

--- a/src/Entities/FallingBlock.h
+++ b/src/Entities/FallingBlock.h
@@ -20,8 +20,8 @@ public:  // tolua_export
 	CLASS_PROTODEF(cFallingBlock)
 
 	/** Creates a new falling block.
-	a_BlockPosition is expected in world coords */
-	cFallingBlock(Vector3i a_BlockPosition, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
+	a_Position is expected in world coords */
+	cFallingBlock(Vector3d a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 
 	// tolua_begin
 
@@ -37,7 +37,6 @@ public:  // tolua_export
 private:
 	BLOCKTYPE  m_BlockType;
 	NIBBLETYPE m_BlockMeta;
-	Vector3i   m_OriginalPosition;  // Position where the falling block has started, in world coords
 } ;  // tolua_export
 
 

--- a/src/Simulator/SandSimulator.cpp
+++ b/src/Simulator/SandSimulator.cpp
@@ -62,7 +62,7 @@ void cSandSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX,
 			);
 			*/
 
-			auto FallingBlock = cpp14::make_unique<cFallingBlock>(Pos, BlockType, a_Chunk->GetMeta(itr->x, itr->y, itr->z));
+			auto FallingBlock = cpp14::make_unique<cFallingBlock>(Vector3d(0.5, 0, 0.5) + Pos, BlockType, a_Chunk->GetMeta(itr->x, itr->y, itr->z));
 			auto FallingBlockPtr = FallingBlock.get();
 			if (!FallingBlockPtr->Initialize(std::move(FallingBlock), m_World))
 			{

--- a/src/Simulator/SandSimulator.cpp
+++ b/src/Simulator/SandSimulator.cpp
@@ -62,12 +62,7 @@ void cSandSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX,
 			);
 			*/
 
-			auto FallingBlock = cpp14::make_unique<cFallingBlock>(Vector3d(0.5, 0, 0.5) + Pos, BlockType, a_Chunk->GetMeta(itr->x, itr->y, itr->z));
-			auto FallingBlockPtr = FallingBlock.get();
-			if (!FallingBlockPtr->Initialize(std::move(FallingBlock), m_World))
-			{
-				continue;
-			}
+			m_World.SpawnFallingBlock(Pos, BlockType, a_Chunk->GetMeta(itr->x, itr->y, itr->z));
 			a_Chunk->SetBlock({itr->x, itr->y, itr->z}, E_BLOCK_AIR, 0);
 		}
 	}

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2039,7 +2039,7 @@ UInt32 cWorld::SpawnItemPickup(Vector3d a_Pos, const cItem & a_Item, Vector3f a_
 
 
 
-UInt32 cWorld::SpawnFallingBlock(Vector3i a_Pos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
+UInt32 cWorld::SpawnFallingBlock(Vector3d a_Pos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 {
 	auto fallingBlock = cpp14::make_unique<cFallingBlock>(a_Pos, a_BlockType, a_BlockMeta);
 	auto fallingBlockPtr = fallingBlock.get();

--- a/src/World.h
+++ b/src/World.h
@@ -564,14 +564,22 @@ public:
 
 	/** Spawns an falling block entity at the given position.
 	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
-	UInt32 SpawnFallingBlock(Vector3i a_Pos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
+	UInt32 SpawnFallingBlock(Vector3d a_Pos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);
 
-	/** OBSOLETE, use the Vector3i-based overload instead.
+	/** Spawns an falling block entity at the given position.
+	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
+	UInt32 SpawnFallingBlock(Vector3i a_BlockPos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
+	{
+		// When creating from a block position (Vector3i), move the spawn point to the middle of the block by adding (0.5, 0.5, 0.5)
+		return SpawnFallingBlock(Vector3d(0.5, 0, 0.5) + a_BlockPos, a_BlockType, a_BlockMeta);
+	}
+
+	/** OBSOLETE, use the Vector3-based overload instead.
 	Spawns an falling block entity at the given position.
 	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
 	UInt32 SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 	{
-		return SpawnFallingBlock({a_X, a_Y, a_Z}, a_BlockType, a_BlockMeta);
+		return SpawnFallingBlock(Vector3i{a_X, a_Y, a_Z}, a_BlockType, a_BlockMeta);
 	}
 
 	/** Spawns an minecart at the given coordinates.

--- a/src/World.h
+++ b/src/World.h
@@ -570,7 +570,7 @@ public:
 	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
 	UInt32 SpawnFallingBlock(Vector3i a_BlockPos, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
 	{
-		// When creating from a block position (Vector3i), move the spawn point to the middle of the block by adding (0.5, 0.5, 0.5)
+		// When creating from a block position (Vector3i), move the spawn point to the middle of the block by adding (0.5, 0, 0.5)
 		return SpawnFallingBlock(Vector3d(0.5, 0, 0.5) + a_BlockPos, a_BlockType, a_BlockMeta);
 	}
 


### PR DESCRIPTION
`cFallingBlock` entity can be created at `Vector3d` coords, instead of `Vector3i`.
Added a `/cake` command to Debuggers that throws a cake in a nice slow arc.