### PR TITLE
Define _DEBUG macro for tests and main server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# TODO: use standard NDEBUG in place of _DEBUG
+if("${CMAKE_BUILD_TYPE}" MATCHES "DEBUG")
+	add_definitions(-D_DEBUG)
+endif()
+
 # The need for speed (in Release):
 if(WHOLE_PROGRAM_OPTIMISATION)
 	include(CheckIPOSupported)


### PR DESCRIPTION
Cuberite can now ASSERT its own failure once again...

Signed-off-by: @tigerw