### PR TITLE
Generate "LuaState_Typedefs.inc" before running clang-tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
     docker: *cube_docker
     steps:
     - attach_workspace: { at: ~/ }
+    - run: (cd src/Bindings && lua BindingsProcessor.lua)
     - run: ./clang-tidy.sh -j 2
 
 workflows:


### PR DESCRIPTION
Should fix the clang-tidy issues