### PR TITLE
Remove pkFishingFloat documentation

### DIFF
--- a/Server/Plugins/APIDump/Classes/Projectiles.lua
+++ b/Server/Plugins/APIDump/Classes/Projectiles.lua
@@ -302,10 +302,6 @@ return
 			{
 				Notes = "The projectile is a (flying) {{cFireworkEntity|firework}}",
 			},
-			pkFishingFloat =
-			{
-				Notes = "The projectile is a {{cFloater|fishing float}}",
-			},
 			pkGhastFireball =
 			{
 				Notes = "The projectile is a {{cGhastFireballEntity|ghast fireball}}",


### PR DESCRIPTION
What's the situation with this one? pkFishingFloat was removed in https://github.com/cuberite/cuberite/commit/0b9b7bc1a8d5cf6f92b802dc376a189ef066e62d#diff-4f2143bf8219268a5c8931a937d6714e, so I'm hitting an error while trying to enable the plugin checker again: https://github.com/cuberite/Core/runs/659588420