### PR TITLE
Fix clang tidy on circle-ci

### DIFF
--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -10,7 +10,7 @@ mkdir -p tidy-build
 cd tidy-build
 cmake --target Cuberite -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
 
-if run-clang-tidy.py $ARGS; then
+if run-clang-tidy $ARGS; then
 	echo "clang-tidy: No violations found"
 else
 	echo "clang-tidy: Found violations"


### PR DESCRIPTION
Problem with the new docker image. Seems the symlink has been renamed. Only `run-clang-tidy-${version}.py` includes the `.py` bit now.