### PR TITLE
ServerHandle: Fix closing failed servers.

### DIFF
--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -63,10 +63,15 @@ cServerHandleImpl::~cServerHandleImpl()
 void cServerHandleImpl::Close(void)
 {
 	// Stop the listener sockets:
-	evconnlistener_disable(m_ConnListener);
+	if (m_ConnListener != nullptr)
+	{
+		evconnlistener_disable(m_ConnListener);
+		m_ConnListener = nullptr;
+	}
 	if (m_SecondaryConnListener != nullptr)
 	{
 		evconnlistener_disable(m_SecondaryConnListener);
+		m_SecondaryConnListener = nullptr;
 	}
 	m_IsListening = false;
 

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -66,12 +66,10 @@ void cServerHandleImpl::Close(void)
 	if (m_ConnListener != nullptr)
 	{
 		evconnlistener_disable(m_ConnListener);
-		m_ConnListener = nullptr;
 	}
 	if (m_SecondaryConnListener != nullptr)
 	{
 		evconnlistener_disable(m_SecondaryConnListener);
-		m_SecondaryConnListener = nullptr;
 	}
 	m_IsListening = false;
 


### PR DESCRIPTION
If the cServerHandle failed to listen, closing it would then crash Cuberite.