### PR TITLE
Prevent crash when breeding

### DIFF
--- a/src/Mobs/Sheep.cpp
+++ b/src/Mobs/Sheep.cpp
@@ -167,12 +167,10 @@ void cSheep::InheritFromParents(cPassiveMonster * a_Parent1, cPassiveMonster * a
 		)
 		{
 			SetFurColor(ColorInheritance[i].Child);
-			m_World->BroadcastEntityMetadata(*this);
 			return;
 		}
 	}
 	SetFurColor(GetRandomProvider().RandBool() ? Parent1->GetFurColor() : Parent2->GetFurColor());
-	m_World->BroadcastEntityMetadata(*this);
 }
 
 


### PR DESCRIPTION
No need to broadcast entity metadata here, since the sheep hasn't spawned yet and its world isn't set at this stage.