### PR TITLE
Fix doors and trapdoors closing on server restart

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/DoorHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/DoorHandler.h
@@ -40,9 +40,11 @@ namespace DoorHandler
 		Power = std::max(Power, Callback.Power);
 
 		cChunkInterface ChunkInterface(a_Chunk.GetWorld()->GetChunkMap());
+		// Use redstone data rather than block state so players can override redstone control
+		const auto Previous = DataForChunk(a_Chunk).ExchangeUpdateOncePowerData(a_Position, Power);
+		const bool IsOpen = (Previous != 0);
 		const bool ShouldBeOpen = Power != 0;
 		const auto AbsolutePosition = cChunkDef::RelativeToAbsolute(a_Position, a_Chunk.GetPos());
-		const bool IsOpen = cBlockDoorHandler::IsOpen(ChunkInterface, AbsolutePosition);
 
 		if (ShouldBeOpen != IsOpen)
 		{

--- a/src/Simulator/IncrementalRedstoneSimulator/SmallGateHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/SmallGateHandler.h
@@ -22,8 +22,10 @@ namespace SmallGateHandler
 	{
 		// LOGD("Evaluating gateydory the fence gate/trapdoor (%d %d %d)", a_Position.x, a_Position.y, a_Position.z);
 
+		// Use redstone data rather than block state so players can override redstone control
+		const auto Previous = DataForChunk(a_Chunk).ExchangeUpdateOncePowerData(a_Position, Power);
+		const bool IsOpen = (Previous != 0);
 		const bool ShouldBeOpen = Power != 0;
-		const bool IsOpen = (a_Meta & 0x4) == 0x4;
 
 		if (ShouldBeOpen != IsOpen)
 		{


### PR DESCRIPTION
Fixes #4831

The redstone sim should only close doors/trapdoors on the falling edge of a redstone signal, not whenever there is no signal.