### PR TITLE
Adding support for 16 steps for rotation in templates for Blocks

### DIFF
--- a/src/Blocks/Mixins.h
+++ b/src/Blocks/Mixins.h
@@ -464,67 +464,67 @@ public:
 	{
 		if ((a_Rotation >= - 11.25f) && (a_Rotation < 11.25f))
 		{
-			return South
+			return South;
 		}
 		else if ((a_Rotation >= 11.25f) && (a_Rotation < 33.75f))
 		{
-			return SouthSouthWest
+			return SouthSouthWest;
 		}
 		else if ((a_Rotation >= 23.75f) && (a_Rotation < 56.25f))
 		{
-			return SouthWest
+			return SouthWest;
 		}
 		else if ((a_Rotation >= 56.25f) && (a_Rotation < 78.75f))
 		{
-			return WestSouthWest
+			return WestSouthWest;
 		}
 		else if ((a_Rotation >= 78.75f) && (a_Rotation < 101.25f))
 		{
-			return West
+			return West;
 		}
 		else if ((a_Rotation >= 101.25f) && (a_Rotation < 123.75f))
 		{
-			return WestNorthWest
+			return WestNorthWest;
 		}
 		else if ((a_Rotation >= 123.75f) && (a_Rotation < 146.25f))
 		{
-			return NorthWest
+			return NorthWest;
 		}
 		else if ((a_Rotation >= 146.25f) && (a_Rotation < 168.75f))
 		{
-			return NorthNorthWest
+			return NorthNorthWest;
 		}
 		else if ((a_Rotation >= -168.75f) && (a_Rotation < -146.25f))
 		{
-			return NorthNorthEast
+			return NorthNorthEast;
 		}
 		else if ((a_Rotation >= -146.25f) && (a_Rotation < -123.75f))
 		{
-			return NorthEast
+			return NorthEast;
 		}
 		else if ((a_Rotation >= -123.75f) && (a_Rotation < -101.25f))
 		{
-			return EastNorthEast
+			return EastNorthEast;
 		}
 		else if ((a_Rotation >= -101.25) && (a_Rotation < -78.75f))
 		{
-			return East
+			return East;
 		}
 		else if ((a_Rotation >= -78.75) && (a_Rotation < -56.25f))
 		{
-			return EastSouthEast
+			return EastSouthEast;
 		}
 		else if ((a_Rotation >= -56.25f) && (a_Rotation < -33.75f))
 		{
-			return SouthEast
+			return SouthEast;
 		}
 		else if ((a_Rotation >= -33.75f) && (a_Rotation < -11.25f))
 		{
-			return SouthSouthEast
+			return SouthSouthEast;
 		}
 		else  // degrees jumping from 180 to -180
 		{
-			return North
+			return North;
 		}
 	}
 };

--- a/src/Blocks/Mixins.h
+++ b/src/Blocks/Mixins.h
@@ -174,7 +174,7 @@ public:
 Inherit from this class providing your base class as Base, the BitMask for the direction bits in bitmask and the masked value for the directions in
 North, NorthNorthEast, NorthEast, EastNorthEast,
 East, EastSouthEast, SouthEast, SouthSouthEast,
-South, SouthSouthWest, SouthWest, WestSouthWest
+South, SouthSouthWest, SouthWest, WestSouthWest,
 West, WestNorthWest, NorthWest, NorthNorthWest.
 There is also an aptional parameter AssertIfNotMatched, set this if it is invalid for a block to exist in any other state. */
 template <class Base, NIBBLETYPE BitMask, NIBBLETYPE North, NIBBLETYPE NorthNorthEast, NIBBLETYPE NorthEast, NIBBLETYPE EastNorthEast,
@@ -184,7 +184,7 @@ template <class Base, NIBBLETYPE BitMask, NIBBLETYPE North, NIBBLETYPE NorthNort
 class cMetaRotatorFine:
 	public Base
 {
-  public:
+public:
 
 	cMetaRotatorFine(BLOCKTYPE a_BlockType):
 		Base(a_BlockType)

--- a/src/Blocks/Mixins.h
+++ b/src/Blocks/Mixins.h
@@ -425,7 +425,7 @@ class cYawRotatorFine:
 		East, EastSouthEast, SouthEast, SouthSouthEast,
 		South, SouthSouthWest, SouthWest, WestSouthWest,
 		West, WestNorthWest, NorthWest, NorthNorthWest, AssertIfNotMatched>;
-  public:
+public:
 
 	cYawRotatorFine(BLOCKTYPE a_BlockType):
 		Super(a_BlockType)
@@ -522,7 +522,7 @@ class cYawRotatorFine:
 		{
 			return SouthSouthEast
 		}
-		else // degrees jumping from 180 to -180
+		else  // degrees jumping from 180 to -180
 		{
 			return North
 		}
@@ -553,6 +553,112 @@ class cPitchYawRotator:
 public:
 
 	cPitchYawRotator(BLOCKTYPE a_BlockType):
+		Super(a_BlockType)
+	{
+	}
+
+
+
+
+
+	virtual bool GetPlacementBlockTypeMeta(
+		cChunkInterface & a_ChunkInterface,
+		cPlayer & a_Player,
+		const Vector3i a_PlacedBlockPos,
+		eBlockFace a_ClickedBlockFace,
+		const Vector3i a_CursorPos,
+		BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta
+	) override
+	{
+		NIBBLETYPE BaseMeta;
+		if (!Super::GetPlacementBlockTypeMeta(a_ChunkInterface, a_Player, a_PlacedBlockPos, a_ClickedBlockFace, a_CursorPos, a_BlockType, BaseMeta))
+		{
+			return false;
+		}
+
+		a_BlockMeta = (BaseMeta & ~BitMask) |  PitchYawToMetaData(a_Player.GetYaw(), a_Player.GetPitch());
+		return true;
+	}
+
+
+
+
+
+	virtual NIBBLETYPE MetaMirrorXZ(NIBBLETYPE a_Meta) override
+	{
+		NIBBLETYPE OtherMeta = a_Meta & (~BitMask);
+		switch (a_Meta & BitMask)
+		{
+			case Down: return Up | OtherMeta;  // Down -> Up
+			case Up: return Down | OtherMeta;  // Up -> Down
+		}
+		// Not Facing Up or Down; No change.
+		return a_Meta;
+	}
+
+
+
+
+
+	/** Converts the rotation and pitch values as returned by cPlayer::GetYaw() and cPlayer::GetPitch()
+	respectively to the appropriate metadata value for a block placed by a player facing that way */
+	static NIBBLETYPE PitchYawToMetaData(double a_Rotation, double a_Pitch)
+	{
+		if (a_Pitch >= 50)
+		{
+			return Up;
+		}
+		else if (a_Pitch <= -50)
+		{
+			return Down;
+		}
+
+		return Super::YawToMetaData(a_Rotation);
+	}
+};
+
+
+
+
+/** Mixin for blocks whose meta on placement depends on the yaw of the player placing the block. BitMask
+selects the direction bits from the block's meta values. */
+template <class Base,
+	NIBBLETYPE BitMask = 0x0F,
+	NIBBLETYPE South = 0x00,
+	NIBBLETYPE SouthSouthWest = 0x01,
+	NIBBLETYPE SouthWest = 0x02,
+	NIBBLETYPE WestSouthWest = 0x03,
+	NIBBLETYPE West = 0x04,
+	NIBBLETYPE WestNorthWest = 0x05,
+	NIBBLETYPE NorthWest = 0x06,
+	NIBBLETYPE NorthNorthWest = 0x07,
+	NIBBLETYPE North = 0x08,
+	NIBBLETYPE NorthNorthEast = 0x09,
+	NIBBLETYPE NorthEast = 0x0a,
+	NIBBLETYPE EastNorthEast = 0x0b,
+	NIBBLETYPE East = 0x0c,
+	NIBBLETYPE EastSouthEast = 0x0d,
+	NIBBLETYPE SouthEast = 0x0e,
+	NIBBLETYPE SouthSouthEast = 0x0f,
+	NIBBLETYPE Up = 0x00,
+	NIBBLETYPE Down = 0x01
+>
+class cPitchYawRotatorFine:
+	public cYawRotatorFine<Base, BitMask,
+		North, NorthNorthEast, NorthEast, EastNorthEast,
+		East, EastSouthEast, SouthEast, SouthSouthEast,
+		South, SouthSouthWest, SouthWest, WestSouthWest,
+		West, WestNorthWest, NorthWest, NorthNorthWest>
+{
+	using Super = cYawRotatorFine<Base, BitMask,
+		North, NorthNorthEast, NorthEast, EastNorthEast,
+		East, EastSouthEast, SouthEast, SouthSouthEast,
+		South, SouthSouthWest, SouthWest, WestSouthWest,
+		West, WestNorthWest, NorthWest, NorthNorthWest>;
+
+public:
+
+	cPitchYawRotatorFine(BLOCKTYPE a_BlockType):
 		Super(a_BlockType)
 	{
 	}

--- a/src/Blocks/Mixins.h
+++ b/src/Blocks/Mixins.h
@@ -392,6 +392,147 @@ public:
 
 
 
+/** Mixin for blocks whose meta on placement depends on the yaw of the player placing the block. BitMask
+selects the direction bits from the block's meta values. */
+template <class Base,
+	NIBBLETYPE BitMask = 0x0F,
+	NIBBLETYPE South = 0x00,
+	NIBBLETYPE SouthSouthWest = 0x01,
+	NIBBLETYPE SouthWest = 0x02,
+	NIBBLETYPE WestSouthWest = 0x03,
+	NIBBLETYPE West = 0x04,
+	NIBBLETYPE WestNorthWest = 0x05,
+	NIBBLETYPE NorthWest = 0x06,
+	NIBBLETYPE NorthNorthWest = 0x07,
+	NIBBLETYPE North = 0x08,
+	NIBBLETYPE NorthNorthEast = 0x09,
+	NIBBLETYPE NorthEast = 0x0a,
+	NIBBLETYPE EastNorthEast = 0x0b,
+	NIBBLETYPE East = 0x0c,
+	NIBBLETYPE EastSouthEast = 0x0d,
+	NIBBLETYPE SouthEast = 0x0e,
+	NIBBLETYPE SouthSouthEast = 0x0f,
+	bool AssertIfNotMatched = false>
+class cYawRotatorFine:
+	public cMetaRotatorFine<Base, BitMask,
+		North, NorthNorthEast, NorthEast, EastNorthEast,
+		East, EastSouthEast, SouthEast, SouthSouthEast,
+		South, SouthSouthWest, SouthWest, WestSouthWest,
+		West, WestNorthWest, NorthWest, NorthNorthWest, AssertIfNotMatched>
+{
+	using Super = cMetaRotatorFine<Base, BitMask,
+		North, NorthNorthEast, NorthEast, EastNorthEast,
+		East, EastSouthEast, SouthEast, SouthSouthEast,
+		South, SouthSouthWest, SouthWest, WestSouthWest,
+		West, WestNorthWest, NorthWest, NorthNorthWest, AssertIfNotMatched>;
+  public:
+
+	cYawRotatorFine(BLOCKTYPE a_BlockType):
+		Super(a_BlockType)
+	{
+	}
+
+
+
+
+
+	virtual bool GetPlacementBlockTypeMeta(
+		cChunkInterface & a_ChunkInterface, cPlayer & a_Player,
+		const Vector3i a_BlockPos,
+		eBlockFace a_BlockFace,
+		const Vector3i a_CursorPos,
+		BLOCKTYPE & a_BlockType, NIBBLETYPE & a_BlockMeta
+	) override
+	{
+		NIBBLETYPE BaseMeta;
+		if (!Super::GetPlacementBlockTypeMeta(a_ChunkInterface, a_Player, a_BlockPos, a_BlockFace, a_CursorPos, a_BlockType, BaseMeta))
+		{
+			return false;
+		}
+
+		a_BlockMeta = (BaseMeta & ~BitMask) | YawToMetaData(a_Player.GetYaw());
+		return true;
+	}
+
+
+
+
+
+	/** Converts the rotation value as returned by cPlayer::GetYaw() to the appropriate metadata
+	value for a block placed by a player facing that way */
+	static NIBBLETYPE YawToMetaData(double a_Rotation)
+	{
+		if ((a_Rotation >= - 11.25f) && (a_Rotation < 11.25f))
+		{
+			return South
+		}
+		else if ((a_Rotation >= 11.25f) && (a_Rotation < 33.75f))
+		{
+			return SouthSouthWest
+		}
+		else if ((a_Rotation >= 23.75f) && (a_Rotation < 56.25f))
+		{
+			return SouthWest
+		}
+		else if ((a_Rotation >= 56.25f) && (a_Rotation < 78.75f))
+		{
+			return WestSouthWest
+		}
+		else if ((a_Rotation >= 78.75f) && (a_Rotation < 101.25f))
+		{
+			return West
+		}
+		else if ((a_Rotation >= 101.25f) && (a_Rotation < 123.75f))
+		{
+			return WestNorthWest
+		}
+		else if ((a_Rotation >= 123.75f) && (a_Rotation < 146.25f))
+		{
+			return NorthWest
+		}
+		else if ((a_Rotation >= 146.25f) && (a_Rotation < 168.75f))
+		{
+			return NorthNorthWest
+		}
+		else if ((a_Rotation >= -168.75f) && (a_Rotation < -146.25f))
+		{
+			return NorthNorthEast
+		}
+		else if ((a_Rotation >= -146.25f) && (a_Rotation < -123.75f))
+		{
+			return NorthEast
+		}
+		else if ((a_Rotation >= -123.75f) && (a_Rotation < -101.25f))
+		{
+			return EastNorthEast
+		}
+		else if ((a_Rotation >= -101.25) && (a_Rotation < -78.75f))
+		{
+			return East
+		}
+		else if ((a_Rotation >= -78.75) && (a_Rotation < -56.25f))
+		{
+			return EastSouthEast
+		}
+		else if ((a_Rotation >= -56.25f) && (a_Rotation < -33.75f))
+		{
+			return SouthEast
+		}
+		else if ((a_Rotation >= -33.75f) && (a_Rotation < -11.25f))
+		{
+			return SouthSouthEast
+		}
+		else // degrees jumping from 180 to -180
+		{
+			return North
+		}
+	}
+};
+
+
+
+
+
 /** Mixin for blocks whose meta on placement depends on the pitch and yaw of the player placing the block. BitMask
 selects the direction bits from the block's meta values. */
 template <

--- a/src/Blocks/Mixins.h
+++ b/src/Blocks/Mixins.h
@@ -170,6 +170,153 @@ public:
 
 
 
+/** Mixin for rotations and reflections following the standard pattern of "apply mask, then use a switch".
+Inherit from this class providing your base class as Base, the BitMask for the direction bits in bitmask and the masked value for the directions in
+North, NorthNorthEast, NorthEast, EastNorthEast,
+East, EastSouthEast, SouthEast, SouthSouthEast,
+South, SouthSouthWest, SouthWest, WestSouthWest
+West, WestNorthWest, NorthWest, NorthNorthWest.
+There is also an aptional parameter AssertIfNotMatched, set this if it is invalid for a block to exist in any other state. */
+template <class Base, NIBBLETYPE BitMask, NIBBLETYPE North, NIBBLETYPE NorthNorthEast, NIBBLETYPE NorthEast, NIBBLETYPE EastNorthEast,
+	NIBBLETYPE East, NIBBLETYPE EastSouthEast, NIBBLETYPE SouthEast, NIBBLETYPE SouthSouthEast,
+	NIBBLETYPE South, NIBBLETYPE SouthSouthWest, NIBBLETYPE SouthWest, NIBBLETYPE WestSouthWest,
+	NIBBLETYPE West, NIBBLETYPE WestNorthWest, NIBBLETYPE NorthWest, NIBBLETYPE NorthNorthWest, bool AssertIfNotMatched = false>
+class cMetaRotatorFine:
+	public Base
+{
+  public:
+
+	cMetaRotatorFine(BLOCKTYPE a_BlockType):
+		Base(a_BlockType)
+	{}
+
+
+
+
+
+	virtual NIBBLETYPE MetaRotateCCW(NIBBLETYPE a_Meta) override
+	{
+		NIBBLETYPE OtherMeta = a_Meta & (~BitMask);
+		switch (a_Meta & BitMask)
+		{
+			case North: return NorthNorthEast | OtherMeta;
+			case NorthNorthEast: return NorthEast | OtherMeta;
+			case NorthEast: return EastNorthEast | OtherMeta;
+			case EastNorthEast: return East | OtherMeta;
+			case East: return EastSouthEast | OtherMeta;
+			case EastSouthEast: return SouthEast | OtherMeta;
+			case SouthEast: return SouthSouthEast | OtherMeta;
+			case SouthSouthEast: return South | OtherMeta;
+			case South: return SouthSouthWest | OtherMeta;
+			case SouthSouthWest: return SouthWest | OtherMeta;
+			case SouthWest: return WestSouthWest | OtherMeta;
+			case WestSouthWest: return West | OtherMeta;
+			case West: return WestNorthWest | OtherMeta;
+			case WestNorthWest: return NorthWest | OtherMeta;
+			case NorthWest: return NorthNorthWest | OtherMeta;
+			case NorthNorthWest: return North | OtherMeta;
+		}
+		if (AssertIfNotMatched)
+		{
+			ASSERT(!"Invalid Meta value");
+		}
+		return a_Meta;
+	}
+
+
+
+
+
+	virtual NIBBLETYPE MetaRotateCW(NIBBLETYPE a_Meta) override
+	{
+		NIBBLETYPE OtherMeta = a_Meta & (~BitMask);
+		switch (a_Meta & BitMask)
+		{
+			case North: return NorthNorthWest | OtherMeta;
+			case NorthNorthWest: return NorthWest | OtherMeta;
+			case NorthWest: return WestNorthWest | OtherMeta;
+			case WestNorthWest: return West | OtherMeta;
+			case West: return WestSouthWest | OtherMeta;
+			case WestSouthWest: return SouthWest | OtherMeta;
+			case SouthWest: return SouthSouthWest | OtherMeta;
+			case SouthSouthWest: return South | OtherMeta;
+			case South: return SouthSouthEast | OtherMeta;
+			case SouthSouthEast: return SouthEast | OtherMeta;
+			case SouthEast: return EastSouthEast | OtherMeta;
+			case EastSouthEast: return East | OtherMeta;
+			case East: return EastNorthEast | OtherMeta;
+			case EastNorthEast: return NorthEast | OtherMeta;
+			case NorthEast: return NorthNorthEast | OtherMeta;
+			case NorthNorthEast: return North | OtherMeta;
+		}
+		if (AssertIfNotMatched)
+		{
+			ASSERT(!"Invalid Meta value");
+		}
+		return a_Meta;
+	}
+
+
+
+
+
+	virtual NIBBLETYPE MetaMirrorXY(NIBBLETYPE a_Meta) override
+	{
+		NIBBLETYPE OtherMeta = a_Meta & (~BitMask);
+		switch (a_Meta & BitMask)
+		{
+			case North: return South | OtherMeta;
+			case NorthNorthEast: return SouthSouthEast | OtherMeta;
+			case NorthEast: return SouthEast | OtherMeta;
+			case EastNorthEast: return EastSouthEast | OtherMeta;
+			case EastSouthEast: return EastNorthEast | OtherMeta;
+			case SouthEast: return NorthEast | OtherMeta;
+			case SouthSouthEast: return NorthNorthEast | OtherMeta;
+			case South: return North | OtherMeta;
+			case SouthSouthWest: return NorthNorthWest;
+			case SouthWest: return NorthWest;
+			case WestSouthWest: return WestNorthWest;
+			case WestNorthWest: return WestSouthWest;
+			case NorthWest: return SouthWest;
+			case NorthNorthWest: return SouthSouthWest;
+		}
+		// Facing East or West; No Change
+		return a_Meta;
+	}
+
+
+
+
+
+	virtual NIBBLETYPE MetaMirrorYZ(NIBBLETYPE a_Meta) override
+	{
+		NIBBLETYPE OtherMeta = a_Meta & (~BitMask);
+		switch (a_Meta & BitMask)
+		{
+			case NorthNorthEast: return NorthNorthWest;
+			case NorthEast: return NorthWest;
+			case EastNorthEast: return WestNorthWest;
+			case East: return West;
+			case EastSouthEast: return WestSouthWest;
+			case SouthEast: return SouthWest;
+			case SouthSouthEast: return SouthSouthWest;
+			case SouthSouthWest: return SouthSouthEast;
+			case SouthWest: return SouthEast;
+			case WestSouthWest: return EastSouthEast;
+			case West: return East;
+			case WestNorthWest: return EastNorthEast;
+			case NorthWest: return NorthEast;
+			case NorthNorthWest: return NorthNorthEast;
+		}
+		// Facing North or South; No change.
+		return a_Meta;
+	}
+};
+
+
+
+
+
 /** Mixin for blocks whose meta on placement depends on the yaw of the player placing the block. BitMask
 selects the direction bits from the block's meta values. */
 template <


### PR DESCRIPTION
I started to implement banners for cuberight and stubled about the problem that the template classes only support 4 steps of rotation.

I'd like to add 16 steps because e.g banners may be placed in 16 different directions.

If there's another way already implemented i'm happy to use that and delete this PR

As the last time feedback if this is neccesary is apreciated before i do the whole thing and trash it
