### PR TITLE
Minimise string copying in logging code

### DIFF
--- a/Tools/MCADefrag/Globals.h
+++ b/Tools/MCADefrag/Globals.h
@@ -135,6 +135,7 @@ typedef unsigned char Byte;
 
 // Common headers (without macros):
 #include "fmt.h"
+#include "LoggerSimple.h"
 #include "StringUtils.h"
 #include "OSSupport/CriticalSection.h"
 #include "OSSupport/Event.h"

--- a/Tools/NoiseSpeedTest/Globals.h
+++ b/Tools/NoiseSpeedTest/Globals.h
@@ -144,6 +144,7 @@ typedef unsigned char Byte;
 
 // Common headers (without macros):
 #include "fmt.h"
+#include "LoggerSimple.h"
 #include "StringUtils.h"
 #include "OSSupport/CriticalSection.h"
 #include "OSSupport/Event.h"

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -33,6 +33,7 @@
 #include "../HTTP/UrlParser.h"
 #include "../Item.h"
 #include "../LineBlockTracer.h"
+#include "../Logger.h"
 #include "../Server.h"
 #include "../Root.h"
 #include "../StringCompression.h"
@@ -401,7 +402,7 @@ static int tolua_LOG(lua_State * tolua_S)
 	}
 
 	// If the param is a cCompositeChat, read the log level from it:
-	cLogger::eLogLevel LogLevel = cLogger::llRegular;
+	eLogLevel LogLevel = eLogLevel::Regular;
 	tolua_Error err;
 	if (tolua_isusertype(tolua_S, 1, "cCompositeChat", false, &err))
 	{
@@ -427,7 +428,7 @@ static int tolua_LOGINFO(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), cLogger::llInfo);
+	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), eLogLevel::Info);
 	return 0;
 }
 
@@ -445,7 +446,7 @@ static int tolua_LOGWARN(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), cLogger::llWarning);
+	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), eLogLevel::Warning);
 	return 0;
 }
 
@@ -463,7 +464,7 @@ static int tolua_LOGERROR(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), cLogger::llError);
+	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), eLogLevel::Error);
 	return 0;
 }
 

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -33,7 +33,6 @@
 #include "../HTTP/UrlParser.h"
 #include "../Item.h"
 #include "../LineBlockTracer.h"
-#include "../Logger.h"
 #include "../Server.h"
 #include "../Root.h"
 #include "../StringCompression.h"
@@ -368,23 +367,19 @@ static int tolua_StringSplitAndTrim(lua_State * tolua_S)
 /** Retrieves the log message from the first param on the Lua stack.
 Can take either a string or a cCompositeChat.
 */
-static AString GetLogMessage(lua_State * tolua_S)
+static void LogFromLuaStack(lua_State * tolua_S, eLogLevel a_LogLevel)
 {
 	tolua_Error err;
 	if (tolua_isusertype(tolua_S, 1, "cCompositeChat", false, &err))
 	{
-		return static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr))->ExtractText();
+		auto Msg = static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr))->ExtractText();
+		Logger::LogSimple(Msg, a_LogLevel);
+		return;
 	}
-	else
-	{
-		size_t len = 0;
-		const char * str = lua_tolstring(tolua_S, 1, &len);
-		if (str != nullptr)
-		{
-			return AString(str, len);
-		}
-	}
-	return "";
+
+	size_t len = 0;
+	const char * str = lua_tolstring(tolua_S, 1, &len);
+	Logger::LogSimple(std::string_view(str, len), a_LogLevel);
 }
 
 
@@ -406,11 +401,13 @@ static int tolua_LOG(lua_State * tolua_S)
 	tolua_Error err;
 	if (tolua_isusertype(tolua_S, 1, "cCompositeChat", false, &err))
 	{
-		LogLevel = cCompositeChat::MessageTypeToLogLevel(static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr))->GetMessageType());
+		LogLevel = cCompositeChat::MessageTypeToLogLevel(
+			static_cast<cCompositeChat *>(tolua_tousertype(tolua_S, 1, nullptr))->GetMessageType()
+		);
 	}
 
 	// Log the message:
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), LogLevel);
+	LogFromLuaStack(tolua_S, LogLevel);
 	return 0;
 }
 
@@ -428,7 +425,7 @@ static int tolua_LOGINFO(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), eLogLevel::Info);
+	LogFromLuaStack(tolua_S, eLogLevel::Info);
 	return 0;
 }
 
@@ -446,7 +443,7 @@ static int tolua_LOGWARN(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), eLogLevel::Warning);
+	LogFromLuaStack(tolua_S, eLogLevel::Warning);
 	return 0;
 }
 
@@ -464,7 +461,7 @@ static int tolua_LOGERROR(lua_State * tolua_S)
 		return 0;
 	}
 
-	cLogger::GetInstance().LogSimple(GetLogMessage(tolua_S), eLogLevel::Error);
+	LogFromLuaStack(tolua_S, eLogLevel::Error);
 	return 0;
 }
 

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -269,24 +269,24 @@ AString cCompositeChat::ExtractText(void) const
 
 
 
-cLogger::eLogLevel cCompositeChat::MessageTypeToLogLevel(eMessageType a_MessageType)
+eLogLevel cCompositeChat::MessageTypeToLogLevel(eMessageType a_MessageType)
 {
 	switch (a_MessageType)
 	{
-		case mtCustom:         return cLogger::llRegular;
-		case mtFailure:        return cLogger::llWarning;
-		case mtInformation:    return cLogger::llInfo;
-		case mtSuccess:        return cLogger::llRegular;
-		case mtWarning:        return cLogger::llWarning;
-		case mtFatal:          return cLogger::llError;
-		case mtDeath:          return cLogger::llRegular;
-		case mtPrivateMessage: return cLogger::llRegular;
-		case mtJoin:           return cLogger::llRegular;
-		case mtLeave:          return cLogger::llRegular;
+		case mtCustom:         return eLogLevel::Regular;
+		case mtFailure:        return eLogLevel::Warning;
+		case mtInformation:    return eLogLevel::Info;
+		case mtSuccess:        return eLogLevel::Regular;
+		case mtWarning:        return eLogLevel::Warning;
+		case mtFatal:          return eLogLevel::Error;
+		case mtDeath:          return eLogLevel::Regular;
+		case mtPrivateMessage: return eLogLevel::Regular;
+		case mtJoin:           return eLogLevel::Regular;
+		case mtLeave:          return eLogLevel::Regular;
 		case mtMaxPlusOne: break;
 	}
 	ASSERT(!"Unhandled MessageType");
-	return cLogger::llError;
+	return eLogLevel::Error;
 }
 
 

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -7,7 +7,6 @@
 
 #include "Defines.h"
 #include "json/json.h"
-#include "Logger.h"
 
 
 
@@ -231,7 +230,7 @@ public:
 
 	/** Converts the MessageType to a LogLevel value.
 	Used by the logging bindings when logging a cCompositeChat object. */
-	static cLogger::eLogLevel MessageTypeToLogLevel(eMessageType a_MessageType);
+	static eLogLevel MessageTypeToLogLevel(eMessageType a_MessageType);
 
 	/** Adds the chat part's style (represented by the part's stylestring) into the Json object. */
 	void AddChatPartStyle(Json::Value & a_Value, const AString & a_PartStyle) const;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -200,46 +200,43 @@ template class SizeChecker<UInt8,  1>;
 // Common headers (part 1, without macros):
 #include "fmt.h"
 #include "StringUtils.h"
+#include "LoggerSimple.h"
 #include "OSSupport/CriticalSection.h"
 #include "OSSupport/Event.h"
 #include "OSSupport/File.h"
 #include "OSSupport/StackTrace.h"
 
-#ifndef TEST_GLOBALS
+#ifdef TEST_GLOBALS
 
-	#include "LoggerSimple.h"
-
-#else
-	#include "fmt/printf.h"
-
-	// Logging functions
-	template <typename ... Args>
-	void LOG(const char * a_Format, const Args & ... a_Args)
+	// Basic logging function implementations
+	namespace Logger
 	{
-		fmt::printf(a_Format, a_Args...);
+
+	inline void LogFormat(
+		std::string_view a_Format, eLogLevel, fmt::format_args a_ArgList
+	)
+	{
+		fmt::vprint(a_Format, a_ArgList);
 		putchar('\n');
 		fflush(stdout);
 	}
 
-	#define LOGERROR   LOG
-	#define LOGWARNING LOG
-	#define LOGD       LOG
-	#define LOGINFO    LOG
-	#define LOGWARN    LOG
-
-	template <typename ... Args>
-	void FLOG(const char * a_Format, const Args & ... a_Args)
+	inline void LogPrintf(
+		std::string_view a_Format, eLogLevel, fmt::printf_args a_ArgList
+	)
 	{
-		fmt::print(a_Format, a_Args...);
+		fmt::vprintf(a_Format, a_ArgList);
 		putchar('\n');
 		fflush(stdout);
 	}
 
-	#define FLOGERROR   FLOG
-	#define FLOGWARNING FLOG
-	#define FLOGD       FLOG
-	#define FLOGINFO    FLOG
-	#define FLOGWARN    FLOG
+	inline void LogSimple(std::string_view a_Message, eLogLevel)
+	{
+		fmt::print("{}\n", a_Message);
+		fflush(stdout);
+	}
+
+	}  // namespace Logger
 
 #endif
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -13,28 +13,25 @@
 
 static void WriteLogOpener(fmt::memory_buffer & Buffer)
 {
-	time_t rawtime;
-	time(&rawtime);
+	const time_t rawtime = time(nullptr);
 
-	struct tm * timeinfo;
+	struct tm timeinfo;
 #ifdef _MSC_VER
-	struct tm timeinforeal;
-	timeinfo = &timeinforeal;
-	localtime_s(timeinfo, &rawtime);
+	localtime_s(&timeinfo, &rawtime);
 #else
-	timeinfo = localtime(&rawtime);
+	localtime_r(&rawtime, &timeinfo);
 #endif
 
 #ifdef _DEBUG
 	const auto ThreadID = std::hash<std::thread::id>()(std::this_thread::get_id());
 	fmt::format_to(
 		Buffer, "[{0:04x}|{1:02d}:{2:02d}:{3:02d}] ",
-		ThreadID, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec
+		ThreadID, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec
 	);
 #else
 	fmt::format_to(
 		Buffer, "[{0:02d}:{1:02d}:{2:02d}] ",
-		timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec
+		timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec
 	);
 #endif
 }

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -11,6 +11,38 @@
 
 
 
+static void WriteLogOpener(fmt::memory_buffer & Buffer)
+{
+	time_t rawtime;
+	time(&rawtime);
+
+	struct tm * timeinfo;
+#ifdef _MSC_VER
+	struct tm timeinforeal;
+	timeinfo = &timeinforeal;
+	localtime_s(timeinfo, &rawtime);
+#else
+	timeinfo = localtime(&rawtime);
+#endif
+
+#ifdef _DEBUG
+	const auto ThreadID = std::hash<std::thread::id>()(std::this_thread::get_id());
+	fmt::format_to(
+		Buffer, "[{0:04x}|{1:02d}:{2:02d}:{3:02d}] ",
+		ThreadID, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec
+	);
+#else
+	fmt::format_to(
+		Buffer, "[{0:02d}:{1:02d}:{2:02d}] ",
+		timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec
+	);
+#endif
+}
+
+
+
+
+
 cLogger & cLogger::GetInstance(void)
 {
 	static cLogger Instance;
@@ -30,32 +62,24 @@ void cLogger::InitiateMultithreading()
 
 
 
-void cLogger::LogSimple(const AString & a_Message, eLogLevel a_LogLevel)
+void cLogger::LogSimple(std::string_view a_Message, eLogLevel a_LogLevel)
 {
-	time_t rawtime;
-	time(&rawtime);
-
-	struct tm * timeinfo;
-	#ifdef _MSC_VER
-		struct tm timeinforeal;
-		timeinfo = &timeinforeal;
-		localtime_s(timeinfo, &rawtime);
-	#else
-		timeinfo = localtime(&rawtime);
-	#endif
-
-	AString Line;
-	#ifdef _DEBUG
-		Printf(Line, "[%04llx|%02d:%02d:%02d] %s\n", static_cast<UInt64>(std::hash<std::thread::id>()(std::this_thread::get_id())), timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, a_Message);
-	#else
-		Printf(Line, "[%02d:%02d:%02d] %s\n", timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, a_Message);
-	#endif
+	fmt::memory_buffer Buffer;
+	WriteLogOpener(Buffer);
+	fmt::format_to(Buffer, "{0}\n", a_Message);
+	LogLine(std::string_view(Buffer.data(), Buffer.size()), a_LogLevel);
+}
 
 
+
+
+
+void cLogger::LogLine(std::string_view a_Line, eLogLevel a_LogLevel)
+{
 	cCSLock Lock(m_CriticalSection);
 	for (size_t i = 0; i < m_LogListeners.size(); i++)
 	{
-		m_LogListeners[i]->Log(Line, a_LogLevel);
+		m_LogListeners[i]->Log(a_Line, a_LogLevel);
 	}
 }
 
@@ -63,18 +87,32 @@ void cLogger::LogSimple(const AString & a_Message, eLogLevel a_LogLevel)
 
 
 
-void cLogger::vLogPrintf(const char * a_Format, eLogLevel a_LogLevel, fmt::printf_args a_ArgList)
+void cLogger::LogPrintf(
+	std::string_view a_Format, eLogLevel a_LogLevel, fmt::printf_args a_ArgList
+)
 {
-	LogSimple(vPrintf(a_Format, a_ArgList), a_LogLevel);
+	fmt::memory_buffer Buffer;
+	WriteLogOpener(Buffer);
+	fmt::printf(Buffer, fmt::to_string_view(a_Format), a_ArgList);
+	fmt::format_to(Buffer, "\n");
+
+	LogLine(std::string_view(Buffer.data(), Buffer.size()), a_LogLevel);
 }
 
 
 
 
 
-void cLogger::vLogFormat(const char * a_Format, eLogLevel a_LogLevel, fmt::format_args a_ArgList)
+void cLogger::LogFormat(
+	std::string_view a_Format, eLogLevel a_LogLevel, fmt::format_args a_ArgList
+)
 {
-	LogSimple(fmt::vformat(a_Format, a_ArgList), a_LogLevel);
+	fmt::memory_buffer Buffer;
+	WriteLogOpener(Buffer);
+	fmt::vformat_to(Buffer, a_Format, a_ArgList);
+	fmt::format_to(Buffer, "\n");
+
+	LogLine(std::string_view(Buffer.data(), Buffer.size()), a_LogLevel);
 }
 
 
@@ -117,72 +155,31 @@ void cLogger::DetachListener(cListener * a_Listener)
 ////////////////////////////////////////////////////////////////////////////////
 // Global functions
 
-void vFLOG(const char * a_Format, fmt::format_args a_ArgList)
+void Logger::LogFormat(
+	std::string_view a_Format, eLogLevel a_LogLevel, fmt::format_args a_ArgList
+)
 {
-	cLogger::GetInstance().vLogFormat(a_Format, cLogger::llRegular, a_ArgList);
+	cLogger::GetInstance().LogFormat(a_Format, a_LogLevel, a_ArgList);
 }
 
 
 
 
 
-void vFLOGINFO(const char * a_Format, fmt::format_args a_ArgList)
+void Logger::LogPrintf(
+	std::string_view a_Format, eLogLevel a_LogLevel, fmt::printf_args a_ArgList
+)
 {
-	cLogger::GetInstance().vLogFormat( a_Format, cLogger::llInfo, a_ArgList);
+	cLogger::GetInstance().LogPrintf(a_Format, a_LogLevel, a_ArgList);
 }
 
 
 
 
 
-void vFLOGWARNING(const char * a_Format, fmt::format_args a_ArgList)
+void Logger::LogSimple(std::string_view a_Message, eLogLevel a_LogLevel)
 {
-	cLogger::GetInstance().vLogFormat( a_Format, cLogger::llWarning, a_ArgList);
-}
-
-
-
-
-
-void vFLOGERROR(const char * a_Format, fmt::format_args a_ArgList)
-{
-	cLogger::GetInstance().vLogFormat(a_Format, cLogger::llError, a_ArgList);
-}
-
-
-
-
-
-void vLOG(const char * a_Format, fmt::printf_args a_ArgList)
-{
-	cLogger::GetInstance().vLogPrintf(a_Format, cLogger::llRegular, a_ArgList);
-}
-
-
-
-
-
-void vLOGINFO(const char * a_Format, fmt::printf_args a_ArgList)
-{
-	cLogger::GetInstance().vLogPrintf(a_Format, cLogger::llInfo, a_ArgList);
-}
-
-
-
-
-
-void vLOGWARNING(const char * a_Format, fmt::printf_args a_ArgList)
-{
-	cLogger::GetInstance().vLogPrintf(a_Format, cLogger::llWarning, a_ArgList);
-}
-
-
-
-
-
-void vLOGERROR(const char * a_Format, fmt::printf_args a_ArgList)
-{
-	cLogger::GetInstance().vLogPrintf( a_Format, cLogger::llError, a_ArgList);
+	cLogger::GetInstance().LogSimple(a_Message, a_LogLevel);
 }
 
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -6,19 +6,10 @@ class cLogger
 {
 public:
 
-	enum eLogLevel
-	{
-		llRegular,
-		llInfo,
-		llWarning,
-		llError,
-	};
-
-
 	class cListener
 	{
 		public:
-		virtual void Log(AString a_Message, eLogLevel a_LogLevel) = 0;
+		virtual void Log(std::string_view a_Message, eLogLevel a_LogLevel) = 0;
 
 		virtual ~cListener(){}
 	};
@@ -59,23 +50,17 @@ public:
 	};
 
 	/** Log a message formatted with a printf style formatting string. */
-	void vLogPrintf(const char * a_Format, eLogLevel a_LogLevel, fmt::printf_args a_ArgList);
-	template <typename... Args>
-	void LogPrintf(const char * a_Format, eLogLevel a_LogLevel, const Args & ... args)
-	{
-		vLogPrintf(a_Format, a_LogLevel, fmt::make_printf_args(args...));
-	}
+	void LogPrintf(
+		std::string_view a_Format, eLogLevel a_LogLevel, fmt::printf_args a_ArgList
+	);
 
 	/** Log a message formatted with a python style formatting string. */
-	void vLogFormat(const char * a_Format, eLogLevel a_LogLevel, fmt::format_args a_ArgList);
-	template <typename... Args>
-	void LogFormat(const char * a_Format, eLogLevel a_LogLevel, const Args & ... args)
-	{
-		vLogFormat(a_Format, a_LogLevel, fmt::make_format_args(args...));
-	}
+	void LogFormat(
+		std::string_view a_Format, eLogLevel a_LogLevel, fmt::format_args a_ArgList
+	);
 
 	/** Logs the simple text message at the specified log level. */
-	void LogSimple(const AString & a_Message, eLogLevel a_LogLevel = llRegular);
+	void LogSimple(std::string_view a_Message, eLogLevel a_LogLevel = eLogLevel::Regular);
 
 	cAttachment AttachListener(std::unique_ptr<cListener> a_Listener);
 
@@ -88,6 +73,7 @@ private:
 	std::vector<std::unique_ptr<cListener>> m_LogListeners;
 
 	void DetachListener(cListener * a_Listener);
+	void LogLine(std::string_view a_Line, eLogLevel a_LogLevel);
 
 };
 

--- a/src/LoggerListeners.cpp
+++ b/src/LoggerListeners.cpp
@@ -21,7 +21,7 @@
 		virtual void Log(std::string_view a_Message, eLogLevel a_LogLevel) override
 		{
 			SetLogColour(a_LogLevel);
-			fwrite(a_Message.data(), 1, a_Message.size(), stdout);
+			fwrite(a_Message.data(), sizeof(char), a_Message.size(), stdout);
 			SetDefaultLogColour();
 		}
 	};
@@ -186,7 +186,7 @@ public:
 				break;
 			}
 		}
-		fwrite(a_Message.data(), 1, a_Message.size(), stdout);
+		fwrite(a_Message.data(), sizeof(char), a_Message.size(), stdout);
 	}
 };
 

--- a/src/LoggerListeners.cpp
+++ b/src/LoggerListeners.cpp
@@ -15,13 +15,13 @@
 	{
 	protected:
 
-		virtual void SetLogColour(cLogger::eLogLevel a_LogLevel) = 0;
+		virtual void SetLogColour(eLogLevel a_LogLevel) = 0;
 		virtual void SetDefaultLogColour() = 0;
 
-		virtual void Log(AString a_Message, cLogger::eLogLevel a_LogLevel) override
+		virtual void Log(std::string_view a_Message, eLogLevel a_LogLevel) override
 		{
 			SetLogColour(a_LogLevel);
-			fputs(a_Message.c_str(), stdout);
+			fwrite(a_Message.data(), 1, a_Message.size(), stdout);
 			SetDefaultLogColour();
 		}
 	};
@@ -46,40 +46,40 @@
 		}
 
 		#ifdef _DEBUG
-			virtual void Log(AString a_Message, cLogger::eLogLevel a_LogLevel) override
+			virtual void Log(std::string_view a_Message, eLogLevel a_LogLevel) override
 			{
 				Super::Log(a_Message, a_LogLevel);
 				// In a Windows Debug build, output the log to debug console as well:
-				OutputDebugStringA(a_Message.c_str());
+				OutputDebugStringA(AString(a_Message).c_str());
 			}
 		#endif
 
 
-		virtual void SetLogColour(cLogger::eLogLevel a_LogLevel) override
+		virtual void SetLogColour(eLogLevel a_LogLevel) override
 		{
 			// by default, gray on black
 			WORD Attrib = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED;
 			switch (a_LogLevel)
 			{
-				case cLogger::llRegular:
+				case eLogLevel::Regular:
 				{
 					// Gray on black
 					Attrib = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED;
 					break;
 				}
-				case cLogger::llInfo:
+				case eLogLevel::Info:
 				{
 					// Yellow on black
 					Attrib = FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
 					break;
 				}
-				case cLogger::llWarning:
+				case eLogLevel::Warning:
 				{
 					// Red on black
 					Attrib = FOREGROUND_RED | FOREGROUND_INTENSITY;
 					break;
 				}
-				case cLogger::llError:
+				case eLogLevel::Error:
 				{
 					// Black on red
 					Attrib = BACKGROUND_RED | BACKGROUND_INTENSITY;
@@ -111,29 +111,29 @@
 		: public cColouredConsoleListener
 	{
 	public:
-		virtual void SetLogColour(cLogger::eLogLevel a_LogLevel) override
+		virtual void SetLogColour(eLogLevel a_LogLevel) override
 		{
 			switch (a_LogLevel)
 			{
-				case cLogger::llRegular:
+				case eLogLevel::Regular:
 				{
 					// Whatever the console default is
 					printf("\x1b[0m");
 					break;
 				}
-				case cLogger::llInfo:
+				case eLogLevel::Info:
 				{
 					// Yellow on black
 					printf("\x1b[33;1m");
 					break;
 				}
-				case cLogger::llWarning:
+				case eLogLevel::Warning:
 				{
 					// Red on black
 					printf("\x1b[31;1m");
 					break;
 				}
-				case cLogger::llError:
+				case eLogLevel::Error:
 				{
 					// Yellow on red
 					printf("\x1b[1;33;41;1m");
@@ -161,33 +161,32 @@ class cVanillaCPPConsoleListener
 	: public cLogger::cListener
 {
 public:
-	virtual void Log(AString a_Message, cLogger::eLogLevel a_LogLevel) override
+	virtual void Log(std::string_view a_Message, eLogLevel a_LogLevel) override
 	{
-		AString LogLevelString;
 		switch (a_LogLevel)
 		{
-			case cLogger::llRegular:
+			case eLogLevel::Regular:
 			{
-				LogLevelString = "Log";
+				fputs("Log: ", stdout);
 				break;
 			}
-			case cLogger::llInfo:
+			case eLogLevel::Info:
 			{
-				LogLevelString = "Info";
+				fputs("Info: ", stdout);
 				break;
 			}
-			case cLogger::llWarning:
+			case eLogLevel::Warning:
 			{
-				LogLevelString = "Warning";
+				fputs("Warning: ", stdout);
 				break;
 			}
-			case cLogger::llError:
+			case eLogLevel::Error:
 			{
-				LogLevelString = "Error";
+				fputs("Error: ", stdout);
 				break;
 			}
 		}
-		printf("%s: %s", LogLevelString.c_str(), a_Message.c_str());
+		fwrite(a_Message.data(), 1, a_Message.size(), stdout);
 	}
 };
 
@@ -199,7 +198,7 @@ public:
 class cNullConsoleListener
 	: public cLogger::cListener
 {
-	virtual void Log(AString a_Message, cLogger::eLogLevel a_LogLevel) override
+	virtual void Log(std::string_view a_Message, eLogLevel a_LogLevel) override
 	{
 	}
 };
@@ -275,36 +274,38 @@ public:
 		return success;
 	}
 
-	virtual void Log(AString a_Message, cLogger::eLogLevel a_LogLevel) override
+	virtual void Log(std::string_view a_Message, eLogLevel a_LogLevel) override
 	{
-		const char * LogLevelPrefix = "Unkn ";
+		std::string_view LogLevelPrefix = "Unkn ";
 		bool ShouldFlush = false;
 		switch (a_LogLevel)
 		{
-			case cLogger::llRegular:
+			case eLogLevel::Regular:
 			{
 				LogLevelPrefix = "     ";
 				break;
 			}
-			case cLogger::llInfo:
+			case eLogLevel::Info:
 			{
 				LogLevelPrefix = "Info ";
 				break;
 			}
-			case cLogger::llWarning:
+			case eLogLevel::Warning:
 			{
 				LogLevelPrefix = "Warn ";
 				ShouldFlush = true;
 				break;
 			}
-			case cLogger::llError:
+			case eLogLevel::Error:
 			{
 				LogLevelPrefix = "Err  ";
 				ShouldFlush = true;
 				break;
 			}
 		}
-		m_File.Printf("%s%s", LogLevelPrefix, a_Message.c_str());
+		m_File.Write(LogLevelPrefix);
+		m_File.Write(a_Message);
+
 		if (ShouldFlush)
 		{
 			m_File.Flush();

--- a/src/LoggerSimple.h
+++ b/src/LoggerSimple.h
@@ -79,7 +79,7 @@ void LOGERROR(std::string_view a_Format, const Args & ... args)
 // Macro variants
 
 // In debug builds, translate LOGD to LOG, otherwise leave it out altogether:
-#ifdef _DEBUG
+#if defined(_DEBUG) || defined(TEST_GLOBALS)
 	#define LOGD LOG
 #else
 	#define LOGD(...)
@@ -87,7 +87,7 @@ void LOGERROR(std::string_view a_Format, const Args & ... args)
 
 #define LOGWARN LOGWARNING
 
-#ifdef _DEBUG
+#if defined(_DEBUG) || defined(TEST_GLOBALS)
 	#define FLOGD FLOG
 #else
 	#define FLOGD(...)

--- a/src/LoggerSimple.h
+++ b/src/LoggerSimple.h
@@ -2,64 +2,77 @@
 // Logging free functions defined in Logger.cpp
 #pragma once
 
+enum class eLogLevel
+{
+	Regular,
+	Info,
+	Warning,
+	Error,
+};
+
+namespace Logger
+{
+
+extern void LogFormat(
+	std::string_view a_Format, eLogLevel a_LogLevel, fmt::format_args a_ArgList
+);
+extern void LogPrintf(
+	std::string_view a_Format, eLogLevel a_LogLevel, fmt::printf_args a_ArgList
+);
+extern void LogSimple(std::string_view a_Message, eLogLevel a_LogLevel);
+
+}  // namespace Logger
+
 // python style format specified logging
 
-extern void vFLOG(const char * a_Format, fmt::format_args a_ArgList);
 template <typename... Args>
-void FLOG(const char * a_Format, const Args & ... args)
+void FLOG(std::string_view a_Format, const Args & ... args)
 {
-	vFLOG(a_Format, fmt::make_format_args(args...));
+	Logger::LogFormat(a_Format, eLogLevel::Regular, fmt::make_format_args(args...));
 }
 
-extern void vFLOGINFO(const char * a_Format, fmt::format_args a_ArgList);
 template <typename... Args>
-void FLOGINFO(const char * a_Format, const Args & ... args)
+void FLOGINFO(std::string_view a_Format, const Args & ... args)
 {
-	vFLOGINFO(a_Format, fmt::make_format_args(args...));
+	Logger::LogFormat(a_Format, eLogLevel::Info, fmt::make_format_args(args...));
 }
 
-extern void vFLOGWARNING(const char * a_Format, fmt::format_args a_ArgList);
 template <typename... Args>
-void FLOGWARNING(const char * a_Format, const Args & ... args)
+void FLOGWARNING(std::string_view a_Format, const Args & ... args)
 {
-	vFLOGWARNING(a_Format, fmt::make_format_args(args...));
+	Logger::LogFormat(a_Format, eLogLevel::Warning, fmt::make_format_args(args...));
 }
 
-extern void vFLOGERROR(const char * a_Format, fmt::format_args a_ArgList);
 template <typename... Args>
-void FLOGERROR(const char * a_Format, const Args & ... args)
+void FLOGERROR(std::string_view a_Format, const Args & ... args)
 {
-	vFLOGERROR(a_Format, fmt::make_format_args(args...));
+	Logger::LogFormat(a_Format, eLogLevel::Error, fmt::make_format_args(args...));
 }
 
 // printf style format specified logging (DEPRECATED)
 
-extern void vLOG(const char * a_Format, fmt::printf_args a_ArgList);
 template <typename... Args>
-void LOG(const char * a_Format, const Args & ... args)
+void LOG(std::string_view a_Format, const Args & ... args)
 {
-	vLOG(a_Format, fmt::make_printf_args(args...));
+	Logger::LogPrintf(a_Format, eLogLevel::Regular, fmt::make_printf_args(args...));
 }
 
-extern void vLOGINFO(const char * a_Format, fmt::printf_args a_ArgList);
 template <typename... Args>
-void LOGINFO(const char * a_Format, const Args & ... args)
+void LOGINFO(std::string_view a_Format, const Args & ... args)
 {
-	vLOGINFO(a_Format, fmt::make_printf_args(args...));
+	Logger::LogPrintf(a_Format, eLogLevel::Info, fmt::make_printf_args(args...));
 }
 
-extern void vLOGWARNING(const char * a_Format, fmt::printf_args a_ArgList);
 template <typename... Args>
-void LOGWARNING(const char * a_Format, const Args & ... args)
+void LOGWARNING(std::string_view a_Format, const Args & ... args)
 {
-	vLOGWARNING(a_Format, fmt::make_printf_args(args...));
+	Logger::LogPrintf(a_Format, eLogLevel::Warning, fmt::make_printf_args(args...));
 }
 
-extern void vLOGERROR(const char * a_Format, fmt::printf_args a_ArgList);
 template <typename... Args>
-void LOGERROR(const char * a_Format, const Args & ... args)
+void LOGERROR(std::string_view a_Format, const Args & ... args)
 {
-	vLOGERROR(a_Format, fmt::make_printf_args(args...));
+	Logger::LogPrintf(a_Format, eLogLevel::Error, fmt::make_printf_args(args...));
 }
 
 

--- a/src/OSSupport/File.h
+++ b/src/OSSupport/File.h
@@ -80,6 +80,11 @@ public:
 	/** Writes up to a_NumBytes bytes from a_Buffer, returns the number of bytes actually written, or -1 on failure; asserts if not open */
 	int Write(const void * a_Buffer, size_t a_NumBytes);
 
+	int Write(std::string_view a_String)
+	{
+		return Write(a_String.data(), a_String.size());
+	}
+
 	/** Seeks to iPosition bytes from file start, returns old position or -1 for failure; asserts if not open */
 	long Seek (int iPosition);
 


### PR DESCRIPTION
Currently, the logging process involves:

* `fmt::format` or `Printf` formats log message then copies into an `AString`
* `LogSimple` then calls `Printf` again, formatting and copying into a new string
* Each `cLogger::cListener` then takes another copy of the string

For a typical logger setup, I expect a minimum of 6 copies and 4 memory allocations for each write to the log.

Now all formatting is done into a single `fmt::memory_buffer` and I never allocate a single `AString`. Since we always format into the same buffer, there should be no copying except to resize the storage. `fmt::memory_buffer` also has a 500 character in place buffer, so I expect this version not to allocate memory or copy at all most of the time.

I've also combined the `LoggerSimple.h` `vLOG` type functions into one for all log levels, matching the `cLogger` interface more closely. This also removes some of the boiler-plate in `Logger.cpp`.