### PR TITLE
Add enhanced Gold generation in Mesa-Type Biomes

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -13647,6 +13647,23 @@ end
 					},
 					Notes = "Returns if the biome is a mountain type biome. So mutations of the extreme hills biome"
 				},
+				IsBiomeMesa =
+				{
+					Params =
+					{
+						{
+							Name = "Biome",
+							Type = "EMCSBiome",
+						}
+					},
+					Returns =
+					{
+						{
+							Type = "boolean",
+						},
+					},
+					Notes = "Returns true if the biome is Mesa-Type (mutations of the extreme Mesa biome)."
+				},
 				IsValidBlock =
 				{
 					Params =

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -13662,7 +13662,7 @@ end
 							Type = "boolean",
 						},
 					},
-					Notes = "Returns true if the biome is Mesa-Type (mutations of the Mesa biome)."
+					Notes = "Returns true if the biome is type of Mesa (mutations of the Mesa biome)."
 				},
 				IsValidBlock =
 				{

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -13662,7 +13662,7 @@ end
 							Type = "boolean",
 						},
 					},
-					Notes = "Returns true if the biome is Mesa-Type (mutations of the extreme Mesa biome)."
+					Notes = "Returns true if the biome is Mesa-Type (mutations of the Mesa biome)."
 				},
 				IsValidBlock =
 				{

--- a/src/BiomeDef.cpp
+++ b/src/BiomeDef.cpp
@@ -246,6 +246,30 @@ bool IsBiomeMountain(EMCSBiome a_Biome)
 
 
 
+bool IsBiomeMesa(EMCSBiome a_Biome)
+{
+	switch (a_Biome)
+	{
+		case biMesa:
+		case biMesaPlateauF:
+		case biMesaPlateau:
+		case biMesaBryce:
+		case biMesaPlateauFM:
+		case biMesaPlateauM:
+		{
+			return true;
+		}
+		default:
+		{
+			return false;
+		}
+	}
+}
+
+
+
+
+
 int GetSnowStartHeight(EMCSBiome a_Biome)
 {
 	switch (a_Biome)

--- a/src/BiomeDef.h
+++ b/src/BiomeDef.h
@@ -154,7 +154,7 @@ extern bool IsBiomeCold(EMCSBiome a_Biome);
 /** Returns true if the biome is a mountain type */
 extern bool IsBiomeMountain(EMCSBiome a_Biome);
 
-/** Return true if the biome is Mesa or one of its mutation. */
+/** Returns true if the biome is Mesa or one of its mutations. */
 extern bool IsBiomeMesa(EMCSBiome a_Biome);
 
 /** Returns the height when a biome when a biome starts snowing. */

--- a/src/BiomeDef.h
+++ b/src/BiomeDef.h
@@ -154,6 +154,9 @@ extern bool IsBiomeCold(EMCSBiome a_Biome);
 /** Returns true if the biome is a mountain type */
 extern bool IsBiomeMountain(EMCSBiome a_Biome);
 
+/** Return true if the biome is Mesa or one of its mutation. */
+extern bool IsBiomeMesa(EMCSBiome a_Biome);
+
 /** Returns the height when a biome when a biome starts snowing. */
 extern int GetSnowStartHeight(EMCSBiome a_Biome);
 

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -1769,6 +1769,25 @@ void cFinishGenOreNests::GenerateOre(
 		}
 	}
 
+	// Gold ores are generated more often in Mesa-Type-Biommes:
+	// https://minecraft.gamepedia.com/Gold_Ore
+	if (a_OreType == E_BLOCK_GOLD_ORE)
+	{
+		auto BiomeSampleOne =    a_ChunkDesc.GetBiome( 4,  4);
+		auto BiomeSampleTwo =    a_ChunkDesc.GetBiome( 4, 12);
+		auto BiomeSampleThree =  a_ChunkDesc.GetBiome(12,  4);
+		auto BiomeSampleFour =   a_ChunkDesc.GetBiome(12, 12);
+
+		if ((IsBiomeMesa(BiomeSampleOne)) ||
+			(IsBiomeMesa(BiomeSampleTwo)) ||
+			(IsBiomeMesa(BiomeSampleThree)) ||
+			(IsBiomeMesa(BiomeSampleFour)))
+		{
+			a_MaxHeight = 76;
+			a_NumNests = 22;  // 2 time default + 20 times mesa bonus
+		}
+	}
+
 	auto chunkX = a_ChunkDesc.GetChunkX();
 	auto chunkZ = a_ChunkDesc.GetChunkZ();
 	auto & blockTypes = a_ChunkDesc.GetBlockTypes();

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -1778,10 +1778,12 @@ void cFinishGenOreNests::GenerateOre(
 		auto BiomeSampleThree =  a_ChunkDesc.GetBiome(12,  4);
 		auto BiomeSampleFour =   a_ChunkDesc.GetBiome(12, 12);
 
-		if ((IsBiomeMesa(BiomeSampleOne)) ||
-			(IsBiomeMesa(BiomeSampleTwo)) ||
-			(IsBiomeMesa(BiomeSampleThree)) ||
-			(IsBiomeMesa(BiomeSampleFour)))
+		if (
+			IsBiomeMesa(BiomeSampleOne) ||
+			IsBiomeMesa(BiomeSampleTwo) ||
+			IsBiomeMesa(BiomeSampleThree) ||
+			IsBiomeMesa(BiomeSampleFour)
+			)
 		{
 			a_MaxHeight = 76;
 			a_NumNests = 22;  // 2 time default + 20 times mesa bonus

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -1769,7 +1769,7 @@ void cFinishGenOreNests::GenerateOre(
 		}
 	}
 
-	// Gold ores are generated more often in Mesa-Type-Biommes:
+	// Gold ores are generated more often in Mesa-Type-Biomes:
 	// https://minecraft.gamepedia.com/Gold_Ore
 	if (a_OreType == E_BLOCK_GOLD_ORE)
 	{


### PR DESCRIPTION
Gold is generated more often in mesa type biomes - fixed that as discussed in the emerald generation pull request