### PR TITLE
Moreplacementfixes

### DIFF
--- a/src/Defines.cpp
+++ b/src/Defines.cpp
@@ -422,6 +422,24 @@ void AddFaceDirection(int & a_BlockX, int & a_BlockY, int & a_BlockZ, eBlockFace
 
 
 
+Vector3i GetBlockNextTo(Vector3i a_CurrentPosition, eBlockFace a_BlockFace)
+{
+	switch (a_BlockFace)
+	{
+		case BLOCK_FACE_XM: return Vector3i(a_CurrentPosition.x - 1, a_CurrentPosition.y, a_CurrentPosition.z);
+		case BLOCK_FACE_XP: return Vector3i(a_CurrentPosition.x + 1, a_CurrentPosition.y, a_CurrentPosition.z);
+		case BLOCK_FACE_YM: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y - 1, a_CurrentPosition.z);
+		case BLOCK_FACE_YP: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y + 1, a_CurrentPosition.z);
+		case BLOCK_FACE_ZM: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y, a_CurrentPosition.z - 1);
+		case BLOCK_FACE_ZP: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y, a_CurrentPosition.z + 1);
+		default: return a_CurrentPosition;
+	}
+}
+
+
+
+
+
 bool ItemCategory::IsPickaxe(short a_ItemType)
 {
 	switch (a_ItemType)

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -4,6 +4,12 @@
 
 
 
+template <typename T> class Vector3;
+typedef Vector3i Vector3<int>;
+
+
+
+
 
 /** List of slot numbers, used for inventory-painting */
 typedef std::vector<int> cSlotNums;
@@ -424,6 +430,24 @@ extern eDamageType StringToDamageType(const AString & a_DamageString);
 /** Modifies the specified coords so that they point to the block adjacent to the one specified through its specified face.
 If a_Inverse is true, the opposite direction is used instead. */
 void AddFaceDirection(int & a_BlockX, int & a_BlockY, int & a_BlockZ, eBlockFace a_BlockFace, bool a_bInverse = false);
+
+/** a_CurrentPosiiton - the block of whom we would like to get the block next to
+a_BlockFace - the face (direction) in which we would like to get the block
+*/
+inline Vector3i GetBlockNextTo(Vector3i a_CurrentPosition, eBlockFace a_BlockFace)
+{
+	switch (a_BlockFace)
+	{
+		case BLOCK_FACE_XM: return Vector3i(a_CurrentPosition.x - 1, a_CurrentPosition.y, a_CurrentPosition.z);
+		case BLOCK_FACE_XP: return Vector3i(a_CurrentPosition.x + 1, a_CurrentPosition.y, a_CurrentPosition.z); 
+		case BLOCK_FACE_YM: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y - 1, a_CurrentPosition.z); 
+		case BLOCK_FACE_YP: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y + 1, a_CurrentPosition.z); 
+		case BLOCK_FACE_ZM: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y, a_CurrentPosition.z - 1); 
+		case BLOCK_FACE_ZP: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y, a_CurrentPosition.z + 1);
+		default: return a_CurrentPosition;
+	}
+}
+
 
 // tolua_end
 

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -431,22 +431,10 @@ extern eDamageType StringToDamageType(const AString & a_DamageString);
 If a_Inverse is true, the opposite direction is used instead. */
 void AddFaceDirection(int & a_BlockX, int & a_BlockY, int & a_BlockZ, eBlockFace a_BlockFace, bool a_bInverse = false);
 
-/** a_CurrentPosiiton - the block of whom we would like to get the block next to
-a_BlockFace - the face (direction) in which we would like to get the block
-*/
-inline Vector3i GetBlockNextTo(Vector3i a_CurrentPosition, eBlockFace a_BlockFace)
-{
-	switch (a_BlockFace)
-	{
-		case BLOCK_FACE_XM: return Vector3i(a_CurrentPosition.x - 1, a_CurrentPosition.y, a_CurrentPosition.z);
-		case BLOCK_FACE_XP: return Vector3i(a_CurrentPosition.x + 1, a_CurrentPosition.y, a_CurrentPosition.z); 
-		case BLOCK_FACE_YM: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y - 1, a_CurrentPosition.z); 
-		case BLOCK_FACE_YP: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y + 1, a_CurrentPosition.z); 
-		case BLOCK_FACE_ZM: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y, a_CurrentPosition.z - 1); 
-		case BLOCK_FACE_ZP: return Vector3i(a_CurrentPosition.x, a_CurrentPosition.y, a_CurrentPosition.z + 1);
-		default: return a_CurrentPosition;
-	}
-}
+/** Same as AddFaceDirection, but contstructs new coordinates and uses vectors
+a_CurrentPosiiton - the block of whom we would like to get the block next to
+a_BlockFace - the face (direction) in which we would like to get the block */
+Vector3i GetBlockNextTo(Vector3i a_CurrentPosition, eBlockFace a_BlockFace);
 
 
 // tolua_end

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -5,7 +5,7 @@
 
 
 template <typename T> class Vector3;
-typedef Vector3i Vector3<int>;
+typedef Vector3<int> Vector3i;
 
 
 

--- a/src/Items/ItemCactus.h
+++ b/src/Items/ItemCactus.h
@@ -8,6 +8,7 @@
 class cItemCactusHandler :
 	public cItemHandler
 {
+	using Super = cItemHandler;
 public:
 	cItemCactusHandler(int a_ItemType) :
 		cItemHandler(a_ItemType)
@@ -22,24 +23,22 @@ public:
 
 
 	virtual bool OnPlayerPlace(
-        cWorld & a_World, cPlayer & a_Player, const cItem & a_EquippedItem,
-        int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace,
-        int a_CursorX, int a_CursorY, int a_CursorZ
-    ) 
+		cWorld & a_World, cPlayer & a_Player, const cItem & a_EquippedItem,
+		int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace,
+		int a_CursorX, int a_CursorY, int a_CursorZ
+	)
 	{
-		/** We will use the block face and the block coordinates to determine if we can place the cactus
-		There must be sand or cactus under the cactus and no blocks on the sides inorder for it to be placed
-		*/
+		// We will use the block face and the block coordinates to determine if we can place the cactus
+		// There must be sand or cactus under the cactus and no blocks on the sides inorder for it to be placed
 		Vector3i PlacementPos = GetBlockNextTo(Vector3i(a_BlockX, a_BlockY, a_BlockZ), a_BlockFace);
 
 		BLOCKTYPE Surface = a_World.GetBlock(PlacementPos - Vector3i(0, 1, 0));
 		if ((Surface != E_BLOCK_SAND) && (Surface != E_BLOCK_CACTUS))
 		{
-			// Cactus can only be placed on sand and itself
 			return false;
 		}
 
-		const Vector3i Offsets[4] = 
+		const Vector3i Offsets[4] =
 		{
 			{1, 0, 0},
 			{-1, 0, 0},
@@ -47,16 +46,16 @@ public:
 			{0, 0, -1}
 		};
 
-		for(int i = 0; i < ARRAYCOUNT(Offsets); i++) 
+		for (int i = 0; i < ARRAYCOUNT(Offsets); i++)
 		{
 			BLOCKTYPE Surrounding = a_World.GetBlock(PlacementPos + Offsets[i]);
-			if(cBlockInfo::IsSolid(Surrounding) || IsBlockLava(Surrounding))
+			if (cBlockInfo::IsSolid(Surrounding) || IsBlockLava(Surrounding))
 			{
 				return false;
 			}
 		}
 
-		return cItemHandler::OnPlayerPlace(a_World, a_Player, a_EquippedItem, 
+		return Super::OnPlayerPlace(a_World, a_Player, a_EquippedItem,
 			a_BlockX, a_BlockY, a_BlockZ, a_BlockFace,
 			a_CursorX, a_CursorY, a_CursorZ
 		);

--- a/src/Items/ItemCactus.h
+++ b/src/Items/ItemCactus.h
@@ -1,0 +1,68 @@
+
+#pragma once
+
+#include "ItemHandler.h"
+
+
+
+class cItemCactusHandler :
+	public cItemHandler
+{
+public:
+	cItemCactusHandler(int a_ItemType) :
+		cItemHandler(a_ItemType)
+	{
+	}
+
+
+	virtual bool IsPlaceable(void) override
+	{
+		return true;
+	}
+
+
+	virtual bool OnPlayerPlace(
+        cWorld & a_World, cPlayer & a_Player, const cItem & a_EquippedItem,
+        int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace,
+        int a_CursorX, int a_CursorY, int a_CursorZ
+    ) 
+	{
+		/** We will use the block face and the block coordinates to determine if we can place the cactus
+		There must be sand or cactus under the cactus and no blocks on the sides inorder for it to be placed
+		*/
+		Vector3i PlacementPos = GetBlockNextTo(Vector3i(a_BlockX, a_BlockY, a_BlockZ), a_BlockFace);
+
+		BLOCKTYPE Surface = a_World.GetBlock(PlacementPos - Vector3i(0, 1, 0));
+		if ((Surface != E_BLOCK_SAND) && (Surface != E_BLOCK_CACTUS))
+		{
+			// Cactus can only be placed on sand and itself
+			return false;
+		}
+
+		const Vector3i Offsets[4] = 
+		{
+			{1, 0, 0},
+			{-1, 0, 0},
+			{0, 0, 1},
+			{0, 0, -1}
+		};
+
+		for(int i = 0; i < ARRAYCOUNT(Offsets); i++) 
+		{
+			BLOCKTYPE Surrounding = a_World.GetBlock(PlacementPos + Offsets[i]);
+			if(cBlockInfo::IsSolid(Surrounding) || IsBlockLava(Surrounding))
+			{
+				return false;
+			}
+		}
+
+		return cItemHandler::OnPlayerPlace(a_World, a_Player, a_EquippedItem, 
+			a_BlockX, a_BlockY, a_BlockZ, a_BlockFace,
+			a_CursorX, a_CursorY, a_CursorZ
+		);
+	}
+} ;
+
+
+
+

--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -217,7 +217,7 @@ cItemHandler * cItemHandler::CreateItemHandler(int a_ItemType)
 		}
 
 		case E_ITEM_BEETROOT_SEEDS:
-		case E_ITEM_CACTUS:
+		case E_BLOCK_CACTUS:
 		{
 			return new cItemCactusHandler(a_ItemType);
 		}
@@ -383,7 +383,7 @@ bool cItemHandler::OnPlayerPlace(
 	}
 	else
 	{
-		AddFaceDirection(absPos.x, absPos.y, absPos.z, a_BlockFace);
+		absPos = GetBlockNextTo(absPos, a_BlockFace);
 
 		if (!cChunkDef::IsValidHeight(absPos.y))
 		{
@@ -398,6 +398,7 @@ bool cItemHandler::OnPlayerPlace(
 		// Check for another block here, remove it if appropriate.
 		if (!BlockHandler(PlaceBlock)->DoesIgnoreBuildCollision(ChunkInterface, absPos, a_Player, PlaceMeta))
 		{
+			LOGD("IgnoreBuildCollision Failed");
 			// Tried to place a block into another?
 			// Happens when you place a block aiming at side of block with a torch on it or stem beside it
 			return false;
@@ -410,6 +411,7 @@ bool cItemHandler::OnPlayerPlace(
 	sSetBlockVector blocks;
 	if (!GetBlocksToPlace(a_World, a_Player, a_EquippedItem, absPos.x, absPos.y, absPos.z, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ, blocks))
 	{
+		LOGD("GetBlocksToPlace Failed");
 		// Handler refused the placement, send that information back to the client:
 		for (const auto & blk: blocks)
 		{
@@ -423,6 +425,7 @@ bool cItemHandler::OnPlayerPlace(
 	// Try to place the blocks:
 	if (!a_Player.PlaceBlocks(blocks))
 	{
+		LOGD("PlaceBlocks Failed");
 		// The placement failed, the blocks have already been re-sent, re-send inventory:
 		a_Player.GetInventory().SendEquippedSlot();
 		return false;

--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -18,6 +18,7 @@
 #include "ItemBrewingStand.h"
 #include "ItemBucket.h"
 #include "ItemCake.h"
+#include "ItemCactus.h"
 #include "ItemCauldron.h"
 #include "ItemChest.h"
 #include "ItemCloth.h"
@@ -216,6 +217,11 @@ cItemHandler * cItemHandler::CreateItemHandler(int a_ItemType)
 		}
 
 		case E_ITEM_BEETROOT_SEEDS:
+		case E_ITEM_CACTUS:
+		{
+			return new cItemCactusHandler(a_ItemType);
+		}
+
 		case E_ITEM_MELON_SEEDS:
 		case E_ITEM_PUMPKIN_SEEDS:
 		case E_ITEM_SEEDS:

--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -117,6 +117,7 @@ cItemHandler * cItemHandler::CreateItemHandler(int a_ItemType)
 
 		// Single item per handler, alphabetically sorted:
 		case E_BLOCK_BIG_FLOWER:         return new cItemBigFlowerHandler;
+		case E_BLOCK_CACTUS:             return new cItemCactusHandler(a_ItemType);
 		case E_BLOCK_CHEST:              return new cItemChestHandler(a_ItemType);
 		case E_BLOCK_LEAVES:             return new cItemLeavesHandler(a_ItemType);
 		case E_BLOCK_LILY_PAD:           return new cItemLilypadHandler(a_ItemType);
@@ -217,11 +218,6 @@ cItemHandler * cItemHandler::CreateItemHandler(int a_ItemType)
 		}
 
 		case E_ITEM_BEETROOT_SEEDS:
-		case E_BLOCK_CACTUS:
-		{
-			return new cItemCactusHandler(a_ItemType);
-		}
-
 		case E_ITEM_MELON_SEEDS:
 		case E_ITEM_PUMPKIN_SEEDS:
 		case E_ITEM_SEEDS:

--- a/src/Items/ItemHandler.cpp
+++ b/src/Items/ItemHandler.cpp
@@ -398,7 +398,6 @@ bool cItemHandler::OnPlayerPlace(
 		// Check for another block here, remove it if appropriate.
 		if (!BlockHandler(PlaceBlock)->DoesIgnoreBuildCollision(ChunkInterface, absPos, a_Player, PlaceMeta))
 		{
-			LOGD("IgnoreBuildCollision Failed");
 			// Tried to place a block into another?
 			// Happens when you place a block aiming at side of block with a torch on it or stem beside it
 			return false;
@@ -411,7 +410,6 @@ bool cItemHandler::OnPlayerPlace(
 	sSetBlockVector blocks;
 	if (!GetBlocksToPlace(a_World, a_Player, a_EquippedItem, absPos.x, absPos.y, absPos.z, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ, blocks))
 	{
-		LOGD("GetBlocksToPlace Failed");
 		// Handler refused the placement, send that information back to the client:
 		for (const auto & blk: blocks)
 		{
@@ -425,7 +423,6 @@ bool cItemHandler::OnPlayerPlace(
 	// Try to place the blocks:
 	if (!a_Player.PlaceBlocks(blocks))
 	{
-		LOGD("PlaceBlocks Failed");
 		// The placement failed, the blocks have already been re-sent, re-send inventory:
 		a_Player.GetInventory().SendEquippedSlot();
 		return false;

--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -18,7 +18,6 @@ public:
 	cItemLilypadHandler(int a_ItemType):
 		super(a_ItemType)
 	{
-		LOGD("Created Lilypad handler");
 	}
 
 
@@ -32,12 +31,9 @@ public:
         int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace
     ) override
 	{
-		LOGD("Lilypad OnItemUse");
 		LOGD(BlockFaceToString(a_BlockFace).c_str());
 		if (a_BlockFace > BLOCK_FACE_NONE)
 		{
-			LOGD("Trying to place block normally");
-			// We clicked on a block; no need to trace, just use normal placement method
 			return OnPlayerPlace(*a_World, *a_Player, a_Item, 
 				a_BlockX, a_BlockY, a_BlockZ, a_BlockFace,
 				0, 0, 0
@@ -85,8 +81,6 @@ public:
 			return false;
 		}
 		
-		LOGD("Found surface %s, trying to place normally", BlockFaceToString(Callbacks.m_BlockFace).c_str());
-
 		// Since we hit fluid, try placing the block on top of the fluid we found
 		// Mimick clicking on top of the fluid to do this
 		return OnPlayerPlace(*a_World, *a_Player, a_Item,
@@ -101,8 +95,6 @@ public:
         int a_CursorX, int a_CursorY, int a_CursorZ
     ) override
 	{
-		LOGD("Called onPlayerPlace");
-		
 		Vector3i PlacementPos = GetBlockNextTo(Vector3i(a_BlockX, a_BlockY, a_BlockZ), a_BlockFace);
 		
 		// If the block where we are trying to place is a water block, try placing on top of the water block instead
@@ -158,7 +150,6 @@ public:
 		// Check for another block here, remove it if appropriate.
 		if (!BlockHandler(PlaceBlock)->DoesIgnoreBuildCollision(ChunkInterface, absPos, a_Player, PlaceMeta))
 		{
-			LOGD("IgnoreBuildCollision Failed");
 			// Tried to place a block into another?
 			// Happens when you place a block aiming at side of block with a torch on it or stem beside it
 			return false;
@@ -170,7 +161,6 @@ public:
 		sSetBlockVector blocks;
 		if (!GetBlocksToPlace(a_World, a_Player, a_EquippedItem, absPos.x, absPos.y, absPos.z, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ, blocks))
 		{
-			LOGD("GetBlocksToPlace Failed");
 			// Handler refused the placement, send that information back to the client:
 			for (const auto & blk: blocks)
 			{
@@ -184,7 +174,6 @@ public:
 		// Try to place the blocks:
 		if (!a_Player.PlaceBlocks(blocks))
 		{
-			LOGD("PlaceBlocks Failed");
 			// The placement failed, the blocks have already been re-sent, re-send inventory:
 			a_Player.GetInventory().SendEquippedSlot();
 			return false;

--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -57,7 +57,7 @@ public:
 			virtual bool OnNextBlock(int a_CBBlockX, int a_CBBlockY, int a_CBBlockZ, BLOCKTYPE a_CBBlockType, NIBBLETYPE a_CBBlockMeta, eBlockFace a_CBEntryFace) override
 			{	
 				if((((a_CBBlockType == E_BLOCK_STATIONARY_WATER) || (a_CBBlockType == E_BLOCK_WATER)) && (a_CBBlockMeta == 0))
-			|| (Surface == E_BLOCK_ICE) || (Surface == E_BLOCK_FROSTED_ICE))                                     // Or (frosted) ice
+				|| (a_CBBlockType == E_BLOCK_ICE) || (a_CBBlockType == E_BLOCK_FROSTED_ICE))
 				{	
 					m_HasHitFluid = true;
 					m_Pos.Set(a_CBBlockX, a_CBBlockY, a_CBBlockZ);

--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -66,7 +66,7 @@ public:
 		Vector3d Start(a_Player->GetEyePosition() + a_Player->GetLookVector());
 		Vector3d End(a_Player->GetEyePosition() + a_Player->GetLookVector() * 5);
 
-		Tracer.Trace(Start.x, Start.y, Start.z, End.x, End.y, End.z);	
+		Tracer.Trace(Start.x, Start.y, Start.z, End.x, End.y, End.z);
 
 		if (!Callbacks.m_HasHitLilyPadSurface)
 		{
@@ -87,7 +87,7 @@ public:
 		int a_CursorX, int a_CursorY, int a_CursorZ
 	) override
 	{
-		// First do lily pad specific checks for water/ice under the lilypad or water in the place of the pad
+		// First do lily pad specific checks for water or ice under the lilypad or water in the place of the pad
 		Vector3i PlacementPos = GetBlockNextTo(Vector3i(a_BlockX, a_BlockY, a_BlockZ), a_BlockFace);
 
 		// If the block where we are trying to place is a water block, try placing on top of the water block instead

--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -18,7 +18,7 @@ public:
 	cItemLilypadHandler(int a_ItemType):
 		super(a_ItemType)
 	{
-
+		LOGD("Created Lilypad handler");
 	}
 
 
@@ -27,23 +27,21 @@ public:
 		return false;  // Set as not placeable so OnItemUse is called
 	}
 
-
-
 	virtual bool OnItemUse(
-		cWorld * a_World, cPlayer * a_Player, cBlockPluginInterface & a_PluginInterface, const cItem & a_Item,
-		int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace
-	) override
+        cWorld * a_World, cPlayer * a_Player, cBlockPluginInterface & a_PluginInterface, const cItem & a_Item,
+        int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace
+    ) override
 	{
+		LOGD("Lilypad OnItemUse");
+		LOGD(BlockFaceToString(a_BlockFace).c_str());
 		if (a_BlockFace > BLOCK_FACE_NONE)
 		{
-			// Clicked on the side of a submerged block; vanilla allows placement, so should we
-			AddFaceDirection(a_BlockX, a_BlockY, a_BlockZ, a_BlockFace);
-			a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, E_BLOCK_LILY_PAD, 0);
-			if (!a_Player->IsGameModeCreative())
-			{
-				a_Player->GetInventory().RemoveOneEquippedItem();
-			}
-			return true;
+			LOGD("Trying to place block normally");
+			// We clicked on a block; no need to trace, just use normal placement method
+			return OnPlayerPlace(*a_World, *a_Player, a_Item, 
+				a_BlockX, a_BlockY, a_BlockZ, a_BlockFace,
+				0, 0, 0
+			);
 		}
 
 		class cCallbacks :
@@ -57,51 +55,153 @@ public:
 			}
 
 			virtual bool OnNextBlock(int a_CBBlockX, int a_CBBlockY, int a_CBBlockZ, BLOCKTYPE a_CBBlockType, NIBBLETYPE a_CBBlockMeta, eBlockFace a_CBEntryFace) override
-			{
-				if (IsBlockWater(a_CBBlockType))
-				{
-					if ((a_CBBlockMeta != 0) || (a_CBEntryFace == BLOCK_FACE_NONE))  // The hit block should be a source. The FACE_NONE check is clicking whilst submerged
-					{
-						return false;
-					}
-					AddFaceDirection(a_CBBlockX, a_CBBlockY, a_CBBlockZ, BLOCK_FACE_YP);  // Always place pad at top of water block
-					if (
-						!IsBlockWater(a_CBBlockType) &&
-						cBlockInfo::FullyOccupiesVoxel(a_CBBlockType)
-						)
-					{
-						// Can't place lilypad on air / in another block!
-						return true;
-					}
+			{	
+				if((((a_CBBlockType == E_BLOCK_STATIONARY_WATER) || (a_CBBlockType == E_BLOCK_WATER)) && (a_CBBlockMeta == 0))
+			|| (Surface == E_BLOCK_ICE) || (Surface == E_BLOCK_FROSTED_ICE))                                     // Or (frosted) ice
+				{	
 					m_HasHitFluid = true;
 					m_Pos.Set(a_CBBlockX, a_CBBlockY, a_CBBlockZ);
+					m_BlockFace = a_CBEntryFace;
 					return true;
+				
 				}
 				return false;
 			}
 
 			Vector3i m_Pos;
+			eBlockFace m_BlockFace;
 			bool m_HasHitFluid;
-
 		};
 
 		cCallbacks Callbacks;
-		cLineBlockTracer Tracer(*a_Player->GetWorld(), Callbacks);
+		cLineBlockTracer Tracer(*a_World, Callbacks);
 		Vector3d Start(a_Player->GetEyePosition() + a_Player->GetLookVector());
 		Vector3d End(a_Player->GetEyePosition() + a_Player->GetLookVector() * 5);
 
 		Tracer.Trace(Start.x, Start.y, Start.z, End.x, End.y, End.z);
 
-		if (Callbacks.m_HasHitFluid)
+		if (!Callbacks.m_HasHitFluid)
 		{
-			a_World->SetBlock(Callbacks.m_Pos.x, Callbacks.m_Pos.y, Callbacks.m_Pos.z, E_BLOCK_LILY_PAD, 0);
-			if (!a_Player->IsGameModeCreative())
-			{
-				a_Player->GetInventory().RemoveOneEquippedItem();
-			}
-			return true;
+			return false;
+		}
+		
+		LOGD("Found surface %s, trying to place normally", BlockFaceToString(Callbacks.m_BlockFace).c_str());
+
+		// Since we hit fluid, try placing the block on top of the fluid we found
+		// Mimick clicking on top of the fluid to do this
+		return OnPlayerPlace(*a_World, *a_Player, a_Item,
+			Callbacks.m_Pos.x, Callbacks.m_Pos.y, Callbacks.m_Pos.z, Callbacks.m_BlockFace,
+			0, 0, 0
+		);
+	}
+
+	virtual bool OnPlayerPlace(
+        cWorld & a_World, cPlayer & a_Player, const cItem & a_EquippedItem,
+        int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace,
+        int a_CursorX, int a_CursorY, int a_CursorZ
+    ) override
+	{
+		LOGD("Called onPlayerPlace");
+		
+		Vector3i PlacementPos = GetBlockNextTo(Vector3i(a_BlockX, a_BlockY, a_BlockZ), a_BlockFace);
+		
+		// If the block where we are trying to place is a water block, try placing on top of the water block instead
+		BLOCKTYPE Placement = a_World.GetBlock(PlacementPos);
+		NIBBLETYPE PlacementMeta = a_World.GetBlockMeta(PlacementPos);
+		if(((Placement == E_BLOCK_STATIONARY_WATER) || (Placement == E_BLOCK_WATER)) && (PlacementMeta == 0))  // A water source is in the place of where we want to place the block
+		{
+			return false;
+		}	
+
+		BLOCKTYPE Surface = a_World.GetBlock(PlacementPos - Vector3i(0, 1, 0));
+		NIBBLETYPE SurfaceMeta = a_World.GetBlockMeta(PlacementPos - Vector3i(0, 1, 0));
+		if(!((((Surface == E_BLOCK_STATIONARY_WATER) || (Surface == E_BLOCK_WATER)) && (SurfaceMeta == 0)) ||  // A water source is below
+			(Surface == E_BLOCK_ICE) || (Surface == E_BLOCK_FROSTED_ICE)))                                     // Or (frosted) ice
+		{
+			return false;
 		}
 
-		return false;
+		// Otherwise do the same exact process as cItemHandler::OnPlayerPlace, but ignore build collision
+
+		Vector3i absPos(a_BlockX, a_BlockY, a_BlockZ);
+
+		if (a_BlockFace < 0)
+		{
+			// Clicked in air
+			return false;
+		}
+	
+		if (!cChunkDef::IsValidHeight(absPos.y))
+		{
+			// The clicked block is outside the world, ignore this call altogether (#128)
+			return false;
+		}
+	
+		BLOCKTYPE ClickedBlock;
+		NIBBLETYPE ClickedBlockMeta;
+		a_World.GetBlockTypeMeta(absPos.x, absPos.y, absPos.z, ClickedBlock, ClickedBlockMeta);
+
+		cChunkInterface ChunkInterface(a_World.GetChunkMap());
+		
+		absPos = GetBlockNextTo(absPos, a_BlockFace);
+
+		if (!cChunkDef::IsValidHeight(absPos.y))
+		{
+			// The block is being placed outside the world, ignore this packet altogether (#128)
+			return false;
+		}
+
+		NIBBLETYPE PlaceMeta;
+		BLOCKTYPE PlaceBlock;
+		a_World.GetBlockTypeMeta(absPos.x, absPos.y, absPos.z, PlaceBlock, PlaceMeta);
+
+		// Check for another block here, remove it if appropriate.
+		if (!BlockHandler(PlaceBlock)->DoesIgnoreBuildCollision(ChunkInterface, absPos, a_Player, PlaceMeta))
+		{
+			LOGD("IgnoreBuildCollision Failed");
+			// Tried to place a block into another?
+			// Happens when you place a block aiming at side of block with a torch on it or stem beside it
+			return false;
+		}
+
+		a_World.DropBlockAsPickups(absPos, &a_Player, nullptr);
+	
+		// Get all the blocks to place:
+		sSetBlockVector blocks;
+		if (!GetBlocksToPlace(a_World, a_Player, a_EquippedItem, absPos.x, absPos.y, absPos.z, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ, blocks))
+		{
+			LOGD("GetBlocksToPlace Failed");
+			// Handler refused the placement, send that information back to the client:
+			for (const auto & blk: blocks)
+			{
+				a_World.SendBlockTo(blk.GetX(), blk.GetY(), blk.GetZ(), a_Player);
+			}
+			a_World.SendBlockTo(absPos.x, absPos.y, absPos.z, a_Player);
+			a_Player.GetInventory().SendEquippedSlot();
+			return false;
+		}
+	
+		// Try to place the blocks:
+		if (!a_Player.PlaceBlocks(blocks))
+		{
+			LOGD("PlaceBlocks Failed");
+			// The placement failed, the blocks have already been re-sent, re-send inventory:
+			a_Player.GetInventory().SendEquippedSlot();
+			return false;
+		}
+	
+		// Remove the "placed" item:
+		if (a_Player.IsGameModeSurvival())
+		{
+			a_Player.GetInventory().RemoveOneEquippedItem();
+		}
+		
+		return true;
 	}
 };
+
+
+
+
+
+


### PR DESCRIPTION
Lily pads should no longer be place-able on non-water or non-ice blocks; before, they had a "pop off" effect where they would appear for a second before being dropped as an item. Same fix for cactus, except on sand.

Fixes #4641 