### PR TITLE
Fixed current end generator

### DIFF
--- a/src/Generating/EndGen.h
+++ b/src/Generating/EndGen.h
@@ -41,10 +41,6 @@ protected:
 	NOISE_DATATYPE m_FrequencyY;
 	NOISE_DATATYPE m_FrequencyZ;
 
-	// Minimum and maximum chunk coords for chunks inside the island area. Chunks outside won't get calculated at all
-	int m_MinChunkX, m_MaxChunkX;
-	int m_MinChunkZ, m_MaxChunkZ;
-
 	// Noise array for the last chunk (in the noise range)
 	cChunkCoords m_LastChunkCoords;
 	NOISE_DATATYPE m_NoiseArray[17 * 17 * 257];  // x + 17 * z + 17 * 17 * y
@@ -55,10 +51,6 @@ protected:
 
 	/** Generates the m_NoiseArray array for the current chunk */
 	void GenerateNoiseArray(void);
-
-	/** Returns true if the chunk is outside of the island's dimensions */
-	bool IsChunkOutsideRange(cChunkCoords a_ChunkCoords);
-
 
 	// cTerrainShapeGen overrides:
 	virtual void GenShape(cChunkCoords a_ChunkCoords, cChunkDesc::Shape & a_Shape) override;


### PR DESCRIPTION
Fixed the current end generator.

![2020-10-04_15 23 07](https://user-images.githubusercontent.com/1160867/95017993-eee9f500-065c-11eb-8858-90baea16e938.png)

There was also a problem where the `m_MinChunkXYZ` variables were reset to 0. As the end generation needs an update anyway since the end now continues to generate after the initial island I removed those variables instead of finding the problem.