### PR TITLE
Set entity world early

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -154,6 +154,7 @@ bool cEntity::Initialize(OwnedEntity a_Self, cWorld & a_EntityWorld)
 
 	ASSERT(m_World == nullptr);
 	ASSERT(GetParentChunk() == nullptr);
+	SetWorld(&a_EntityWorld);
 	a_EntityWorld.AddEntity(std::move(a_Self));
 
 	return true;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1025,6 +1025,7 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 	for (auto & Entity : EntitiesToAdd)
 	{
 		auto EntityPtr = Entity.get();
+		ASSERT(EntityPtr->GetWorld() == this);
 		m_ChunkMap->AddEntity(std::move(Entity));
 		EntityPtr->OnAddToWorld(*this);
 		ASSERT(!EntityPtr->IsTicking());

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1024,7 +1024,6 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 	}
 	for (auto & Entity : EntitiesToAdd)
 	{
-		Entity->SetWorld(this);
 		auto EntityPtr = Entity.get();
 		m_ChunkMap->AddEntity(std::move(Entity));
 		EntityPtr->OnAddToWorld(*this);


### PR DESCRIPTION
In hindsight, I'm not happy with https://github.com/cuberite/cuberite/pull/4606. It seems too dangerous, and plugins probably have to possibility to crash the server while the world is unset.

Closes https://github.com/cuberite/cuberite/issues/4703