### PR TITLE
fixed missing include for FreeBSD.

### DIFF
--- a/src/OSSupport/Network.h
+++ b/src/OSSupport/Network.h
@@ -13,6 +13,14 @@
 
 
 
+#ifdef __FreeBSD__
+#include <netinet/in.h>
+#endif
+
+
+
+
+
 // fwd:
 class cTCPLink;
 typedef std::shared_ptr<cTCPLink> cTCPLinkPtr;

--- a/src/OSSupport/Network.h
+++ b/src/OSSupport/Network.h
@@ -14,7 +14,7 @@
 
 
 #ifdef __FreeBSD__
-#include <netinet/in.h>
+	#include <netinet/in.h>
 #endif
 
 
@@ -362,7 +362,6 @@ public:
 	/** Returns all local IP addresses for network interfaces currently available. */
 	static AStringVector EnumLocalIPAddresses(void);
 };
-
 
 
 


### PR DESCRIPTION
Hello,

I tried to build cuberite on both my FreeBSD 12.1-RELEASE server and Ubuntu Server 20.4.1 on VM.
Building on Ubuntu Server was passed. But It was failed on FreeBSD with some error messages described below.

```
In file included from /home/(username)/minecraft/cuberite/build-cuberite/CMakeFiles/Cuberite.dir/Unity/unity_35_cxx.cxx:3:
In file included from /home/(username)/minecraft/cuberite/src/UI/Window.cpp:7:
In file included from /home/(username)/minecraft/cuberite/src/UI/../ClientHandle.h:12:
/home/(username)/minecraft/cuberite/src/OSSupport/Network.h:285:63: error: unknown type name 'sockaddr_in'
                virtual bool OnNameResolvedV4(const AString & a_Name, const sockaddr_in * a_IP) { return true; }
                                                                            ^
/home/(username)/minecraft/cuberite/src/OSSupport/Network.h:291:63: error: unknown type name 'sockaddr_in6'
                virtual bool OnNameResolvedV6(const AString & a_Name, const sockaddr_in6 * a_IP) { return true; }
                                                                            ^
In file included from /home/(username)/minecraft/cuberite/build-cuberite/CMakeFiles/Cuberite.dir/Unity/unity_37_cxx.cxx:5:
In file included from /home/(username)/minecraft/cuberite/src/WorldStorage/NBTChunkSerializer.cpp:16:
In file included from /home/(username)/minecraft/cuberite/src/WorldStorage/../BlockEntities/BrewingstandEntity.h:6:
In file included from /home/(username)/minecraft/cuberite/src/WorldStorage/../BlockEntities/../Root.h:7:
In file included from /home/(username)/minecraft/cuberite/src/HTTP/HTTPServer.h:12:
/home/(username)/minecraft/cuberite/src/HTTP/../OSSupport/Network.h:285:63: error: unknown type name 'sockaddr_in'
                virtual bool OnNameResolvedV4(const AString & a_Name, const sockaddr_in * a_IP) { return true; }
                                                                            ^
/home/(username)/minecraft/cuberite/src/HTTP/../OSSupport/Network.h:291:63: error: unknown type name 'sockaddr_in6'
In file included from /home/(username)/minecraft/cuberite/build-cuberite/CMakeFiles/Cuberite.dir/Unity/unity_36_cxx.cxx:4:
In file included from /home/(username)/minecraft/cuberite/src/UI/FurnaceWindow.cpp:10:
In file included from /home/(username)/minecraft/cuberite/src/UI/../Root.h:7:
In file included from /home/(username)/minecraft/cuberite/src/HTTP/HTTPServer.h:12:
/home/(username)/minecraft/cuberite/src/HTTP/../OSSupport/Network.h:285:63: error: unknown type name 'sockaddr_in'
                virtual bool OnNameResolvedV4(const AString & a_Name, const sockaddr_in * a_IP) { return true; }
                                                                            ^
/home/(username)/minecraft/cuberite/src/HTTP/../OSSupport/Network.h:291:63: error: unknown type name 'sockaddr_in6'
                virtual bool OnNameResolvedV6(const AString & a_Name, const sockaddr_in6 * a_IP) { return true; }
                                                                            ^
                virtual bool OnNameResolvedV6(const AString & a_Name, const sockaddr_in6 * a_IP) { return true; }
```

To fix this error, I searched the web and then I found that there is missing include in "src/OSSupport/Network.h".
So I fixed it. This makes only FreeBSD to include <netinet.in.h>.
