### PR TITLE
Fix SetBlockMeta call in observer handler

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/ObserverHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/ObserverHandler.h
@@ -83,13 +83,13 @@ public:
 		{
 			// Remain on for 1 tick before resetting
 			*DelayInfo = std::make_pair(1, false);
-			a_World.SetBlockMeta(a_Position.x, a_Position.y, a_Position.z, a_Meta | 0x8, a_Meta);
+			a_World.SetBlockMeta(a_Position, a_Meta | 0x8);
 		}
 		else
 		{
 			// We've reset. Erase delay data in preparation for detecting further updates
 			Data->m_MechanismDelays.erase(a_Position);
-			a_World.SetBlockMeta(a_Position.x, a_Position.y, a_Position.z, a_Meta & ~0x8, a_Meta);
+			a_World.SetBlockMeta(a_Position, a_Meta & ~0x8);
 		}
 
 		return { a_Position + cBlockObserverHandler::GetSignalOutputOffset(a_Meta) };


### PR DESCRIPTION
Noticed an MSVC warning about `NIBBLETYPE` being cast to `bool`. The last argument is `bool a_ShouldMarkDirty` so I don't think passing `a_Meta` makes sense.