### PR TITLE
Clarify chunk destruction

### DIFF
--- a/src/BlockEntities/JukeboxEntity.cpp
+++ b/src/BlockEntities/JukeboxEntity.cpp
@@ -24,19 +24,6 @@ cJukeboxEntity::cJukeboxEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Ve
 
 
 
-cJukeboxEntity::~cJukeboxEntity()
-{
-	if (m_World && IsPlayingRecord())
-	{
-		// Stop playing music when destroyed by any means
-		m_World->BroadcastSoundParticleEffect(EffectID::SFX_RANDOM_PLAY_MUSIC_DISC, GetPos(), 0);
-	}
-}
-
-
-
-
-
 void cJukeboxEntity::Destroy(void)
 {
 	ASSERT(m_World != nullptr);

--- a/src/BlockEntities/JukeboxEntity.h
+++ b/src/BlockEntities/JukeboxEntity.h
@@ -22,7 +22,6 @@ public:  // tolua_export
 	BLOCKENTITY_PROTODEF(cJukeboxEntity)
 
 	cJukeboxEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
-	virtual ~cJukeboxEntity() override;
 
 	// tolua_begin
 

--- a/src/Blocks/BlockGrass.h
+++ b/src/Blocks/BlockGrass.h
@@ -52,7 +52,7 @@ private:
 		const Vector3i a_RelPos
 	) const override
 	{
-		if (!a_Chunk.GetWorld()->IsChunkLighted(a_Chunk.GetPosX(), a_Chunk.GetPosZ()))
+		if (!a_Chunk.IsLightValid())
 		{
 			a_Chunk.GetWorld()->QueueLightChunk(a_Chunk.GetPosX(), a_Chunk.GetPosZ());
 			return;
@@ -133,7 +133,7 @@ private:
 		}
 
 		auto Chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(a_RelPos);
-		if (Chunk == nullptr)
+		if ((Chunk == nullptr) || !Chunk->IsValid())
 		{
 			// Unloaded chunk
 			return;

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -90,6 +90,11 @@ public:
 	/** Returns true if the chunk could have been unloaded if it weren't dirty */
 	bool CanUnloadAfterSaving(void) const;
 
+	/** Called when the chunkmap unloads unused chunks.
+	Notifies contained entities that they are being unloaded and should for example, broadcast a destroy packet.
+	Not called during server shutdown; such cleanup during shutdown is unnecessary. */
+	void OnUnload();
+
 	bool IsLightValid(void) const {return m_IsLightValid; }
 
 	/*

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1717,10 +1717,17 @@ void cChunkMap::UnloadUnusedChunks(void)
 	for (auto itr = m_Chunks.begin(); itr != m_Chunks.end();)
 	{
 		if (
-			(itr->second.CanUnload()) &&  // Can unload
+			itr->second.CanUnload() &&  // Can unload
 			!cPluginManager::Get()->CallHookChunkUnloading(*GetWorld(), itr->first.ChunkX, itr->first.ChunkZ)  // Plugins agree
 		)
 		{
+			// First notify plugins:
+			cPluginManager::Get()->CallHookChunkUnloaded(*m_World, itr->first.ChunkX, itr->first.ChunkZ);
+
+			// Notify entities within the chunk, while everything's still valid:
+			itr->second.OnUnload();
+
+			// Kill the chunk:
 			itr = m_Chunks.erase(itr);
 		}
 		else

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -129,7 +129,6 @@ cClientHandle::~cClientHandle()
 		{
 			RemoveFromAllChunks();
 			m_Player->GetWorld()->RemoveClientFromChunkSender(this);
-			m_Player->DestroyNoScheduling(true);
 		}
 		// Send the Offline PlayerList packet:
 		cRoot::Get()->BroadcastPlayerListsRemovePlayer(*m_Player);

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -250,21 +250,6 @@ void cEntity::Destroy()
 
 
 
-void cEntity::DestroyNoScheduling(bool a_ShouldBroadcast)
-{
-	SetIsTicking(false);
-	if (a_ShouldBroadcast)
-	{
-		m_World->BroadcastDestroyEntity(*this);
-	}
-
-	Destroyed();
-}
-
-
-
-
-
 void cEntity::TakeDamage(cEntity & a_Attacker)
 {
 	int RawDamage = a_Attacker.GetRawDamageAgainst(*this);

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -341,9 +341,6 @@ public:
 	initialize clients with our position. */
 	Vector3d GetLastSentPosition(void) const { return m_LastSentPosition; }
 
-	/** Destroy the entity without scheduling memory freeing. This should only be used by cChunk or cClientHandle for internal memory management. */
-	void DestroyNoScheduling(bool a_ShouldBroadcast);
-
 	/** Makes this entity take damage specified in the a_TDI.
 	The TDI is sent through plugins first, then applied.
 	If it returns false, the entity hasn't receive any damage. */

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -226,6 +226,7 @@ cWorld::cWorld(
 
 	cFile::CreateFolderRecursive(m_DataPath);
 
+	// TODO: unique ptr unnecessary
 	m_ChunkMap = std::make_unique<cChunkMap>(this);
 	m_ChunkMap->TrackInDeadlockDetect(a_DeadlockDetect, m_WorldName);
 
@@ -964,11 +965,6 @@ void cWorld::Stop(cDeadlockDetect & a_DeadlockDetect)
 
 		m_MapManager.SaveMapData();
 	}
-
-	// Explicitly destroy the chunkmap, so that it's guaranteed to be destroyed before the other internals
-	// This fixes crashes on stopping the server, because chunk destructor deletes entities and those access the world.
-	// TODO: destructors should only be used for releasing resources, not doing extra work
-	m_ChunkMap.reset();
 }
 
 


### PR DESCRIPTION
The aim of this PR is to make sure cChunk's destructor doesn't access objects already destroyed. Destructors should be used for releasing resources under our control; doing extra work especially in delicate scenarios like shutdown is a recipe for crashes.

The crash in #4894 was due to the chunkmap, and thus all chunks, being explicitly (and unexpectedly) destroyed the moment cRoot got a stop signal and called cWorld::Stop. When the plugin manager attempted to unload plugins, cLuaWindow tried to enumerate players and hit an invalid chunkmap.

cWorld::Stop no longer jumps the gun by deleting the chunkmap early. Contrary to the comment, cEntity doesn't do any manipulation during destruction. Of the block entities, only Jukeboxes tried to access the world in its destructor to stop playing music. Thankfully music abruptly stopping on chunk unload is undesired behaviour and the client doesn't accept sound effect packets to unloaded chunks, so the destructor was safely deleted.

Entities need to broadcast to clients a 'destroy' packet when they are despawned, but only if there was a corresponding 'spawn' packet. Nothing needs to be broadcast during server shutdown. This is now all handled by cEntity::OnAddedToWorld/OnRemovedFromWorld.

To this effect cEntity::DestroyNoScheduling has been removed. Firstly, we need to always broadcast despawns since entities in unloaded chunks are known to misbehave: #3696. Additionally, we do not need to call Destroyed since cWorld::RemoveEntity will do it (and if the entity was merely in an unloaded chunk, it has not been Destroyed, only suspended).

The last point should fix two issues, firstly that players no longer broadcast two 'despawn' packets, one from cWorld::RemovePlayer, another from DestroyNoScheduling. Secondly, we no longer forget to reset pointers to destroyed entities when a leashed mob unloads.