### PR TITLE
fixing washing away of redstone mechanisms

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneSimulatorChunkData.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneSimulatorChunkData.h
@@ -44,6 +44,7 @@ public:
 	void ErasePowerData(const Vector3i & a_Position)
 	{
 		m_CachedPowerLevels.erase(a_Position);
+		m_MechanismDelays.erase(a_Position);
 	}
 
 	cRedstoneHandler::PoweringData ExchangeUpdateOncePowerData(const Vector3i & a_Position, cRedstoneHandler::PoweringData a_PoweringData)


### PR DESCRIPTION
@tigerw recommended this to be added. Because the water washed away the redstone mechanism but not its delay and due to that some places got broken and were not powerable with redstone anymore.

fixes #4635