### PR TITLE
Cleanup some workarounds and warnings

### DIFF
--- a/src/BlockType.cpp
+++ b/src/BlockType.cpp
@@ -25,18 +25,9 @@ class cBlockIDMap
 	typedef std::map<AString, std::pair<short, short>, Comparator> ItemMap;
 
 public:
-	static bool m_bHasRunInit;
 
 	cBlockIDMap(void)
 	{
-		// Dont load items.ini on construct, this will search the wrong path when running as a service.
-	}
-
-
-	void init()
-	{
-		m_bHasRunInit = true;
-
 		cIniFile Ini;
 		if (!Ini.ReadFile("items.ini"))
 		{
@@ -189,8 +180,11 @@ protected:
 
 
 
-bool cBlockIDMap::m_bHasRunInit = false;
-static cBlockIDMap gsBlockIDMap;
+static cBlockIDMap & GetBlockIDMap()
+{
+	static cBlockIDMap IDMap;
+	return IDMap;
+}
 
 
 
@@ -224,11 +218,7 @@ int BlockStringToType(const AString & a_BlockTypeString)
 		return res;
 	}
 
-	if (!gsBlockIDMap.m_bHasRunInit)
-	{
-		gsBlockIDMap.init();
-	}
-	return gsBlockIDMap.Resolve(TrimString(a_BlockTypeString));
+	return GetBlockIDMap().Resolve(TrimString(a_BlockTypeString));
 }
 
 
@@ -243,11 +233,7 @@ bool StringToItem(const AString & a_ItemTypeString, cItem & a_Item)
 		ItemName = ItemName.substr(10);
 	}
 
-	if (!gsBlockIDMap.m_bHasRunInit)
-	{
-		gsBlockIDMap.init();
-	}
-	return gsBlockIDMap.ResolveItem(ItemName, a_Item);
+	return GetBlockIDMap().ResolveItem(ItemName, a_Item);
 }
 
 
@@ -256,11 +242,7 @@ bool StringToItem(const AString & a_ItemTypeString, cItem & a_Item)
 
 AString ItemToString(const cItem & a_Item)
 {
-	if (!gsBlockIDMap.m_bHasRunInit)
-	{
-		gsBlockIDMap.init();
-	}
-	return gsBlockIDMap.Desolve(a_Item.m_ItemType, a_Item.m_ItemDamage);
+	return GetBlockIDMap().Desolve(a_Item.m_ItemType, a_Item.m_ItemDamage);
 }
 
 
@@ -269,11 +251,7 @@ AString ItemToString(const cItem & a_Item)
 
 AString ItemTypeToString(short a_ItemType)
 {
-	if (!gsBlockIDMap.m_bHasRunInit)
-	{
-		gsBlockIDMap.init();
-	}
-	return gsBlockIDMap.Desolve(a_ItemType, -1);
+	return GetBlockIDMap().Desolve(a_ItemType, -1);
 }
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,13 +177,6 @@ include_directories (SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/../lib/TCLAP/include")
 
 configure_file("BuildInfo.h.cmake" "${CMAKE_BINARY_DIR}/include/BuildInfo.h")
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	set_source_files_properties(BlockType.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=global-constructors")
-	set_source_files_properties(ByteBuffer.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=global-constructors")
-	set_source_files_properties(ClientHandle.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=global-constructors ")
-	set_source_files_properties(Statistics.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=global-constructors")
-endif()
-
 if (NOT MSVC)
 	# Bindings need to reference other folders, so they are done here instead
 	# lib dependencies are not included

--- a/src/FastRandom.cpp
+++ b/src/FastRandom.cpp
@@ -5,38 +5,18 @@
 #include "Globals.h"
 #include "FastRandom.h"
 
-#if defined (__GNUC__)
-	#define ATTRIBUTE_TLS static __thread
-#elif defined (_MSC_VER)
-	#define ATTRIBUTE_TLS static __declspec(thread)
-#else
-	#define ATTRIBUTE_TLS thread_local
-#endif
-
 
 
 
 
 MTRand & GetRandomProvider()
 {
-	// Some compilers don't support thread_local for non-POD types, this is purely a work around for that restriction.
-	// There should be minimal overhead for the non-initializing case and all thread's instances are deleted properly.
-	ATTRIBUTE_TLS MTRand * LocalPtr = nullptr;
-	if (LocalPtr == nullptr)
-	{
-		// This list allows deletion of elements as if they had static storage duration
-		static std::mutex CSDeleteList;
-		static std::list<std::unique_ptr<MTRand>> DeleteList;
-
-		cRandomDeviceSeeder seeder;
-		auto NewInstance = cpp14::make_unique<MTRand>(seeder);
-		auto TempPtr = NewInstance.get();
-
-		std::lock_guard<std::mutex> Lock(CSDeleteList);
-		DeleteList.push_front(std::move(NewInstance));
-		LocalPtr = TempPtr;  // Set after push_back so LocalPtr won't dangle if it throws
-	}
-	return *LocalPtr;
+	thread_local MTRand Random = []
+		{
+			cRandomDeviceSeeder Seeder;
+			return MTRand(Seeder);
+		}();
+	return Random;
 }
 
 
@@ -45,15 +25,11 @@ MTRand & GetRandomProvider()
 
 UInt32 Detail::GetRandomSeed()
 {
-	ATTRIBUTE_TLS bool SeedCounterInitialized = false;
-	ATTRIBUTE_TLS UInt32 SeedCounter = 0;
-
-	if (!SeedCounterInitialized)
-	{
-		std::random_device rd;
-		std::uniform_int_distribution<UInt32> dist;
-		SeedCounter = dist(rd);
-		SeedCounterInitialized = true;
-	}
+	thread_local UInt32 SeedCounter = []
+		{
+			std::random_device rd;
+			std::uniform_int_distribution<UInt32> dist;
+			return dist(rd);
+		}();
 	return ++SeedCounter;
 }

--- a/src/Generating/CMakeLists.txt
+++ b/src/Generating/CMakeLists.txt
@@ -67,10 +67,6 @@ SET (HDRS
 	VillageGen.h
 )
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	set_source_files_properties(CompoGenBiomal.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=global-constructors")
-endif()
-
 if(NOT MSVC)
 	add_library(Generating ${SRCS} ${HDRS})
 	target_link_libraries(Generating fmt::fmt OSSupport Blocks Bindings)

--- a/src/Generating/CompoGenBiomal.cpp
+++ b/src/Generating/CompoGenBiomal.cpp
@@ -48,7 +48,7 @@ public:
 	const BlockInfo * Get(void) const { return m_Pattern; }
 
 protected:
-	BlockInfo m_Pattern[cChunkDef::Height];
+	BlockInfo m_Pattern[cChunkDef::Height] = {};
 } ;
 
 

--- a/src/Generating/CompoGenBiomal.cpp
+++ b/src/Generating/CompoGenBiomal.cpp
@@ -27,24 +27,22 @@ class cPattern
 public:
 	struct BlockInfo
 	{
-		BLOCKTYPE  m_BlockType;
-		NIBBLETYPE m_BlockMeta;
+		BLOCKTYPE  m_BlockType = E_BLOCK_STONE;
+		NIBBLETYPE m_BlockMeta = 0;
 	};
 
-	cPattern(BlockInfo * a_TopBlocks, size_t a_Count)
+	constexpr cPattern(std::initializer_list<BlockInfo> a_TopBlocks)
 	{
+		ASSERT(a_TopBlocks.size() <= cChunkDef::Height);
 		// Copy the pattern into the top:
-		for (size_t i = 0; i < a_Count; i++)
+		size_t i = 0;
+		for (const auto & Block : a_TopBlocks)
 		{
-			m_Pattern[i] = a_TopBlocks[i];
+			m_Pattern[i] = Block;
+			++i;
 		}
 
-		// Fill the rest with stone:
-		static BlockInfo Stone = {E_BLOCK_STONE, 0};
-		for (int i = static_cast<int>(a_Count); i < cChunkDef::Height; i++)
-		{
-			m_Pattern[i] = Stone;
-		}
+		// The remaining blocks default to stone
 	}
 
 	const BlockInfo * Get(void) const { return m_Pattern; }
@@ -58,9 +56,9 @@ protected:
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// The arrays to use for the top block pattern definitions:
+// Land top block patterns:
 
-static cPattern::BlockInfo tbGrass[] =
+static constexpr cPattern patGrass =
 {
 	{E_BLOCK_GRASS, 0},
 	{E_BLOCK_DIRT,  E_META_DIRT_NORMAL},
@@ -68,7 +66,7 @@ static cPattern::BlockInfo tbGrass[] =
 	{E_BLOCK_DIRT,  E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbSand[] =
+static constexpr cPattern patSand =
 {
 	{ E_BLOCK_SAND, 0},
 	{ E_BLOCK_SAND, 0},
@@ -76,7 +74,7 @@ static cPattern::BlockInfo tbSand[] =
 	{ E_BLOCK_SANDSTONE, 0},
 } ;
 
-static cPattern::BlockInfo tbDirt[] =
+static constexpr cPattern patDirt =
 {
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
@@ -84,7 +82,7 @@ static cPattern::BlockInfo tbDirt[] =
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbPodzol[] =
+static constexpr cPattern patPodzol =
 {
 	{E_BLOCK_DIRT, E_META_DIRT_PODZOL},
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
@@ -92,7 +90,7 @@ static cPattern::BlockInfo tbPodzol[] =
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbGrassLess[] =
+static constexpr cPattern patGrassLess =
 {
 	{E_BLOCK_DIRT, E_META_DIRT_GRASSLESS},
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
@@ -100,7 +98,7 @@ static cPattern::BlockInfo tbGrassLess[] =
 	{E_BLOCK_DIRT, E_META_DIRT_NORMAL},
 } ;
 
-static cPattern::BlockInfo tbMycelium[] =
+static constexpr cPattern patMycelium =
 {
 	{E_BLOCK_MYCELIUM, 0},
 	{E_BLOCK_DIRT,     0},
@@ -108,7 +106,7 @@ static cPattern::BlockInfo tbMycelium[] =
 	{E_BLOCK_DIRT,     0},
 } ;
 
-static cPattern::BlockInfo tbGravel[] =
+static constexpr cPattern patGravel =
 {
 	{E_BLOCK_GRAVEL, 0},
 	{E_BLOCK_GRAVEL, 0},
@@ -116,7 +114,7 @@ static cPattern::BlockInfo tbGravel[] =
 	{E_BLOCK_STONE,  0},
 } ;
 
-static cPattern::BlockInfo tbStone[] =
+static constexpr cPattern patStone =
 {
 	{E_BLOCK_STONE,   0},
 	{E_BLOCK_STONE,   0},
@@ -127,9 +125,9 @@ static cPattern::BlockInfo tbStone[] =
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Ocean floor pattern top-block definitions:
+// Ocean floor patterns:
 
-static cPattern::BlockInfo tbOFSand[] =
+static constexpr cPattern patOFSand =
 {
 	{E_BLOCK_SAND, 0},
 	{E_BLOCK_SAND, 0},
@@ -137,7 +135,7 @@ static cPattern::BlockInfo tbOFSand[] =
 	{E_BLOCK_SANDSTONE, 0}
 } ;
 
-static cPattern::BlockInfo tbOFClay[] =
+static constexpr cPattern patOFClay =
 {
 	{ E_BLOCK_CLAY, 0},
 	{ E_BLOCK_CLAY, 0},
@@ -145,32 +143,12 @@ static cPattern::BlockInfo tbOFClay[] =
 	{ E_BLOCK_SAND, 0},
 } ;
 
-static cPattern::BlockInfo tbOFOrangeClay[] =
+static constexpr cPattern patOFOrangeClay =
 {
 	{ E_BLOCK_STAINED_CLAY, E_META_STAINED_GLASS_ORANGE},
 	{ E_BLOCK_STAINED_CLAY, E_META_STAINED_GLASS_ORANGE},
 	{ E_BLOCK_STAINED_CLAY, E_META_STAINED_GLASS_ORANGE},
 } ;
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// Individual patterns to use:
-
-static cPattern patGrass    (tbGrass,     ARRAYCOUNT(tbGrass));
-static cPattern patSand     (tbSand,      ARRAYCOUNT(tbSand));
-static cPattern patDirt     (tbDirt,      ARRAYCOUNT(tbDirt));
-static cPattern patPodzol   (tbPodzol,    ARRAYCOUNT(tbPodzol));
-static cPattern patGrassLess(tbGrassLess, ARRAYCOUNT(tbGrassLess));
-static cPattern patMycelium (tbMycelium,  ARRAYCOUNT(tbMycelium));
-static cPattern patGravel   (tbGravel,    ARRAYCOUNT(tbGravel));
-static cPattern patStone    (tbStone,     ARRAYCOUNT(tbStone));
-
-static cPattern patOFSand      (tbOFSand,       ARRAYCOUNT(tbOFSand));
-static cPattern patOFClay      (tbOFClay,       ARRAYCOUNT(tbOFClay));
-static cPattern patOFOrangeClay(tbOFOrangeClay, ARRAYCOUNT(tbOFOrangeClay));
 
 
 

--- a/src/OSSupport/CMakeLists.txt
+++ b/src/OSSupport/CMakeLists.txt
@@ -40,10 +40,6 @@ SET (HDRS
 	WinStackWalker.h
 )
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	add_flags_cxx("-Wno-error=global-constructors ")
-endif()
-
 if(NOT MSVC)
 	add_library(OSSupport ${SRCS} ${HDRS})
 	target_link_libraries(OSSupport fmt::fmt)

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -36,12 +36,7 @@
 
 
 
-#ifdef __clang__
-	#pragma clang diagnostic push
-	#pragma clang diagnostic ignored "-Wglobal-constructors"
-#endif
-
-static const Vector3i gCrossCoords[] =
+static constexpr Vector3i gCrossCoords[] =
 {
 	{ 1, 0,  0},
 	{-1, 0,  0},
@@ -53,7 +48,7 @@ static const Vector3i gCrossCoords[] =
 
 
 
-static const Vector3i gNeighborCoords[] =
+static constexpr Vector3i gNeighborCoords[] =
 {
 	{ 1,  0,  0},
 	{-1,  0,  0},
@@ -61,11 +56,7 @@ static const Vector3i gNeighborCoords[] =
 	{ 0, -1,  0},
 	{ 0,  0,  1},
 	{ 0,  0, -1},
-} ;
-
-#ifdef __clang__
-	#pragma clang diagnostic pop
-#endif
+};
 
 
 

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -6,6 +6,10 @@
 #include "Statistics.h"
 
 
+#ifdef __clang__
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wglobal-constructors"
+#endif
 
 cStatInfo cStatInfo::ms_Info[statCount] =
 {
@@ -75,6 +79,10 @@ cStatInfo cStatInfo::ms_Info[statCount] =
 	cStatInfo(statJunkFished,     "stat.junkFished"),
 	cStatInfo(statTreasureFished, "stat.treasureFished")
 };
+
+#ifdef __clang__
+	#pragma clang diagnostic pop
+#endif
 
 
 

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -17,8 +17,8 @@ public:
 	T x, y, z;
 
 
-	inline Vector3(void) : x(0), y(0), z(0) {}
-	inline Vector3(T a_x, T a_y, T a_z) : x(a_x), y(a_y), z(a_z) {}
+	constexpr Vector3(void) : x(0), y(0), z(0) {}
+	constexpr Vector3(T a_x, T a_y, T a_z) : x(a_x), y(a_y), z(a_z) {}
 
 
 	#ifdef TOLUA_EXPOSITION  // Hardcoded copy constructors (tolua++ does not support function templates .. yet)
@@ -31,7 +31,12 @@ public:
 	// tolua_end
 	// Conversion constructors where U is not the same as T leaving the copy-constructor implicitly generated
 	template <typename U, typename = typename std::enable_if<!std::is_same<U, T>::value>::type>
-	Vector3(const Vector3<U> & a_Rhs): x(static_cast<T>(a_Rhs.x)), y(static_cast<T>(a_Rhs.y)), z(static_cast<T>(a_Rhs.z)) {}
+	constexpr Vector3(const Vector3<U> & a_Rhs):
+			x(static_cast<T>(a_Rhs.x)),
+			y(static_cast<T>(a_Rhs.y)),
+			z(static_cast<T>(a_Rhs.z))
+	{
+	}
 	// tolua_begin
 
 	inline void Set(T a_x, T a_y, T a_z)


### PR DESCRIPTION
This removes a couple of memorable workarounds limited by MSVC 2013:
- compilicated mess in `FastRandom.cpp` to workaround lack of proper `thread_local` support in MSVC 2013
- Global-constructor warnings in clang due to no `constexpr` support.