### PR TITLE
Cleaning up some BlockEntty -> NBT tag code

### DIFF
--- a/src/BlockEntities/BeaconEntity.cpp
+++ b/src/BlockEntities/BeaconEntity.cpp
@@ -7,6 +7,7 @@
 #include "../Entities/Player.h"
 #include "../UI/BeaconWindow.h"
 #include "../ClientHandle.h"
+#include "../WorldStorage/FastNBT.h"
 
 
 
@@ -324,3 +325,14 @@ bool cBeaconEntity::UsedBy(cPlayer * a_Player)
 
 
 
+
+void cBeaconEntity::SerializeBlockEntity(cFastNBTWriter & a_Nbt) const
+{
+	a_Nbt.AddInt("x",         GetPosX());
+	a_Nbt.AddInt("y",         GetPosY());
+	a_Nbt.AddInt("z",         GetPosZ());
+	a_Nbt.AddInt("Primary",   GetPrimaryEffect());
+	a_Nbt.AddInt("Secondary", GetSecondaryEffect());
+	a_Nbt.AddInt("Levels",    GetBeaconLevel());
+	a_Nbt.AddString("id", "Beacon");  // "Tile Entity ID" - MC wiki; vanilla server always seems to send this though
+}

--- a/src/BlockEntities/BeaconEntity.h
+++ b/src/BlockEntities/BeaconEntity.h
@@ -35,6 +35,7 @@ public:  // tolua_export
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	/** Modify the beacon level. (It is needed to load the beacon corectly) */
 	void SetBeaconLevel(char a_Level) { m_BeaconLevel = a_Level; }

--- a/src/BlockEntities/BedEntity.cpp
+++ b/src/BlockEntities/BedEntity.cpp
@@ -56,3 +56,12 @@ void cBedEntity::SetColor(short a_Color)
 		a_World.BroadcastBlockEntity(Pos);
 	});
 }
+
+
+
+
+
+void cBedEntity::SerializeBlockEntity(cFastNBTWriter & a_Nbt) const
+{
+	LOG("Test Bed");
+}

--- a/src/BlockEntities/BedEntity.h
+++ b/src/BlockEntities/BedEntity.h
@@ -41,6 +41,7 @@ public:  // tolua_export
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual bool UsedBy(cPlayer * a_Player) override { return false; }
 	virtual void SendTo(cClientHandle & a_Client) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 private:
 	short m_Color;

--- a/src/BlockEntities/BlockEntity.h
+++ b/src/BlockEntities/BlockEntity.h
@@ -32,6 +32,7 @@ class cChunk;
 class cPlayer;
 class cWorld;
 class cBlockEntity;
+class cFastNBTWriter;
 
 using OwnedBlockEntity = std::unique_ptr<cBlockEntity>;
 using cBlockEntities = std::unordered_map<size_t, OwnedBlockEntity>;
@@ -139,6 +140,8 @@ public:
 		return false;
 	}
 
+	/** serialized the event for sending, saving, loading */
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const = 0;
 
 protected:
 

--- a/src/BlockEntities/BrewingstandEntity.cpp
+++ b/src/BlockEntities/BrewingstandEntity.cpp
@@ -187,6 +187,14 @@ bool cBrewingstandEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cBrewingstandEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Brewing Stand");
+}
+
+
+
+
 void cBrewingstandEntity::BroadcastProgress(short a_ProgressbarID, short a_Value)
 {
 	cWindow * Window = GetWindow();

--- a/src/BlockEntities/BrewingstandEntity.h
+++ b/src/BlockEntities/BrewingstandEntity.h
@@ -53,6 +53,7 @@ public:
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	// tolua_begin
 

--- a/src/BlockEntities/ChestEntity.cpp
+++ b/src/BlockEntities/ChestEntity.cpp
@@ -135,6 +135,15 @@ bool cChestEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cChestEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Chest");
+}
+
+
+
+
+
 void cChestEntity::ScanNeighbours()
 {
 	// Callback for finding neighbouring chest:

--- a/src/BlockEntities/ChestEntity.h
+++ b/src/BlockEntities/ChestEntity.h
@@ -45,6 +45,7 @@ public:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	/** Search horizontally adjacent blocks for neighbouring chests of the same type and links them together. */
 	void ScanNeighbours();

--- a/src/BlockEntities/CommandBlockEntity.cpp
+++ b/src/BlockEntities/CommandBlockEntity.cpp
@@ -39,6 +39,14 @@ bool cCommandBlockEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cCommandBlockEntity::SerializeBlockEntity(cFastNBTWriter & a_Nbt) const
+{
+	LOG("Test Command Block");
+}
+
+
+
+
 
 void cCommandBlockEntity::SetCommand(const AString & a_Cmd)
 {

--- a/src/BlockEntities/CommandBlockEntity.h
+++ b/src/BlockEntities/CommandBlockEntity.h
@@ -36,6 +36,7 @@ public:  // tolua_export
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	void SetLastOutput(const AString & a_LastOut);
 

--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -23,6 +23,15 @@ cDispenserEntity::cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta
 
 
 
+void cDispenserEntity::SerializeBlockEntity(cFastNBTWriter & a_Nbt) const
+{
+	LOG("Test Dispenser");
+}
+
+
+
+
+
 void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 {
 	Vector3i dispRelCoord(GetRelPos());

--- a/src/BlockEntities/DispenserEntity.h
+++ b/src/BlockEntities/DispenserEntity.h
@@ -22,6 +22,8 @@ public:  // tolua_export
 	/** Constructor used for normal operation */
 	cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
+
 	// tolua_begin
 
 	/** Spawns a projectile of the given kind in front of the dispenser with the specified speed.

--- a/src/BlockEntities/DropperEntity.cpp
+++ b/src/BlockEntities/DropperEntity.cpp
@@ -20,6 +20,15 @@ cDropperEntity::cDropperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Ve
 
 
 
+void cDropperEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Dropper");
+}
+
+
+
+
+
 void cDropperEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 {
 	DropFromSlot(a_Chunk, a_SlotNum);

--- a/src/BlockEntities/DropperEntity.h
+++ b/src/BlockEntities/DropperEntity.h
@@ -29,6 +29,7 @@ public:  // tolua_export
 
 	/** Constructor used for normal operation */
 	cDropperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 
 protected:

--- a/src/BlockEntities/EnderChestEntity.cpp
+++ b/src/BlockEntities/EnderChestEntity.cpp
@@ -48,6 +48,13 @@ void cEnderChestEntity::SendTo(cClientHandle & a_Client)
 
 
 
+void cEnderChestEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Enderchest");
+}
+
+
+
 bool cEnderChestEntity::UsedBy(cPlayer * a_Player)
 {
 	if (

--- a/src/BlockEntities/EnderChestEntity.h
+++ b/src/BlockEntities/EnderChestEntity.h
@@ -27,6 +27,7 @@ public:  // tolua_export
 	// cBlockEntity overrides:
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	static void LoadFromJson(const Json::Value & a_Value, cItemGrid & a_Grid);
 	static void SaveToJson(Json::Value & a_Value, const cItemGrid & a_Grid);

--- a/src/BlockEntities/FlowerPotEntity.cpp
+++ b/src/BlockEntities/FlowerPotEntity.cpp
@@ -85,6 +85,14 @@ void cFlowerPotEntity::SendTo(cClientHandle & a_Client)
 
 
 
+void cFlowerPotEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test FlowerPot");
+}
+
+
+
+
 bool cFlowerPotEntity::IsFlower(short m_ItemType, short m_ItemData)
 {
 	switch (m_ItemType)

--- a/src/BlockEntities/FlowerPotEntity.h
+++ b/src/BlockEntities/FlowerPotEntity.h
@@ -50,6 +50,7 @@ public:  // tolua_export
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	static bool IsFlower(short m_ItemType, short m_ItemData);
 

--- a/src/BlockEntities/FurnaceEntity.cpp
+++ b/src/BlockEntities/FurnaceEntity.cpp
@@ -162,6 +162,14 @@ bool cFurnaceEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cFurnaceEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Furnace");
+}
+
+
+
+
 bool cFurnaceEntity::ContinueCooking(void)
 {
 	UpdateInput();

--- a/src/BlockEntities/FurnaceEntity.h
+++ b/src/BlockEntities/FurnaceEntity.h
@@ -51,6 +51,7 @@ public:
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	/** Restarts cooking
 	Used after the furnace is loaded from storage to set up the internal variables so that cooking continues, if it was active

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -136,6 +136,15 @@ bool cHopperEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cHopperEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Hopper");
+}
+
+
+
+
+
 void cHopperEntity::OpenNewWindow(void)
 {
 	OpenWindow(new cHopperWindow(this));

--- a/src/BlockEntities/HopperEntity.h
+++ b/src/BlockEntities/HopperEntity.h
@@ -59,6 +59,7 @@ protected:
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	/** Opens a new chest window for this chest. Scans for neighbors to open a double chest window, if appropriate. */
 	void OpenNewWindow(void);

--- a/src/BlockEntities/JukeboxEntity.cpp
+++ b/src/BlockEntities/JukeboxEntity.cpp
@@ -81,6 +81,15 @@ bool cJukeboxEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cJukeboxEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Jukebox");
+}
+
+
+
+
+
 bool cJukeboxEntity::PlayRecord(int a_Record)
 {
 	if (!IsRecordItem(a_Record))

--- a/src/BlockEntities/JukeboxEntity.h
+++ b/src/BlockEntities/JukeboxEntity.h
@@ -51,6 +51,7 @@ public:  // tolua_export
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle &) override {}
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 private:
 	int m_Record;

--- a/src/BlockEntities/MobHeadEntity.cpp
+++ b/src/BlockEntities/MobHeadEntity.cpp
@@ -51,6 +51,15 @@ bool cMobHeadEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cMobHeadEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Mob Head");
+}
+
+
+
+
+
 void cMobHeadEntity::SetType(const eMobHeadType & a_Type)
 {
 	if ((!m_OwnerName.empty()) && (a_Type != SKULL_TYPE_PLAYER))

--- a/src/BlockEntities/MobHeadEntity.h
+++ b/src/BlockEntities/MobHeadEntity.h
@@ -73,6 +73,7 @@ public:  // tolua_export
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 private:
 

--- a/src/BlockEntities/MobSpawnerEntity.cpp
+++ b/src/BlockEntities/MobSpawnerEntity.cpp
@@ -112,6 +112,15 @@ bool cMobSpawnerEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 
 
+void cMobSpawnerEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Mob Spawner");
+}
+
+
+
+
+
 void cMobSpawnerEntity::ResetTimer(void)
 {
 	m_SpawnDelay = GetRandomProvider().RandInt<short>(200, 800);

--- a/src/BlockEntities/MobSpawnerEntity.h
+++ b/src/BlockEntities/MobSpawnerEntity.h
@@ -32,6 +32,7 @@ public:  // tolua_export
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 	// tolua_begin
 

--- a/src/BlockEntities/NoteEntity.cpp
+++ b/src/BlockEntities/NoteEntity.cpp
@@ -43,6 +43,15 @@ bool cNoteEntity::UsedBy(cPlayer * a_Player)
 
 
 
+void cNoteEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Noteblock");
+}
+
+
+
+
+
 void cNoteEntity::MakeSound(void)
 {
 	char instrument;

--- a/src/BlockEntities/NoteEntity.h
+++ b/src/BlockEntities/NoteEntity.h
@@ -55,6 +55,7 @@ public:  // tolua_export
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle &) override {}
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 private:
 	char m_Pitch;

--- a/src/BlockEntities/SignEntity.cpp
+++ b/src/BlockEntities/SignEntity.cpp
@@ -91,3 +91,12 @@ void cSignEntity::SendTo(cClientHandle & a_Client)
 {
 	a_Client.SendUpdateSign(m_Pos.x, m_Pos.y, m_Pos.z, m_Line[0], m_Line[1], m_Line[2], m_Line[3]);
 }
+
+
+
+
+
+void cSignEntity::SerializeBlockEntity(cFastNBTWriter &a_Nbt) const
+{
+	LOG("Test Sign");
+}

--- a/src/BlockEntities/SignEntity.h
+++ b/src/BlockEntities/SignEntity.h
@@ -47,6 +47,7 @@ public:  // tolua_export
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
+	virtual void SerializeBlockEntity(cFastNBTWriter & a_Nbt) const override;
 
 private:
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -3369,19 +3369,14 @@ void cProtocol_1_8_0::WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity &
 		case E_BLOCK_BEACON:
 		{
 			auto & BeaconEntity = static_cast<const cBeaconEntity &>(a_BlockEntity);
-			Writer.AddInt("x",         BeaconEntity.GetPosX());
-			Writer.AddInt("y",         BeaconEntity.GetPosY());
-			Writer.AddInt("z",         BeaconEntity.GetPosZ());
-			Writer.AddInt("Primary",   BeaconEntity.GetPrimaryEffect());
-			Writer.AddInt("Secondary", BeaconEntity.GetSecondaryEffect());
-			Writer.AddInt("Levels",    BeaconEntity.GetBeaconLevel());
-			Writer.AddString("id", "Beacon");  // "Tile Entity ID" - MC wiki; vanilla server always seems to send this though
+			BeaconEntity.SerializeBlockEntity(Writer);
 			break;
 		}
 
 		case E_BLOCK_COMMAND_BLOCK:
 		{
 			auto & CommandBlockEntity = static_cast<const cCommandBlockEntity &>(a_BlockEntity);
+			CommandBlockEntity.SerializeBlockEntity(Writer);
 			Writer.AddByte("TrackOutput", 1);  // Neither I nor the MC wiki has any idea about this
 			Writer.AddInt("SuccessCount", CommandBlockEntity.GetResult());
 			Writer.AddInt("x", CommandBlockEntity.GetPosX());

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -375,11 +375,12 @@ public:
 
 	void AddBeaconEntity(cBeaconEntity * a_Entity)
 	{
-		mWriter.BeginCompound("");
+		mWriter.BeginCompound(""); /*
 			AddBasicTileEntity(a_Entity, "Beacon");
 			mWriter.AddInt("Levels", a_Entity->GetBeaconLevel());
 			mWriter.AddInt("Primary", static_cast<int>(a_Entity->GetPrimaryEffect()));
-			mWriter.AddInt("Secondary", static_cast<int>(a_Entity->GetSecondaryEffect()));
+			mWriter.AddInt("Secondary", static_cast<int>(a_Entity->GetSecondaryEffect())); */
+			a_Entity->SerializeBlockEntity(mWriter);
 			mWriter.BeginList("Items", TAG_Compound);
 				AddItemGrid(a_Entity->GetContents());
 			mWriter.EndList();


### PR DESCRIPTION
I noticed that some of the code used for storing a BlockEntity to disk and sending it to the player is duplicated so i started to mere the code in a function of the block entity itself

I started with the beacon as an example if this even accepted the rest may follow if allowed