### PR TITLE
Require semi-colon at end of function-like macros

### DIFF
--- a/Tools/ProtoProxy/Connection.cpp
+++ b/Tools/ProtoProxy/Connection.cpp
@@ -38,21 +38,21 @@
 
 #define HANDLE_CLIENT_PACKET_READ(Proc, Type, Var) \
 	Type Var; \
-	{ \
+	do { \
 		if (!m_ClientBuffer.Proc(Var)) \
 		{ \
 			return false; \
 		} \
-	}
+	} while(false)
 
 #define HANDLE_SERVER_PACKET_READ(Proc, Type, Var) \
 	Type Var; \
-	{ \
+	do { \
 		if (!m_ServerBuffer.Proc(Var)) \
 		{ \
 			return false; \
 		} \
-	}
+	} while(false)
 
 #define CLIENTSEND(...) SendData(m_ClientSocket, __VA_ARGS__, "Client")
 #define SERVERSEND(...) SendData(m_ServerSocket, __VA_ARGS__, "Server")
@@ -60,7 +60,7 @@
 #define SERVERENCRYPTSEND(...) SendEncryptedData(m_ServerSocket, m_ServerEncryptor, __VA_ARGS__, "Server")
 
 #define COPY_TO_SERVER() \
-	{ \
+	do { \
 		AString ToServer; \
 		m_ClientBuffer.ReadAgain(ToServer); \
 		switch (m_ServerState) \
@@ -84,10 +84,10 @@
 			} \
 		} \
 		DebugSleep(50); \
-	}
+	} while (false)
 
 #define COPY_TO_CLIENT() \
-	{ \
+	do { \
 		AString ToClient; \
 		m_ServerBuffer.ReadAgain(ToClient); \
 		switch (m_ClientState) \
@@ -110,10 +110,10 @@
 			\
 		} \
 		DebugSleep(50); \
-	}
+	} while (false)
 
 #define HANDLE_CLIENT_READ(Proc) \
-	{ \
+	do { \
 		if (!Proc) \
 		{ \
 			AString Leftover; \
@@ -122,16 +122,16 @@
 			m_ClientBuffer.ResetRead(); \
 			return true; \
 		} \
-	}
+	} while (false)
 
 #define HANDLE_SERVER_READ(Proc) \
-	{ \
+	do { \
 		if (!Proc) \
 		{ \
 			m_ServerBuffer.ResetRead(); \
 			return true; \
 		} \
-	}
+	} while (false)
 
 
 
@@ -1777,7 +1777,7 @@ bool cConnection::HandleServerKeepAlive(void)
 	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, PingID);
 	Log("Received a PACKET_KEEP_ALIVE from the server:");
 	Log("  ID = %u", PingID);
-	COPY_TO_CLIENT()
+	COPY_TO_CLIENT();
 	return true;
 }
 
@@ -1875,7 +1875,7 @@ bool cConnection::HandleServerMapChunk(void)
 
 	// TODO: Save the compressed data into a file for later analysis
 
-	COPY_TO_CLIENT()
+	COPY_TO_CLIENT();
 	return true;
 }
 
@@ -2238,9 +2238,9 @@ bool cConnection::HandleServerSpawnNamedEntity(void)
 	sSpawnDatas Data;
 	for (UInt32 i = 0; i < DataCount; i++)
 	{
-		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Name)
-		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Value)
-		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Signature)
+		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Name);
+		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Value);
+		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Signature);
 		Data.push_back(sSpawnData(Name, Value, Signature));
 	}
 	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosX);

--- a/tests/Generating/BasicGeneratorTest.cpp
+++ b/tests/Generating/BasicGeneratorTest.cpp
@@ -186,7 +186,7 @@ static void testGenerateNether(cChunkGenerator & aDefaultNetherGen)
 				}
 				TEST_EQUAL_MSG(y, prevHeight, Printf("Failed: Same height across the entire chunk, at {%d, %d}: exp %d, got %d; top block: %d",
 					x, z, prevHeight, y, chd.GetBlockType(x, y, z)
-				))
+				));
 				auto blockType = chd.GetBlockType(x, y, z);
 				TEST_EQUAL_MSG(blockType, E_BLOCK_BEDROCK,
 					Printf("Bedrock ceiling at {%d, %d, %d}: %d", x, y, z, blockType)

--- a/tests/Generating/PieceRotationTest.cpp
+++ b/tests/Generating/PieceRotationTest.cpp
@@ -53,11 +53,14 @@ public:
 
 
 
-#define EXPECT(X) if (!(X)) \
-	{ \
-		ASSERT(X); \
-		throw cTestFailure(#X, __FILE__, __LINE__); \
-	}
+#define EXPECT(X) \
+	do { \
+		if (!(X)) \
+		{ \
+			ASSERT(X); \
+			throw cTestFailure(#X, __FILE__, __LINE__); \
+		} \
+	} while (false)
 
 
 

--- a/tests/TestHelpers.h
+++ b/tests/TestHelpers.h
@@ -45,12 +45,14 @@ public:
 
 /** Checks that the two values are equal; if not, throws a TestException. */
 #define TEST_EQUAL(VAL1, VAL2) \
-	if (VAL1 != VAL2) \
-	{ \
-		throw TestException(__FILE__, __LINE__, __FUNCTION__, Printf("Equality test failed: %s != %s", \
-			#VAL1, #VAL2 \
-		)); \
-	}
+	do { \
+		if (VAL1 != VAL2) \
+		{ \
+			throw TestException( \
+				__FILE__, __LINE__, __FUNCTION__, \
+				Printf("Equality test failed: %s != %s", #VAL1, #VAL2)); \
+		} \
+	}	while (false)
 
 
 
@@ -58,12 +60,14 @@ public:
 
 /** Checks that the two values are equal; if not, throws a TestException, includes the specified message. */
 #define TEST_EQUAL_MSG(VAL1, VAL2, MSG) \
-	if (VAL1 != VAL2) \
-	{ \
-		throw TestException(__FILE__, __LINE__, __FUNCTION__, Printf("Equality test failed: %s != %s (%s)", \
-			#VAL1, #VAL2, MSG \
-		)); \
-	}
+	do { \
+		if (VAL1 != VAL2) \
+		{ \
+			throw TestException( \
+				__FILE__, __LINE__, __FUNCTION__, \
+				Printf("Equality test failed: %s != %s (%s)", #VAL1, #VAL2, MSG)); \
+		} \
+	} while (false)
 
 
 
@@ -71,12 +75,15 @@ public:
 
 /** Checks that the two values are not equal; if they are, throws a TestException. */
 #define TEST_NOTEQUAL(VAL1, VAL2) \
-	if (VAL1 == VAL2) \
-	{ \
-		throw TestException(__FILE__, __LINE__, __FUNCTION__, Printf("Inequality test failed: %s == %s", \
-			#VAL1, #VAL2 \
-		)); \
-	}
+	do { \
+		if (VAL1 == VAL2) \
+		{ \
+			throw TestException( \
+				__FILE__, __LINE__, __FUNCTION__, \
+				Printf("Inequality test failed: %s == %s", #VAL1, #VAL2) \
+				); \
+		} \
+	} while(false)
 
 
 
@@ -124,29 +131,36 @@ public:
 
 /** Checks that the statement throws an exception of the specified class. */
 #define TEST_THROWS(Stmt, ExcClass) \
-	try \
-	{ \
-		Stmt; \
-		throw TestException(__FILE__, __LINE__, __FUNCTION__, Printf("Failed to throw an exception of type %s", \
-			#ExcClass \
-		)); \
-	} \
-	catch (const ExcClass &) \
-	{ \
-		/* This is the expected case. */ \
-	} \
-	catch (const std::exception & exc) \
-	{ \
-		throw TestException(__FILE__, __LINE__, __FUNCTION__, Printf("An unexpected std::exception descendant was thrown, was expecting type %s. Message is: %s", \
-			#ExcClass, exc.what() \
-		)); \
-	} \
-	catch (...) \
-	{ \
-		throw TestException(__FILE__, __LINE__, __FUNCTION__, Printf("An unexpected unknown exception object was thrown, was expecting type %s", \
-			#ExcClass \
-		)); \
-	}
+	do { \
+		try \
+		{ \
+			Stmt; \
+			throw TestException( \
+				__FILE__, __LINE__, __FUNCTION__, \
+				Printf("Failed to throw an exception of type %s", #ExcClass) \
+				); \
+		} \
+		catch (const ExcClass &) \
+		{ \
+			/* This is the expected case. */ \
+		} \
+		catch (const std::exception & exc) \
+		{ \
+			throw TestException( \
+				__FILE__, __LINE__, __FUNCTION__, \
+				Printf("An unexpected std::exception descendant was thrown, was expecting type %s. Message is: %s", \
+					#ExcClass, exc.what() \
+				)); \
+		} \
+		catch (...)\
+		{ \
+			throw TestException( \
+				__FILE__, __LINE__, __FUNCTION__, \
+				Printf("An unexpected unknown exception object was thrown, was expecting type %s", \
+							 #ExcClass \
+					)); \
+		} \
+	} while (false)
 
 
 
@@ -154,19 +168,23 @@ public:
 
 /** Checks that the statement throws an exception of any type. */
 #define TEST_THROWS_ANY(Stmt) \
-	try \
-	{ \
-		Stmt; \
-		throw TestException(__FILE__, __LINE__, __FUNCTION__, "Failed to throw an exception of any type"); \
-	} \
-	catch (const TestException & exc) \
-	{ \
-		throw exc; \
-	} \
-	catch (...) \
-	{ \
-		/* This is the expected case */ \
-	}
+	do { \
+		try \
+		{ \
+			Stmt; \
+			throw TestException( \
+				__FILE__, __LINE__, __FUNCTION__, \
+				"Failed to throw an exception of any type"); \
+		} \
+		catch (const TestException & exc) \
+		{ \
+			throw exc; \
+		} \
+		catch (...)\
+		{ \
+			/* This is the expected case */ \
+		} \
+	} while (false)
 
 
 
@@ -174,7 +192,7 @@ public:
 
 /** Fails the test unconditionally, with the specified message. */
 #define TEST_FAIL(MSG) \
-	throw TestException(__FILE__, __LINE__, __FUNCTION__, MSG);
+	throw TestException(__FILE__, __LINE__, __FUNCTION__, MSG)
 
 
 
@@ -184,7 +202,7 @@ public:
 #ifdef _DEBUG
 	#define TEST_ASSERTS(Stmt) TEST_THROWS(Stmt, cAssertFailure)
 #else
-	#define TEST_ASSERTS(Stmt) LOG("Skipped, cannot test in Release mode: TEST_ASSERT(%s); (%s:%d)", #Stmt, __FILE__, __LINE__);
+	#define TEST_ASSERTS(Stmt) LOG("Skipped, cannot test in Release mode: TEST_ASSERT(%s); (%s:%d)", #Stmt, __FILE__, __LINE__)
 #endif  // else _DEBUG
 
 


### PR DESCRIPTION
clang >= 8  has a "-Wextra-semi-stmt" warning for redundant semi-colons.
Main build was fixed in #4346, this finishes the job for `tests` and `Tools`.