### PR TITLE
Adding block entity transmission to 1.13

### DIFF
--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -27,6 +27,7 @@ Implements the 1.13 protocol classes:
 #include "../Server.h"
 #include "../World.h"
 #include "../JsonUtils.h"
+#include "../WorldStorage/FastNBT.h"
 
 #include "../Bindings/PluginManager.h"
 

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -176,7 +176,6 @@ void cProtocol_1_13::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	cPacketizer Pkt(*this, pktUpdateBlockEntity);
-	cFastNBTWriter Writer;
 
 	Pkt.WriteXYZPosition64(a_BlockEntity.GetPosX(), a_BlockEntity.GetPosY(), a_BlockEntity.GetPosZ());
 

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -192,7 +192,7 @@ void cProtocol_1_13::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 		// case structure tile entity: Action = 7;  break;  // Update Structure tile entity
 		case E_BLOCK_END_GATEWAY:   Action = 8;  break;  // Update destination for a end gateway entity
 		case E_BLOCK_SIGN_POST:     Action = 9;  break;  // Update sign entity
-		// case E_BLOCK_SHULKER_BOX:   Action = 10; break; // sets shulker box - not used just here if anyone is confused from reading the protocol wiki
+		// case E_BLOCK_SHULKER_BOX:   Action = 10; break;  // sets shulker box - not used just here if anyone is confused from reading the protocol wiki
 		case E_BLOCK_BED:           Action = 11; break;  // Update bed color
 		default: ASSERT(!"Unhandled or unimplemented BlockEntity update request!"); break;
 	}

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -27,7 +27,6 @@ Implements the 1.13 protocol classes:
 #include "../Server.h"
 #include "../World.h"
 #include "../JsonUtils.h"
-#include "../WorldStorage/FastNBT.h"
 
 #include "../Bindings/PluginManager.h"
 

--- a/src/Protocol/Protocol_1_13.h
+++ b/src/Protocol/Protocol_1_13.h
@@ -82,6 +82,7 @@ protected:
 
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 	virtual void HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer) override;
+	virtual void HandlePacketSetBeaconEffect(cByteBuffer & a_ByteBuffer);
 
 	virtual bool ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) override;
 	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) override;


### PR DESCRIPTION
related: #4428 

I found a missing package type: added PacketSetBeaconEffect
The client sends this to set the beacon effects in the beacon window

At this point this relies on the last implementation of the nbt serialasation implemented in 1.11

This needs more testing

- [x] Set data of a mob spawner
- [x] Set command block text (command and last execution status)
The block spawns but isn't interactable  - further research needed
- [x] Set the level, primary, and secondary powers of a beacon
- [x] Set rotation and skin of mob head
 Mob Heads were renamed during "the flattening" there is a block spawning but neither rotation nor head type works because this is not related to a block entity anymore
- [x] Declare a conduit
the conduit is not implemented (doesn't exist as item or block)
- [x] Set base color and patterns on a banner
dependent on other pull request - is ticked off due to implementation in other pull request
- [x] Set the data for a Structure tile entity
Ok this is fun but not at all implemented - so i tick this of (all that is possible is implemented)
- [x] Set the destination for a end gateway
So the block exists in the enum, but the item/block is not implemented at this point so this is ticked of too
- [x] Set the text on a sign
- [x] Declare a bed
the color of the bed got moved to the block data so it doesn't display the correct color but is useable

Some Types don't work due to missing block data:
- Bed

Some blocks were renamed during "the flattening"
- Mob Heads

Some Blocks are not implemented:
- conduit
- Banner