### PR TITLE
added HandleCraftItem call to ShiftClickedResult to make sure achievements are awarded

### DIFF
--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -692,6 +692,9 @@ void cSlotAreaCrafting::ShiftClickedResult(cPlayer & a_Player)
 		// Broadcast the window, we sometimes move items to different locations than Vanilla, causing needless desyncs:
 		m_ParentWindow.BroadcastWholeWindow();
 
+		// added this to make sure that achievements are awarded
+		HandleCraftItem(Result, a_Player);
+
 		// If the recipe has changed, bail out:
 		if (!Recipe.GetResult().IsEqual(Result))
 		{

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -692,7 +692,7 @@ void cSlotAreaCrafting::ShiftClickedResult(cPlayer & a_Player)
 		// Broadcast the window, we sometimes move items to different locations than Vanilla, causing needless desyncs:
 		m_ParentWindow.BroadcastWholeWindow();
 
-		// added this to make sure that achievements are awarded
+		// added achievements processing
 		HandleCraftItem(Result, a_Player);
 
 		// If the recipe has changed, bail out:

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -692,7 +692,7 @@ void cSlotAreaCrafting::ShiftClickedResult(cPlayer & a_Player)
 		// Broadcast the window, we sometimes move items to different locations than Vanilla, causing needless desyncs:
 		m_ParentWindow.BroadcastWholeWindow();
 
-		// added achievements processing
+		// Added achievements processing
 		HandleCraftItem(Result, a_Player);
 
 		// If the recipe has changed, bail out:


### PR DESCRIPTION
I was doing some changes at the achievements system as I noticed that crafting based achievements are not awarded if you shift click the crafting process

fixed it