### PR TITLE
Add cEntity::GetBoundingBox, and use where appropriate.

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3190,6 +3190,16 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "Returns the number of hitpoints out of RawDamage that the currently equipped armor would cover. See {{TakeDamageInfo}} for more information on attack damage.",
 				},
+				GetBoundingBox =
+				{
+					Returns =
+					{
+						{
+							Type = "cBoundingBox",
+						},
+					},
+					Notes = "Returns the bounding box of the entity, which has width and height corresponding to the entity, and is aligned with the block grid."
+				}
 				GetChunkX =
 				{
 					Returns =

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3198,8 +3198,8 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 							Type = "cBoundingBox",
 						},
 					},
-					Notes = "Returns the bounding box of the entity, which has width and height corresponding to the entity, and is aligned with the block grid."
-				}
+					Notes = "Returns the bounding box of the entity, which has width and height corresponding to the entity, and is aligned with the block grid.",
+				},
 				GetChunkX =
 				{
 					Returns =

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1625,7 +1625,7 @@ void cChunk::SetAreaBiome(int a_MinRelX, int a_MaxRelX, int a_MinRelZ, int a_Max
 
 void cChunk::CollectPickupsByPlayer(cPlayer & a_Player)
 {
-	auto BoundingBox = cBoundingBox(a_Player.GetPosition(), a_Player.GetWidth(), a_Player.GetHeight());
+	auto BoundingBox = a_Player.GetBoundingBox();
 	BoundingBox.Expand(1, 0.5, 1);
 
 	for (auto & Entity : m_Entities)
@@ -1876,8 +1876,7 @@ bool cChunk::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback a_Ca
 		{
 			continue;
 		}
-		cBoundingBox EntBox(Entity->GetPosition(), Entity->GetWidth() / 2, Entity->GetHeight());
-		if (!EntBox.DoesIntersect(a_Box))
+		if (!Entity->GetBoundingBox().DoesIntersect(a_Box))
 		{
 			// The entity is not in the specified box
 			continue;

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1298,9 +1298,8 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 
 			if (!a_Entity.IsTNT() && !a_Entity.IsFallingBlock())  // Don't apply damage to other TNT entities and falling blocks, they should be invincible
 			{
-				cBoundingBox bbEntity(a_Entity.GetPosition(), a_Entity.GetWidth() / 2, a_Entity.GetHeight());
-
-				if (!bbTNT.IsInside(bbEntity))  // If bbEntity is inside bbTNT, not vice versa!
+				auto EntityBox = a_Entity.GetBoundingBox();
+				if (!bbTNT.IsInside(EntityBox))  // If entity box is inside tnt box, not vice versa!
 				{
 					return false;
 				}

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -2353,7 +2353,7 @@ float cEntity::GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_Ex
 		return 0;
 	}
 
-	cBoundingBox EntityBox(GetPosition(), m_Width / 2, m_Height);
+	auto EntityBox = GetBoundingBox();
 	cBoundingBox ExplosionBox(a_ExplosionPosition, a_ExlosionPower * 2.0);
 	cBoundingBox IntersectionBox(EntityBox);
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "../BoundingBox.h"
 #include "../Item.h"
 #include "../OSSupport/AtomicUniquePtr.h"
 
@@ -238,6 +239,8 @@ public:
 
 	int GetChunkX(void) const { return FloorC(m_Position.x / cChunkDef::Width); }
 	int GetChunkZ(void) const { return FloorC(m_Position.z / cChunkDef::Width); }
+
+	cBoundingBox GetBoundingBox() const { return cBoundingBox(GetPosition(), GetWidth() / 2, GetHeight()); }
 
 	void SetHeadYaw (double a_HeadYaw);
 	void SetMass    (double a_Mass);

--- a/src/Entities/Floater.cpp
+++ b/src/Entities/Floater.cpp
@@ -31,7 +31,7 @@ public:
 			return false;
 		}
 
-		cBoundingBox EntBox(a_Entity.GetPosition(), a_Entity.GetWidth() / 2, a_Entity.GetHeight());
+		auto EntBox = a_Entity.GetBoundingBox();
 
 		double LineCoeff;
 		eBlockFace Face;

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -84,7 +84,7 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	// Spectators cannot push entities around
 	if ((!IsPlayer()) || (!static_cast<cPlayer *>(this)->IsGameModeSpectator()))
 	{
-		m_World->ForEachEntityInBox(cBoundingBox(GetPosition(), GetWidth(), GetHeight()), [=](cEntity & a_Entity)
+		m_World->ForEachEntityInBox(GetBoundingBox(), [=](cEntity & a_Entity)
 			{
 				if (a_Entity.GetUniqueID() == GetUniqueID())
 				{

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -2780,7 +2780,7 @@ bool cPlayer::DoesPlacingBlocksIntersectEntity(const sSetBlockVector & a_Blocks)
 			{
 				return false;
 			}
-			cBoundingBox EntBox(a_Entity.GetPosition(), a_Entity.GetWidth() / 2, a_Entity.GetHeight());
+			auto EntBox = a_Entity.GetBoundingBox();
 			for (auto BlockBox : PlacementBoxes)
 			{
 				// Put in a little bit of wiggle room

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -147,7 +147,7 @@ public:
 			}
 		}
 
-		cBoundingBox EntBox(a_Entity.GetPosition(), a_Entity.GetWidth() / 2, a_Entity.GetHeight());
+		auto EntBox = a_Entity.GetBoundingBox();
 
 		// Instead of colliding the bounding box with another bounding box in motion, we collide an enlarged bounding box with a hairline.
 		// The results should be good enough for our purposes


### PR DESCRIPTION
As per @peterbell10's comment: https://github.com/cuberite/cuberite/pull/4707#discussion_r419094871