### PR TITLE
Enable some more clang-tidy linter checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
     docker: *cube_docker
     steps:
     - attach_workspace: { at: ~/ }
-    - run: (cd src/Bindings && lua BindingsProcessor.lua)
     - run: ./clang-tidy.sh -j 2
 
 workflows:

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,39 @@
+# Not the exact style guide but enough for basic clang-tidy fix-its
+Language: Cpp
+BasedOnStyle: LLVM
+
+AlignAfterOpenBracket: AlwaysBreak
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+PointerAlignment: Middle
+SortIncludes: false
+SpacesBeforeTrailingComments: 2
+UseTab: Always
+MaxEmptyLinesToKeep: 5
+
+TabWidth: 4
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+IndentWidth: 4
+IndentCaseLabels: true
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+
+# Always include globals first
+IncludeCategories:
+  - Regex: 'Globals.h'
+    Priority: -1

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,3 +20,4 @@ CheckOptions:
 #  value:           camelBack
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/cuberite/src/\.?[^\.]'
+FormatStyle: 'file'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: >-
   readability-redundant-string-cstr,
   readability-redundant-string-init,
   readability-redundant-control-flow,
+  performance-unnecessary-value-param,
 CheckOptions:
 - key:             readability-identifier-naming.PrivateMemberPrefix
   value:           'm_'
@@ -18,6 +19,9 @@ CheckOptions:
 #  value:           CamelCase
 #- key:             readability-identifier-naming.EnumCase
 #  value:           camelBack
+
+- key: performance-unnecessary-value-param.AllowedTypes
+  value: 'cEntityEffect;cNoise'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/cuberite/src/\.?[^\.]'
 FormatStyle: 'file'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,7 @@
-Checks: '-*,readability-identifier-naming'
+Checks: >-
+  -*,
+  readability-identifier-naming,
+  readability-redundant-string-cstr
 CheckOptions:
 - key:             readability-identifier-naming.PrivateMemberPrefix
   value:           'm_'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >-
   readability-redundant-string-init,
   readability-redundant-control-flow,
   performance-unnecessary-value-param,
+  performance-unnecessary-copy-initialization,
 CheckOptions:
 - key:             readability-identifier-naming.PrivateMemberPrefix
   value:           'm_'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 Checks: >-
   -*,
   readability-identifier-naming,
-  readability-redundant-string-cstr
+  readability-redundant-string-cstr,
+  readability-redundant-string-init,
 CheckOptions:
 - key:             readability-identifier-naming.PrivateMemberPrefix
   value:           'm_'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,6 @@ Checks: >-
   readability-identifier-naming,
   readability-redundant-string-cstr,
   readability-redundant-string-init,
-  readability-redundant-control-flow,
   readability-simplify-boolean-expr,
   performance-unnecessary-value-param,
   performance-unnecessary-copy-initialization,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >-
   readability-identifier-naming,
   readability-redundant-string-cstr,
   readability-redundant-string-init,
+  readability-redundant-control-flow,
 CheckOptions:
 - key:             readability-identifier-naming.PrivateMemberPrefix
   value:           'm_'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: >-
   readability-redundant-string-cstr,
   readability-redundant-string-init,
   readability-redundant-control-flow,
+  readability-simplify-boolean-expr,
   performance-unnecessary-value-param,
   performance-unnecessary-copy-initialization,
   performance-for-range-copy,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,8 @@ Checks: >-
   readability-redundant-control-flow,
   performance-unnecessary-value-param,
   performance-unnecessary-copy-initialization,
+  performance-for-range-copy,
+  performance-implicit-conversion-in-loop,
 CheckOptions:
 - key:             readability-identifier-naming.PrivateMemberPrefix
   value:           'm_'

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -6,9 +6,15 @@ FIXES_FILE="tidy-fixes.yaml"
 REGEX="/cuberite/src/\.?[^\.]"
 ARGS="-header-filter $REGEX -quiet -export-fixes $FIXES_FILE "$@" $REGEX"
 
+# Generate the compilation database
 mkdir -p tidy-build
 cd tidy-build
 cmake --target Cuberite -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+
+# Ensure LuaState_Typedefs.inc has been generated
+pushd ../src/Bindings
+lua BindingsProcessor.lua
+popd
 
 if run-clang-tidy $ARGS; then
 	echo "clang-tidy: No violations found"

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -12,9 +12,7 @@ cd tidy-build
 cmake --target Cuberite -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
 
 # Ensure LuaState_Typedefs.inc has been generated
-pushd ../src/Bindings
-lua BindingsProcessor.lua
-popd
+(cd ../src/Bindings && lua BindingsProcessor.lua)
 
 if run-clang-tidy $ARGS; then
 	echo "clang-tidy: No violations found"

--- a/src/Bindings/LuaServerHandle.cpp
+++ b/src/Bindings/LuaServerHandle.cpp
@@ -36,8 +36,8 @@ void cLuaServerHandle::SetServerHandle(cServerHandlePtr a_ServerHandle, cLuaServ
 {
 	ASSERT(m_ServerHandle == nullptr);  // The handle can be set only once
 
-	m_ServerHandle = a_ServerHandle;
-	m_Self = a_Self;
+	m_ServerHandle = std::move(a_ServerHandle);
+	m_Self = std::move(a_Self);
 }
 
 

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -2014,7 +2014,7 @@ bool cLuaState::CheckParamStaticSelf(const char * a_SelfClassName)
 
 
 
-bool cLuaState::IsParamUserType(int a_ParamIdx, AString a_UserType)
+bool cLuaState::IsParamUserType(int a_ParamIdx, const AString & a_UserType)
 {
 	ASSERT(IsValid());
 

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -815,7 +815,7 @@ public:
 	bool CheckParamStaticSelf(const char * a_SelfClassName);
 
 	/** Returns true if the specified parameter is of the specified class. */
-	bool IsParamUserType(int a_ParamIdx, AString a_UserType);
+	bool IsParamUserType(int a_ParamIdx, const AString & a_UserType);
 
 	/** Returns true if the specified parameter is a number. */
 	bool IsParamNumber(int a_ParamIdx);

--- a/src/Bindings/LuaUDPEndpoint.cpp
+++ b/src/Bindings/LuaUDPEndpoint.cpp
@@ -40,7 +40,7 @@ bool cLuaUDPEndpoint::Open(UInt16 a_Port, cLuaUDPEndpointPtr a_Self)
 	ASSERT(m_Self == nullptr);  // Must not be opened yet
 	ASSERT(m_Endpoint == nullptr);
 
-	m_Self = a_Self;
+	m_Self = std::move(a_Self);
 	m_Endpoint = cNetwork::CreateUDPEndpoint(a_Port, *this);
 	return m_Endpoint->IsOpen();
 }

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -409,7 +409,7 @@ static int tolua_LOG(lua_State * tolua_S)
 	}
 
 	// Log the message:
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), LogLevel);
+	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), LogLevel);
 	return 0;
 }
 
@@ -427,7 +427,7 @@ static int tolua_LOGINFO(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), cLogger::llInfo);
+	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), cLogger::llInfo);
 	return 0;
 }
 
@@ -445,7 +445,7 @@ static int tolua_LOGWARN(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), cLogger::llWarning);
+	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), cLogger::llWarning);
 	return 0;
 }
 
@@ -463,7 +463,7 @@ static int tolua_LOGERROR(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S).c_str(), cLogger::llError);
+	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), cLogger::llError);
 	return 0;
 }
 

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -108,7 +108,7 @@ bool cPluginLua::Load(void)
 	std::string PluginPath = GetLocalFolder() + "/";
 
 	// List all Lua files for this plugin. Info.lua has a special handling - make it the last to load:
-	AStringVector Files = cFile::GetFolderContents(PluginPath.c_str());
+	AStringVector Files = cFile::GetFolderContents(PluginPath);
 	AStringVector LuaFiles;
 	bool HasInfoLua = false;
 	for (AStringVector::const_iterator itr = Files.begin(), end = Files.end(); itr != end; ++itr)

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -1739,7 +1739,7 @@ AStringVector cPluginManager::GetFoldersToLoad(cSettingsRepositoryInterface & a_
 	// Get the old format plugin list, and migrate it.
 	// Upgrade path added on 2020-03-27
 	auto OldValues = a_Settings.GetValues("Plugins");
-	for (auto NameValue : OldValues)
+	for (const auto & NameValue : OldValues)
 	{
 		AString ValueName = NameValue.first;
 		if (ValueName.compare("Plugin") == 0)
@@ -1759,7 +1759,7 @@ AStringVector cPluginManager::GetFoldersToLoad(cSettingsRepositoryInterface & a_
 
 	// Get the list of plugins to load:
 	auto Values = a_Settings.GetValues("Plugins");
-	for (auto NameValue : Values)
+	for (const auto & NameValue : Values)
 	{
 		AString Enabled = NameValue.second;
 		if (Enabled == "1")

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -1401,7 +1401,7 @@ bool cPluginManager::BindCommand(
 
 	auto & reg = m_Commands[a_Command];
 	reg.m_Plugin     = a_Plugin;
-	reg.m_Handler    = a_Handler;
+	reg.m_Handler    = std::move(a_Handler);
 	reg.m_Permission = a_Permission;
 	reg.m_HelpString = a_HelpString;
 	return true;
@@ -1508,7 +1508,7 @@ bool cPluginManager::BindConsoleCommand(
 
 	auto & reg = m_ConsoleCommands[a_Command];
 	reg.m_Plugin     = a_Plugin;
-	reg.m_Handler    = a_Handler;
+	reg.m_Handler    = std::move(a_Handler);
 	reg.m_Permission = "";
 	reg.m_HelpString = a_HelpString;
 	return true;

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -57,7 +57,7 @@ void cPluginManager::RefreshPluginList(void)
 {
 	// Get a list of currently available folders:
 	AString PluginsPath = GetPluginsPath() + "/";
-	AStringVector Contents = cFile::GetFolderContents(PluginsPath.c_str());
+	AStringVector Contents = cFile::GetFolderContents(PluginsPath);
 	AStringVector Folders;
 	for (auto & item: Contents)
 	{

--- a/src/BlockEntities/DropSpenserEntity.cpp
+++ b/src/BlockEntities/DropSpenserEntity.cpp
@@ -51,7 +51,6 @@ void cDropSpenserEntity::AddDropSpenserDir(Vector3i & a_RelCoord, NIBBLETYPE a_D
 		case E_META_DROPSPENSER_FACING_XP: a_RelCoord.x++; return;
 	}
 	LOGWARNING("%s: Unhandled direction: %d", __FUNCTION__, a_Direction);
-	return;
 }
 
 

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -575,11 +575,7 @@ bool cHopperEntity::MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords)
 			FLOGWARNING("{0}: A chest entity was not found where expected, at {1} ({2}, {3}})", __FUNCTION__, a_Coords + ofs, ofs.x, ofs.z);
 			continue;
 		}
-		if (MoveItemsToGrid(*chest))
-		{
-			return true;
-		}
-		return false;
+		return MoveItemsToGrid(*chest);
 	}
 
 	// The chest was single and nothing could be moved

--- a/src/BlockEntities/MobSpawnerEntity.cpp
+++ b/src/BlockEntities/MobSpawnerEntity.cpp
@@ -76,14 +76,7 @@ bool cMobSpawnerEntity::UsedBy(cPlayer * a_Player)
 
 void cMobSpawnerEntity::UpdateActiveState(void)
 {
-	if (GetNearbyPlayersNum() > 0)
-	{
-		m_IsActive = true;
-	}
-	else
-	{
-		m_IsActive = false;
-	}
+	m_IsActive = (GetNearbyPlayersNum() > 0);
 }
 
 

--- a/src/BlockTypeRegistry.cpp
+++ b/src/BlockTypeRegistry.cpp
@@ -17,7 +17,7 @@ BlockInfo::BlockInfo(
 ):
 	m_PluginName(aPluginName),
 	m_BlockTypeName(aBlockTypeName),
-	m_Handler(aHandler),
+	m_Handler(std::move(aHandler)),
 	m_Hints(aHints),
 	m_HintCallbacks(aHintCallbacks)
 {
@@ -94,7 +94,9 @@ void BlockTypeRegistry::registerBlockType(
 	const std::map<AString, BlockInfo::HintCallback> & aHintCallbacks
 )
 {
-	auto blockInfo = std::make_shared<BlockInfo>(aPluginName, aBlockTypeName, aHandler, aHints, aHintCallbacks);
+	auto blockInfo = std::make_shared<BlockInfo>(
+		aPluginName, aBlockTypeName, std::move(aHandler), aHints, aHintCallbacks
+	);
 
 	// Check previous registrations:
 	cCSLock lock(m_CSRegistry);
@@ -191,8 +193,8 @@ void BlockTypeRegistry::removeBlockTypeHint(
 // BlockTypeRegistry::AlreadyRegisteredException:
 
 BlockTypeRegistry::AlreadyRegisteredException::AlreadyRegisteredException(
-	std::shared_ptr<BlockInfo> aPreviousRegistration,
-	std::shared_ptr<BlockInfo> aNewRegistration
+	const std::shared_ptr<BlockInfo> & aPreviousRegistration,
+	const std::shared_ptr<BlockInfo> & aNewRegistration
 ) :
 	Super(message(aPreviousRegistration, aNewRegistration)),
 	m_PreviousRegistration(aPreviousRegistration),
@@ -205,8 +207,8 @@ BlockTypeRegistry::AlreadyRegisteredException::AlreadyRegisteredException(
 
 
 AString BlockTypeRegistry::AlreadyRegisteredException::message(
-	std::shared_ptr<BlockInfo> aPreviousRegistration,
-	std::shared_ptr<BlockInfo> aNewRegistration
+	const std::shared_ptr<BlockInfo> & aPreviousRegistration,
+	const std::shared_ptr<BlockInfo> & aNewRegistration
 )
 {
 	return Printf("Attempting to register BlockTypeName %s from plugin %s, while it is already registered in plugin %s",

--- a/src/BlockTypeRegistry.h
+++ b/src/BlockTypeRegistry.h
@@ -164,8 +164,8 @@ public:
 	/** Creates a new instance of the exception that provides info on both the original registration and the newly attempted
 	registration that caused the failure. */
 	AlreadyRegisteredException(
-		std::shared_ptr<BlockInfo> aPreviousRegistration,
-		std::shared_ptr<BlockInfo> aNewRegistration
+		const std::shared_ptr<BlockInfo> & aPreviousRegistration,
+		const std::shared_ptr<BlockInfo> & aNewRegistration
 	);
 
 	// Simple getters:
@@ -182,8 +182,8 @@ private:
 	/** Returns the general exception message formatted by the two registrations.
 	The output is used when logging. */
 	static AString message(
-		std::shared_ptr<BlockInfo> aPreviousRegistration,
-		std::shared_ptr<BlockInfo> aNewRegistration
+		const std::shared_ptr<BlockInfo> & aPreviousRegistration,
+		const std::shared_ptr<BlockInfo> & aNewRegistration
 	);
 };
 

--- a/src/Blocks/BlockBed.cpp
+++ b/src/Blocks/BlockBed.cpp
@@ -128,11 +128,7 @@ bool cBlockBedHandler::OnUse(
 	// Fast-forward the time if all players in the world are in their beds:
 	auto TimeFastForwardTester = [](cPlayer & a_OtherPlayer)
 	{
-		if (!a_OtherPlayer.IsInBed())
-		{
-			return true;
-		}
-		return false;
+		return !a_OtherPlayer.IsInBed();
 	};
 	if (a_WorldInterface.ForEachPlayer(TimeFastForwardTester))
 	{

--- a/src/Blocks/BlockFire.h
+++ b/src/Blocks/BlockFire.h
@@ -167,8 +167,6 @@ public:
 				}
 			}
 		}
-
-		return;
 	}
 
 	/** Evaluates if coordinates are a portal going XP / XM; returns true if so, and writes boundaries to variable

--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -285,11 +285,7 @@ bool cBoundingBox::Intersect(const cBoundingBox & a_Other, cBoundingBox & a_Inte
 	}
 	a_Intersection.m_Min.z = std::max(m_Min.z, a_Other.m_Min.z);
 	a_Intersection.m_Max.z = std::min(m_Max.z, a_Other.m_Max.z);
-	if (a_Intersection.m_Min.z >= a_Intersection.m_Max.z)
-	{
-		return false;
-	}
-	return true;
+	return (a_Intersection.m_Min.z < a_Intersection.m_Max.z);
 }
 
 

--- a/src/BrewingRecipes.cpp
+++ b/src/BrewingRecipes.cpp
@@ -75,7 +75,7 @@ void cBrewingRecipes::AddRecipeFromLine(AString a_Line, unsigned int a_LineNum)
 		return;
 	}
 
-	const AStringVector & IngredientAndOutput = StringSplit(InputAndIngredient[1].c_str(), "=");
+	const AStringVector & IngredientAndOutput = StringSplit(InputAndIngredient[1], "=");
 	if (IngredientAndOutput.size() != 2)
 	{
 		LOGWARNING("brewing.txt: line %d: A line with '=' was expected", a_LineNum);

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1749,8 +1749,6 @@ void cChunk::RemoveClient(cClientHandle * a_Client)
 			a_Client->SendDestroyEntity(*Entity);
 		}
 	}
-
-	return;
 }
 
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2078,12 +2078,10 @@ bool cClientHandle::CheckBlockInteractionsRate(void)
 	ASSERT(m_Player != nullptr);
 	ASSERT(m_Player->GetWorld() != nullptr);
 
-	if ((cRoot::Get()->GetServer()->ShouldLimitPlayerBlockChanges()) && (m_NumBlockChangeInteractionsThisTick > MAX_BLOCK_CHANGE_INTERACTIONS))
-	{
-		return false;
-	}
-
-	return true;
+	return !(
+		(cRoot::Get()->GetServer()->ShouldLimitPlayerBlockChanges()) &&
+		(m_NumBlockChangeInteractionsThisTick > MAX_BLOCK_CHANGE_INTERACTIONS)
+	);
 }
 
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2078,10 +2078,12 @@ bool cClientHandle::CheckBlockInteractionsRate(void)
 	ASSERT(m_Player != nullptr);
 	ASSERT(m_Player->GetWorld() != nullptr);
 
-	return !(
-		(cRoot::Get()->GetServer()->ShouldLimitPlayerBlockChanges()) &&
-		(m_NumBlockChangeInteractionsThisTick > MAX_BLOCK_CHANGE_INTERACTIONS)
-	);
+	if (!cRoot::Get()->GetServer()->ShouldLimitPlayerBlockChanges())
+	{
+		return true;
+	}
+
+	return (m_NumBlockChangeInteractionsThisTick <= MAX_BLOCK_CHANGE_INTERACTIONS);
 }
 
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -213,7 +213,10 @@ void cClientHandle::GenerateOfflineUUID(void)
 
 
 
-AString cClientHandle::FormatChatPrefix(bool ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString m_Color1, AString m_Color2)
+AString cClientHandle::FormatChatPrefix(
+	bool ShouldAppendChatPrefixes, const AString & a_ChatPrefixS,
+	const AString & m_Color1, const AString & m_Color2
+)
 {
 	if (ShouldAppendChatPrefixes)
 	{
@@ -3310,7 +3313,7 @@ void cClientHandle::SocketClosed(void)
 void cClientHandle::SetSelf(cClientHandlePtr a_Self)
 {
 	ASSERT(m_Self == nullptr);
-	m_Self = a_Self;
+	m_Self = std::move(a_Self);
 }
 
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -107,7 +107,10 @@ public:  // tolua_export
 	/** Formats the type of message with the proper color and prefix for sending to the client. */
 	static AString FormatMessageType(bool ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData);
 
-	static AString FormatChatPrefix(bool ShouldAppendChatPrefixes, AString a_ChatPrefixS, AString m_Color1, AString m_Color2);
+	static AString FormatChatPrefix(
+		bool ShouldAppendChatPrefixes, const AString & a_ChatPrefixS,
+		const AString & m_Color1, const AString & m_Color2
+	);
 
 	void Kick(const AString & a_Reason);  // tolua_export
 

--- a/src/CraftingRecipes.cpp
+++ b/src/CraftingRecipes.cpp
@@ -400,7 +400,7 @@ void cCraftingRecipes::AddRecipeLine(int a_LineNum, const AString & a_RecipeLine
 	}
 	if (ResultSplit.size() > 1)
 	{
-		if (!StringToInteger<char>(ResultSplit[1].c_str(), Recipe->m_Result.m_ItemCount))
+		if (!StringToInteger<char>(ResultSplit[1], Recipe->m_Result.m_ItemCount))
 		{
 			LOGWARNING("crafting.txt: line %d: Cannot parse result count, ignoring the recipe.", a_LineNum);
 			LOGINFO("Offending line: \"%s\"", a_RecipeLine.c_str());
@@ -452,7 +452,7 @@ bool cCraftingRecipes::ParseItem(const AString & a_String, cItem & a_Item)
 	if (Split.size() > 1)
 	{
 		AString Damage = TrimString(Split[1]);
-		if (!StringToInteger<short>(Damage.c_str(), a_Item.m_ItemDamage))
+		if (!StringToInteger<short>(Damage, a_Item.m_ItemDamage))
 		{
 			// Parsing the number failed
 			return false;

--- a/src/CraftingRecipes.cpp
+++ b/src/CraftingRecipes.cpp
@@ -893,7 +893,7 @@ void cCraftingRecipes::HandleDyedLeather(const cItem * a_CraftingGrid, cCrafting
 			for (int y = 0; y < a_GridHeight; ++y)
 			{
 				int GridIdx = x + a_GridStride * y;
-				if ((a_CraftingGrid[GridIdx].m_ItemType == result_type) && (found == false))
+				if ((a_CraftingGrid[GridIdx].m_ItemType == result_type) && !found)
 				{
 					found = true;
 					temp = a_CraftingGrid[GridIdx].CopyOne();

--- a/src/Defines.cpp
+++ b/src/Defines.cpp
@@ -160,17 +160,10 @@ AString BlockFaceToString(eBlockFace a_BlockFace)
 
 bool IsValidBlock(int a_BlockType)
 {
-	if (
-		(
-		(a_BlockType > -1) &&
-		(a_BlockType <= E_BLOCK_MAX_TYPE_ID)
-		) ||
+	return(
+		((a_BlockType > -1) && (a_BlockType <= E_BLOCK_MAX_TYPE_ID)) ||
 		(a_BlockType == 255)  // the blocks 253-254 don't exist yet -> https://minecraft.gamepedia.com/Data_values#Block_IDs
-	)
-	{
-		return true;
-	}
-	return false;
+	);
 }
 
 

--- a/src/Defines.cpp
+++ b/src/Defines.cpp
@@ -160,7 +160,7 @@ AString BlockFaceToString(eBlockFace a_BlockFace)
 
 bool IsValidBlock(int a_BlockType)
 {
-	return(
+	return (
 		((a_BlockType > -1) && (a_BlockType <= E_BLOCK_MAX_TYPE_ID)) ||
 		(a_BlockType == 255)  // the blocks 253-254 don't exist yet -> https://minecraft.gamepedia.com/Data_values#Block_IDs
 	);

--- a/src/Enchantments.cpp
+++ b/src/Enchantments.cpp
@@ -1112,7 +1112,9 @@ void cEnchantments::RemoveEnchantmentWeightFromVector(cWeightedEnchantments & a_
 
 
 
-void cEnchantments::CheckEnchantmentConflictsFromVector(cWeightedEnchantments & a_Enchantments, cEnchantments a_FirstEnchantment)
+void cEnchantments::CheckEnchantmentConflictsFromVector(
+	cWeightedEnchantments & a_Enchantments, const cEnchantments & a_FirstEnchantment
+)
 {
 	if (a_FirstEnchantment.GetLevel(cEnchantments::enchProtection) > 0)
 	{

--- a/src/Enchantments.cpp
+++ b/src/Enchantments.cpp
@@ -304,7 +304,7 @@ bool cEnchantments::CanAddEnchantment(int a_EnchantmentID) const
 		// {enchInfinity, enchMending}
 	};
 
-	for (auto excl: IncompatibleEnchantments)
+	for (const auto & excl: IncompatibleEnchantments)
 	{
 		if (excl.count(a_EnchantmentID) != 0)
 		{

--- a/src/Enchantments.h
+++ b/src/Enchantments.h
@@ -137,7 +137,7 @@ public:
 	static void RemoveEnchantmentWeightFromVector(cWeightedEnchantments & a_Enchantments, const cEnchantments & a_Enchantment);
 
 	/** Check enchantment conflicts from enchantments from the vector */
-	static void CheckEnchantmentConflictsFromVector(cWeightedEnchantments & a_Enchantments, cEnchantments a_FirstEnchantment);
+	static void CheckEnchantmentConflictsFromVector(cWeightedEnchantments & a_Enchantments, const cEnchantments & a_FirstEnchantment);
 
 	/** Gets random enchantment from Vector and returns it */
 	static cEnchantments GetRandomEnchantmentFromVector(cWeightedEnchantments & a_Enchantments);

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -617,7 +617,6 @@ int cEntity::GetRawDamageAgainst(const cEntity & a_Receiver)
 void cEntity::ApplyArmorDamage(int DamageBlocked)
 {
 	// cEntities don't necessarily have armor to damage.
-	return;
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -2040,11 +2040,10 @@ bool cEntity::IsA(const char * a_ClassName) const
 
 bool cEntity::IsAttachedTo(const cEntity * a_Entity) const
 {
-	if ((m_AttachedTo != nullptr) && (a_Entity->GetUniqueID() == m_AttachedTo->GetUniqueID()))
-	{
-		return true;
-	}
-	return false;
+	return (
+		(m_AttachedTo != nullptr) &&
+		(a_Entity->GetUniqueID() == m_AttachedTo->GetUniqueID())
+	);
 }
 
 

--- a/src/Entities/LeashKnot.cpp
+++ b/src/Entities/LeashKnot.cpp
@@ -85,7 +85,6 @@ void cLeashKnot::KilledBy(TakeDamageInfo & a_TDI)
 	Super::KilledBy(a_TDI);
 	m_World->BroadcastSoundEffect("entity.leashknot.break", GetPosition(), 1, 1);
 	Destroy();
-	return;
 }
 
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1869,14 +1869,8 @@ bool cPlayer::PermissionMatches(const AStringVector & a_Permission, const AStrin
 	}
 
 	// So far all the sub-items have matched
-	// If the sub-item count is the same, then the permission matches:
-	if (lenP == lenT)
-	{
-		return true;
-	}
-
-	// There are more sub-items in either the permission or the template, not a match:
-	return false;
+	// If the sub-item count is the same, then the permission matches
+	return (lenP == lenT);
 }
 
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -86,7 +86,7 @@ const int cPlayer::EATING_TICKS = 30;
 
 
 
-cPlayer::cPlayer(cClientHandlePtr a_Client, const AString & a_PlayerName) :
+cPlayer::cPlayer(const cClientHandlePtr & a_Client, const AString & a_PlayerName) :
 	Super(etPlayer, 0.6, 1.8),
 	m_bVisible(true),
 	m_FoodLevel(MAX_FOOD_LEVEL),

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -48,7 +48,7 @@ public:
 	CLASS_PROTODEF(cPlayer)
 
 
-	cPlayer(cClientHandlePtr a_Client, const AString & a_PlayerName);
+	cPlayer(const cClientHandlePtr & a_Client, const AString & a_PlayerName);
 
 	virtual bool Initialize(OwnedEntity a_Self, cWorld & a_World) override;
 

--- a/src/FurnaceRecipe.cpp
+++ b/src/FurnaceRecipe.cpp
@@ -233,7 +233,7 @@ bool cFurnaceRecipe::ParseItem(const AString & a_String, cItem & a_Item)
 
 	if (SplitAmount.size() > 1)
 	{
-		if (!StringToInteger<char>(SplitAmount[1].c_str(), a_Item.m_ItemCount))
+		if (!StringToInteger<char>(SplitAmount[1], a_Item.m_ItemCount))
 		{
 			return false;
 		}
@@ -241,7 +241,7 @@ bool cFurnaceRecipe::ParseItem(const AString & a_String, cItem & a_Item)
 
 	if (SplitMeta.size() > 1)
 	{
-		if (!StringToInteger<short>(SplitMeta[1].c_str(), a_Item.m_ItemDamage))
+		if (!StringToInteger<short>(SplitMeta[1], a_Item.m_ItemDamage))
 		{
 			return false;
 		}

--- a/src/Generating/BioGen.cpp
+++ b/src/Generating/BioGen.cpp
@@ -167,7 +167,7 @@ void cBioGenMulticache::GenBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMa
 
 void cBioGenMulticache::InitializeBiomeGen(cIniFile & a_IniFile)
 {
-	for (auto itr : m_Caches)
+	for (const auto & itr : m_Caches)
 	{
 		itr->InitializeBiomeGen(a_IniFile);
 	}

--- a/src/Generating/BioGen.cpp
+++ b/src/Generating/BioGen.cpp
@@ -58,7 +58,7 @@ void cBioGenConstant::InitializeBiomeGen(cIniFile & a_IniFile)
 // cBioGenCache:
 
 cBioGenCache::cBioGenCache(cBiomeGenPtr a_BioGenToCache, size_t a_CacheSize) :
-	m_BioGenToCache(a_BioGenToCache),
+	m_BioGenToCache(std::move(a_BioGenToCache)),
 	m_CacheSize(a_CacheSize),
 	m_NumHits(0),
 	m_NumMisses(0),
@@ -139,7 +139,7 @@ void cBioGenCache::InitializeBiomeGen(cIniFile & a_IniFile)
 ////////////////////////////////////////////////////////////////////////////////
 // cBioGenMulticache:
 
-cBioGenMulticache::cBioGenMulticache(cBiomeGenPtr a_BioGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches) :
+cBioGenMulticache::cBioGenMulticache(const cBiomeGenPtr & a_BioGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches) :
 	m_NumSubCaches(a_NumSubCaches)
 {
 	m_Caches.reserve(a_NumSubCaches);

--- a/src/Generating/BioGen.h
+++ b/src/Generating/BioGen.h
@@ -97,7 +97,7 @@ public:
 	This allows us to use shorter cache depths with faster lookups for more covered area. (#381)
 	a_SubCacheSize defines the size of each sub-cache
 	a_NumSubCaches defines how many sub-caches are used for the multicache. */
-	cBioGenMulticache(cBiomeGenPtr a_BioGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches);
+	cBioGenMulticache(const cBiomeGenPtr & a_BioGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches);
 
 protected:
 	typedef std::vector<cBiomeGenPtr> cBiomeGenPtrs;

--- a/src/Generating/CompoGen.cpp
+++ b/src/Generating/CompoGen.cpp
@@ -330,7 +330,7 @@ void cCompoGenNether::InitializeCompoGen(cIniFile & a_IniFile)
 // cCompoGenCache:
 
 cCompoGenCache::cCompoGenCache(cTerrainCompositionGenPtr a_Underlying, int a_CacheSize) :
-	m_Underlying(a_Underlying),
+	m_Underlying(std::move(a_Underlying)),
 	m_CacheSize(a_CacheSize),
 	m_CacheOrder(new int[ToUnsigned(a_CacheSize)]),
 	m_CacheData(new sCacheData[ToUnsigned(a_CacheSize)]),

--- a/src/Generating/ComposableGenerator.cpp
+++ b/src/Generating/ComposableGenerator.cpp
@@ -39,8 +39,8 @@
 
 cTerrainCompositionGenPtr cTerrainCompositionGen::CreateCompositionGen(
 	cIniFile & a_IniFile,
-	cBiomeGenPtr a_BiomeGen,
-	cTerrainShapeGenPtr a_ShapeGen,
+	const cBiomeGenPtr & a_BiomeGen,
+	const cTerrainShapeGenPtr & a_ShapeGen,
 	int a_Seed
 )
 {

--- a/src/Generating/ComposableGenerator.h
+++ b/src/Generating/ComposableGenerator.h
@@ -98,7 +98,7 @@ public:
 	*/
 	static cTerrainShapeGenPtr CreateShapeGen(
 		cIniFile & a_IniFile,
-		cBiomeGenPtr a_BiomeGen,
+		const cBiomeGenPtr & a_BiomeGen,
 		int a_Seed,
 		bool & a_CacheOffByDefault
 	);
@@ -137,7 +137,7 @@ public:
 	/** Creates a cTerrainHeightGen descendant based on the INI file settings. */
 	static cTerrainHeightGenPtr CreateHeightGen(
 		cIniFile & a_IniFile,
-		cBiomeGenPtr a_BiomeGen,
+		const cBiomeGenPtr & a_BiomeGen,
 		int a_Seed,
 		bool & a_CacheOffByDefault
 	);
@@ -169,8 +169,8 @@ public:
 	a_ShapeGen is the underlying shape generator, some composition generators may depend on it providing additional shape around the chunk. */
 	static cTerrainCompositionGenPtr CreateCompositionGen(
 		cIniFile & a_IniFile,
-		cBiomeGenPtr a_BiomeGen,
-		cTerrainShapeGenPtr a_ShapeGen,
+		const cBiomeGenPtr & a_BiomeGen,
+		const cTerrainShapeGenPtr & a_ShapeGen,
 		int a_Seed
 	);
 } ;

--- a/src/Generating/CompositedHeiGen.h
+++ b/src/Generating/CompositedHeiGen.h
@@ -21,9 +21,9 @@ class cCompositedHeiGen:
 {
 public:
 	cCompositedHeiGen(cBiomeGenPtr a_BiomeGen, cTerrainShapeGenPtr a_ShapeGen, cTerrainCompositionGenPtr a_CompositionGen):
-		m_BiomeGen(a_BiomeGen),
-		m_ShapeGen(a_ShapeGen),
-		m_CompositionGen(a_CompositionGen)
+		m_BiomeGen(std::move(a_BiomeGen)),
+		m_ShapeGen(std::move(a_ShapeGen)),
+		m_CompositionGen(std::move(a_CompositionGen))
 	{
 	}
 

--- a/src/Generating/DistortedHeightmap.cpp
+++ b/src/Generating/DistortedHeightmap.cpp
@@ -118,7 +118,7 @@ const cDistortedHeightmap::sGenParam cDistortedHeightmap::m_GenParam[256] =
 
 
 
-cDistortedHeightmap::cDistortedHeightmap(int a_Seed, cBiomeGenPtr a_BiomeGen) :
+cDistortedHeightmap::cDistortedHeightmap(int a_Seed, const cBiomeGenPtr & a_BiomeGen) :
 	m_NoiseDistortX(a_Seed + 1000),
 	m_NoiseDistortZ(a_Seed + 2000),
 	m_CurChunkCoords(0x7fffffff, 0x7fffffff),  // Set impossible coords for the chunk so that it's always considered stale

--- a/src/Generating/DistortedHeightmap.h
+++ b/src/Generating/DistortedHeightmap.h
@@ -26,7 +26,7 @@ class cDistortedHeightmap :
 	public cTerrainShapeGen
 {
 public:
-	cDistortedHeightmap(int a_Seed, cBiomeGenPtr a_BiomeGen);
+	cDistortedHeightmap(int a_Seed, const cBiomeGenPtr & a_BiomeGen);
 
 protected:
 	typedef cChunkDef::BiomeMap BiomeNeighbors[3][3];

--- a/src/Generating/DungeonRoomsFinisher.cpp
+++ b/src/Generating/DungeonRoomsFinisher.cpp
@@ -289,7 +289,7 @@ protected:
 
 cDungeonRoomsFinisher::cDungeonRoomsFinisher(cTerrainShapeGenPtr a_ShapeGen, int a_Seed, int a_GridSize, int a_MaxSize, int a_MinSize, const AString & a_HeightDistrib) :
 	Super(a_Seed + 100, a_GridSize, a_GridSize, a_GridSize, a_GridSize, a_MaxSize, a_MaxSize, 1024),
-	m_ShapeGen(a_ShapeGen),
+	m_ShapeGen(std::move(a_ShapeGen)),
 	m_MaxHalfSize((a_MaxSize + 1) / 2),
 	m_MinHalfSize((a_MinSize + 1) / 2),
 	m_HeightProbability(cChunkDef::Height)

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -275,7 +275,7 @@ void cFinishGenClumpTopBlock::TryPlaceFoliageClump(cChunkDesc & a_ChunkDesc, int
 
 
 
-void cFinishGenClumpTopBlock::ParseConfigurationString(AString a_RawClumpInfo, std::vector<BiomeInfo> & a_Output)
+void cFinishGenClumpTopBlock::ParseConfigurationString(const AString & a_RawClumpInfo, std::vector<BiomeInfo> & a_Output)
 {
 	// Initialize the vector for all biomes.
 	for (int i = static_cast<int>(a_Output.size()); i < static_cast<int>(biMaxVariantBiome); i++)

--- a/src/Generating/FinishGen.h
+++ b/src/Generating/FinishGen.h
@@ -104,7 +104,7 @@ public:
 		BiomeInfo(int a_MinNumClumpsPerChunk, int a_MaxNumClumpsPerChunk, std::vector<FoliageInfo> a_Blocks) :
 			m_MinNumClumpsPerChunk(a_MinNumClumpsPerChunk),
 			m_MaxNumClumpsPerChunk(a_MaxNumClumpsPerChunk),
-			m_Blocks(a_Blocks)
+			m_Blocks(std::move(a_Blocks))
 		{}
 	};
 
@@ -118,7 +118,7 @@ public:
 
 	/** Parses a string and puts a vector with a length of biMaxVariantBiome in a_Output.
 	The format of the string is "<Biomes separated with a comma>;<Blocks separated with a comma>". This can also be repeated with a | */
-	static void ParseConfigurationString(AString a_String, std::vector<BiomeInfo> & a_Output);
+	static void ParseConfigurationString(const AString & a_String, std::vector<BiomeInfo> & a_Output);
 
 	/** Parses an inifile in search for all clumps */
 	static std::vector<BiomeInfo> ParseIniFile(cIniFile & a_IniFile, AString a_ClumpPrefix);

--- a/src/Generating/HeiGen.cpp
+++ b/src/Generating/HeiGen.cpp
@@ -107,7 +107,7 @@ void cHeiGenFlat::InitializeHeightGen(cIniFile & a_IniFile)
 // cHeiGenCache:
 
 cHeiGenCache::cHeiGenCache(cTerrainHeightGenPtr a_HeiGenToCache, size_t a_CacheSize) :
-	m_HeiGenToCache(a_HeiGenToCache),
+	m_HeiGenToCache(std::move(a_HeiGenToCache)),
 	m_CacheSize(a_CacheSize),
 	m_NumHits(0),
 	m_NumMisses(0),
@@ -219,7 +219,7 @@ bool cHeiGenCache::GetHeightAt(int a_ChunkX, int a_ChunkZ, int a_RelX, int a_Rel
 ////////////////////////////////////////////////////////////////////////////////
 // cHeiGenMultiCache:
 
-cHeiGenMultiCache::cHeiGenMultiCache(cTerrainHeightGenPtr a_HeiGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches):
+cHeiGenMultiCache::cHeiGenMultiCache(const cTerrainHeightGenPtr & a_HeiGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches):
 	m_NumSubCaches(a_NumSubCaches)
 {
 	// Create the individual sub-caches:
@@ -638,7 +638,7 @@ public:
 
 	cHeiGenMinMax(int a_Seed, cBiomeGenPtr a_BiomeGen):
 		m_Noise(a_Seed),
-		m_BiomeGen(a_BiomeGen),
+		m_BiomeGen(std::move(a_BiomeGen)),
 		m_TotalWeight(0)
 	{
 		// Initialize the weights:
@@ -831,7 +831,7 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 // cTerrainHeightGen:
 
-cTerrainHeightGenPtr cTerrainHeightGen::CreateHeightGen(cIniFile & a_IniFile, cBiomeGenPtr a_BiomeGen, int a_Seed, bool & a_CacheOffByDefault)
+cTerrainHeightGenPtr cTerrainHeightGen::CreateHeightGen(cIniFile & a_IniFile, const cBiomeGenPtr & a_BiomeGen, int a_Seed, bool & a_CacheOffByDefault)
 {
 	AString HeightGenName = a_IniFile.GetValueSet("Generator", "HeightGen", "");
 	if (HeightGenName.empty())

--- a/src/Generating/HeiGen.h
+++ b/src/Generating/HeiGen.h
@@ -73,7 +73,7 @@ class cHeiGenMultiCache:
 	public cTerrainHeightGen
 {
 public:
-	cHeiGenMultiCache(cTerrainHeightGenPtr a_HeightGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches);
+	cHeiGenMultiCache(const cTerrainHeightGenPtr & a_HeightGenToCache, size_t a_SubCacheSize, size_t a_NumSubCaches);
 
 	// cTerrainHeightGen overrides:
 	virtual void GenHeightMap(cChunkCoords a_ChunkCoords, cChunkDef::HeightMap & a_HeightMap) override;
@@ -176,7 +176,7 @@ public:
 
 	cHeiGenBiomal(int a_Seed, cBiomeGenPtr a_BiomeGen):
 		m_Noise(a_Seed),
-		m_BiomeGen(a_BiomeGen)
+		m_BiomeGen(std::move(a_BiomeGen))
 	{
 	}
 

--- a/src/Generating/Noise3DGenerator.cpp
+++ b/src/Generating/Noise3DGenerator.cpp
@@ -511,7 +511,7 @@ cBiomalNoise3DComposable::cBiomalNoise3DComposable(int a_Seed, cBiomeGenPtr a_Bi
 	m_DensityNoiseA(a_Seed + 1),
 	m_DensityNoiseB(a_Seed + 2),
 	m_BaseNoise(a_Seed + 3),
-	m_BiomeGen(a_BiomeGen),
+	m_BiomeGen(std::move(a_BiomeGen)),
 	m_LastChunkCoords(0x7fffffff, 0x7fffffff)  // Set impossible coords for the chunk so that it's always considered stale
 {
 	// Generate the weight distribution for summing up neighboring biomes:

--- a/src/Generating/PiecePool.h
+++ b/src/Generating/PiecePool.h
@@ -183,7 +183,7 @@ public:
 
 	void SetVerticalStrategy(cVerticalStrategyPtr a_VerticalStrategy)
 	{
-		m_VerticalStrategy = a_VerticalStrategy;
+		m_VerticalStrategy = std::move(a_VerticalStrategy);
 	}
 
 	cVerticalStrategyPtr GetVerticalStrategy(void) const

--- a/src/Generating/PieceStructuresGen.cpp
+++ b/src/Generating/PieceStructuresGen.cpp
@@ -23,8 +23,8 @@ public:
 
 	cGen(int a_Seed, cBiomeGenPtr a_BiomeGen, cTerrainHeightGenPtr a_HeightGen, int a_SeaLevel, const AString & a_Name):
 		Super(a_Seed),
-		m_BiomeGen(a_BiomeGen),
-		m_HeightGen(a_HeightGen),
+		m_BiomeGen(std::move(a_BiomeGen)),
+		m_HeightGen(std::move(a_HeightGen)),
 		m_SeaLevel(a_SeaLevel),
 		m_Name(a_Name),
 		m_MaxDepth(5)
@@ -131,7 +131,7 @@ cPieceStructuresGen::cPieceStructuresGen(int a_Seed):
 
 
 
-bool cPieceStructuresGen::Initialize(const AString & a_Prefabs, int a_SeaLevel, cBiomeGenPtr a_BiomeGen, cTerrainHeightGenPtr a_HeightGen)
+bool cPieceStructuresGen::Initialize(const AString & a_Prefabs, int a_SeaLevel, const cBiomeGenPtr & a_BiomeGen, const cTerrainHeightGenPtr & a_HeightGen)
 {
 	// Load each piecepool:
 	auto structures = StringSplitAndTrim(a_Prefabs, "|");

--- a/src/Generating/PieceStructuresGen.h
+++ b/src/Generating/PieceStructuresGen.h
@@ -34,7 +34,7 @@ public:
 	a_Prefabs contains the list of prefab sets that should be activated, "|"-separated.
 	All problems are logged to the console and the generator skips over them.
 	Returns true if at least one prefab set is valid (the generator should be kept). */
-	bool Initialize(const AString & a_Prefabs, int a_SeaLevel, cBiomeGenPtr a_BiomeGen, cTerrainHeightGenPtr a_HeightGen);
+	bool Initialize(const AString & a_Prefabs, int a_SeaLevel, const cBiomeGenPtr & a_BiomeGen, const cTerrainHeightGenPtr & a_HeightGen);
 
 	// cFinishGen override:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;

--- a/src/Generating/PrefabStructure.cpp
+++ b/src/Generating/PrefabStructure.cpp
@@ -19,7 +19,7 @@ cPrefabStructure::cPrefabStructure(
 ):
 	Super(a_GridX, a_GridZ, a_OriginX, a_OriginZ),
 	m_Pieces(std::move(a_Pieces)),
-	m_HeightGen(a_HeightGen)
+	m_HeightGen(std::move(a_HeightGen))
 {
 }
 

--- a/src/Generating/ProtIntGen.h
+++ b/src/Generating/ProtIntGen.h
@@ -198,7 +198,7 @@ public:
 
 	cProtIntGenZoom(int a_Seed, Underlying a_UnderlyingGen):
 		Super(a_Seed),
-		m_UnderlyingGen(a_UnderlyingGen)
+		m_UnderlyingGen(std::move(a_UnderlyingGen))
 	{
 	}
 
@@ -269,7 +269,7 @@ public:
 
 	cProtIntGenSmooth(int a_Seed, Underlying a_Underlying):
 		Super(a_Seed),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -342,7 +342,7 @@ class cProtIntGenAvgValues:
 public:
 
 	cProtIntGenAvgValues(Underlying a_Underlying):
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -387,7 +387,7 @@ class cProtIntGenAvg4Values:
 public:
 
 	cProtIntGenAvg4Values(Underlying a_Underlying):
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -438,7 +438,7 @@ class cProtIntGenWeightAvg:
 public:
 
 	cProtIntGenWeightAvg(Underlying a_Underlying):
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -490,7 +490,7 @@ public:
 		m_ChancePct(a_ChancePct),
 		m_Min(a_Min),
 		m_Range(a_Range),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -537,7 +537,7 @@ public:
 		Super(a_Seed),
 		m_Range(a_HalfRange * 2 + 1),
 		m_HalfRange(a_HalfRange),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -580,7 +580,7 @@ public:
 	cProtIntGenRndAvg(int a_Seed, int a_AvgChancePct, Underlying a_Underlying):
 		Super(a_Seed),
 		m_AvgChancePct(a_AvgChancePct),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -638,7 +638,7 @@ public:
 	cProtIntGenRndBetween(int a_Seed, int a_AvgChancePct, Underlying a_Underlying):
 		Super(a_Seed),
 		m_AvgChancePct(a_AvgChancePct),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -693,7 +693,7 @@ class cProtIntGenBeaches:
 public:
 
 	cProtIntGenBeaches(Underlying a_Underlying):
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -798,7 +798,7 @@ public:
 	cProtIntGenAddIslands(int a_Seed, int a_Chance, Underlying a_Underlying):
 		Super(a_Seed),
 		m_Chance(a_Chance),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -842,7 +842,7 @@ class cProtIntGenBiomeGroupEdges:
 public:
 
 	cProtIntGenBiomeGroupEdges(Underlying a_Underlying):
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -941,7 +941,7 @@ public:
 
 	cProtIntGenBiomes(int a_Seed, Underlying a_Underlying):
 		Super(a_Seed),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -1072,7 +1072,7 @@ public:
 		m_From(a_From),
 		m_To(a_To),
 		m_Chance(a_Chance),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -1131,8 +1131,8 @@ class cProtIntGenMixRivers:
 public:
 
 	cProtIntGenMixRivers(Underlying a_Biomes, Underlying a_Rivers):
-		m_Biomes(a_Biomes),
-		m_Rivers(a_Rivers)
+		m_Biomes(std::move(a_Biomes)),
+		m_Rivers(std::move(a_Rivers))
 	{
 	}
 
@@ -1197,7 +1197,7 @@ public:
 
 	cProtIntGenRiver(int a_Seed, Underlying a_Underlying):
 		Super(a_Seed),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -1256,7 +1256,7 @@ public:
 		Super(a_Seed),
 		m_Chance(a_Chance),
 		m_ToValue(a_ToValue),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -1347,7 +1347,7 @@ public:
 		Super(a_Seed),
 		m_Chance(a_Chance),
 		m_ToValue(a_ToValue),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -1396,7 +1396,7 @@ public:
 	cProtIntGenRareBiomeGroups(int a_Seed, int a_Chance, Underlying a_Underlying):
 		Super(a_Seed),
 		m_Chance(a_Chance),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -1444,8 +1444,8 @@ public:
 
 	cProtIntGenAlternateBiomes(int a_Seed, Underlying a_Alterations, Underlying a_BaseBiomes):
 		Super(a_Seed),
-		m_Alterations(a_Alterations),
-		m_BaseBiomes(a_BaseBiomes)
+		m_Alterations(std::move(a_Alterations)),
+		m_BaseBiomes(std::move(a_BaseBiomes))
 	{
 	}
 
@@ -1510,7 +1510,7 @@ public:
 
 	cProtIntGenBiomeEdges(int a_Seed, Underlying a_Underlying):
 		Super(a_Seed),
-		m_Underlying(a_Underlying)
+		m_Underlying(std::move(a_Underlying))
 	{
 	}
 
@@ -1670,8 +1670,8 @@ public:
 
 	cProtIntGenMBiomes(int a_Seed, Underlying a_Alteration, Underlying a_Underlying):
 		Super(a_Seed),
-		m_Underlying(a_Underlying),
-		m_Alteration(a_Alteration)
+		m_Underlying(std::move(a_Underlying)),
+		m_Alteration(std::move(a_Alteration))
 	{
 	}
 

--- a/src/Generating/ShapeGen.cpp
+++ b/src/Generating/ShapeGen.cpp
@@ -24,7 +24,7 @@ class cTerrainHeightToShapeGen:
 {
 public:
 	cTerrainHeightToShapeGen(cTerrainHeightGenPtr a_HeightGen):
-		m_HeightGen(a_HeightGen)
+		m_HeightGen(std::move(a_HeightGen))
 	{
 	}
 
@@ -77,7 +77,7 @@ typedef std::shared_ptr<cTerrainHeightToShapeGen> cTerrainHeightToShapeGenPtr;
 
 cTerrainShapeGenPtr cTerrainShapeGen::CreateShapeGen(
 	cIniFile & a_IniFile,
-	cBiomeGenPtr a_BiomeGen,
+	const cBiomeGenPtr & a_BiomeGen,
 	int a_Seed,
 	bool & a_CacheOffByDefault
 )

--- a/src/Generating/StructGen.h
+++ b/src/Generating/StructGen.h
@@ -25,9 +25,9 @@ public:
 	cStructGenTrees(int a_Seed, cBiomeGenPtr a_BiomeGen, cTerrainShapeGenPtr a_ShapeGen, cTerrainCompositionGenPtr a_CompositionGen) :
 		m_Seed(a_Seed),
 		m_Noise(a_Seed),
-		m_BiomeGen(a_BiomeGen),
-		m_ShapeGen(a_ShapeGen),
-		m_CompositionGen(a_CompositionGen)
+		m_BiomeGen(std::move(a_BiomeGen)),
+		m_ShapeGen(std::move(a_ShapeGen)),
+		m_CompositionGen(std::move(a_CompositionGen))
 	{}
 
 protected:
@@ -82,7 +82,7 @@ public:
 		m_Noise(a_Seed),
 		m_Seed(a_Seed),
 		m_Fluid(a_Fluid),
-		m_ShapeGen(a_ShapeGen),
+		m_ShapeGen(std::move(a_ShapeGen)),
 		m_Probability(a_Probability)
 	{
 	}

--- a/src/Generating/Trees.cpp
+++ b/src/Generating/Trees.cpp
@@ -615,7 +615,7 @@ void GetAcaciaTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBl
 	a_OtherBlocks.push_back(sSetBlock(BranchPos.x, BranchPos.y + 1, BranchPos.z, E_BLOCK_NEW_LEAVES, E_META_NEWLEAVES_ACACIA));
 
 	// Choose if we have to add another branch
-	bool TwoTop = (a_Noise.IntNoise3D(a_BlockPos) < 0 ? true : false);
+	bool TwoTop = (a_Noise.IntNoise3D(a_BlockPos) < 0);
 	if (!TwoTop)
 	{
 		return;

--- a/src/Generating/TwoHeights.cpp
+++ b/src/Generating/TwoHeights.cpp
@@ -21,7 +21,7 @@ class cTwoHeights:
 
 public:
 
-	cTwoHeights(int a_Seed, cBiomeGenPtr a_BiomeGen):
+	cTwoHeights(int a_Seed, const cBiomeGenPtr & a_BiomeGen):
 		m_Seed(a_Seed),
 		m_Choice(a_Seed),
 		m_HeightA(a_Seed + 1, a_BiomeGen),
@@ -113,7 +113,7 @@ protected:
 
 
 
-cTerrainShapeGenPtr CreateShapeGenTwoHeights(int a_Seed, cBiomeGenPtr a_BiomeGen)
+cTerrainShapeGenPtr CreateShapeGenTwoHeights(int a_Seed, const cBiomeGenPtr & a_BiomeGen)
 {
 	return std::make_shared<cTwoHeights>(a_Seed, a_BiomeGen);
 }

--- a/src/Generating/TwoHeights.h
+++ b/src/Generating/TwoHeights.h
@@ -16,7 +16,7 @@
 
 /** Creates and returns a new instance of the cTwoHeights terrain shape generator.
 The instance must be Initialize()-d before it is used. */
-extern cTerrainShapeGenPtr CreateShapeGenTwoHeights(int a_Seed, cBiomeGenPtr a_BiomeGen);
+extern cTerrainShapeGenPtr CreateShapeGenTwoHeights(int a_Seed, const cBiomeGenPtr & a_BiomeGen);
 
 
 

--- a/src/Generating/VillageGen.cpp
+++ b/src/Generating/VillageGen.cpp
@@ -137,7 +137,7 @@ public:
 			{a_OriginX + a_MaxSize, cChunkDef::Height - 1, a_OriginZ + a_MaxSize}
 		),
 		m_Prefabs(a_Prefabs),
-		m_HeightGen(a_HeightGen)
+		m_HeightGen(std::move(a_HeightGen))
 	{
 		// Generate the pieces for this village; don't care about the Y coord:
 		cPieceGeneratorBFSTree pg(*this, a_Seed);
@@ -348,8 +348,8 @@ cVillageGen::cVillageGen(
 	m_MaxSize(a_MaxSize),
 	m_MinDensity(a_MinDensity),
 	m_MaxDensity(a_MaxDensity),
-	m_BiomeGen(a_BiomeGen),
-	m_HeightGen(a_HeightGen)
+	m_BiomeGen(std::move(a_BiomeGen)),
+	m_HeightGen(std::move(a_HeightGen))
 {
 	for (const auto & toLoad: a_PrefabsToLoad)
 	{

--- a/src/HTTP/HTTPMessage.h
+++ b/src/HTTP/HTTPMessage.h
@@ -126,7 +126,7 @@ public:
 	bool DoesAllowKeepAlive(void) const { return m_AllowKeepAlive; }
 
 	/** Attaches any kind of data to this request, to be later retrieved by GetUserData(). */
-	void SetUserData(cUserDataPtr a_UserData) { m_UserData = a_UserData; }
+	void SetUserData(cUserDataPtr a_UserData) { m_UserData = std::move(a_UserData); }
 
 	/** Returns the data attached to this request by the class client. */
 	cUserDataPtr GetUserData(void) { return m_UserData; }

--- a/src/HTTP/HTTPServer.cpp
+++ b/src/HTTP/HTTPServer.cpp
@@ -137,7 +137,7 @@ bool cHTTPServer::Start(cCallbacks & a_Callbacks, const AStringVector & a_Ports)
 
 	// Open up requested ports:
 	AStringVector ports;
-	for (auto port : a_Ports)
+	for (const auto & port : a_Ports)
 	{
 		UInt16 PortNum;
 		if (!StringToInteger(port, PortNum))
@@ -175,7 +175,7 @@ bool cHTTPServer::Start(cCallbacks & a_Callbacks, const AStringVector & a_Ports)
 
 void cHTTPServer::Stop(void)
 {
-	for (auto handle : m_ServerHandles)
+	for (const auto & handle : m_ServerHandles)
 	{
 		handle->Close();
 	}

--- a/src/HTTP/SslHTTPServerConnection.cpp
+++ b/src/HTTP/SslHTTPServerConnection.cpp
@@ -11,7 +11,9 @@
 
 
 
-cSslHTTPServerConnection::cSslHTTPServerConnection(cHTTPServer & a_HTTPServer, std::shared_ptr<const cSslConfig> a_Config):
+cSslHTTPServerConnection::cSslHTTPServerConnection(
+	cHTTPServer & a_HTTPServer, const std::shared_ptr<const cSslConfig> & a_Config
+):
 	Super(a_HTTPServer),
 	m_Ssl(64000)
 {

--- a/src/HTTP/SslHTTPServerConnection.h
+++ b/src/HTTP/SslHTTPServerConnection.h
@@ -25,7 +25,7 @@ public:
 
 	/** Creates a new connection on the specified server.
 	Sends the specified cert as the server certificate, uses the private key for decryption. */
-	cSslHTTPServerConnection(cHTTPServer & a_HTTPServer, std::shared_ptr<const cSslConfig> a_Config);
+	cSslHTTPServerConnection(cHTTPServer & a_HTTPServer, const std::shared_ptr<const cSslConfig> & a_Config);
 
 	virtual ~cSslHTTPServerConnection() override;
 

--- a/src/HTTP/UrlClient.cpp
+++ b/src/HTTP/UrlClient.cpp
@@ -159,7 +159,7 @@ protected:
 	}
 
 
-	std::pair<bool, AString> DoRequest(std::shared_ptr<cUrlClientRequest> a_Self);
+	std::pair<bool, AString> DoRequest(const std::shared_ptr<cUrlClientRequest> & a_Self);
 
 
 	// cNetwork::cConnectCallbacks override: TCP link connected:
@@ -572,7 +572,7 @@ void cUrlClientRequest::OnRemoteClosed()
 
 
 
-std::pair<bool, AString> cUrlClientRequest::DoRequest(std::shared_ptr<cUrlClientRequest> a_Self)
+std::pair<bool, AString> cUrlClientRequest::DoRequest(const std::shared_ptr<cUrlClientRequest> & a_Self)
 {
 	// We need a shared pointer to self, care must be taken not to pass any other ptr:
 	ASSERT(a_Self.get() == this);
@@ -630,7 +630,7 @@ std::pair<bool, AString> cUrlClient::Get(
 	const AString & a_URL,
 	cCallbacksPtr && a_Callbacks,
 	AStringMap a_Headers,
-	AString a_Body,
+	const AString & a_Body,
 	AStringMap a_Options
 )
 {

--- a/src/HTTP/UrlClient.h
+++ b/src/HTTP/UrlClient.h
@@ -124,7 +124,7 @@ public:
 		const AString & a_URL,
 		cCallbacksPtr && a_Callbacks,
 		AStringMap a_Headers = AStringMap(),
-		AString a_Body = AString(),
+		const AString & a_Body = AString(),
 		AStringMap a_Options = AStringMap()
 	);
 

--- a/src/IniFile.cpp
+++ b/src/IniFile.cpp
@@ -934,7 +934,7 @@ AStringVector ReadUpgradeIniPorts(
 
 	AStringVector Ports;
 
-	for (auto pair : a_Settings.GetValues(a_KeyName))
+	for (const auto & pair : a_Settings.GetValues(a_KeyName))
 	{
 		if (pair.first != a_PortsValueName)
 		{

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -772,7 +772,7 @@ void cItems::Set(int a_Idx, short a_ItemType, char a_ItemCount, short a_ItemDama
 
 bool cItems::Contains(const cItem & a_Item)
 {
-	for (auto itr : *this)
+	for (const auto & itr : *this)
 	{
 		if (a_Item.IsEqual(itr))
 		{
@@ -788,7 +788,7 @@ bool cItems::Contains(const cItem & a_Item)
 
 bool cItems::ContainsType(const cItem & a_Item)
 {
-	for (auto itr : *this)
+	for (const auto & itr : *this)
 	{
 		if (a_Item.IsSameType(itr))
 		{

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -30,7 +30,7 @@ void cLogger::InitiateMultithreading()
 
 
 
-void cLogger::LogSimple(AString a_Message, eLogLevel a_LogLevel)
+void cLogger::LogSimple(const AString & a_Message, eLogLevel a_LogLevel)
 {
 	time_t rawtime;
 	time(&rawtime);

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -75,7 +75,7 @@ public:
 	}
 
 	/** Logs the simple text message at the specified log level. */
-	void LogSimple(AString a_Message, eLogLevel a_LogLevel = llRegular);
+	void LogSimple(const AString & a_Message, eLogLevel a_LogLevel = llRegular);
 
 	cAttachment AttachListener(std::unique_ptr<cListener> a_Listener);
 

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -151,12 +151,14 @@ bool cMap::UpdatePixel(unsigned int a_X, unsigned int a_Z)
 				ChunkHeight /= 4;
 				while (((--Height) != -1) && IsBlockWater(a_Chunk.GetBlock(RelX, Height, RelZ)))
 				{
+					continue;
 				}
 			}
 			else if (ColourID == 0)
 			{
 				while (((--Height) != -1) && ((ColourID = BlockHandler(a_Chunk.GetBlock(RelX, Height, RelZ))->GetMapBaseColourID(a_Chunk.GetMeta(RelX, Height, RelZ))) == 0))
 				{
+					continue;
 				}
 			}
 

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -151,14 +151,12 @@ bool cMap::UpdatePixel(unsigned int a_X, unsigned int a_Z)
 				ChunkHeight /= 4;
 				while (((--Height) != -1) && IsBlockWater(a_Chunk.GetBlock(RelX, Height, RelZ)))
 				{
-					continue;
 				}
 			}
 			else if (ColourID == 0)
 			{
 				while (((--Height) != -1) && ((ColourID = BlockHandler(a_Chunk.GetBlock(RelX, Height, RelZ))->GetMapBaseColourID(a_Chunk.GetMeta(RelX, Height, RelZ))) == 0))
 				{
-					continue;
 				}
 			}
 

--- a/src/MemorySettingsRepository.cpp
+++ b/src/MemorySettingsRepository.cpp
@@ -110,7 +110,7 @@ void cMemorySettingsRepository::AddValue (const AString & a_KeyName, const AStri
 std::vector<std::pair<AString, AString>> cMemorySettingsRepository::GetValues(AString a_keyName)
 {
 	std::vector<std::pair<AString, AString>> ret;
-	for (auto pair : m_Map[a_keyName])
+	for (const auto & pair : m_Map[a_keyName])
 	{
 		ret.emplace_back(pair.first, pair.second.getStringValue());
 	}

--- a/src/MemorySettingsRepository.cpp
+++ b/src/MemorySettingsRepository.cpp
@@ -23,11 +23,7 @@ bool cMemorySettingsRepository::HasValue(const AString & a_KeyName, const AStrin
 		return false;
 	}
 	auto iter = outerIter->second.find(a_ValueName);
-	if (iter == outerIter->second.end())
-	{
-		return false;
-	}
-	return true;
+	return (iter != outerIter->second.end());
 }
 
 

--- a/src/MemorySettingsRepository.h
+++ b/src/MemorySettingsRepository.h
@@ -57,7 +57,7 @@ private:
 			#ifdef _DEBUG
 				m_Type(eType::String),
 			#endif
-			m_stringValue (value)
+			m_stringValue (std::move(value))
 		{
 		}
 

--- a/src/MobCensus.cpp
+++ b/src/MobCensus.cpp
@@ -22,11 +22,8 @@ bool cMobCensus::IsCapped(cMonster::eFamily a_MobFamily)
 	const int ratio = 319;  // This should be 256 as we are only supposed to take account from chunks that are in 17 x 17 from a player
 	// but for now, we use all chunks loaded by players. that means 19 x 19 chunks. That's why we use 256 * (19 * 19) / (17 * 17) = 319
 	// MG TODO : code the correct count
-	if ((GetCapMultiplier(a_MobFamily) * GetNumChunks()) / ratio >= m_MobFamilyCollecter.GetNumberOfCollectedMobs(a_MobFamily))
-	{
-		return false;
-	}
-	return true;
+	const auto MobCap = ((GetCapMultiplier(a_MobFamily) * GetNumChunks()) / ratio);
+	return (MobCap < m_MobFamilyCollecter.GetNumberOfCollectedMobs(a_MobFamily));
 }
 
 

--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -83,11 +83,10 @@ void cCreeper::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	{
 		auto ProjectileCreatorCallback = [](cEntity & a_Entity)
 			{
-				if (a_Entity.IsMob() && ((static_cast<cMonster &>(a_Entity)).GetMobType() == mtSkeleton))
-				{
-					return true;
-				}
-				return false;
+				return (
+					a_Entity.IsMob() &&
+					((static_cast<cMonster &>(a_Entity)).GetMobType() == mtSkeleton)
+				);
 			};
 
 		if (GetWorld()->DoWithEntityByID(static_cast<cProjectileEntity *>(a_Killer)->GetCreatorUniqueID(), ProjectileCreatorCallback))

--- a/src/Mobs/EnderDragon.cpp
+++ b/src/Mobs/EnderDragon.cpp
@@ -19,7 +19,6 @@ cEnderDragon::cEnderDragon(void) :
 
 void cEnderDragon::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 {
-	return;
 }
 
 

--- a/src/Mobs/EnderDragon.cpp
+++ b/src/Mobs/EnderDragon.cpp
@@ -19,6 +19,7 @@ cEnderDragon::cEnderDragon(void) :
 
 void cEnderDragon::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 {
+	// No drops
 }
 
 

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -325,7 +325,7 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		else
 		{
 			// Note that m_NextWayPointPosition is actually returned by GetNextWayPoint)
-			switch (m_PathFinder.GetNextWayPoint(*Chunk, GetPosition(), &m_FinalDestination, &m_NextWayPointPosition, m_EMState == IDLE ? true : false))
+			switch (m_PathFinder.GetNextWayPoint(*Chunk, GetPosition(), &m_FinalDestination, &m_NextWayPointPosition, m_EMState == IDLE))
 			{
 				case ePathFinderStatus::PATH_FOUND:
 				{

--- a/src/Mobs/PassiveMonster.cpp
+++ b/src/Mobs/PassiveMonster.cpp
@@ -138,7 +138,7 @@ void cPassiveMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		{
 			m_World->DoWithNearestPlayer(GetPosition(), static_cast<float>(m_SightDistance), [&](cPlayer & a_Player) -> bool
 			{
-				cItem EquippedItem = a_Player.GetEquippedItem();
+				const cItem & EquippedItem = a_Player.GetEquippedItem();
 				if (FollowedItems.ContainsType(EquippedItem))
 				{
 					Vector3d PlayerPos = a_Player.GetPosition();

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -639,15 +639,8 @@ bool cPath::SpecialIsSolidFromThisDirection(BLOCKTYPE a_Type, NIBBLETYPE a_Meta,
 	// If there is a nonsolid above a fence
 	if (!cBlockInfo::IsSolid(a_Type))
 	{
-			// If we're coming from below
-			if (a_Direction.y > 0)
-			{
-				return true;  // treat the nonsolid as solid
-			}
-			else
-			{
-				return false;  // Treat it as a nonsolid because we are not coming from below
-			}
+		// Only treat as solid when we're coming from below
+		return (a_Direction.y > 0);
 	}
 
 	/* switch (a_Type)

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -278,9 +278,6 @@ bool cPathFinder::PathIsTooOld() const
 	{
 		acceptableDeviation = 1;
 	}
-	if ((m_FinalDestination - m_DeviationOrigin).SqrLength() > acceptableDeviation * acceptableDeviation)
-	{
-		return true;
-	}
-	return false;
+	const auto DeviationSqr = (m_FinalDestination - m_DeviationOrigin).SqrLength();
+	return (DeviationSqr > acceptableDeviation * acceptableDeviation);
 }

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -279,5 +279,5 @@ bool cPathFinder::PathIsTooOld() const
 		acceptableDeviation = 1;
 	}
 	const auto DeviationSqr = (m_FinalDestination - m_DeviationOrigin).SqrLength();
-	return (DeviationSqr > acceptableDeviation * acceptableDeviation);
+	return (DeviationSqr > (acceptableDeviation * acceptableDeviation));
 }

--- a/src/OSSupport/HostnameLookup.cpp
+++ b/src/OSSupport/HostnameLookup.cpp
@@ -16,7 +16,7 @@
 // cHostnameLookup:
 
 cHostnameLookup::cHostnameLookup(const AString & a_Hostname, cNetwork::cResolveNameCallbacksPtr a_Callbacks):
-	m_Callbacks(a_Callbacks),
+	m_Callbacks(std::move(a_Callbacks)),
 	m_Hostname(a_Hostname)
 {
 }

--- a/src/OSSupport/IPLookup.cpp
+++ b/src/OSSupport/IPLookup.cpp
@@ -17,10 +17,10 @@
 // cIPLookup:
 
 cIPLookup::cIPLookup(const AString & a_IP, cNetwork::cResolveNameCallbacksPtr a_Callbacks):
-	m_Callbacks(a_Callbacks),
+	m_Callbacks(std::move(a_Callbacks)),
 	m_IP(a_IP)
 {
-	ASSERT(a_Callbacks != nullptr);
+	ASSERT(m_Callbacks != nullptr);
 }
 
 

--- a/src/OSSupport/Network.h
+++ b/src/OSSupport/Network.h
@@ -132,7 +132,7 @@ protected:
 
 	/** Creates a new link, with the specified callbacks. */
 	cTCPLink(cCallbacksPtr a_Callbacks):
-		m_Callbacks(a_Callbacks)
+		m_Callbacks(std::move(a_Callbacks))
 	{
 	}
 };

--- a/src/OSSupport/NetworkSingleton.cpp
+++ b/src/OSSupport/NetworkSingleton.cpp
@@ -182,7 +182,7 @@ void cNetworkSingleton::SignalizeStartup(evutil_socket_t a_Socket, short a_Event
 
 
 
-void cNetworkSingleton::AddLink(cTCPLinkPtr a_Link)
+void cNetworkSingleton::AddLink(const cTCPLinkPtr & a_Link)
 {
 	ASSERT(!m_HasTerminated);
 	cCSLock Lock(m_CS);
@@ -211,7 +211,7 @@ void cNetworkSingleton::RemoveLink(const cTCPLink * a_Link)
 
 
 
-void cNetworkSingleton::AddServer(cServerHandlePtr a_Server)
+void cNetworkSingleton::AddServer(const cServerHandlePtr & a_Server)
 {
 	ASSERT(!m_HasTerminated);
 	cCSLock Lock(m_CS);

--- a/src/OSSupport/NetworkSingleton.h
+++ b/src/OSSupport/NetworkSingleton.h
@@ -61,7 +61,7 @@ public:
 
 	/** Adds the specified link to m_Connections.
 	Used by the underlying link implementation when a new link is created. */
-	void AddLink(cTCPLinkPtr a_Link);
+	void AddLink(const cTCPLinkPtr & a_Link);
 
 	/** Removes the specified link from m_Connections.
 	Used by the underlying link implementation when the link is closed / errored. */
@@ -70,7 +70,7 @@ public:
 	/** Adds the specified link to m_Servers.
 	Used by the underlying server handle implementation when a new listening server is created.
 	Only servers that succeed in listening are added. */
-	void AddServer(cServerHandlePtr a_Server);
+	void AddServer(const cServerHandlePtr & a_Server);
 
 	/** Removes the specified server from m_Servers.
 	Used by the underlying server handle implementation when the server is closed. */

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -79,7 +79,7 @@ void cServerHandleImpl::Close(void)
 		cCSLock Lock(m_CS);
 		std::swap(Conns, m_Connections);
 	}
-	for (auto conn: Conns)
+	for (const auto & conn: Conns)
 	{
 		conn->Shutdown();
 	}

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -32,7 +32,7 @@ static bool IsValidSocket(evutil_socket_t a_Socket)
 // cServerHandleImpl:
 
 cServerHandleImpl::cServerHandleImpl(cNetwork::cListenCallbacksPtr a_ListenCallbacks):
-	m_ListenCallbacks(a_ListenCallbacks),
+	m_ListenCallbacks(std::move(a_ListenCallbacks)),
 	m_ConnListener(nullptr),
 	m_SecondaryConnListener(nullptr),
 	m_IsListening(false),
@@ -100,7 +100,7 @@ cServerHandleImplPtr cServerHandleImpl::Listen(
 	cNetwork::cListenCallbacksPtr a_ListenCallbacks
 )
 {
-	cServerHandleImplPtr res = cServerHandleImplPtr{new cServerHandleImpl(a_ListenCallbacks)};
+	cServerHandleImplPtr res{new cServerHandleImpl(std::move(a_ListenCallbacks))};
 	res->m_SelfPtr = res;
 	if (res->Listen(a_Port))
 	{
@@ -108,7 +108,7 @@ cServerHandleImplPtr cServerHandleImpl::Listen(
 	}
 	else
 	{
-		a_ListenCallbacks->OnError(res->m_ErrorCode, res->m_ErrorMsg);
+		res->m_ListenCallbacks->OnError(res->m_ErrorCode, res->m_ErrorMsg);
 		res->m_SelfPtr.reset();
 	}
 	return res;
@@ -363,7 +363,7 @@ cServerHandlePtr cNetwork::Listen(
 	cNetwork::cListenCallbacksPtr a_ListenCallbacks
 )
 {
-	return cServerHandleImpl::Listen(a_Port, a_ListenCallbacks);
+	return cServerHandleImpl::Listen(a_Port, std::move(a_ListenCallbacks));
 }
 
 

--- a/src/OSSupport/TCPLinkImpl.cpp
+++ b/src/OSSupport/TCPLinkImpl.cpp
@@ -18,7 +18,7 @@
 // cTCPLinkImpl:
 
 cTCPLinkImpl::cTCPLinkImpl(cTCPLink::cCallbacksPtr a_LinkCallbacks):
-	Super(a_LinkCallbacks),
+	Super(std::move(a_LinkCallbacks)),
 	m_BufferEvent(bufferevent_socket_new(cNetworkSingleton::Get().GetEventBase(), -1, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_THREADSAFE | BEV_OPT_DEFER_CALLBACKS | BEV_OPT_UNLOCK_CALLBACKS)),
 	m_LocalPort(0),
 	m_RemotePort(0),
@@ -31,9 +31,9 @@ cTCPLinkImpl::cTCPLinkImpl(cTCPLink::cCallbacksPtr a_LinkCallbacks):
 
 
 cTCPLinkImpl::cTCPLinkImpl(evutil_socket_t a_Socket, cTCPLink::cCallbacksPtr a_LinkCallbacks, cServerHandleImplPtr a_Server, const sockaddr * a_Address, socklen_t a_AddrLen):
-	Super(a_LinkCallbacks),
+	Super(std::move(a_LinkCallbacks)),
 	m_BufferEvent(bufferevent_socket_new(cNetworkSingleton::Get().GetEventBase(), a_Socket, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_THREADSAFE | BEV_OPT_DEFER_CALLBACKS | BEV_OPT_UNLOCK_CALLBACKS)),
-	m_Server(a_Server),
+	m_Server(std::move(a_Server)),
 	m_LocalPort(0),
 	m_RemotePort(0),
 	m_ShouldShutdown(false)
@@ -65,8 +65,8 @@ cTCPLinkImplPtr cTCPLinkImpl::Connect(const AString & a_Host, UInt16 a_Port, cTC
 	ASSERT(a_ConnectCallbacks != nullptr);
 
 	// Create a new link:
-	cTCPLinkImplPtr res{new cTCPLinkImpl(a_LinkCallbacks)};  // Cannot use std::make_shared here, constructor is not accessible
-	res->m_ConnectCallbacks = a_ConnectCallbacks;
+	cTCPLinkImplPtr res{new cTCPLinkImpl(std::move(a_LinkCallbacks))};  // Cannot use std::make_shared here, constructor is not accessible
+	res->m_ConnectCallbacks = std::move(a_ConnectCallbacks);
 	cNetworkSingleton::Get().AddLink(res);
 	res->m_Callbacks->OnLinkCreated(res);
 	res->Enable(res);
@@ -149,7 +149,7 @@ cTCPLinkImplPtr cTCPLinkImpl::Connect(const AString & a_Host, UInt16 a_Port, cTC
 void cTCPLinkImpl::Enable(cTCPLinkImplPtr a_Self)
 {
 	// Take hold of a shared copy of self, to keep as long as the callbacks are coming:
-	m_Self = a_Self;
+	m_Self = std::move(a_Self);
 
 	// Set the LibEvent callbacks and enable processing:
 	bufferevent_setcb(m_BufferEvent, ReadCallback, WriteCallback, EventCallback, this);
@@ -550,7 +550,7 @@ cTCPLinkImpl::cLinkTlsContext::cLinkTlsContext(cTCPLinkImpl & a_Link):
 
 void cTCPLinkImpl::cLinkTlsContext::SetSelf(cLinkTlsContextWPtr a_Self)
 {
-	m_Self = a_Self;
+	m_Self = std::move(a_Self);
 }
 
 
@@ -700,7 +700,7 @@ bool cNetwork::Connect(
 )
 {
 	// Add a connection request to the queue:
-	cTCPLinkImplPtr Conn = cTCPLinkImpl::Connect(a_Host, a_Port, a_LinkCallbacks, a_ConnectCallbacks);
+	cTCPLinkImplPtr Conn = cTCPLinkImpl::Connect(a_Host, a_Port, std::move(a_LinkCallbacks), std::move(a_ConnectCallbacks));
 	return (Conn != nullptr);
 }
 

--- a/src/OverridesSettingsRepository.cpp
+++ b/src/OverridesSettingsRepository.cpp
@@ -112,7 +112,7 @@ std::vector<std::pair<AString, AString>> cOverridesSettingsRepository::GetValues
 
 	auto ret = overrides;
 
-	for (auto mainpair : main)
+	for (const auto & mainpair : main)
 	{
 		bool found = false;
 		for (const auto & overridepair : overrides)

--- a/src/OverridesSettingsRepository.cpp
+++ b/src/OverridesSettingsRepository.cpp
@@ -123,7 +123,7 @@ std::vector<std::pair<AString, AString>> cOverridesSettingsRepository::GetValues
 				break;
 			}
 		}
-		if (found == false)
+		if (!found)
 		{
 			ret.push_back(mainpair);
 		}

--- a/src/Protocol/Protocol_1_10.cpp
+++ b/src/Protocol/Protocol_1_10.cpp
@@ -618,7 +618,7 @@ void cProtocol_1_10_0::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity 
 			Writer.AddInt("x", CommandBlockEntity.GetPosX());
 			Writer.AddInt("y", CommandBlockEntity.GetPosY());
 			Writer.AddInt("z", CommandBlockEntity.GetPosZ());
-			Writer.AddString("Command", CommandBlockEntity.GetCommand().c_str());
+			Writer.AddString("Command", CommandBlockEntity.GetCommand());
 			// You can set custom names for windows in Vanilla
 			// For a command block, this would be the 'name' prepended to anything it outputs into global chat
 			// MCS doesn't have this, so just leave it @ '@'. (geddit?)

--- a/src/Protocol/Protocol_1_11.cpp
+++ b/src/Protocol/Protocol_1_11.cpp
@@ -446,7 +446,7 @@ void cProtocol_1_11_0::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity 
 			Writer.AddInt("x", CommandBlockEntity.GetPosX());
 			Writer.AddInt("y", CommandBlockEntity.GetPosY());
 			Writer.AddInt("z", CommandBlockEntity.GetPosZ());
-			Writer.AddString("Command", CommandBlockEntity.GetCommand().c_str());
+			Writer.AddString("Command", CommandBlockEntity.GetCommand());
 			// You can set custom names for windows in Vanilla
 			// For a command block, this would be the 'name' prepended to anything it outputs into global chat
 			// MCS doesn't have this, so just leave it @ '@'. (geddit?)

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -831,7 +831,7 @@ void cProtocol_1_8_0::SendPaintingSpawn(const cPainting & a_Painting)
 
 	cPacketizer Pkt(*this, pktSpawnPainting);
 	Pkt.WriteVarInt32(a_Painting.GetUniqueID());
-	Pkt.WriteString(a_Painting.GetName().c_str());
+	Pkt.WriteString(a_Painting.GetName());
 	Pkt.WritePosition64(static_cast<Int32>(PosX), static_cast<Int32>(PosY), static_cast<Int32>(PosZ));
 	Pkt.WriteBEInt8(static_cast<Int8>(a_Painting.GetProtocolFacing()));
 }
@@ -3266,7 +3266,7 @@ void cProtocol_1_8_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 
 		if (!a_Item.IsCustomNameEmpty())
 		{
-			Writer.AddString("Name", a_Item.m_CustomName.c_str());
+			Writer.AddString("Name", a_Item.m_CustomName);
 		}
 		if (!a_Item.IsLoreEmpty())
 		{
@@ -3327,7 +3327,7 @@ void cProtocol_1_8_0::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity &
 			Writer.AddInt("x", CommandBlockEntity.GetPosX());
 			Writer.AddInt("y", CommandBlockEntity.GetPosY());
 			Writer.AddInt("z", CommandBlockEntity.GetPosZ());
-			Writer.AddString("Command", CommandBlockEntity.GetCommand().c_str());
+			Writer.AddString("Command", CommandBlockEntity.GetCommand());
 			// You can set custom names for windows in Vanilla
 			// For a command block, this would be the 'name' prepended to anything it outputs into global chat
 			// MCS doesn't have this, so just leave it @ '@'. (geddit?)

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -302,7 +302,7 @@ void cProtocol_1_9_0::SendPaintingSpawn(const cPainting & a_Painting)
 	// TODO: Bad way to write a UUID, and it's not a true UUID, but this is functional for now.
 	Pkt.WriteBEUInt64(0);
 	Pkt.WriteBEUInt64(a_Painting.GetUniqueID());
-	Pkt.WriteString(a_Painting.GetName().c_str());
+	Pkt.WriteString(a_Painting.GetName());
 	Pkt.WritePosition64(static_cast<Int32>(PosX), static_cast<Int32>(PosY), static_cast<Int32>(PosZ));
 	Pkt.WriteBEInt8(static_cast<Int8>(a_Painting.GetProtocolFacing()));
 }
@@ -1413,7 +1413,7 @@ void cProtocol_1_9_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 
 		if (!a_Item.IsCustomNameEmpty())
 		{
-			Writer.AddString("Name", a_Item.m_CustomName.c_str());
+			Writer.AddString("Name", a_Item.m_CustomName);
 		}
 		if (!a_Item.IsLoreEmpty())
 		{
@@ -1489,7 +1489,7 @@ void cProtocol_1_9_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 
 		PotionID = "minecraft:" + PotionID;
 
-		Writer.AddString("Potion", PotionID.c_str());
+		Writer.AddString("Potion", PotionID);
 	}
 	if (a_Item.m_ItemType == E_ITEM_SPAWN_EGG)
 	{
@@ -1545,7 +1545,7 @@ void cProtocol_1_9_0::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity &
 			Writer.AddInt("x", CommandBlockEntity.GetPosX());
 			Writer.AddInt("y", CommandBlockEntity.GetPosY());
 			Writer.AddInt("z", CommandBlockEntity.GetPosZ());
-			Writer.AddString("Command", CommandBlockEntity.GetCommand().c_str());
+			Writer.AddString("Command", CommandBlockEntity.GetCommand());
 			// You can set custom names for windows in Vanilla
 			// For a command block, this would be the 'name' prepended to anything it outputs into global chat
 			// MCS doesn't have this, so just leave it @ '@'. (geddit?)

--- a/src/RCONServer.cpp
+++ b/src/RCONServer.cpp
@@ -124,7 +124,7 @@ cRCONServer::cRCONServer(cServer & a_Server) :
 
 cRCONServer::~cRCONServer()
 {
-	for (auto srv: m_ListenServers)
+	for (const auto & srv: m_ListenServers)
 	{
 		srv->Close();
 	}
@@ -153,7 +153,7 @@ void cRCONServer::Initialize(cSettingsRepositoryInterface & a_Settings)
 	AStringVector Ports = ReadUpgradeIniPorts(a_Settings, "RCON", "Ports", "PortsIPv4", "PortsIPv6", "25575");
 
 	// Start listening on each specified port:
-	for (auto port: Ports)
+	for (const auto & port: Ports)
 	{
 		UInt16 PortNum;
 		if (!StringToInteger(port, PortNum))

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -527,7 +527,7 @@ void cRoot::LoadWorlds(cDeadlockDetect & a_dd, cSettingsRepositoryInterface & a_
 
 		// The default world is an overworld with no links
 		eDimension Dimension = dimOverworld;
-		AString LinkTo = "";
+		AString LinkTo;
 
 		// if the world is called x_nether
 		if ((LowercaseName.size() > NetherAppend.size()) && (LowercaseName.substr(LowercaseName.size() - NetherAppend.size()) == NetherAppend))

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -891,11 +891,7 @@ bool cRoot::FindAndDoWithPlayer(const AString & a_PlayerName, cPlayerListCallbac
 				m_BestRating = Rating;
 				++m_NumMatches;
 			}
-			if (Rating == m_NameLength)  // Perfect match
-			{
-				return true;
-			}
-			return false;
+			return (Rating == m_NameLength);  // Perfect match
 		}
 
 		cCallback (const AString & a_CBPlayerName) :

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -505,7 +505,7 @@ void cRoot::LoadWorlds(cDeadlockDetect & a_dd, cSettingsRepositoryInterface & a_
 	*/
 
 	bool FoundAdditionalWorlds = false;
-	for (auto WorldNameValue : Worlds)
+	for (const auto & WorldNameValue : Worlds)
 	{
 		AString ValueName = WorldNameValue.first;
 		if (ValueName.compare("World") != 0)

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -473,7 +473,7 @@ void cRoot::LoadWorlds(cDeadlockDetect & a_dd, cSettingsRepositoryInterface & a_
 	// Get the default world
 	AString DefaultWorldName = a_Settings.GetValueSet("Worlds", "DefaultWorld", "world");
 	AString DefaultWorldPath = a_Settings.GetValueSet("WorldPaths", DefaultWorldName, DefaultWorldName);
-	m_pDefaultWorld = new cWorld(DefaultWorldName.c_str(), DefaultWorldPath.c_str(), a_dd, WorldNames);
+	m_pDefaultWorld = new cWorld(DefaultWorldName, DefaultWorldPath, a_dd, WorldNames);
 	m_WorldsByName[ DefaultWorldName ] = m_pDefaultWorld;
 
 	// Then load the other worlds
@@ -571,7 +571,7 @@ void cRoot::LoadWorlds(cDeadlockDetect & a_dd, cSettingsRepositoryInterface & a_
 			}
 			Dimension = dimEnd;
 		}
-		NewWorld = new cWorld(WorldName.c_str(), WorldPath.c_str(), a_dd, WorldNames, Dimension, LinkTo);
+		NewWorld = new cWorld(WorldName, WorldPath, a_dd, WorldNames, Dimension, LinkTo);
 		m_WorldsByName[WorldName] = NewWorld;
 	}  // for i - Worlds
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -292,7 +292,7 @@ const AStringMap & cServer::GetRegisteredForgeMods(const UInt32 a_Protocol)
 bool cServer::IsPlayerInQueue(const AString & a_Username)
 {
 	cCSLock Lock(m_CSClients);
-	for (auto client : m_Clients)
+	for (const auto & client : m_Clients)
 	{
 		if ((client->GetUsername()).compare(a_Username) == 0)
 		{
@@ -403,7 +403,7 @@ void cServer::TickClients(float a_Dt)
 
 bool cServer::Start(void)
 {
-	for (auto port: m_Ports)
+	for (const auto & port: m_Ports)
 	{
 		UInt16 PortNum;
 		if (!StringToInteger(port, PortNum))
@@ -636,7 +636,7 @@ void cServer::BindBuiltInConsoleCommands(void)
 void cServer::Shutdown(void)
 {
 	// Stop listening on all sockets:
-	for (auto srv: m_ServerHandles)
+	for (const auto & srv: m_ServerHandles)
 	{
 		srv->Close();
 	}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -422,11 +422,7 @@ bool cServer::Start(void)
 		LOGERROR("Couldn't open any ports. Aborting the server");
 		return false;
 	}
-	if (!m_TickThread.Start())
-	{
-		return false;
-	}
-	return true;
+	return m_TickThread.Start();
 }
 
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -289,7 +289,7 @@ const AStringMap & cServer::GetRegisteredForgeMods(const UInt32 a_Protocol)
 
 
 
-bool cServer::IsPlayerInQueue(AString a_Username)
+bool cServer::IsPlayerInQueue(const AString & a_Username)
 {
 	cCSLock Lock(m_CSClients);
 	for (auto client : m_Clients)

--- a/src/Server.h
+++ b/src/Server.h
@@ -83,7 +83,7 @@ public:
 
 	/** Check if the player is queued to be transferred to a World.
 	Returns true is Player is found in queue. */
-	bool IsPlayerInQueue(AString a_Username);
+	bool IsPlayerInQueue(const AString & a_Username);
 
 	/** Can login more than once with same username.
 	Returns false if it is not allowed, true otherwise. */

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -1052,7 +1052,7 @@ AStringVector MergeStringVectors(const AStringVector & a_Strings1, const AString
 	AStringVector res = a_Strings1;
 
 	// Add each item from strings2 that is not already present:
-	for (auto item : a_Strings2)
+	for (const auto & item : a_Strings2)
 	{
 		if (std::find(res.begin(), res.end(), item) == res.end())
 		{

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -527,11 +527,7 @@ static bool isLegalUTF8(const unsigned char * source, int length)
 		}
 		case 1: if ((*source >= 0x80) && (*source < 0xc2)) return false;
 	}
-	if (*source > 0xf4)
-	{
-		return false;
-	}
-	return true;
+	return (*source <= 0xf4);
 }
 
 
@@ -1094,11 +1090,7 @@ bool StringToFloat(const AString & a_String, float & a_Num)
 {
 	char *err;
 	a_Num = strtof(a_String.c_str(), &err);
-	if (*err != 0)
-	{
-		return false;
-	}
-	return true;
+	return (*err == 0);
 }
 
 

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -2297,7 +2297,6 @@ void cSlotAreaInventoryBase::Clicked(cPlayer & a_Player, int a_SlotNum, eClickAc
 
 	// Survival inventory and all other windows' inventory has the same handling as normal slot areas
 	Super::Clicked(a_Player, a_SlotNum, a_ClickAction, a_ClickedItem);
-	return;
 }
 
 

--- a/src/WebAdmin.cpp
+++ b/src/WebAdmin.cpp
@@ -167,7 +167,7 @@ bool cWebAdmin::LoadLoginPage(void)
 void cWebAdmin::RemoveAllPluginWebTabs(const AString & a_PluginName)
 {
 	cCSLock lock(m_CS);
-	m_WebTabs.erase(std::remove_if(m_WebTabs.begin(), m_WebTabs.end(), [=](cWebTabPtr a_CBWebTab)
+	m_WebTabs.erase(std::remove_if(m_WebTabs.begin(), m_WebTabs.end(), [=](const cWebTabPtr & a_CBWebTab)
 		{
 			return (a_CBWebTab->m_PluginName == a_PluginName);
 		}),
@@ -519,7 +519,7 @@ void cWebAdmin::AddWebTab(
 )
 {
 	cCSLock lock(m_CS);
-	m_WebTabs.emplace_back(std::make_shared<cWebTab>(a_Title, a_UrlPath, a_PluginName, a_Callback));
+	m_WebTabs.emplace_back(std::make_shared<cWebTab>(a_Title, a_UrlPath, a_PluginName, std::move(a_Callback)));
 }
 
 

--- a/src/WebAdmin.h
+++ b/src/WebAdmin.h
@@ -140,7 +140,7 @@ public:
 			m_Title(a_Title),
 			m_UrlPath(a_UrlPath),
 			m_PluginName(a_PluginName),
-			m_Callback(a_Callback)
+			m_Callback(std::move(a_Callback))
 		{
 		}
 	};

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -3061,7 +3061,7 @@ void cWorld::QueueSaveAllChunks(void)
 void cWorld::QueueTask(std::function<void(cWorld &)> a_Task)
 {
 	cCSLock Lock(m_CSTasks);
-	m_Tasks.emplace_back(0, a_Task);
+	m_Tasks.emplace_back(0, std::move(a_Task));
 }
 
 
@@ -3075,7 +3075,7 @@ void cWorld::ScheduleTask(int a_DelayTicks, std::function<void (cWorld &)> a_Tas
 	// Insert the task into the list of scheduled tasks
 	{
 		cCSLock Lock(m_CSTasks);
-		m_Tasks.emplace_back(TargetTick, a_Task);
+		m_Tasks.emplace_back(TargetTick, std::move(a_Task));
 	}
 }
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1206,11 +1206,8 @@ void cWorld::TickQueuedTasks(void)
 		// Partition everything to be executed by returning false to move to end of list if time reached
 		auto MoveBeginIterator = std::partition(m_Tasks.begin(), m_Tasks.end(), [this](const decltype(m_Tasks)::value_type & a_Task)
 			{
-				if (a_Task.first < std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count())
-				{
-					return false;
-				}
-				return true;
+				const auto WorldAgeTicks = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count();
+				return (a_Task.first >= WorldAgeTicks);
 			}
 		);
 

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -2496,7 +2496,7 @@ void cWSSAnvil::LoadOcelotFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 	int SittingIdx = a_NBT.FindChildByName(a_TagIdx, "Sitting");
 	if ((SittingIdx > 0) && (a_NBT.GetType(SittingIdx) == TAG_Byte))
 	{
-		bool Sitting = ((a_NBT.GetByte(SittingIdx) == 1) ? true : false);
+		bool Sitting = (a_NBT.GetByte(SittingIdx) == 1);
 		Monster->SetIsSitting(Sitting);
 	}
 
@@ -2915,13 +2915,13 @@ void cWSSAnvil::LoadWolfFromNBT(cEntityList & a_Entities, const cParsedNBT & a_N
 	int SittingIdx = a_NBT.FindChildByName(a_TagIdx, "Sitting");
 	if ((SittingIdx > 0) && (a_NBT.GetType(SittingIdx) == TAG_Byte))
 	{
-		bool Sitting = ((a_NBT.GetByte(SittingIdx) == 1) ? true : false);
+		bool Sitting = (a_NBT.GetByte(SittingIdx) == 1);
 		Monster->SetIsSitting(Sitting);
 	}
 	int AngryIdx = a_NBT.FindChildByName(a_TagIdx, "Angry");
 	if ((AngryIdx > 0) && (a_NBT.GetType(AngryIdx) == TAG_Byte))
 	{
-		bool Angry = ((a_NBT.GetByte(AngryIdx) == 1) ? true : false);
+		bool Angry = (a_NBT.GetByte(AngryIdx) == 1);
 		Monster->SetIsAngry(Angry);
 	}
 	int CollarColorIdx = a_NBT.FindChildByName(a_TagIdx, "CollarColor");

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -3518,7 +3518,7 @@ bool cWSSAnvil::cMCAFile::GetChunkData(const cChunkCoords & a_Chunk, AString & a
 	if (CompressionType != 2)
 	{
 		// Chunk is in an unknown compression
-		m_ParentSchema.ChunkLoadFailed(a_Chunk.m_ChunkX, a_Chunk.m_ChunkZ, Printf("Unknown chunk compression: %d", CompressionType).c_str(), a_Data);
+		m_ParentSchema.ChunkLoadFailed(a_Chunk.m_ChunkX, a_Chunk.m_ChunkZ, Printf("Unknown chunk compression: %d", CompressionType), a_Data);
 		return false;
 	}
 	return true;

--- a/src/mbedTLS++/BlockingSslClientSocket.cpp
+++ b/src/mbedTLS++/BlockingSslClientSocket.cpp
@@ -356,7 +356,7 @@ void cBlockingSslClientSocket::OnReceivedData(const char * a_Data, size_t a_Size
 
 void cBlockingSslClientSocket::SetLink(cTCPLinkPtr a_Link)
 {
-	m_Socket = a_Link;
+	m_Socket = std::move(a_Link);
 }
 
 

--- a/src/mbedTLS++/SslContext.cpp
+++ b/src/mbedTLS++/SslContext.cpp
@@ -41,7 +41,7 @@ int cSslContext::Initialize(std::shared_ptr<const cSslConfig> a_Config)
 	}
 
 	// Check the Config:
-	m_Config = a_Config;
+	m_Config = std::move(a_Config);
 	if (m_Config == nullptr)
 	{
 		ASSERT(!"Config must not be nullptr");


### PR DESCRIPTION
This enables a small selection of extra `clang-tidy` checks. See documentation for meanings:
https://clang.llvm.org/extra/clang-tidy/checks/list.html

For each commit I enabled a check and ran `clang-tidy.sh` with `-fix` to apply the auto fix-its. I had to manually reviewed all the changes because the fix-its aren't perfect. In some cases they even introduced use-after-move bugs.