### PR TITLE
Fixes windows hack in Compile.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -516,9 +516,10 @@ exit 0
 # Called via hack in line 2.
 :windows_detected
 @echo off
+cls
 echo This script is not available for Windows yet, sorry.
 echo You can still download the Windows binaries from: https://cuberite.org/
 echo You can also manually compile for Windows. See: https://github.com/cuberite/cuberite
 rem windows_exit
-exit
+goto :EOF
 }


### PR DESCRIPTION
- ``exit`` replaced with ``goto :EOF``
- added ``CLS`` to clear console spam from non-windows commands

Exit causes the entire windows CMD to exit before the user can actually see the message you wanted to print. You could just remove the exit command, but then the last closing brace is interpreted as command causing a spammy "command not recognised" message. ``goto :EOF`` jumps to then end of the file, cleanly returning to the CMD.
