### PR TITLE
Fix arrows preventing block placement

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Gareth Nelson
 GefaketHD
 HaoTNN
 Howaner
+ion232 (Arran Ireland)
 jan64
 jasperarmstrong
 kevinr (Kevin Riggle)

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -195,3 +195,12 @@ void cArrowEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		}
 	}
 }
+
+
+
+
+
+bool cArrowEntity::DoesPreventBlockPlacement(void) const
+{
+	return false;
+}

--- a/src/Entities/ArrowEntity.h
+++ b/src/Entities/ArrowEntity.h
@@ -104,4 +104,7 @@ protected:
 	virtual void CollectedBy(cPlayer & a_Player) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
+	// cEntity overrides:
+	virtual bool DoesPreventBlockPlacement(void) const override;
+
 };  // tolua_export


### PR DESCRIPTION
Changes ArrowEntity to override DoesPreventBlockPlacement to return false instead of the default true.
The implementation of DoesPreventBlockPlacement could be changed if there are instances where an arrow should prevent block placement.

Fixes #4815