### PR TITLE
Changed large stack-based allocations to heap-based.

### DIFF
--- a/src/ChunkGeneratorThread.cpp
+++ b/src/ChunkGeneratorThread.cpp
@@ -245,17 +245,17 @@ void cChunkGeneratorThread::DoGenerate(cChunkCoords a_Coords)
 	ASSERT(m_PluginInterface != nullptr);
 	ASSERT(m_ChunkSink != nullptr);
 
-	cChunkDesc ChunkDesc(a_Coords);
-	m_PluginInterface->CallHookChunkGenerating(ChunkDesc);
-	m_Generator->Generate(ChunkDesc);
-	m_PluginInterface->CallHookChunkGenerated(ChunkDesc);
+	auto ChunkDesc = std::make_unique<cChunkDesc>(a_Coords);
+	m_PluginInterface->CallHookChunkGenerating(*ChunkDesc);
+	m_Generator->Generate(*ChunkDesc);
+	m_PluginInterface->CallHookChunkGenerated(*ChunkDesc);
 
 	#ifdef _DEBUG
 		// Verify that the generator has produced valid data:
-		ChunkDesc.VerifyHeightmap();
+		ChunkDesc->VerifyHeightmap();
 	#endif
 
-	m_ChunkSink->OnChunkGenerated(ChunkDesc);
+	m_ChunkSink->OnChunkGenerated(*ChunkDesc);
 }
 
 

--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -33,7 +33,7 @@ public:
 	0 = air
 	1 = solid
 	Indexed as [y + 256 * x + 256 * 16 * z]. */
-	typedef Byte Shape[256 * 16 * 16];
+	using Shape = Byte[256 * 16 * 16];
 
 	/** Uncompressed block metas, 1 meta per byte */
 	typedef NIBBLETYPE BlockNibbleBytes[cChunkDef::NumBlocks];

--- a/src/Generating/ComposableGenerator.cpp
+++ b/src/Generating/ComposableGenerator.cpp
@@ -155,27 +155,33 @@ void cComposableGenerator::GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef:
 
 void cComposableGenerator::Generate(cChunkDesc & a_ChunkDesc)
 {
+	// Wrap a cChunkDesc::Shape into a structure so that we can make a unique_ptr out of it:
+	struct ShapeHelper
+	{
+		cChunkDesc::Shape mShape;
+	};
+	auto shape = std::make_unique<ShapeHelper>();
+
 	if (a_ChunkDesc.IsUsingDefaultBiomes())
 	{
 		m_BiomeGen->GenBiomes(a_ChunkDesc.GetChunkCoords(), a_ChunkDesc.GetBiomeMap());
 	}
 
-	cChunkDesc::Shape shape;
 	if (a_ChunkDesc.IsUsingDefaultHeight())
 	{
-		m_ShapeGen->GenShape(a_ChunkDesc.GetChunkCoords(), shape);
-		a_ChunkDesc.SetHeightFromShape(shape);
+		m_ShapeGen->GenShape(a_ChunkDesc.GetChunkCoords(), shape->mShape);
+		a_ChunkDesc.SetHeightFromShape(shape->mShape);
 	}
 	else
 	{
 		// Convert the heightmap in a_ChunkDesc into shape:
-		a_ChunkDesc.GetShapeFromHeight(shape);
+		a_ChunkDesc.GetShapeFromHeight(shape->mShape);
 	}
 
 	bool ShouldUpdateHeightmap = false;
 	if (a_ChunkDesc.IsUsingDefaultComposition())
 	{
-		m_CompositionGen->ComposeTerrain(a_ChunkDesc, shape);
+		m_CompositionGen->ComposeTerrain(a_ChunkDesc, shape->mShape);
 	}
 
 	if (a_ChunkDesc.IsUsingDefaultFinish())

--- a/src/Generating/ComposableGenerator.cpp
+++ b/src/Generating/ComposableGenerator.cpp
@@ -158,7 +158,7 @@ void cComposableGenerator::Generate(cChunkDesc & a_ChunkDesc)
 	// Wrap a cChunkDesc::Shape into a structure so that we can make a unique_ptr out of it:
 	struct ShapeHelper
 	{
-		cChunkDesc::Shape mShape;
+		cChunkDesc::Shape m_Shape;
 	};
 	auto shape = std::make_unique<ShapeHelper>();
 
@@ -169,19 +169,19 @@ void cComposableGenerator::Generate(cChunkDesc & a_ChunkDesc)
 
 	if (a_ChunkDesc.IsUsingDefaultHeight())
 	{
-		m_ShapeGen->GenShape(a_ChunkDesc.GetChunkCoords(), shape->mShape);
-		a_ChunkDesc.SetHeightFromShape(shape->mShape);
+		m_ShapeGen->GenShape(a_ChunkDesc.GetChunkCoords(), shape->m_Shape);
+		a_ChunkDesc.SetHeightFromShape(shape->m_Shape);
 	}
 	else
 	{
 		// Convert the heightmap in a_ChunkDesc into shape:
-		a_ChunkDesc.GetShapeFromHeight(shape->mShape);
+		a_ChunkDesc.GetShapeFromHeight(shape->m_Shape);
 	}
 
 	bool ShouldUpdateHeightmap = false;
 	if (a_ChunkDesc.IsUsingDefaultComposition())
 	{
-		m_CompositionGen->ComposeTerrain(a_ChunkDesc, shape->mShape);
+		m_CompositionGen->ComposeTerrain(a_ChunkDesc, shape->m_Shape);
 	}
 
 	if (a_ChunkDesc.IsUsingDefaultFinish())

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -45,7 +45,7 @@ void cStructGenTrees::GenFinish(cChunkDesc & a_ChunkDesc)
 				WorkerDesc->SetChunkCoords({BaseX, BaseZ});
 				m_BiomeGen->GenBiomes           ({BaseX, BaseZ}, WorkerDesc->GetBiomeMap());
 				m_ShapeGen->GenShape            ({BaseX, BaseZ}, WorkerShape->mShape);
-				WorkerDesc->SetHeightFromShape   (WorkerShape->mShape);
+				WorkerDesc->SetHeightFromShape  (WorkerShape->mShape);
 				m_CompositionGen->ComposeTerrain(*WorkerDesc, WorkerShape->mShape);
 			}
 			else

--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -243,7 +243,13 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 		return;
 	}
 
-	cChunkDef::BlockNibbles BlockLight, SkyLight;
+	// Wrap the output lighting data into a structure so that we can use it in a unique_ptr:
+	struct OutputLightingData
+	{
+		cChunkDef::BlockNibbles mBlockLight;
+		cChunkDef::BlockNibbles mSkyLight;
+	};
+	auto Output = std::make_unique<OutputLightingData>();
 
 	ReadChunks(a_Item.m_ChunkX, a_Item.m_ChunkZ);
 
@@ -312,10 +318,10 @@ void cLightingThread::LightChunk(cLightingChunkStay & a_Item)
 	}
 	//*/
 
-	CompressLight(m_BlockLight, BlockLight);
-	CompressLight(m_SkyLight, SkyLight);
+	CompressLight(m_BlockLight, Output->mBlockLight);
+	CompressLight(m_SkyLight, Output->mSkyLight);
 
-	m_World.ChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ, BlockLight, SkyLight);
+	m_World.ChunkLighted(a_Item.m_ChunkX, a_Item.m_ChunkZ, Output->mBlockLight, Output->mSkyLight);
 
 	if (a_Item.m_CallbackAfter != nullptr)
 	{

--- a/src/StringCompression.cpp
+++ b/src/StringCompression.cpp
@@ -183,7 +183,7 @@ extern int InflateString(const char * a_Data, size_t a_Length, AString & a_Uncom
 {
 	a_Uncompressed.reserve(a_Length);
 
-	char Buffer[64 KiB];
+	char Buffer[4 KiB];
 	z_stream strm;
 	memset(&strm, 0, sizeof(strm));
 	strm.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(a_Data));

--- a/src/StringCompression.cpp
+++ b/src/StringCompression.cpp
@@ -57,7 +57,7 @@ int CompressStringGZIP(const char * a_Data, size_t a_Length, AString & a_Compres
 
 	a_Compressed.reserve(a_Length);
 
-	char Buffer[64 KiB];
+	char Buffer[4 KiB];
 	z_stream strm;
 	memset(&strm, 0, sizeof(strm));
 	strm.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(a_Data));
@@ -121,7 +121,7 @@ extern int UncompressStringGZIP(const char * a_Data, size_t a_Length, AString & 
 
 	a_Uncompressed.reserve(a_Length);
 
-	char Buffer[64 KiB];
+	char Buffer[4 KiB];
 	z_stream strm;
 	memset(&strm, 0, sizeof(strm));
 	strm.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(a_Data));


### PR DESCRIPTION
Now Cuberite can run with 64 KiB thread stack.

I'm not too happy about the wrappers, but I could not find any other solution. `unique_ptr` just doesn't play nice with `typedef`-ed arrays. Perhaps @peterbell10 could come up with something more elegant?

Fixes #3406.