### PR TITLE
Filter blocks to add to redstone sim's wake queue

### DIFF
--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -150,6 +150,7 @@ public:
 
 	int GetPosX(void) const { return m_PosX; }
 	int GetPosZ(void) const { return m_PosZ; }
+	cChunkCoords GetPos() const { return {m_PosX, m_PosZ}; }
 
 	cWorld * GetWorld(void) const { return m_World; }
 

--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
@@ -157,8 +157,7 @@ void cIncrementalRedstoneSimulator::Simulate(float a_dt)
 		if (CurrentHandler == nullptr)  // Block at CurrentPosition doesn't have a corresponding redstone handler
 		{
 			// Clean up cached PowerData for CurrentPosition
-			static_cast<cIncrementalRedstoneSimulator *>(m_World.GetRedstoneSimulator())->GetChunkData()->ErasePowerData(CurrentLocation);
-
+			GetChunkData()->ErasePowerData(CurrentLocation);
 			continue;
 		}
 
@@ -190,6 +189,66 @@ void cIncrementalRedstoneSimulator::Simulate(float a_dt)
 		if (IsAlwaysTicked(CurrentBlock))
 		{
 			m_Data.GetActiveBlocks().emplace_back(CurrentLocation);
+		}
+	}
+}
+
+
+
+
+
+void cIncrementalRedstoneSimulator::AddBlock(Vector3i a_Block, cChunk * a_Chunk)
+{
+	// Can't inspect block, so queue update anyway
+	if (a_Chunk == nullptr)
+	{
+		m_Data.WakeUp(a_Block);
+		return;
+	}
+
+	const auto RelPos = cChunkDef::AbsoluteToRelative(a_Block, a_Chunk->GetPos());
+	const auto CurBlock = a_Chunk->GetBlock(RelPos);
+
+	// Always update mechanisms
+	if (IsMechanism(CurBlock))
+	{
+		m_Data.WakeUp(a_Block);
+		return;
+	}
+
+	// Never update blocks without a handler
+	if (GetComponentHandler(CurBlock) == nullptr)
+	{
+		GetChunkData()->ErasePowerData(a_Block);
+		return;
+	}
+
+	// Only update others if there is a mechanism nearby
+	for (int x = -1; x < 2; ++x)
+	{
+		for (int y = -1; y < 2; ++y)
+		{
+			if (!cChunkDef::IsValidHeight(RelPos.y + y))
+			{
+				continue;
+			}
+
+			for (int z = -1; z < 2; ++z)
+			{
+				auto CheckPos = RelPos + Vector3i{x, y, z};
+				BLOCKTYPE Block;
+				NIBBLETYPE Meta;
+
+				// If we can't read the block, assume it is a mechanism
+				if (
+					!a_Chunk->UnboundedRelGetBlock(CheckPos, Block, Meta) ||
+					IsMechanism(Block)
+				)
+				{
+					m_Data.WakeUp(a_Block);
+					return;
+				}
+			}
 		}
 	}
 }

--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
@@ -209,8 +209,8 @@ void cIncrementalRedstoneSimulator::AddBlock(Vector3i a_Block, cChunk * a_Chunk)
 	const auto RelPos = cChunkDef::AbsoluteToRelative(a_Block, a_Chunk->GetPos());
 	const auto CurBlock = a_Chunk->GetBlock(RelPos);
 
-	// Always update mechanisms
-	if (IsMechanism(CurBlock))
+	// Always update redstone devices
+	if (IsRedstone(CurBlock))
 	{
 		m_Data.WakeUp(a_Block);
 		return;
@@ -223,7 +223,7 @@ void cIncrementalRedstoneSimulator::AddBlock(Vector3i a_Block, cChunk * a_Chunk)
 		return;
 	}
 
-	// Only update others if there is a mechanism nearby
+	// Only update others if there is a redstone device nearby
 	for (int x = -1; x < 2; ++x)
 	{
 		for (int y = -1; y < 2; ++y)
@@ -242,7 +242,7 @@ void cIncrementalRedstoneSimulator::AddBlock(Vector3i a_Block, cChunk * a_Chunk)
 				// If we can't read the block, assume it is a mechanism
 				if (
 					!a_Chunk->UnboundedRelGetBlock(CheckPos, Block, Meta) ||
-					IsMechanism(Block)
+					IsRedstone(Block)
 				)
 				{
 					m_Data.WakeUp(a_Block);

--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.h
@@ -31,10 +31,7 @@ public:
 		return IsRedstone(a_BlockType);
 	}
 
-	virtual void AddBlock(Vector3i a_Block, cChunk * a_Chunk) override
-	{
-		m_Data.WakeUp(a_Block);
-	}
+	virtual void AddBlock(Vector3i a_Block, cChunk * a_Chunk) override;
 
 	/** Returns if a block is a mechanism (something that accepts power and does something)
 	Used by torches to determine if they will power a block


### PR DESCRIPTION
Fixes #4402

Instead of adding every block in the world to the update queue, this only adds blocks with a redstone mechanism nearby. Or, if we can't read its neighbours I add it anyway just in case.

This still allows for indirect powering through solid blocks but the update queue is a lot smaller in the common case.