### PR TITLE
Acquire chunk map CS when accessing player entities

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -434,7 +434,14 @@ bool cServer::Start(void)
 
 bool cServer::Command(cClientHandle & a_Client, AString & a_Cmd)
 {
-	return cRoot::Get()->GetPluginManager()->CallHookChat(*(a_Client.GetPlayer()), a_Cmd);
+	bool Res = cRoot::Get()->DoWithPlayerByUUID(
+		a_Client.GetUUID(),
+		[&](cPlayer & a_Player)
+		{
+			return cRoot::Get()->GetPluginManager()->CallHookChat(a_Player, a_Cmd);
+		}
+	);
+	return Res;
 }
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -1197,7 +1197,7 @@ private:
 	std::unique_ptr<cFireSimulator>      m_FireSimulator;
 	cRedstoneSimulator * m_RedstoneSimulator;
 
-	cCriticalSection m_CSPlayers;
+	// Protect with chunk map CS
 	cPlayerList      m_Players;
 
 	cWorldStorage    m_Storage;


### PR DESCRIPTION
This was supposed to be a quick fix for https://github.com/cuberite/cuberite/pull/4623#discussion_r407242620

However, there are a bunch of different places in `cWorld` where player entities could be accessed without the chunk map CS. Dropping `m_CSPlayers` and forcing the chunk map CS to be held should fix this.