### PR TITLE
cWindow: Changed XYZ to Vector3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ build-cuberite
 # clang-tidy
 tidy-build
 run-clang-tidy.py
+/VS2019-x64

--- a/src/Blocks/BlockAnvil.h
+++ b/src/Blocks/BlockAnvil.h
@@ -44,7 +44,7 @@ public:
 		const Vector3i a_CursorPos
 	) override
 	{
-		cWindow * Window = new cAnvilWindow(a_BlockPos.x, a_BlockPos.y, a_BlockPos.z);
+		cWindow * Window = new cAnvilWindow(a_BlockPos);
 		a_Player.OpenWindow(*Window);
 		return true;
 	}

--- a/src/Blocks/BlockEnchantmentTable.h
+++ b/src/Blocks/BlockEnchantmentTable.h
@@ -34,7 +34,7 @@ public:
 		const Vector3i a_CursorPos
 	) override
 	{
-		cWindow * Window = new cEnchantingWindow(a_BlockPos.x, a_BlockPos.y, a_BlockPos.z);
+		cWindow * Window = new cEnchantingWindow(a_BlockPos);
 		a_Player.OpenWindow(*Window);
 		return true;
 	}

--- a/src/Blocks/BlockWorkbench.h
+++ b/src/Blocks/BlockWorkbench.h
@@ -34,7 +34,7 @@ public:
 		const Vector3i a_CursorPos
 	) override
 	{
-		cWindow * Window = new cCraftingWindow(a_BlockPos.x, a_BlockPos.y, a_BlockPos.z);
+		cWindow * Window = new cCraftingWindow(a_BlockPos);
 		a_Player.OpenWindow(*Window);
 		return true;
 	}

--- a/src/UI/AnvilWindow.cpp
+++ b/src/UI/AnvilWindow.cpp
@@ -10,12 +10,10 @@
 
 
 
-cAnvilWindow::cAnvilWindow(int a_BlockX, int a_BlockY, int a_BlockZ) :
+cAnvilWindow::cAnvilWindow(Vector3i a_BlockPos) :
 	cWindow(wtAnvil, "Repair"),
 	m_RepairedItemName(""),
-	m_BlockX(a_BlockX),
-	m_BlockY(a_BlockY),
-	m_BlockZ(a_BlockZ)
+	m_BlockPos(a_BlockPos)
 {
 	m_AnvilSlotArea = new cSlotAreaAnvil(*this);
 	m_SlotAreas.push_back(m_AnvilSlotArea);
@@ -49,11 +47,9 @@ void cAnvilWindow::SetRepairedItemName(const AString & a_Name, cPlayer * a_Playe
 
 
 
-void cAnvilWindow::GetBlockPos(int & a_PosX, int & a_PosY, int & a_PosZ)
+void cAnvilWindow::GetBlockPos(Vector3i & a_Pos)
 {
-	a_PosX = m_BlockX;
-	a_PosY = m_BlockY;
-	a_PosZ = m_BlockZ;
+	a_Pos = m_BlockPos;
 }
 
 

--- a/src/UI/AnvilWindow.h
+++ b/src/UI/AnvilWindow.h
@@ -22,7 +22,7 @@ class cAnvilWindow:
 
 public:
 
-	cAnvilWindow(int a_BlockX, int a_BlockY, int a_BlockZ);
+	cAnvilWindow(Vector3i a_BlockPos);
 
 	/** Gets the repaired item name. */
 	AString GetRepairedItemName(void) const;
@@ -31,14 +31,14 @@ public:
 	void SetRepairedItemName(const AString & a_Name, cPlayer * a_Player);
 
 	/** Gets the Position from the Anvil */
-	void GetBlockPos(int & a_PosX, int & a_PosY, int & a_PosZ);
+	void GetBlockPos(Vector3i & a_Pos);
 
 	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 protected:
 	cSlotAreaAnvil * m_AnvilSlotArea;
 	AString m_RepairedItemName;
-	int m_BlockX, m_BlockY, m_BlockZ;
+	Vector3i m_BlockPos;
 };
 
 

--- a/src/UI/CraftingWindow.cpp
+++ b/src/UI/CraftingWindow.cpp
@@ -10,7 +10,7 @@
 
 
 
-cCraftingWindow::cCraftingWindow(int a_BlockX, int a_BlockY, int a_BlockZ) :
+cCraftingWindow::cCraftingWindow(Vector3i a_Block) : // This Vector3i is never saved or used? Consider removing
 	cWindow(wtWorkbench, "Crafting Table")
 {
 	m_SlotAreas.push_back(new cSlotAreaCrafting(3, *this));

--- a/src/UI/CraftingWindow.h
+++ b/src/UI/CraftingWindow.h
@@ -22,7 +22,7 @@ class cCraftingWindow:
 
 public:
 
-	cCraftingWindow(int a_BlockX, int a_BlockY, int a_BlockZ);
+	cCraftingWindow(Vector3i a_Block);
 
 	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 };

--- a/src/UI/EnchantingWindow.cpp
+++ b/src/UI/EnchantingWindow.cpp
@@ -11,14 +11,12 @@
 
 
 
-cEnchantingWindow::cEnchantingWindow(int a_BlockX, int a_BlockY, int a_BlockZ) :
+cEnchantingWindow::cEnchantingWindow(Vector3i a_Block) :
 	cWindow(wtEnchantment, "Enchant"),
 	m_SlotArea(),
-	m_BlockX(a_BlockX),
-	m_BlockY(a_BlockY),
-	m_BlockZ(a_BlockZ)
+	m_Block(a_Block)
 {
-	m_SlotArea = new cSlotAreaEnchanting(*this, m_BlockX, m_BlockY, m_BlockZ);
+	m_SlotArea = new cSlotAreaEnchanting(*this, m_Block);
 	m_SlotAreas.push_back(m_SlotArea);
 	m_SlotAreas.push_back(new cSlotAreaInventory(*this));
 	m_SlotAreas.push_back(new cSlotAreaHotBar(*this));

--- a/src/UI/EnchantingWindow.h
+++ b/src/UI/EnchantingWindow.h
@@ -22,7 +22,7 @@ class cEnchantingWindow:
 
 public:
 
-	cEnchantingWindow(int a_BlockX, int a_BlockY, int a_BlockZ);
+	cEnchantingWindow(Vector3i a_Block);
 
 	virtual void SetProperty(short a_Property, short a_Value, cPlayer & a_Player) override;
 
@@ -37,7 +37,7 @@ public:
 
 protected:
 	short m_PropertyValue[3];
-	int m_BlockX, m_BlockY, m_BlockZ;
+	Vector3i m_Block;
 };
 
 

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -996,14 +996,14 @@ void cSlotAreaAnvil::OnTakeResult(cPlayer & a_Player)
 	m_MaximumCost = 0;
 	static_cast<cAnvilWindow &>(m_ParentWindow).SetRepairedItemName("", nullptr);
 
-	int PosX, PosY, PosZ;
-	static_cast<cAnvilWindow &>(m_ParentWindow).GetBlockPos(PosX, PosY, PosZ);
+	Vector3i Pos;
+	static_cast<cAnvilWindow &>(m_ParentWindow).GetBlockPos(Pos);
 
 	BLOCKTYPE Block;
 	NIBBLETYPE BlockMeta;
-	a_Player.GetWorld()->GetBlockTypeMeta(PosX, PosY, PosZ, Block, BlockMeta);
+	a_Player.GetWorld()->GetBlockTypeMeta(Pos, Block, BlockMeta);
 
-	const Vector3i BlockPos{PosX, PosY, PosZ};
+	const Vector3i BlockPos{Pos};
 	if (!a_Player.IsGameModeCreative() && (Block == E_BLOCK_ANVIL) && GetRandomProvider().RandBool(0.12))
 	{
 		NIBBLETYPE Orientation = BlockMeta & 0x3;
@@ -1013,13 +1013,13 @@ void cSlotAreaAnvil::OnTakeResult(cPlayer & a_Player)
 		if (AnvilDamage > 2)
 		{
 			// Anvil will break
-			a_Player.GetWorld()->SetBlock(PosX, PosY, PosZ, E_BLOCK_AIR, 0);
+			a_Player.GetWorld()->SetBlock(Pos, E_BLOCK_AIR, 0);
 			a_Player.GetWorld()->BroadcastSoundParticleEffect(EffectID::SFX_RANDOM_ANVIL_BREAK, BlockPos, 0);
 			a_Player.CloseWindow(false);
 		}
 		else
 		{
-			a_Player.GetWorld()->SetBlockMeta(PosX, PosY, PosZ, static_cast<NIBBLETYPE>(Orientation | (AnvilDamage << 2)));
+			a_Player.GetWorld()->SetBlockMeta(Pos, static_cast<NIBBLETYPE>(Orientation | (AnvilDamage << 2)));
 			a_Player.GetWorld()->BroadcastSoundParticleEffect(EffectID::SFX_RANDOM_ANVIL_USE, BlockPos, 0);
 		}
 	}
@@ -1407,11 +1407,9 @@ void cSlotAreaBeacon::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 ////////////////////////////////////////////////////////////////////////////////
 // cSlotAreaEnchanting:
 
-cSlotAreaEnchanting::cSlotAreaEnchanting(cWindow & a_ParentWindow, int a_BlockX, int a_BlockY, int a_BlockZ) :
+cSlotAreaEnchanting::cSlotAreaEnchanting(cWindow & a_ParentWindow, Vector3i a_Block) :
 	cSlotAreaTemporary(2, a_ParentWindow),
-	m_BlockX(a_BlockX),
-	m_BlockY(a_BlockY),
-	m_BlockZ(a_BlockZ)
+	m_Block(a_Block)
 {
 }
 
@@ -1644,7 +1642,7 @@ int cSlotAreaEnchanting::GetBookshelvesCount(cWorld & a_World)
 {
 	int Bookshelves = 0;
 	cBlockArea Area;
-	Area.Read(a_World, m_BlockX - 2, m_BlockX + 2, m_BlockY, m_BlockY + 1, m_BlockZ - 2, m_BlockZ + 2);
+	Area.Read(a_World, m_Block.x - 2, m_Block.x + 2, m_Block.y, m_Block.y + 1, m_Block.z - 2, m_Block.z + 2);
 
 	static const struct
 	{

--- a/src/UI/SlotArea.h
+++ b/src/UI/SlotArea.h
@@ -381,7 +381,7 @@ class cSlotAreaEnchanting:
 
 public:
 
-	cSlotAreaEnchanting(cWindow & a_ParentWindow, int a_BlockX, int a_BlockY, int a_BlockZ);
+	cSlotAreaEnchanting(cWindow & a_ParentWindow, Vector3i a_Block);
 
 	// cSlotArea overrides:
 	virtual void Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
@@ -399,7 +399,7 @@ protected:
 	/** Handles a click in the item slot. */
 	void UpdateResult(cPlayer & a_Player);
 
-	int m_BlockX, m_BlockY, m_BlockZ;
+	Vector3i m_Block;
 };
 
 


### PR DESCRIPTION
Converted the depreciated X,Y,Z coordinate format into the newer Vector3 format for cWindow and all of its decendants.
Previous PR had a small style issue, now resolved.
Fixes #4675