### PR TITLE
Adding Cloning Infrastructure for entities

### DIFF
--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -55,6 +55,22 @@ bool cArrowEntity::CanPickup(const cPlayer & a_Player) const
 
 
 
+void cArrowEntity::CopyFrom(const cEntity &a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & Arrow = static_cast<const cArrowEntity &>(a_Src);
+	m_PickupState = Arrow.m_PickupState;
+	m_DamageCoeff = Arrow.m_DamageCoeff;
+	m_IsCritical = Arrow.m_IsCritical;
+	m_Timer = Arrow.m_Timer;
+	m_bIsCollected = Arrow.m_bIsCollected;
+	m_HitBlockPos = Arrow.m_HitBlockPos;
+}
+
+
+
+
+
 void cArrowEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
 	// Save the direction we're going in before Super resets it

--- a/src/Entities/ArrowEntity.h
+++ b/src/Entities/ArrowEntity.h
@@ -78,6 +78,9 @@ public:
 	/** Sets the block arrow is in. To be used by the MCA loader only! */
 	void SetBlockHit(const Vector3i & a_BlockHit) { m_HitBlockPos = a_BlockHit; }
 
+	// cEntity Overrides:
+	void CopyFrom(const cEntity &a_Src) override;
+
 protected:
 
 	/** Determines when the arrow can be picked up by players */

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -208,6 +208,21 @@ void cBoat::UpdatePaddles(bool a_RightPaddleUsed, bool a_LeftPaddleUsed)
 
 
 
+void cBoat::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & Boat = static_cast<const cBoat &>(a_Src);
+	m_LastDamage = Boat.m_LastDamage;
+	m_ForwardDirection = Boat.m_ForwardDirection;
+	m_DamageTaken = Boat.m_DamageTaken;
+	m_RightPaddleUsed = Boat.m_RightPaddleUsed;
+	m_LeftPaddleUsed = Boat.m_LeftPaddleUsed;
+}
+
+
+
+
+
 cBoat::eMaterial cBoat::ItemToMaterial(const cItem & a_Item)
 {
 	switch (a_Item.m_ItemType)

--- a/src/Entities/Boat.h
+++ b/src/Entities/Boat.h
@@ -82,6 +82,10 @@ public:
 	void SetLastDamage(int TimeSinceLastHit);
 
 	void UpdatePaddles(bool rightPaddleUsed, bool leftPaddleUsed);
+
+	// cEntity overrides:
+	void CopyFrom(const cEntity &a_Src) override;
+
 private:
 	int m_LastDamage;
 	int m_ForwardDirection;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -19,6 +19,7 @@
 
 // Descendants for cloning
 #include "Boat.h"
+#include "EnderCrystal.h"
 #include "ExpOrb.h"
 #include "FallingBlock.h"
 #include "Floater.h"

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -601,8 +601,16 @@ public:
 	@param a_ExplosionPosition explosion position
 	@param a_ExlosionPower explosion power
 	@return exposure rate */
-	virtual float GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_ExlosionPower);
+	virtual float GetExplosionExposureRate(Vector3d a_ExplosionPosition, float a_ExplosionPower);
 
+	/** Makes an exact copy of this entity, except for its m_World (set to nullptr), and at a new position.
+	Uses CopyFrom() to copy the properties. */
+	virtual std::unique_ptr<cEntity> Clone(Vector3d a_Pos);
+
+	/** Copies all properties of a_Src into this entity, except for its m_World and location.
+	Each non-abstract descendant should override to copy its specific properties, and call
+	Super::CopyFrom(a_Src) to copy the common ones. */
+	virtual void CopyFrom(const cEntity & a_Src);
 
 protected:
 

--- a/src/Entities/ExpOrb.cpp
+++ b/src/Entities/ExpOrb.cpp
@@ -129,3 +129,14 @@ std::vector<int> cExpOrb::Split(int a_Reward)
 }
 
 
+
+
+
+void cExpOrb::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & ExpOrb = static_cast<const cExpOrb &>(a_Src);
+	m_Timer = ExpOrb.m_Timer;
+}
+
+

--- a/src/Entities/ExpOrb.h
+++ b/src/Entities/ExpOrb.h
@@ -47,6 +47,9 @@ public:  // tolua_export
 	/** Split reward into small values according to regular Minecraft rules */
 	static std::vector<int> Split(int a_Reward);
 
+	// cEntity override
+	void CopyFrom(const cEntity &a_Src) override;
+
 protected:
 	int m_Reward;
 

--- a/src/Entities/FireworkEntity.cpp
+++ b/src/Entities/FireworkEntity.cpp
@@ -21,6 +21,17 @@ cFireworkEntity::cFireworkEntity(cEntity * a_Creator, Vector3d a_Pos, const cIte
 
 
 
+void cFireworkEntity::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & Firework = static_cast<const cFireworkEntity &>(a_Src);
+	m_TicksToExplosion = Firework.m_TicksToExplosion;
+}
+
+
+
+
+
 void cFireworkEntity::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	int RelX = POSX_TOINT - a_Chunk.GetPosX() * cChunkDef::Width;

--- a/src/Entities/FireworkEntity.h
+++ b/src/Entities/FireworkEntity.h
@@ -46,6 +46,9 @@ public:  // tolua_export
 
 	// tolua_end
 
+	// Entity overrides
+	void CopyFrom(const cEntity &a_Src) override;
+
 protected:
 
 	// cProjectileEntity overrides:

--- a/src/Entities/Floater.cpp
+++ b/src/Entities/Floater.cpp
@@ -197,3 +197,16 @@ void cFloater::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 	BroadcastMovementUpdate();
 }
+
+
+
+
+
+void cFloater::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & Floater = static_cast<const cFloater &>(a_Src);
+	m_CanPickupItem = Floater.m_CanPickupItem;
+	m_CountDownTime = Floater.m_CountDownTime;
+	m_AttachedMobID = Floater.m_AttachedMobID;
+}

--- a/src/Entities/Floater.h
+++ b/src/Entities/Floater.h
@@ -25,11 +25,16 @@ public:  // tolua_export
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
 	// tolua_begin
-	bool CanPickup(void)       const { return m_CanPickupItem; }
+	bool CanPickup(void)          const { return m_CanPickupItem; }
 	UInt32 GetOwnerID(void)       const { return m_PlayerID; }
 	UInt32 GetAttachedMobID(void) const { return m_AttachedMobID; }
 	Vector3d GetBitePos(void)     const { return m_BitePos; }
 	// tolua_end
+
+	int GetPickupCountTine(void)  const { return m_CountDownTime; }
+
+	// cEntity overrides:
+	void CopyFrom(const cEntity &a_Src) override;
 
 protected:
 	// Position

--- a/src/Entities/ItemFrame.cpp
+++ b/src/Entities/ItemFrame.cpp
@@ -20,6 +20,18 @@ cItemFrame::cItemFrame(eBlockFace a_BlockFace, Vector3d a_Pos):
 
 
 
+void cItemFrame::CopyFrom(const cEntity &a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & ItemFrame = static_cast<const cItemFrame &>(a_Src);
+	m_Item = ItemFrame.m_Item;
+	m_ItemRotation = ItemFrame.m_ItemRotation;
+}
+
+
+
+
+
 void cItemFrame::OnRightClicked(cPlayer & a_Player)
 {
 	Super::OnRightClicked(a_Player);

--- a/src/Entities/ItemFrame.h
+++ b/src/Entities/ItemFrame.h
@@ -37,6 +37,9 @@ public:  // tolua_export
 
 	// tolua_end
 
+	// cEntity overrides:
+	virtual void CopyFrom(const cEntity & a_Src) override;
+
 private:
 
 	virtual void OnRightClicked(cPlayer & a_Player) override;

--- a/src/Entities/LeashKnot.cpp
+++ b/src/Entities/LeashKnot.cpp
@@ -159,3 +159,15 @@ cLeashKnot * cLeashKnot::FindKnotAtPos(cWorldInterface & a_WorldInterface, Vecto
 
 
 
+
+void cLeashKnot::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & LeashKnot = static_cast<const cLeashKnot &>(a_Src);
+	m_ShouldSelfDestroy = LeashKnot.m_ShouldSelfDestroy;
+	m_TicksToSelfDestroy = LeashKnot.m_TicksToSelfDestroy;
+}
+
+
+
+

--- a/src/Entities/LeashKnot.h
+++ b/src/Entities/LeashKnot.h
@@ -30,6 +30,9 @@ public:  // tolua_export
 	/** Returns the leash knot entity representing the knot at the specified position. Returns nullptr if there's no knot. */
 	static cLeashKnot * FindKnotAtPos(cWorldInterface & a_WorldInterface, Vector3i a_BlockPos);
 
+	// cEntity overrides
+	virtual void CopyFrom(const cEntity & a_Src) override;
+
 private:
 
 	/** When a fence is destroyed, the knot on it gets destroyed after a while. This flag turns on the countdown to self destroy. */

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1326,6 +1326,66 @@ void cMinecart::Destroyed()
 
 
 
+std::unique_ptr<cEntity> cMinecart::MakeClone(Vector3d a_Pos)
+{
+	switch (m_Payload)
+	{
+		case mpNone:
+		{
+			auto & Rideable = static_cast<cRideableMinecart &>(*this);
+			auto Clone = std::make_unique<cRideableMinecart>(a_Pos, Rideable.GetContent(), (int) Rideable.GetHeight());
+			Clone->CopyFrom(Rideable);
+			return Clone;
+		}
+		case mpChest:
+		{
+			auto & Chest = static_cast<cRideableMinecart &>(*this);
+			auto Clone = std::make_unique<cMinecartWithChest>(a_Pos);
+			Clone->CopyFrom(Chest);
+			return Clone;
+		}
+		case mpFurnace:
+		{
+			auto & Furnace = static_cast<cMinecartWithFurnace &>(*this);
+			auto Clone = std::make_unique<cMinecartWithFurnace>(a_Pos);
+			Clone->CopyFrom(Furnace);
+			return Clone;
+		}
+		case mpTNT:
+		{
+			auto Clone = std::make_unique<cMinecartWithTNT>(a_Pos);
+			Clone->CopyFrom(*this);
+			return Clone;
+		}
+		case mpHopper:
+		{
+			auto & Hopper = static_cast<cMinecartWithHopper &>(*this);
+			auto Clone = std::make_unique<cMinecartWithHopper>(a_Pos);
+			Clone->CopyFrom(Hopper);
+			return Clone;
+		}
+	}
+	UNREACHABLE("Tried to clone unknown Minecart type!");
+	return nullptr;
+}
+
+
+
+
+
+void cMinecart::CopyFrom(const cEntity & a_Src)
+{
+	auto & Minecart = static_cast<const cMinecart &>(a_Src);
+	Super::CopyFrom(a_Src);
+	m_LastDamage = Minecart.m_LastDamage;
+	m_DetectorRailPosition = Minecart.m_DetectorRailPosition;
+	m_bIsOnDetectorRail = Minecart.m_bIsOnDetectorRail;
+}
+
+
+
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // cRideableMinecart:
 
@@ -1365,6 +1425,15 @@ void cRideableMinecart::OnRightClicked(cPlayer & a_Player)
 
 	// Attach the player to this minecart
 	a_Player.AttachTo(this);
+}
+
+
+
+
+
+void cRideableMinecart::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
 }
 
 
@@ -1445,6 +1514,17 @@ void cMinecartWithChest::Destroyed()
 
 
 
+void cMinecartWithChest::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & Chest = static_cast<const cMinecartWithChest &>(a_Src);
+	m_Contents.CopyFrom(Chest.m_Contents);
+}
+
+
+
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // cMinecartWithFurnace:
 
@@ -1512,6 +1592,18 @@ void cMinecartWithFurnace::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk
 
 
 
+void cMinecartWithFurnace::CopyFrom(const cEntity &a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & Furnace = static_cast<const cMinecartWithFurnace &>(a_Src);
+	m_FueledTimeLeft = Furnace.m_FueledTimeLeft;
+	m_IsFueled = Furnace.m_IsFueled;
+}
+
+
+
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // cMinecartWithTNT:
 
@@ -1521,6 +1613,13 @@ cMinecartWithTNT::cMinecartWithTNT(Vector3d a_Pos):
 }
 
 // TODO: Make it activate when passing over activator rail
+
+
+
+void cMinecartWithTNT::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+}
 
 
 
@@ -1536,3 +1635,9 @@ cMinecartWithHopper::cMinecartWithHopper(Vector3d a_Pos):
 
 // TODO: Make it suck up blocks and travel further than any other cart and physics and put and take blocks
 // AND AVARYTHING!!
+
+
+void cMinecartWithHopper::CopyFrom(const cEntity &a_Src)
+{
+	Super::CopyFrom(a_Src);
+}

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -45,6 +45,9 @@ public:
 	int LastDamage(void) const { return m_LastDamage; }
 	ePayload GetPayload(void) const { return m_Payload; }
 
+	std::unique_ptr<cEntity> MakeClone(Vector3d a_Pos);
+	void CopyFrom(const cEntity &a_Src) override;
+
 
 protected:
 
@@ -115,6 +118,7 @@ public:
 
 	// cEntity overrides:
 	virtual void OnRightClicked(cPlayer & a_Player) override;
+	void CopyFrom(const cEntity &a_Src) override;
 
 protected:
 
@@ -148,6 +152,9 @@ public:
 
 	const cItem & GetSlot(int a_Idx) const { return m_Contents.GetSlot(a_Idx); }
 	void SetSlot(int a_Idx, const cItem & a_Item) { m_Contents.SetSlot(a_Idx, a_Item); }
+
+	// cEntity overrides:
+	void CopyFrom(const cEntity &a_Src) override;
 
 
 protected:
@@ -194,6 +201,7 @@ public:
 	// cEntity overrides:
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
+	void CopyFrom(const cEntity &a_Src) override;
 
 	// Set functions.
 	void SetIsFueled(bool a_IsFueled, int a_FueledTimeLeft = -1) {m_IsFueled = a_IsFueled; m_FueledTimeLeft = a_FueledTimeLeft;}
@@ -222,6 +230,9 @@ public:
 	CLASS_PROTODEF(cMinecartWithTNT)
 
 	cMinecartWithTNT(Vector3d a_Pos);
+
+	// cEntity overrides:
+	void CopyFrom(const cEntity &a_Src) override;
 } ;
 
 
@@ -238,4 +249,7 @@ public:
 	CLASS_PROTODEF(cMinecartWithHopper)
 
 	cMinecartWithHopper(Vector3d a_Pos);
+
+	// cEntity overrides:
+	void CopyFrom(const cEntity &a_Src) override;
 } ;

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -266,3 +266,19 @@ bool cPickup::CollectedBy(cPlayer & a_Dest)
 	// LOG("Pickup %d cannot be collected by \"%s\", because there's no space in the inventory.", a_Dest->GetName().c_str(), m_UniqueID);
 	return false;
 }
+
+
+
+
+
+void cPickup::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & Other = static_cast<const cPickup &>(a_Src);
+	m_Timer = Other.m_Timer;
+	m_Item = Other.m_Item;
+	m_bCollected = Other.m_bCollected;
+	m_bIsPlayerCreated = Other.m_bIsPlayerCreated;
+	m_bCanCombine = Other.m_bCanCombine;
+	m_Lifetime = Other.m_Lifetime;
+}

--- a/src/Entities/Pickup.h
+++ b/src/Entities/Pickup.h
@@ -65,6 +65,8 @@ public:  // tolua_export
 	/** Returns true if created by player (i.e. vomiting), used for determining picking-up delay time */
 	bool IsPlayerCreated(void) const { return m_bIsPlayerCreated; }  // tolua_export
 
+	void CopyFrom(const cEntity &a_Src) override;
+
 private:
 
 	/** The number of ticks that the entity has existed / timer between collect and destroy; in msec */

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -354,6 +354,58 @@ AString cProjectileEntity::GetMCAClassName(void) const
 
 
 
+std::unique_ptr<cEntity> cProjectileEntity::MakeClone(Vector3d a_Pos)
+{
+	cEntity * Creator;
+	m_World->DoWithEntityByID(m_CreatorData.m_UniqueID, [&] (cEntity & a_Entity){ Creator = & a_Entity;  return true; });
+	std::unique_ptr<cEntity> Clone;
+	switch (m_ProjectileKind)
+	{
+		case pkArrow:         Clone = std::make_unique<cArrowEntity>           (Creator, a_Pos, m_Speed);
+		case pkEgg:           Clone = std::make_unique<cThrownEggEntity>       (Creator, a_Pos, m_Speed);
+		case pkEnderPearl:    Clone = std::make_unique<cThrownEnderPearlEntity>(Creator, a_Pos, m_Speed);
+		case pkSnowball:      Clone = std::make_unique<cThrownSnowballEntity>  (Creator, a_Pos, m_Speed);
+		case pkGhastFireball: Clone = std::make_unique<cGhastFireballEntity>   (Creator, a_Pos, m_Speed);
+		case pkFireCharge:    Clone = std::make_unique<cFireChargeEntity>      (Creator, a_Pos, m_Speed);
+		case pkExpBottle:     Clone = std::make_unique<cExpBottleEntity>       (Creator, a_Pos, m_Speed);
+		case pkWitherSkull:   Clone = std::make_unique<cWitherSkullEntity>     (Creator, a_Pos, m_Speed);
+		case pkFirework:
+		{
+			auto & Firework = static_cast<cFireworkEntity &>(*this);
+			auto Item = Firework.GetItem();
+			if (Item.m_FireworkItem.m_Colours.empty())
+			{
+				return nullptr;
+			}
+
+			Clone = std::make_unique<cFireworkEntity>(Creator, a_Pos, Item);
+		}
+		case pkSplashPotion:
+		{
+			auto & SplashPotion = static_cast<cSplashPotionEntity &>(*this);
+			auto Item = SplashPotion.GetItem();
+			Clone = std::make_unique<cSplashPotionEntity>(Creator, a_Pos, m_Speed, Item);
+		}
+	}
+	Clone->CopyFrom(*this);
+	return Clone;
+}
+
+
+
+
+
+void cProjectileEntity::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & Projectile = static_cast<const cProjectileEntity &>(a_Src);
+	m_IsInGround = Projectile.m_IsInGround;
+}
+
+
+
+
+
 void cProjectileEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	Super::Tick(a_Dt, a_Chunk);

--- a/src/Entities/ProjectileEntity.h
+++ b/src/Entities/ProjectileEntity.h
@@ -110,6 +110,15 @@ public:
 	/** Sets the internal InGround flag. To be used by MCA loader only! */
 	void SetIsInGround(bool a_IsInGround) { m_IsInGround = a_IsInGround; }
 
+	/** Makes an exact copy of this entity, except for its m_World (set to nullptr), and at a new position.
+	Uses CopyFrom() to copy the properties. */
+	std::unique_ptr<cEntity> MakeClone(Vector3d a_Pos);
+
+	/** Copies all properties of a_Src into this entity, except for its m_World and location.
+	Each non-abstract descendant should override to copy its specific properties, and call
+	Super::CopyFrom(a_Src) to copy the common ones. */
+	virtual void CopyFrom(const cEntity & a_Src);
+
 protected:
 
 	/** A structure that stores the Entity ID and Playername of the projectile's creator

--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -34,6 +34,20 @@ cSplashPotionEntity::cSplashPotionEntity(
 
 
 
+void cSplashPotionEntity::CopyFrom(const cEntity &a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & SplashPotion = static_cast<const cSplashPotionEntity &>(a_Src);
+	m_EntityEffectType = SplashPotion.m_EntityEffectType;
+	m_EntityEffect = SplashPotion.m_EntityEffect;
+	m_PotionColor = SplashPotion.m_PotionColor;
+	m_DestroyTimer = SplashPotion.m_DestroyTimer;
+}
+
+
+
+
+
 void cSplashPotionEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
 	Splash(a_HitPos);

--- a/src/Entities/SplashPotionEntity.h
+++ b/src/Entities/SplashPotionEntity.h
@@ -52,6 +52,9 @@ public:  // tolua_export
 	cEntityEffect        GetEntityEffect(void)     const { return m_EntityEffect; }
 	void SetEntityEffect(cEntityEffect a_EntityEffect) { m_EntityEffect = a_EntityEffect; }
 
+	// cEntity overrides:
+	void CopyFrom(const cEntity &a_Src) override;
+
 protected:
 
 	cEntityEffect::eType m_EntityEffectType;

--- a/src/Entities/TNTEntity.cpp
+++ b/src/Entities/TNTEntity.cpp
@@ -68,3 +68,12 @@ void cTNTEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 
 
+
+void cTNTEntity::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+}
+
+
+
+

--- a/src/Entities/TNTEntity.h
+++ b/src/Entities/TNTEntity.h
@@ -38,6 +38,9 @@ public:  // tolua_export
 
 	// tolua_end
 
+	// cEntityOverrides:
+	void CopyFrom(const cEntity &a_Src) override;
+
 protected:
 	int m_FuseTicks;      ///< How much ticks is left, while the tnt will explode
 };  // tolua_export

--- a/src/Entities/ThrownEggEntity.cpp
+++ b/src/Entities/ThrownEggEntity.cpp
@@ -72,6 +72,17 @@ void cThrownEggEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 
 
+void cThrownEggEntity::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & Egg = static_cast<const cThrownEggEntity &>(a_Src);
+	m_DestroyTimer = Egg.m_DestroyTimer;
+}
+
+
+
+
+
 void cThrownEggEntity::TrySpawnChicken(Vector3d a_HitPos)
 {
 	auto & Random = GetRandomProvider();

--- a/src/Entities/ThrownEggEntity.h
+++ b/src/Entities/ThrownEggEntity.h
@@ -30,6 +30,9 @@ public:  // tolua_export
 
 	cThrownEggEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
+	// cEntityOverrides:
+	void CopyFrom(const cEntity & a_Src) override;
+
 protected:
 
 	// cProjectileEntity overrides:

--- a/src/Entities/ThrownEnderPearlEntity.cpp
+++ b/src/Entities/ThrownEnderPearlEntity.cpp
@@ -19,6 +19,17 @@ cThrownEnderPearlEntity::cThrownEnderPearlEntity(cEntity * a_Creator, Vector3d a
 
 
 
+void cThrownEnderPearlEntity::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & EnderPearl = static_cast<const cThrownEnderPearlEntity &>(a_Src);
+	m_DestroyTimer = EnderPearl.m_DestroyTimer;
+}
+
+
+
+
+
 void cThrownEnderPearlEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
 	// TODO: Tweak a_HitPos based on block face.

--- a/src/Entities/ThrownEnderPearlEntity.h
+++ b/src/Entities/ThrownEnderPearlEntity.h
@@ -30,6 +30,9 @@ public:  // tolua_export
 
 	cThrownEnderPearlEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
+	// cEntity overrides:
+	void CopyFrom(const cEntity & a_Src) override;
+
 protected:
 
 	// cProjectileEntity overrides:

--- a/src/Entities/ThrownSnowballEntity.cpp
+++ b/src/Entities/ThrownSnowballEntity.cpp
@@ -18,6 +18,17 @@ cThrownSnowballEntity::cThrownSnowballEntity(cEntity * a_Creator, Vector3d a_Pos
 
 
 
+void cThrownSnowballEntity::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	const auto & SnowBall = static_cast<const cThrownSnowballEntity &>(a_Src);
+	m_DestroyTimer = SnowBall.m_DestroyTimer;
+}
+
+
+
+
+
 void cThrownSnowballEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
 	m_DestroyTimer = 2;

--- a/src/Entities/ThrownSnowballEntity.h
+++ b/src/Entities/ThrownSnowballEntity.h
@@ -30,6 +30,9 @@ public:  // tolua_export
 
 	cThrownSnowballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
+	// cEntity overrides:
+	void CopyFrom(const cEntity &a_Src) override;
+
 protected:
 
 	// cProjectileEntity overrides:

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1512,3 +1512,62 @@ void cMonster::Unleash(bool a_ShouldDropLeashPickup)
 {
 	Unleash(a_ShouldDropLeashPickup, true);
 }
+
+
+
+
+
+std::unique_ptr<cEntity> cMonster::MakeClone(Vector3d a_Pos)
+{
+	auto Clone = NewMonsterFromType(m_MobType);
+	Clone->CopyFrom(*this);
+	Clone->SetPosition(a_Pos);
+	return Clone;
+}
+
+
+
+
+
+void cMonster::CopyFrom(const cEntity & a_Src)
+{
+	Super::CopyFrom(a_Src);
+	auto & Monster = static_cast<const cMonster &>(a_Src);
+	m_PathFinder = cPathFinder(GetWidth(), GetHeight());
+	m_PathfinderActivated = Monster.m_PathfinderActivated;
+	m_FinalDestination = Monster.m_FinalDestination;
+	m_JumpCoolDown= Monster.m_JumpCoolDown;
+	m_IdleInterval = Monster.m_IdleInterval;
+	m_DestroyTimer = Monster.m_DestroyTimer;
+	m_CustomName = Monster.m_CustomName;
+	m_CustomNameAlwaysVisible = Monster.m_CustomNameAlwaysVisible;
+	m_SoundHurt = Monster.m_SoundHurt;
+	m_SoundDeath = Monster.m_SoundDeath;
+	m_SoundAmbient = Monster.m_SoundAmbient;
+	m_AttackRate = Monster.m_AttackRate;
+	m_AttackDamage = Monster.m_AttackDamage;
+	m_AttackRange = Monster.m_AttackRange;
+	m_AttackCoolDownTicksLeft = Monster.m_AttackCoolDownTicksLeft;
+	m_SightDistance = Monster.m_SightDistance;
+	m_DropChanceWeapon = Monster.m_DropChanceWeapon;
+	m_DropChanceHelmet = Monster.m_DropChanceHelmet;
+	m_DropChanceChestplate = Monster.m_DropChanceChestplate;
+	m_DropChanceLeggings = Monster.m_DropChanceLeggings;
+	m_DropChanceBoots = Monster.m_DropChanceBoots;
+	m_CanPickUpLoot = Monster.m_CanPickUpLoot;
+	m_TicksSinceLastDamaged = Monster.m_TicksSinceLastDamaged;
+
+	m_BurnsInDaylight = Monster.m_BurnsInDaylight;
+	m_RelativeWalkSpeed = Monster.m_RelativeWalkSpeed;
+	m_AmbientSoundTimer = Monster.m_AmbientSoundTimer;
+	m_Age = Monster.m_Age;
+	m_AgingTimer = Monster.m_AgingTimer;
+	m_WasLastTargetAPlayer = Monster.m_WasLastTargetAPlayer;
+	m_LeashedTo = Monster.m_LeashedTo;
+	m_LeashToPos->x = Monster.m_LeashToPos->x;
+	m_LeashToPos->y = Monster.m_LeashToPos->y;
+	m_LeashToPos->z = Monster.m_LeashToPos->z;
+	m_IsLeashActionJustDone = Monster.m_IsLeashActionJustDone;
+	m_CanBeLeashed = Monster.m_CanBeLeashed;
+	m_Target = Monster.m_Target;
+}

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -217,6 +217,15 @@ public:
 	/** Returns if this mob last target was a player to avoid destruction on player quit */
 	bool WasLastTargetAPlayer() const { return m_WasLastTargetAPlayer; }
 
+	/** Makes an exact copy of this entity, except for its m_World (set to nullptr), and at a new position.
+	Uses CopyFrom() to copy the properties. */
+	std::unique_ptr<cEntity> MakeClone(Vector3d a_Pos);
+
+	/** Copies all properties of a_Src into this entity, except for its m_World and location.
+	Each non-abstract descendant should override to copy its specific properties, and call
+	Super::CopyFrom(a_Src) to copy the common ones. */
+	virtual void CopyFrom(const cEntity & a_Src) override;
+
 protected:
 
 	/** The pathfinder instance handles pathfinding for this monster. */


### PR DESCRIPTION
This PR adds a clone infrastructure like the one for block entities.

This is needed for some things:
- Entities in ```cBlockArea```
- Custom Mobs in mob spawners #4916 
- #4919 
- ...

Things that are missing
- [ ] Mobs
- [ ] handle attached entities (that need some tinkering). at the moment only the pointers are copied numbly)
- [ ] testing