### PR TITLE
Protocol: Avoid crashing on invalid sign text

### DIFF
--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -2742,7 +2742,7 @@ void cProtocol_1_8_0::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 	for (int i = 0; i < 4; i++)
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Line);
-		if (JsonUtils::ParseString(Line, root))
+		if (JsonUtils::ParseString(Line, root) && root.isString())
 		{
 			Lines[i] = root.asString();
 		}


### PR DESCRIPTION
Fixes #4746, or at least it should prevent the crash. The sign won't actually be updated.