### PR TITLE
Only store IDs across ticks

### DIFF
--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -489,7 +489,7 @@ public:
 	/** Returns true if a world change is scheduled to happen. */
 	bool IsWorldChangeScheduled() const
 	{
-		return (m_WorldChangeInfo.load() != nullptr);
+		return (m_WorldChangeInfo.m_NewWorld != nullptr);
 	}
 
 	/** Updates clients of changes in the entity. */
@@ -662,8 +662,8 @@ protected:
 
 	cWorld * m_World;
 
-	/** If not nullptr, a world change is scheduled and a task is queued in the current world. */
-	cAtomicUniquePtr<sWorldChangeInfo> m_WorldChangeInfo;
+	/** If field m_NewWorld not nullptr, a world change is scheduled and a task is queued in the current world. */
+	sWorldChangeInfo m_WorldChangeInfo;
 
 	/** Whether the entity is capable of taking fire or lava damage. */
 	bool m_IsFireproof;

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -465,21 +465,21 @@ public:
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
 
 	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
-	OBSOLETE void ScheduleMoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true)
+	OBSOLETE void ScheduleMoveToWorld(cWorld & a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true)
 	{
 		LOGWARNING("ScheduleMoveToWorld is deprecated, use MoveToWorld instead");
 		MoveToWorld(a_World, a_NewPosition, a_ShouldSetPortalCooldown, a_ShouldSendRespawn);
 	}
 
-	bool MoveToWorld(cWorld * a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true);
+	bool MoveToWorld(cWorld & a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true);
 
-	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
+	bool MoveToWorld(cWorld & a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
 	{
 		return MoveToWorld(a_World, a_NewPosition, false, a_ShouldSendRespawn);
 	}
 
 	/** Moves entity to specified world, taking a world pointer */
-	bool MoveToWorld(cWorld * a_World, bool a_ShouldSendRespawn = true);
+	bool MoveToWorld(cWorld & a_World, bool a_ShouldSendRespawn = true);
 
 	/** Moves entity to specified world, taking a world name */
 	bool MoveToWorld(const AString & a_WorldName, bool a_ShouldSendRespawn = true);

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1222,7 +1222,7 @@ void cPlayer::Respawn(void)
 
 	if (GetWorld() != m_SpawnWorld)
 	{
-		MoveToWorld(m_SpawnWorld, GetLastBedPos(), false, false);
+		MoveToWorld(*m_SpawnWorld, GetLastBedPos(), false, false);
 	}
 	else
 	{

--- a/src/NetherPortalScanner.cpp
+++ b/src/NetherPortalScanner.cpp
@@ -17,7 +17,7 @@ const double cNetherPortalScanner::AcrossOffset = 0.5;
 
 
 
-cNetherPortalScanner::cNetherPortalScanner(cEntity & a_MovingEntity, cWorld * a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY) :
+cNetherPortalScanner::cNetherPortalScanner(cEntity & a_MovingEntity, cWorld & a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY) :
 	m_EntityID(a_MovingEntity.GetUniqueID()),
 	m_SourceWorld(*a_MovingEntity.GetWorld()),
 	m_World(a_DestinationWorld),
@@ -39,7 +39,7 @@ cNetherPortalScanner::cNetherPortalScanner(cEntity & a_MovingEntity, cWorld * a_
 			Add(x, z);
 		}
 	}
-	Enable(*a_DestinationWorld->GetChunkMap());
+	Enable(*a_DestinationWorld.GetChunkMap());
 }
 
 
@@ -49,7 +49,7 @@ cNetherPortalScanner::cNetherPortalScanner(cEntity & a_MovingEntity, cWorld * a_
 void cNetherPortalScanner::OnChunkAvailable(int a_ChunkX, int a_ChunkZ)
 {
 	cChunkDef::BlockTypes blocks;
-	m_World->GetChunkBlockTypes(a_ChunkX, a_ChunkZ, blocks);
+	m_World.GetChunkBlockTypes(a_ChunkX, a_ChunkZ, blocks);
 
 	// Iterate through all of the blocks in the chunk
 	for (unsigned int i = 0; i < cChunkDef::NumBlocks; i++)
@@ -92,7 +92,7 @@ bool cNetherPortalScanner::IsValidBuildLocation(Vector3i a_BlockPos)
 	{
 		for (int j = 0; j < PortalLength; j++)
 		{
-			BLOCKTYPE blocktype = m_World->GetBlock(a_BlockPos.x + i, a_BlockPos.y, a_BlockPos.z + j);
+			BLOCKTYPE blocktype = m_World.GetBlock(a_BlockPos.x + i, a_BlockPos.y, a_BlockPos.z + j);
 			if (!cBlockInfo::IsSolid(blocktype))
 			{
 				return false;
@@ -101,7 +101,7 @@ bool cNetherPortalScanner::IsValidBuildLocation(Vector3i a_BlockPos)
 			// Check the airspace
 			for (int k = 1; k < PortalHeight; k++)
 			{
-				blocktype = m_World->GetBlock(a_BlockPos.x + i, a_BlockPos.y + k, a_BlockPos.z + j);
+				blocktype = m_World.GetBlock(a_BlockPos.x + i, a_BlockPos.y + k, a_BlockPos.z + j);
 				if (blocktype != E_BLOCK_AIR)
 				{
 					return false;
@@ -121,15 +121,15 @@ bool cNetherPortalScanner::OnAllChunksAvailable(void)
 	if (m_FoundPortal)
 	{
 		// Find the bottom of this portal
-		while (m_World->GetBlock(m_PortalLoc.x, m_PortalLoc.y, m_PortalLoc.z) == E_BLOCK_NETHER_PORTAL)
+		while (m_World.GetBlock(m_PortalLoc.x, m_PortalLoc.y, m_PortalLoc.z) == E_BLOCK_NETHER_PORTAL)
 		{
 			m_PortalLoc.y -= 1;
 		}
 		m_PortalLoc.y += 1;
 
 		// Figure out which way the portal is facing
-		int BXP = m_World->GetBlock(m_PortalLoc.x + 1, m_PortalLoc.y, m_PortalLoc.z);
-		int BXM = m_World->GetBlock(m_PortalLoc.x - 1, m_PortalLoc.y, m_PortalLoc.z);
+		int BXP = m_World.GetBlock(m_PortalLoc.x + 1, m_PortalLoc.y, m_PortalLoc.z);
+		int BXM = m_World.GetBlock(m_PortalLoc.x - 1, m_PortalLoc.y, m_PortalLoc.z);
 		if ((BXP == E_BLOCK_NETHER_PORTAL) || (BXM == E_BLOCK_NETHER_PORTAL))
 		{
 			// The long axis is along X
@@ -208,11 +208,11 @@ void cNetherPortalScanner::BuildNetherPortal(Vector3i a_Location, Direction a_Di
 			{
 				if (a_Direction == Direction::Y)
 				{
-					m_World->SetBlock(x + i, y + k, z + j, E_BLOCK_AIR, 0);
+					m_World.SetBlock(x + i, y + k, z + j, E_BLOCK_AIR, 0);
 				}
 				else if (a_Direction == Direction::X)
 				{
-					m_World->SetBlock(x + j, y + k, z + i, E_BLOCK_AIR, 0);
+					m_World.SetBlock(x + j, y + k, z + i, E_BLOCK_AIR, 0);
 				}
 			}
 		}
@@ -226,11 +226,11 @@ void cNetherPortalScanner::BuildNetherPortal(Vector3i a_Location, Direction a_Di
 			// +2 on the short axis because that's where we deposit the entity
 			if (a_Direction == Direction::Y)
 			{
-				m_World->SetBlock(x + 2, y, z + j, E_BLOCK_OBSIDIAN, 0);
+				m_World.SetBlock(x + 2, y, z + j, E_BLOCK_OBSIDIAN, 0);
 			}
 			else if (a_Direction == Direction::X)
 			{
-				m_World->SetBlock(x + j, y, z + 2, E_BLOCK_OBSIDIAN, 0);
+				m_World.SetBlock(x + j, y, z + 2, E_BLOCK_OBSIDIAN, 0);
 			}
 		}
 	}
@@ -240,31 +240,31 @@ void cNetherPortalScanner::BuildNetherPortal(Vector3i a_Location, Direction a_Di
 	{
 		if (a_Direction == Direction::Y)
 		{
-			m_World->SetBlock(x + 1, y + i, z, E_BLOCK_OBSIDIAN, 0);
-			m_World->SetBlock(x + 1, y + i, z + 3, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x + 1, y + i, z, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x + 1, y + i, z + 3, E_BLOCK_OBSIDIAN, 0);
 		}
 		else if (a_Direction == Direction::X)
 		{
-			m_World->SetBlock(x, y + i, z + 1, E_BLOCK_OBSIDIAN, 0);
-			m_World->SetBlock(x + 3, y + i, z + 1, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x, y + i, z + 1, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x + 3, y + i, z + 1, E_BLOCK_OBSIDIAN, 0);
 		}
 	}
 	for (int i = 0; i < PortalLength; i++)
 	{
 		if (a_Direction == Direction::Y)
 		{
-			m_World->SetBlock(x + 1, y + 4, z + i, E_BLOCK_OBSIDIAN, 0);
-			m_World->SetBlock(x + 1, y, z + i, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x + 1, y + 4, z + i, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x + 1, y, z + i, E_BLOCK_OBSIDIAN, 0);
 		}
 		else if (a_Direction == Direction::X)
 		{
-			m_World->SetBlock(x + i, y + 4, z + 1, E_BLOCK_OBSIDIAN, 0);
-			m_World->SetBlock(x + i, y, z + 1, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x + i, y + 4, z + 1, E_BLOCK_OBSIDIAN, 0);
+			m_World.SetBlock(x + i, y, z + 1, E_BLOCK_OBSIDIAN, 0);
 		}
 	}
 
 	// Fill the frame (place a fire in the bottom)
-	m_World->SetBlock(x + 1, y + 1, z + 1, E_BLOCK_FIRE, 0);
+	m_World.SetBlock(x + 1, y + 1, z + 1, E_BLOCK_FIRE, 0);
 }
 
 

--- a/src/NetherPortalScanner.h
+++ b/src/NetherPortalScanner.h
@@ -15,7 +15,7 @@ class cWorld;
 class cNetherPortalScanner : public cChunkStay
 {
 public:
-	cNetherPortalScanner(cEntity * a_MovingEntity, cWorld * a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY);
+	cNetherPortalScanner(cEntity & a_MovingEntity, cWorld * a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY);
 	virtual void OnChunkAvailable(int a_ChunkX, int a_ChunkY) override;
 	virtual bool OnAllChunksAvailable(void) override;
 	virtual void OnDisabled(void) override;
@@ -48,8 +48,11 @@ private:
 	/** Whether the given location is a valid location to build a portal. */
 	bool IsValidBuildLocation(Vector3i a_BlockPosition);
 
-	/** The entity that's being moved. */
-	cEntity * m_Entity;
+	/** The ID of the entity that's being moved. */
+	UInt32 m_EntityID;
+
+	/** The world we're moving the entity from, used to query the entity ID. */
+	cWorld & m_SourceWorld;
 
 	/** The world we're moving the entity to. */
 	cWorld * m_World;

--- a/src/NetherPortalScanner.h
+++ b/src/NetherPortalScanner.h
@@ -15,7 +15,7 @@ class cWorld;
 class cNetherPortalScanner : public cChunkStay
 {
 public:
-	cNetherPortalScanner(cEntity & a_MovingEntity, cWorld * a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY);
+	cNetherPortalScanner(cEntity & a_MovingEntity, cWorld & a_DestinationWorld, Vector3d a_DestPosition, int a_MaxY);
 	virtual void OnChunkAvailable(int a_ChunkX, int a_ChunkY) override;
 	virtual bool OnAllChunksAvailable(void) override;
 	virtual void OnDisabled(void) override;
@@ -55,7 +55,7 @@ private:
 	cWorld & m_SourceWorld;
 
 	/** The world we're moving the entity to. */
-	cWorld * m_World;
+	cWorld & m_World;
 
 	/** Whether we found a portal during the loading of the chunks. */
 	bool m_FoundPortal;


### PR DESCRIPTION
Ironic, we could advise plugins to do this, but couldn't do the same ourselves.

@mathiascode and @peterbell10 do you know why there is a lock + atomics in MoveToWorld? I was under the impression that it should only be called from the tick thread during tick.

Tentative fix for #4582.