### PR TITLE
Fixed spawning of mobs from dispenser

### DIFF
--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -9,7 +9,7 @@
 #include "../Entities/Boat.h"
 #include "../Entities/ProjectileEntity.h"
 #include "../Simulator/FluidSimulator.h"
-
+#include "../Items/ItemSpawnEgg.h"
 
 
 
@@ -114,7 +114,8 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 		{
 			double MobX = 0.5 + dispAbsCoord.x;
 			double MobZ = 0.5 + dispAbsCoord.z;
-			if (m_World->SpawnMob(MobX, dispAbsCoord.y, MobZ, static_cast<eMonsterType>(m_Contents.GetSlot(a_SlotNum).m_ItemDamage), false) != cEntity::INVALID_ID)
+			auto MonsterType = cItemSpawnEggHandler::ItemDamageToMonsterType(m_Contents.GetSlot(a_SlotNum).m_ItemDamage);
+			if (m_World->SpawnMob(MobX, dispAbsCoord.y, MobZ, static_cast<eMonsterType>(MonsterType), false) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}

--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -115,7 +115,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 			double MobX = 0.5 + dispAbsCoord.x;
 			double MobZ = 0.5 + dispAbsCoord.z;
 			auto MonsterType = cItemSpawnEggHandler::ItemDamageToMonsterType(m_Contents.GetSlot(a_SlotNum).m_ItemDamage);
-			if (m_World->SpawnMob(MobX, dispAbsCoord.y, MobZ, static_cast<eMonsterType>(MonsterType), false) != cEntity::INVALID_ID)
+			if (m_World->SpawnMob(MobX, dispAbsCoord.y, MobZ, MonsterType, false) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}


### PR DESCRIPTION
The item damage from the spawn egg was used, but `SpawnMob` requires a `eMonsterType`. Use `cItemSpawnEggHandler::ItemDamageToMonsterType` to correct that problem.