### PR TITLE
Fix enderchest placement rotation

### DIFF
--- a/src/Blocks/BlockEnderchest.h
+++ b/src/Blocks/BlockEnderchest.h
@@ -8,9 +8,9 @@
 
 
 class cBlockEnderchestHandler :
-	public cYawRotator<cBlockEntityHandler>
+	public cYawRotator<cBlockEntityHandler, 0x07, 0x03, 0x04, 0x02, 0x05>
 {
-	using Super = cYawRotator<cBlockEntityHandler>;
+	using Super = cYawRotator<cBlockEntityHandler, 0x07, 0x03, 0x04, 0x02, 0x05>;
 
 public:
 


### PR DESCRIPTION
The enderchest didn't have the same type of cYawRotator that a normal chest has. I have tested that this works and the fix produces the correct behaviour.

Fixes #4810