### PR TITLE
Cleanup unneeded globals

### DIFF
--- a/Tools/AnvilStats/Globals.h
+++ b/Tools/AnvilStats/Globals.h
@@ -18,65 +18,14 @@
 
 	#define _CRT_SECURE_NO_WARNINGS
 
-	#define OBSOLETE __declspec(deprecated)
-
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
-
-	#define FORMATSTRING(formatIndex, va_argsIndex)
-
-	// MSVC has its own custom version of zu format
-	#define SIZE_T_FMT "%Iu"
-	#define SIZE_T_FMT_PRECISION(x) "%" #x "Iu"
-	#define SIZE_T_FMT_HEX "%Ix"
-
-	#define NORETURN      __declspec(noreturn)
-
 #elif defined(__GNUC__)
 
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	// TODO: Can GCC mark virtual methods as overriding (forcing them to have a virtual function of the same signature in the base class)
-	#define override
-
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
-
-	// Some portability macros :)
-	#define stricmp strcasecmp
-
-	#define FORMATSTRING(formatIndex, va_argsIndex) __attribute__((format (printf, formatIndex, va_argsIndex)))
-
-	#define SIZE_T_FMT "%zu"
-	#define SIZE_T_FMT_PRECISION(x) "%" #x "zu"
-	#define SIZE_T_FMT_HEX "%zx"
-
-	#define NORETURN      __attribute((__noreturn__))
-
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
-
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark virtual methods as overriding (forcing them to have a virtual function of the same signature in the base class)
-	#define override
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
 
 #endif
 
@@ -218,18 +167,6 @@ typedef unsigned short     UInt16;
 #define VERIFY(x) (!!(x) || (LOGERROR("Verification failed: %s, file %s, line %i", #x, __FILE__, __LINE__), exit(1), 0))
 
 typedef unsigned char Byte;
-
-
-
-
-
-/** A generic interface used mainly in ForEach() functions */
-template <typename Type> class cItemCallback
-{
-public:
-	/** Called for each item in the internal list; return true to stop the loop, or false to continue enumerating */
-	virtual bool Item(Type * a_Type) = 0;
-} ;
 
 
 

--- a/Tools/GrownBiomeGenVisualiser/Globals.h
+++ b/Tools/GrownBiomeGenVisualiser/Globals.h
@@ -16,53 +16,14 @@
 	// Disable some warnings that we don't care about:
 	#pragma warning(disable:4100)
 
-	#define OBSOLETE __declspec(deprecated)
-
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
-
-	#define NORETURN      __declspec(noreturn)
-
 #elif defined(__GNUC__)
 
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	// override is part of c++11
-	#if __cplusplus < 201103L
-		#define override
-	#endif
-
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
-
-	// Some portability macros :)
-	#define stricmp strcasecmp
-
-	#define NORETURN      __attribute((__noreturn__))
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
-
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark virtual methods as overriding (forcing them to have a virtual function of the same signature in the base class)
-	#define override
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
 
 #endif
 
@@ -209,19 +170,6 @@ typedef unsigned char Byte;
 
 // Pretty much the same as ASSERT() but stays in Release builds
 #define VERIFY(x) (!!(x) || (LOGERROR("Verification failed: %s, file %s, line %i", #x, __FILE__, __LINE__), exit(1), 0))
-
-
-
-
-
-/** A generic interface used mainly in ForEach() functions */
-template <typename Type> class cItemCallback
-{
-public:
-	/** Called for each item in the internal list; return true to stop the loop, or false to continue enumerating */
-	virtual bool Item(Type * a_Type) = 0;
-	virtual ~cItemCallback() {}
-} ;
 
 
 

--- a/Tools/MCADefrag/Globals.h
+++ b/Tools/MCADefrag/Globals.h
@@ -16,45 +16,14 @@
 	// Disable some warnings that we don't care about:
 	#pragma warning(disable:4100)
 
-	#define OBSOLETE __declspec(deprecated)
-
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
-
-	#define NORETURN      __declspec(noreturn)
-
 #elif defined(__GNUC__)
 
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
-
-	// Some portability macros :)
-	#define stricmp strcasecmp
-
-	#define NORETURN      __attribute((__noreturn__))
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
-
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
 
 #endif
 
@@ -197,19 +166,6 @@ typedef unsigned char Byte;
 
 // Pretty much the same as ASSERT() but stays in Release builds
 #define VERIFY(x) (!!(x) || (LOGERROR("Verification failed: %s, file %s, line %i", #x, __FILE__, __LINE__), exit(1), 0))
-
-
-
-
-
-/** A generic interface used mainly in ForEach() functions */
-template <typename Type> class cItemCallback
-{
-public:
-	/** Called for each item in the internal list; return true to stop the loop, or false to continue enumerating */
-	virtual bool Item(Type * a_Type) = 0;
-	virtual ~cItemCallback() {}
-} ;
 
 
 #include "BiomeDef.h"

--- a/Tools/NoiseSpeedTest/Globals.h
+++ b/Tools/NoiseSpeedTest/Globals.h
@@ -16,45 +16,14 @@
 	// Disable some warnings that we don't care about:
 	#pragma warning(disable:4100)
 
-	#define OBSOLETE __declspec(deprecated)
-
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
-
-	#define NORETURN      __declspec(noreturn)
-
 #elif defined(__GNUC__)
 
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
-
-	// Some portability macros :)
-	#define stricmp strcasecmp
-
-	#define NORETURN      __attribute((__noreturn__))
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
-
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
 
 #endif
 
@@ -206,19 +175,6 @@ typedef unsigned char Byte;
 
 // Pretty much the same as ASSERT() but stays in Release builds
 #define VERIFY(x) (!!(x) || (LOGERROR("Verification failed: %s, file %s, line %i", #x, __FILE__, __LINE__), exit(1), 0))
-
-
-
-
-
-/** A generic interface used mainly in ForEach() functions */
-template <typename Type> class cItemCallback
-{
-public:
-	/** Called for each item in the internal list; return true to stop the loop, or false to continue enumerating */
-	virtual bool Item(Type * a_Type) = 0;
-	virtual ~cItemCallback() {}
-} ;
 
 
 

--- a/Tools/ProtoProxy/Globals.h
+++ b/Tools/ProtoProxy/Globals.h
@@ -16,43 +16,14 @@
 	// Disable some warnings that we don't care about:
 	#pragma warning(disable:4100)
 
-	#define OBSOLETE __declspec(deprecated)
-
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
-
 #elif defined(__GNUC__)
 
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
-
-	// Some portability macros :)
-	#define stricmp strcasecmp
-
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
-
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
-
 
 #endif
 
@@ -199,18 +170,8 @@ typedef unsigned char Byte;
 // Pretty much the same as ASSERT() but stays in Release builds
 #define VERIFY(x) (!!(x) || (LOGERROR("Verification failed: %s, file %s, line %i", #x, __FILE__, __LINE__), exit(1), 0))
 
-// C++11 has std::shared_ptr in <memory>, included earlier
-#define SharedPtr std::shared_ptr
 
 
 
 
 
-
-/* A generic interface used mainly in ForEach() functions */
-template <typename Type> class cItemCallback
-{
-public:
-	/* Called for each item in the internal list; return true to stop the loop, or false to continue enumerating */
-	virtual bool Item(Type * a_Type) = 0;
-} ;

--- a/Tools/QtBiomeVisualiser/Globals.h
+++ b/Tools/QtBiomeVisualiser/Globals.h
@@ -32,90 +32,19 @@
 	// 2014_01_06 xoft: Disabled this warning because MSVC is stupid and reports it in obviously wrong places
 	// #pragma warning(3 : 4244)  // Conversion from 'type1' to 'type2', possible loss of data
 
-	#define OBSOLETE __declspec(deprecated)
-
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
 
 	#define FORMATSTRING(formatIndex, va_argsIndex)
-
-	// MSVC has its own custom version of zu format
-	#define SIZE_T_FMT "%Iu"
-	#define SIZE_T_FMT_PRECISION(x) "%" #x "Iu"
-	#define SIZE_T_FMT_HEX "%Ix"
-
-	#define NORETURN      __declspec(noreturn)
-
 #elif defined(__GNUC__)
 
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	// override is part of c++11
-	#if __cplusplus < 201103L
-		#define override
-	#endif
-
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
-
-	// Some portability macros :)
-	#define stricmp strcasecmp
 
 	#define FORMATSTRING(formatIndex, va_argsIndex) __attribute__((format (printf, formatIndex, va_argsIndex)))
-
-	#if defined(_WIN32)
-		// We're compiling on MinGW, which uses an old MSVCRT library that has no support for size_t printfing.
-		// We need direct size formats:
-		#if defined(_WIN64)
-			#define SIZE_T_FMT "%I64u"
-			#define SIZE_T_FMT_PRECISION(x) "%" #x "I64u"
-			#define SIZE_T_FMT_HEX "%I64x"
-		#else
-			#define SIZE_T_FMT "%u"
-			#define SIZE_T_FMT_PRECISION(x) "%" #x "u"
-			#define SIZE_T_FMT_HEX "%x"
-		#endif
-	#else
-		// We're compiling on Linux, so we can use libc's size_t printf format:
-		#define SIZE_T_FMT "%zu"
-		#define SIZE_T_FMT_PRECISION(x) "%" #x "zu"
-		#define SIZE_T_FMT_HEX "%zx"
-	#endif
-
-	#define NORETURN      __attribute((__noreturn__))
-
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
 
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark virtual methods as overriding (forcing them to have a virtual function of the same signature in the base class)
-	#define override
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
-
-#endif
-
-
-#ifdef  _DEBUG
-	#define NORETURNDEBUG NORETURN
-#else
-	#define NORETURNDEBUG
 #endif
 
 
@@ -327,20 +256,6 @@ around it, "(32 KiB)") */
 
 // C++11 has std::shared_ptr in <memory>, included earlier
 #define SharedPtr std::shared_ptr
-
-
-
-
-
-/** A generic interface used mainly in ForEach() functions */
-template <typename Type> class cItemCallback
-{
-public:
-	virtual ~cItemCallback() {}
-
-	/** Called for each item in the internal list; return true to stop the loop, or false to continue enumerating */
-	virtual bool Item(Type * a_Type) = 0;
-} ;
 
 
 

--- a/Tools/RCONClient/Globals.h
+++ b/Tools/RCONClient/Globals.h
@@ -16,21 +16,6 @@
 	// Disable some warnings that we don't care about:
 	#pragma warning(disable:4100)
 
-	#define OBSOLETE __declspec(deprecated)
-
-	// No alignment needed in MSVC
-	#define ALIGN_8
-	#define ALIGN_16
-
-	#define FORMATSTRING(formatIndex, va_argsIndex)
-
-	// MSVC has its own custom version of zu format
-	#define SIZE_T_FMT "%Iu"
-	#define SIZE_T_FMT_PRECISION(x) "%" #x "Iu"
-	#define SIZE_T_FMT_HEX "%Ix"
-
-	#define NORETURN      __declspec(noreturn)
-
 	// Use non-standard defines in <cmath>
 	#define _USE_MATH_DEFINES
 
@@ -39,60 +24,9 @@
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	// TODO: Can GCC mark virtual methods as overriding (forcing them to have a virtual function of the same signature in the base class)
-	#define override
-
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define ALIGN_8 __attribute__((aligned(8)))
-	#define ALIGN_16 __attribute__((aligned(16)))
-
-	// Some portability macros :)
-	#define stricmp strcasecmp
-
-	#define FORMATSTRING(formatIndex, va_argsIndex) __attribute__((format (printf, formatIndex, va_argsIndex)))
-
-	#if defined(_WIN32)
-		// We're compiling on MinGW, which uses an old MSVCRT library that has no support for size_t printfing.
-		// We need direct size formats:
-		#if defined(_WIN64)
-			#define SIZE_T_FMT "%I64u"
-			#define SIZE_T_FMT_PRECISION(x) "%" #x "I64u"
-			#define SIZE_T_FMT_HEX "%I64x"
-		#else
-			#define SIZE_T_FMT "%u"
-			#define SIZE_T_FMT_PRECISION(x) "%" #x "u"
-			#define SIZE_T_FMT_HEX "%x"
-		#endif
-	#else
-		// We're compiling on Linux, so we can use libc's size_t printf format:
-		#define SIZE_T_FMT "%zu"
-		#define SIZE_T_FMT_PRECISION(x) "%" #x "zu"
-		#define SIZE_T_FMT_HEX "%zx"
-	#endif
-
-	#define NORETURN      __attribute((__noreturn__))
-
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
-
-	/*
-	// Copy and uncomment this into another #elif section based on your compiler identification
-
-	// Explicitly mark classes as abstract (no instances can be created)
-	#define abstract
-
-	// Mark virtual methods as overriding (forcing them to have a virtual function of the same signature in the base class)
-	#define override
-
-	// Mark functions as obsolete, so that their usage results in a compile-time warning
-	#define OBSOLETE
-
-	// Mark types / variables for alignment. Do the platforms need it?
-	#define ALIGN_8
-	#define ALIGN_16
-	*/
 
 #endif
 

--- a/Tools/ToLuaDoxy/Globals.h
+++ b/Tools/ToLuaDoxy/Globals.h
@@ -75,7 +75,7 @@
 
 
 // Common headers (part 1, without macros):
-#include "../../source/StringUtils.h"
+#include "../../src/StringUtils.h"
 
 
 

--- a/src/AllocationPool.h
+++ b/src/AllocationPool.h
@@ -34,7 +34,7 @@ public:
 	virtual void Free(T * a_ptr) = 0;
 
 	/** Two pools compare equal if memory allocated by one can be freed by the other */
-	bool IsEqual(const cAllocationPool & a_Other) const NOEXCEPT
+	bool IsEqual(const cAllocationPool & a_Other) const noexcept
 	{
 		return ((this == &a_Other) || DoIsEqual(a_Other) || a_Other.DoIsEqual(*this));
 	}
@@ -50,7 +50,7 @@ public:
 	}
 
 private:
-	virtual bool DoIsEqual(const cAllocationPool & a_Other) const NOEXCEPT = 0;
+	virtual bool DoIsEqual(const cAllocationPool & a_Other) const noexcept = 0;
 };
 
 
@@ -176,7 +176,7 @@ private:
 	std::list<void *> m_FreeList;
 	std::unique_ptr<typename cAllocationPool<T>::cStarvationCallbacks> m_Callbacks;
 
-	virtual bool DoIsEqual(const cAllocationPool<T> & a_Other) const NOEXCEPT override
+	virtual bool DoIsEqual(const cAllocationPool<T> & a_Other) const noexcept override
 	{
 		return (dynamic_cast<const cListAllocationPool<T>*>(&a_Other) != nullptr);
 	}

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -78,7 +78,7 @@ public:
 				}
 			}
 
-			~cStackBalanceCheck() CAN_THROW
+			~cStackBalanceCheck() noexcept(false)
 			{
 				auto currStackPos = lua_gettop(m_LuaState);
 				if (currStackPos != m_StackPos)
@@ -118,7 +118,7 @@ public:
 		{
 		}
 
-		~cStackBalancePopper() CAN_THROW
+		~cStackBalancePopper() noexcept(false)
 		{
 			auto curTop = lua_gettop(m_LuaState);
 			if (curTop > m_Count)
@@ -478,7 +478,7 @@ public:
 			std::swap(m_StackLen, a_Src.m_StackLen);
 		}
 
-		~cStackValue() CAN_THROW
+		~cStackValue() noexcept(false)
 		{
 			if (m_LuaState != nullptr)
 			{

--- a/src/DeadlockDetect.h
+++ b/src/DeadlockDetect.h
@@ -80,7 +80,7 @@ protected:
 	/** Called when a deadlock is detected in a world. Aborts the server.
 	a_WorldName is the name of the world whose age has triggered the detection.
 	a_WorldAge is the age (in ticks) in which the world is stuck. */
-	NORETURN void DeadlockDetected(const AString & a_WorldName, Int64 a_WorldAge);
+	[[noreturn]] void DeadlockDetected(const AString & a_WorldName, Int64 a_WorldAge);
 
 	/** Outputs a listing of the tracked CSs, together with their name and state. */
 	void ListTrackedCSs();

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -469,7 +469,7 @@ public:
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
 
 	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
-	OBSOLETE void ScheduleMoveToWorld(cWorld & a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true)
+	[[deprecated]] void ScheduleMoveToWorld(cWorld & a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true)
 	{
 		LOGWARNING("ScheduleMoveToWorld is deprecated, use MoveToWorld instead");
 		MoveToWorld(a_World, a_NewPosition, a_ShouldSetPortalCooldown, a_ShouldSendRespawn);

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -36,17 +36,6 @@
 	// 2014_01_06 xoft: Disabled this warning because MSVC is stupid and reports it in obviously wrong places
 	// #pragma warning(3 : 4244)  // Conversion from 'type1' to 'type2', possible loss of data
 
-	#define OBSOLETE __declspec(deprecated)
-
-	#define NORETURN __declspec(noreturn)
-	#if (_MSC_VER < 1900)  // noexcept support was added in VS 2015
-		#define NOEXCEPT  throw()
-		#define CAN_THROW throw(...)
-	#else
-		#define NOEXCEPT  noexcept
-		#define CAN_THROW noexcept(false)
-	#endif
-
 	// Use non-standard defines in <cmath>
 	#define _USE_MATH_DEFINES
 
@@ -73,30 +62,10 @@
 	// TODO: Can GCC explicitly mark classes as abstract (no instances can be created)?
 	#define abstract
 
-	// override is part of c++11
-	#if __cplusplus < 201103L
-		#define override
-	#endif
-
-	#define OBSOLETE __attribute__((deprecated))
-
-	#define NORETURN __attribute((__noreturn__))
-	#define NOEXCEPT  noexcept
-	#define CAN_THROW noexcept(false)
-
 #else
 
 	#error "You are using an unsupported compiler, you might need to #define some stuff here for your compiler"
 
-#endif
-
-
-
-
-#ifdef  _DEBUG
-	#define NORETURNDEBUG NORETURN
-#else
-	#define NORETURNDEBUG
 #endif
 
 
@@ -367,15 +336,11 @@ typename std::enable_if<std::is_arithmetic<T>::value, C>::type CeilC(T a_Value)
 
 
 
-//temporary replacement for std::make_unique until we get c++14
+// TODO: Replace cpp14 with std at point of use
 
 namespace cpp14
 {
-	template <class T, class... Args>
-	std::unique_ptr<T> make_unique(Args&&... args)
-	{
-		return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-	}
+using std::make_unique;
 }
 
 // a tick is 50 ms

--- a/src/LazyArray.h
+++ b/src/LazyArray.h
@@ -21,7 +21,7 @@ public:
 	using iterator = pointer;
 	using const_iterator = const_pointer;
 
-	cLazyArray(size_type a_Size) NOEXCEPT:
+	cLazyArray(size_type a_Size) noexcept:
 		m_Size{ a_Size }
 	{
 		ASSERT(a_Size > 0);
@@ -37,7 +37,7 @@ public:
 		}
 	}
 
-	cLazyArray(cLazyArray && a_Other) NOEXCEPT:
+	cLazyArray(cLazyArray && a_Other) noexcept:
 		m_Array{ std::move(a_Other.m_Array) },
 		m_Size{ a_Other.m_Size }
 	{
@@ -49,7 +49,7 @@ public:
 		return *this;
 	}
 
-	cLazyArray & operator = (cLazyArray && a_Other) NOEXCEPT
+	cLazyArray & operator = (cLazyArray && a_Other) noexcept
 	{
 		m_Array = std::move(a_Other.m_Array);
 		m_Size = a_Other.m_Size;
@@ -77,7 +77,7 @@ public:
 	iterator        end()       { return data() + m_Size; }
 	const_iterator  end() const { return cend(); }
 
-	size_type size() const NOEXCEPT { return m_Size; }
+	size_type size() const noexcept { return m_Size; }
 
 	const T * data() const
 	{
@@ -95,13 +95,13 @@ public:
 		return const_cast<T *>(const_this->data());
 	}
 
-	void swap(cLazyArray & a_Other) NOEXCEPT
+	void swap(cLazyArray & a_Other) noexcept
 	{
 		std::swap(m_Array, a_Other.m_Array);
 		std::swap(m_Size, a_Other.m_Size);
 	}
 
-	friend void swap(cLazyArray & a_Lhs, cLazyArray & a_Rhs) NOEXCEPT
+	friend void swap(cLazyArray & a_Lhs, cLazyArray & a_Rhs) noexcept
 	{
 		a_Lhs.swap(a_Rhs);
 	}
@@ -124,7 +124,7 @@ public:
 	}
 
 	/** Returns true if the array has already been allocated. */
-	bool IsStorageAllocated() const NOEXCEPT { return (m_Array != nullptr); }
+	bool IsStorageAllocated() const noexcept { return (m_Array != nullptr); }
 
 private:
 	// Mutable so const data() can allocate the array

--- a/src/OSSupport/AtomicUniquePtr.h
+++ b/src/OSSupport/AtomicUniquePtr.h
@@ -11,34 +11,34 @@ public:
 	static_assert(!std::is_array<T>::value, "cAtomicUniquePtr does not support arrays");
 	DISALLOW_COPY_AND_ASSIGN(cAtomicUniquePtr);
 
-	cAtomicUniquePtr() NOEXCEPT:
+	cAtomicUniquePtr() noexcept:
 		m_Ptr(nullptr)
 	{
 	}
 
 
-	cAtomicUniquePtr(std::unique_ptr<T> a_Ptr) NOEXCEPT:
+	cAtomicUniquePtr(std::unique_ptr<T> a_Ptr) noexcept:
 		m_Ptr(a_Ptr.release())
 	{
 	}
 
-	cAtomicUniquePtr & operator = (std::unique_ptr<T> a_Ptr) NOEXCEPT
+	cAtomicUniquePtr & operator = (std::unique_ptr<T> a_Ptr) noexcept
 	{
 		store(std::move(a_Ptr));
 		return *this;
 	}
 
-	~cAtomicUniquePtr() NOEXCEPT
+	~cAtomicUniquePtr() noexcept
 	{
 		delete load();
 	}
 
-	operator T * () const NOEXCEPT
+	operator T * () const noexcept
 	{
 		return load();
 	}
 
-	bool compare_exchange_weak(T *& a_Expected, std::unique_ptr<T> && a_Desired, std::memory_order a_Order = std::memory_order_seq_cst) NOEXCEPT
+	bool compare_exchange_weak(T *& a_Expected, std::unique_ptr<T> && a_Desired, std::memory_order a_Order = std::memory_order_seq_cst) noexcept
 	{
 		bool DidExchange = m_Ptr.compare_exchange_weak(a_Expected, a_Desired.get(), a_Order);
 		if (DidExchange)
@@ -49,7 +49,7 @@ public:
 		return DidExchange;
 	}
 
-	bool compare_exchange_strong(T *& a_Expected, std::unique_ptr<T> && a_Desired, std::memory_order a_Order = std::memory_order_seq_cst) NOEXCEPT
+	bool compare_exchange_strong(T *& a_Expected, std::unique_ptr<T> && a_Desired, std::memory_order a_Order = std::memory_order_seq_cst) noexcept
 	{
 		bool DidExchange = m_Ptr.compare_exchange_strong(a_Expected, a_Desired.get(), a_Order);
 		if (DidExchange)
@@ -60,17 +60,17 @@ public:
 		return DidExchange;
 	}
 
-	std::unique_ptr<T> exchange(std::unique_ptr<T> a_Ptr, std::memory_order a_Order = std::memory_order_seq_cst) NOEXCEPT
+	std::unique_ptr<T> exchange(std::unique_ptr<T> a_Ptr, std::memory_order a_Order = std::memory_order_seq_cst) noexcept
 	{
 		return std::unique_ptr<T>{ m_Ptr.exchange(a_Ptr.release(), a_Order) };
 	}
 
-	T * load(std::memory_order a_Order = std::memory_order_seq_cst) const NOEXCEPT
+	T * load(std::memory_order a_Order = std::memory_order_seq_cst) const noexcept
 	{
 		return m_Ptr.load(a_Order);
 	}
 
-	void store(std::unique_ptr<T> a_Ptr, std::memory_order a_Order = std::memory_order_seq_cst) NOEXCEPT
+	void store(std::unique_ptr<T> a_Ptr, std::memory_order a_Order = std::memory_order_seq_cst) noexcept
 	{
 		// Store new value and delete old value
 		delete m_Ptr.exchange(a_Ptr.release(), a_Order);

--- a/src/OSSupport/NetworkSingleton.cpp
+++ b/src/OSSupport/NetworkSingleton.cpp
@@ -24,7 +24,7 @@ cNetworkSingleton::cNetworkSingleton() :
 
 
 
-cNetworkSingleton::~cNetworkSingleton() CAN_THROW
+cNetworkSingleton::~cNetworkSingleton() noexcept(false)
 {
 	// Check that Terminate has been called already:
 	ASSERT(m_HasTerminated);

--- a/src/OSSupport/NetworkSingleton.h
+++ b/src/OSSupport/NetworkSingleton.h
@@ -39,7 +39,7 @@ class cNetworkSingleton
 {
 public:
 	cNetworkSingleton();
-	~cNetworkSingleton() CAN_THROW;
+	~cNetworkSingleton() noexcept(false);
 
 	/** Returns the singleton instance of this class */
 	static cNetworkSingleton & Get(void);

--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -37,7 +37,7 @@ class cNBTParseErrorCategory final :
 	cNBTParseErrorCategory() = default;
 public:
 	/** Category name */
-	virtual const char * name() const NOEXCEPT override
+	virtual const char * name() const noexcept override
 	{
 		return "NBT parse error";
 	}
@@ -46,7 +46,7 @@ public:
 	virtual AString message(int a_Condition) const override;
 
 	/** Returns the canonical error category instance. */
-	static const cNBTParseErrorCategory & Get() NOEXCEPT
+	static const cNBTParseErrorCategory & Get() noexcept
 	{
 		static cNBTParseErrorCategory Category;
 		return Category;
@@ -123,7 +123,7 @@ AString cNBTParseErrorCategory::message(int a_Condition) const
 
 
 
-std::error_code make_error_code(eNBTParseError a_Err) NOEXCEPT
+std::error_code make_error_code(eNBTParseError a_Err) noexcept
 {
 	return { static_cast<int>(a_Err), cNBTParseErrorCategory::Get() };
 }

--- a/src/WorldStorage/FastNBT.h
+++ b/src/WorldStorage/FastNBT.h
@@ -126,7 +126,7 @@ enum class eNBTParseError
 };
 
 // The following is required to make an error_code constructible from an eNBTParseError
-std::error_code make_error_code(eNBTParseError a_Err) NOEXCEPT;
+std::error_code make_error_code(eNBTParseError a_Err) noexcept;
 
 namespace std
 {

--- a/tests/ChunkData/ArraytoCoord.cpp
+++ b/tests/ChunkData/ArraytoCoord.cpp
@@ -22,7 +22,7 @@ static void test()
 			delete a_Ptr;
 		}
 
-		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const noexcept override
 		{
 			return false;
 		}

--- a/tests/ChunkData/Coordinates.cpp
+++ b/tests/ChunkData/Coordinates.cpp
@@ -22,7 +22,7 @@ static void test()
 			delete a_Ptr;
 		}
 
-		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const noexcept override
 		{
 			return false;
 		}

--- a/tests/ChunkData/Copies.cpp
+++ b/tests/ChunkData/Copies.cpp
@@ -25,7 +25,7 @@ static void test()
 			delete a_Ptr;
 		}
 
-		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection>&) const NOEXCEPT override
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection>&) const noexcept override
 		{
 			return false;
 		}

--- a/tests/ChunkData/CopyBlocks.cpp
+++ b/tests/ChunkData/CopyBlocks.cpp
@@ -32,7 +32,7 @@ static void test()
 			delete a_Ptr;
 		}
 
-		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const noexcept override
 		{
 			return false;
 		}

--- a/tests/ChunkData/creatable.cpp
+++ b/tests/ChunkData/creatable.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
 			delete a_Ptr;
 		}
 
-		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const NOEXCEPT override
+		virtual bool DoIsEqual(const cAllocationPool<cChunkData::sChunkSection> &) const noexcept override
 		{
 			return false;
 		}


### PR DESCRIPTION
Cleanup some old globals in the main header and for tools:

- `override` is a keyword since C++11
- `OBSOLETE` is made obsolete by the `[[deprecated]]` attribute
- `ALIGN_{8,16}` isn't used anywhere, and was replaced with `alignas()`
- `NORETURN` is now the attribute `[[noreturn]]`
- `NOEXCEPT` and `CAN_THROW` are replaced with `noexcept` and `noexcept(false)`

And some other random things that aren't used like formatting stuff from before `fmt` and `cItemCallback` that hasn't been used since we started supporting lambdas.