### PR TITLE
Fix silk-touching glowing redstone

### DIFF
--- a/src/Blocks/BlockOre.h
+++ b/src/Blocks/BlockOre.h
@@ -27,7 +27,12 @@ public:
 		// If using silk-touch, drop self rather than the resource:
 		if (ToolHasSilkTouch(a_Tool))
 		{
-			return cItem(m_BlockType);
+			switch (m_BlockType)
+			{
+				// If it was a glowing redstone ore, drop a normal redstone ore
+				case E_BLOCK_REDSTONE_ORE_GLOWING:   return cItem(E_BLOCK_REDSTONE_ORE);
+				default:                             return cItem(m_BlockType);
+			}
 		}
 
 		// TODO: Handle the Fortune enchantment here

--- a/src/Blocks/CMakeLists.txt
+++ b/src/Blocks/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources(
 	BlockRail.h
 	BlockRedstone.h
 	BlockRedstoneLamp.h
+	BlockRedstoneOre.h
 	BlockRedstoneRepeater.h
 	BlockRedstoneTorch.h
 	BlockSand.h


### PR DESCRIPTION
Fixed silk touch pickaxe not dropping redstone ore (it was dropping null a item instead) when breaking glowing redstone, implemented in #4661.
Also added src/BlocksRedstoneOre.h to relevant CMakeLists.txt