### PR TITLE
Warnings improvements

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -111,14 +111,6 @@ function(set_global_flags)
 	endif()
 endfunction()
 
-function (try_add_flag TARGET FLAG)
-	include(CheckCXXCompilerFlag)
-	check_cxx_compiler_flag("${FLAG}" "HAS_FLAG_${FLAG}")
-	if ("${HAS_FLAG_${FLAG}}")
-		target_compile_options(${TARGET} PRIVATE "${FLAG}")
-	endif()
-endfunction()
-
 function(set_exe_flags TARGET)
 	if (MSVC)
 		# TODO: MSVC level 4, warnings as errors
@@ -158,15 +150,27 @@ function(set_exe_flags TARGET)
 			-Wno-switch-enum
 
 			# Weverything with Clang exceptions:
-			-Weverything -Wno-error=disabled-macro-expansion -Wno-weak-vtables
-			-Wno-exit-time-destructors -Wno-string-conversion -Wno-c++98-compat-pedantic
-			-Wno-documentation -Wno-documentation-unknown-command -Wno-reserved-id-macro
-			-Wno-error=unused-command-line-argument
+			-Weverything -Wno-exit-time-destructors -Wno-error=disabled-macro-expansion
+			-Wno-weak-vtables -Wno-string-conversion -Wno-c++98-compat-pedantic -Wno-documentation
+			-Wno-documentation-unknown-command -Wno-reserved-id-macro -Wno-error=unused-command-line-argument
 		)
 
-		# We aren't using C++11
-		try_add_flag(${TARGET} -Wno-return-std-move-in-c++11)
-		# int to float conversions happen a lot, not worth fixing all warnings
-		try_add_flag(${TARGET} -Wno-implicit-int-float-conversion)
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7)
+			target_compile_options(
+				${TARGET} PRIVATE
+
+				# We aren't using C++11:
+				-Wno-return-std-move-in-c++11
+			)
+		endif()
+
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+			target_compile_options(
+				${TARGET} PRIVATE
+
+				# int to float conversions happen a lot, not worth fixing all warnings:
+				-Wno-implicit-int-float-conversion
+			)
+		endif()
 	endif()
 endfunction()

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -665,10 +665,9 @@ public:
 	bool GetStackValue(int a_StackPos, cUUID & a_Value);
 
 	// template to catch all of the various c++ integral types without overload conflicts
-	template <class T>
-	bool GetStackValue(int a_StackPos, T & a_ReturnedVal, typename std::enable_if<std::is_integral<T>::value>::type * unused = nullptr)
+	template <class T, typename = std::enable_if_t<std::is_integral_v<T>>>
+	bool GetStackValue(int a_StackPos, T & a_ReturnedVal)
 	{
-		UNUSED(unused);
 		if (!lua_isnumber(m_LuaState, a_StackPos))  // Also accepts strings representing a number: https://pgl.yoyo.org/luai/i/lua_isnumber
 		{
 			return false;

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -2760,7 +2760,7 @@ static int tolua_cItem_EnchantByXPLevels(lua_State * tolua_S)
 
 	// Get the params:
 	cItem * Self;
-	int NumXPLevels;
+	unsigned NumXPLevels;
 	L.GetStackValue(1, Self);
 	L.GetStackValue(2, NumXPLevels);
 

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -479,8 +479,15 @@ bool cChunk::HasBlockEntityAt(Vector3i a_BlockPos)
 
 void cChunk::Stay(bool a_Stay)
 {
-	m_StayCount += (a_Stay ? 1 : -1);
-	ASSERT(m_StayCount >= 0);
+	if (a_Stay)
+	{
+		m_StayCount++;
+	}
+	else
+	{
+		ASSERT(m_StayCount != 0);
+		m_StayCount--;
+	}
 }
 
 

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -589,7 +589,7 @@ private:
 	cBlockEntities m_BlockEntities;
 
 	/** Number of times the chunk has been requested to stay (by various cChunkStay objects); if zero, the chunk can be unloaded */
-	int m_StayCount;
+	unsigned m_StayCount;
 
 	int m_PosX, m_PosZ;
 	cWorld *    m_World;
@@ -619,7 +619,7 @@ private:
 	/** If greater than zero, the chunk is ticked even if it has no clients.
 	Manipulated by the SetAlwaysTicked() function, allows for nested calls of the function.
 	This is the support for plugin-accessible chunk tick forcing. */
-	int m_AlwaysTicked;
+	unsigned m_AlwaysTicked;
 
 	// Pick up a random block of this chunk
 	void GetRandomBlockCoords(int & a_X, int & a_Y, int & a_Z);

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -50,12 +50,12 @@ class cClientHandle  // tolua_export
 public:  // tolua_export
 
 	#if defined(ANDROID)
-		static const int DEFAULT_VIEW_DISTANCE = 4;  // The default ViewDistance (used when no value is set in Settings.ini)
+		static const unsigned DEFAULT_VIEW_DISTANCE = 4;  // The default ViewDistance (used when no value is set in Settings.ini)
 	#else
-		static const int DEFAULT_VIEW_DISTANCE = 10;
+		static const unsigned DEFAULT_VIEW_DISTANCE = 10;
 	#endif
-	static const int MAX_VIEW_DISTANCE = 32;
-	static const int MIN_VIEW_DISTANCE = 1;
+	static const unsigned MAX_VIEW_DISTANCE = 32;
+	static const unsigned MIN_VIEW_DISTANCE = 1;
 
 	/** The percentage how much a block has to be broken.
 	Should be a value between 0.7 (70% broken) and 1 (100% broken) depending on lag.
@@ -63,7 +63,7 @@ public:  // tolua_export
 	static float FASTBREAK_PERCENTAGE;
 
 	/** Creates a new client with the specified IP address in its description and the specified initial view distance. */
-	cClientHandle(const AString & a_IPString, int a_ViewDistance);
+	cClientHandle(const AString & a_IPString, unsigned a_ViewDistance);
 
 	virtual ~cClientHandle() override;
 
@@ -242,13 +242,13 @@ public:  // tolua_export
 	inline short GetPing(void) const { return static_cast<short>(std::chrono::duration_cast<std::chrono::milliseconds>(m_Ping).count()); }
 
 	/** Sets the maximal view distance. */
-	void SetViewDistance(int a_ViewDistance);
+	void SetViewDistance(unsigned a_ViewDistance);
 
 	/** Returns the view distance that the player currently have. */
-	int GetViewDistance(void) const { return m_CurrentViewDistance; }
+	unsigned GetViewDistance(void) const { return m_CurrentViewDistance; }
 
 	/** Returns the view distance that the player request, not the used view distance. */
-	int GetRequestedViewDistance(void) const { return m_RequestedViewDistance; }
+	unsigned GetRequestedViewDistance(void) const { return m_RequestedViewDistance; }
 
 	void SetLocale(const AString & a_Locale) { m_Locale = a_Locale; }
 	AString GetLocale(void) const { return m_Locale; }
@@ -304,7 +304,7 @@ public:  // tolua_export
 
 	/** Called when the protocol receives a MC|Beacon plugin message, indicating that the player set an effect
 	in the beacon UI. */
-	void HandleBeaconSelection(int a_PrimaryEffect, int a_SecondaryEffect);
+	void HandleBeaconSelection(unsigned a_PrimaryEffect, unsigned a_SecondaryEffect);
 
 	/** Called when the protocol detects a chat packet. */
 	void HandleChat(const AString & a_Message);
@@ -422,10 +422,10 @@ private:
 	AStringMap m_ForgeMods;
 
 	/** The actual view distance used, the minimum of client's requested view distance and world's max view distance. */
-	int m_CurrentViewDistance;
+	unsigned m_CurrentViewDistance;
 
 	/** The requested view distance from the player. It isn't clamped with 1 and the max view distance of the world. */
-	int m_RequestedViewDistance;
+	unsigned m_RequestedViewDistance;
 
 	AString m_IPString;
 

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -489,9 +489,20 @@ inline void VectorToEuler(double a_X, double a_Y, double a_Z, double & a_Pan, do
 
 
 
-template <class T> inline T Diff(T a_Val1, T a_Val2)
+template <class T, typename = std::enable_if_t<!std::is_integral_v<T>>>
+inline T Diff(T a_Val1, T a_Val2)
 {
 	return std::abs(a_Val1 - a_Val2);
+}
+
+
+
+
+
+template <class T, typename = std::enable_if_t<std::is_integral_v<T>>>
+inline auto Diff(T a_Val1, T a_Val2)
+{
+	return static_cast<std::make_unsigned_t<T>>(std::abs(a_Val1 - a_Val2));
 }
 
 

--- a/src/Enchantments.cpp
+++ b/src/Enchantments.cpp
@@ -400,7 +400,7 @@ bool cEnchantments::operator !=(const cEnchantments & a_Other) const
 
 
 
-void cEnchantments::AddItemEnchantmentWeights(cWeightedEnchantments & a_Enchantments, short a_ItemType, int a_EnchantmentLevel)
+void cEnchantments::AddItemEnchantmentWeights(cWeightedEnchantments & a_Enchantments, short a_ItemType, unsigned a_EnchantmentLevel)
 {
 	if (ItemCategory::IsSword(a_ItemType))
 	{

--- a/src/Enchantments.h
+++ b/src/Enchantments.h
@@ -126,7 +126,7 @@ public:
 	static unsigned int GetLevelCap(int a_EnchantmentID);
 
 	/** Add enchantment weights from item to the vector */
-	static void AddItemEnchantmentWeights(cWeightedEnchantments & a_Enchantments, short a_ItemType, int a_EnchantmentLevel);
+	static void AddItemEnchantmentWeights(cWeightedEnchantments & a_Enchantments, short a_ItemType, unsigned a_EnchantmentLevel);
 
 	/** Add a enchantment with weight to the vector */
 	static void AddEnchantmentWeightToVector(cWeightedEnchantments & a_Enchantments, int a_Weight, int a_EnchantmentID, unsigned int a_EnchantmentLevel);

--- a/src/IniFile.h
+++ b/src/IniFile.h
@@ -77,7 +77,6 @@ public:
 	cIniFile(void);
 
 	// tolua_end
-	virtual ~cIniFile() override = default;
 
 	virtual std::vector<std::pair<AString, AString>> GetValues(AString a_keyName) override;
 

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -356,95 +356,93 @@ bool cItem::IsEnchantable(short a_ItemType, bool a_FromBook)
 
 
 
-int cItem::GetEnchantability()
+unsigned cItem::GetEnchantability()
 {
-	int Enchantability = 0;
-
 	switch (m_ItemType)
 	{
-		case E_ITEM_WOODEN_SWORD: Enchantability = 15; break;
-		case E_ITEM_WOODEN_PICKAXE: Enchantability = 15; break;
-		case E_ITEM_WOODEN_SHOVEL: Enchantability = 15; break;
-		case E_ITEM_WOODEN_AXE: Enchantability = 15; break;
-		case E_ITEM_WOODEN_HOE: Enchantability = 15; break;
+		case E_ITEM_WOODEN_SWORD:
+		case E_ITEM_WOODEN_PICKAXE:
+		case E_ITEM_WOODEN_SHOVEL:
+		case E_ITEM_WOODEN_AXE:
+		case E_ITEM_WOODEN_HOE: return 15;
 
-		case E_ITEM_LEATHER_CAP: Enchantability = 15; break;
-		case E_ITEM_LEATHER_TUNIC: Enchantability = 15; break;
-		case E_ITEM_LEATHER_PANTS: Enchantability = 15; break;
-		case E_ITEM_LEATHER_BOOTS: Enchantability = 15; break;
+		case E_ITEM_LEATHER_CAP:
+		case E_ITEM_LEATHER_TUNIC:
+		case E_ITEM_LEATHER_PANTS:
+		case E_ITEM_LEATHER_BOOTS: return 15;
 
-		case E_ITEM_STONE_SWORD: Enchantability = 5; break;
-		case E_ITEM_STONE_PICKAXE: Enchantability = 5; break;
-		case E_ITEM_STONE_SHOVEL: Enchantability = 5; break;
-		case E_ITEM_STONE_AXE: Enchantability = 5; break;
-		case E_ITEM_STONE_HOE: Enchantability = 5; break;
+		case E_ITEM_STONE_SWORD:
+		case E_ITEM_STONE_PICKAXE:
+		case E_ITEM_STONE_SHOVEL:
+		case E_ITEM_STONE_AXE:
+		case E_ITEM_STONE_HOE: return 5;
 
-		case E_ITEM_IRON_HELMET: Enchantability = 9; break;
-		case E_ITEM_IRON_CHESTPLATE: Enchantability = 9; break;
-		case E_ITEM_IRON_LEGGINGS: Enchantability = 9; break;
-		case E_ITEM_IRON_BOOTS: Enchantability = 9; break;
+		case E_ITEM_IRON_HELMET:
+		case E_ITEM_IRON_CHESTPLATE:
+		case E_ITEM_IRON_LEGGINGS:
+		case E_ITEM_IRON_BOOTS: return 9;
 
-		case E_ITEM_IRON_SWORD: Enchantability = 14; break;
-		case E_ITEM_IRON_PICKAXE: Enchantability = 14; break;
-		case E_ITEM_IRON_SHOVEL: Enchantability = 14; break;
-		case E_ITEM_IRON_AXE: Enchantability = 14; break;
-		case E_ITEM_IRON_HOE: Enchantability = 14; break;
+		case E_ITEM_IRON_SWORD:
+		case E_ITEM_IRON_PICKAXE:
+		case E_ITEM_IRON_SHOVEL:
+		case E_ITEM_IRON_AXE:
+		case E_ITEM_IRON_HOE: return 14;
 
-		case E_ITEM_CHAIN_HELMET: Enchantability = 12; break;
-		case E_ITEM_CHAIN_CHESTPLATE: Enchantability = 12; break;
-		case E_ITEM_CHAIN_LEGGINGS: Enchantability = 12; break;
-		case E_ITEM_CHAIN_BOOTS: Enchantability = 12; break;
+		case E_ITEM_CHAIN_HELMET:
+		case E_ITEM_CHAIN_CHESTPLATE:
+		case E_ITEM_CHAIN_LEGGINGS:
+		case E_ITEM_CHAIN_BOOTS: return 12;
 
-		case E_ITEM_DIAMOND_HELMET: Enchantability = 10; break;
-		case E_ITEM_DIAMOND_CHESTPLATE: Enchantability = 10; break;
-		case E_ITEM_DIAMOND_LEGGINGS: Enchantability = 10; break;
-		case E_ITEM_DIAMOND_BOOTS: Enchantability = 10; break;
+		case E_ITEM_DIAMOND_HELMET:
+		case E_ITEM_DIAMOND_CHESTPLATE:
+		case E_ITEM_DIAMOND_LEGGINGS:
+		case E_ITEM_DIAMOND_BOOTS: return 10;
 
-		case E_ITEM_DIAMOND_SWORD: Enchantability = 10; break;
-		case E_ITEM_DIAMOND_PICKAXE: Enchantability = 10; break;
-		case E_ITEM_DIAMOND_SHOVEL: Enchantability = 10; break;
-		case E_ITEM_DIAMOND_AXE: Enchantability = 10; break;
-		case E_ITEM_DIAMOND_HOE: Enchantability = 10; break;
+		case E_ITEM_DIAMOND_SWORD:
+		case E_ITEM_DIAMOND_PICKAXE:
+		case E_ITEM_DIAMOND_SHOVEL:
+		case E_ITEM_DIAMOND_AXE:
+		case E_ITEM_DIAMOND_HOE: return 10;
 
-		case E_ITEM_GOLD_HELMET: Enchantability = 25; break;
-		case E_ITEM_GOLD_CHESTPLATE: Enchantability = 25; break;
-		case E_ITEM_GOLD_LEGGINGS: Enchantability = 25; break;
-		case E_ITEM_GOLD_BOOTS: Enchantability = 25; break;
+		case E_ITEM_GOLD_HELMET:
+		case E_ITEM_GOLD_CHESTPLATE:
+		case E_ITEM_GOLD_LEGGINGS:
+		case E_ITEM_GOLD_BOOTS: return 25;
 
-		case E_ITEM_GOLD_SWORD: Enchantability = 22; break;
-		case E_ITEM_GOLD_PICKAXE: Enchantability = 22; break;
-		case E_ITEM_GOLD_SHOVEL: Enchantability = 22; break;
-		case E_ITEM_GOLD_AXE: Enchantability = 22; break;
-		case E_ITEM_GOLD_HOE: Enchantability = 22; break;
+		case E_ITEM_GOLD_SWORD:
+		case E_ITEM_GOLD_PICKAXE:
+		case E_ITEM_GOLD_SHOVEL:
+		case E_ITEM_GOLD_AXE:
+		case E_ITEM_GOLD_HOE: return 22;
 
-		case E_ITEM_FISHING_ROD: Enchantability = 1; break;
-		case E_ITEM_BOW: Enchantability = 1; break;
-		case E_ITEM_BOOK: Enchantability = 1; break;
+		case E_ITEM_FISHING_ROD:
+		case E_ITEM_BOW:
+		case E_ITEM_BOOK: return 1;
 	}
 
-	return Enchantability;
+	return 0;
 }
 
 
 
 
 
-bool cItem::EnchantByXPLevels(int a_NumXPLevels, MTRand & a_Random)
+bool cItem::EnchantByXPLevels(unsigned a_NumXPLevels, MTRand & a_Random)
 {
 	if (!cItem::IsEnchantable(m_ItemType))
 	{
 		return false;
 	}
 
-	int Enchantability = GetEnchantability();
+	const auto Enchantability = GetEnchantability();
 	if (Enchantability == 0)
 	{
 		return false;
 	}
 
-	int ModifiedEnchantmentLevel = a_NumXPLevels + a_Random.RandInt(Enchantability / 4) + a_Random.RandInt(Enchantability / 4) + 1;
-	float RandomBonus = 1.0F + (a_Random.RandReal() + a_Random.RandReal() - 1.0F) * 0.15F;
-	int FinalEnchantmentLevel = static_cast<int>(ModifiedEnchantmentLevel * RandomBonus + 0.5F);
+	const auto ModifiedEnchantmentLevel = a_NumXPLevels + a_Random.RandInt(Enchantability / 4) + a_Random.RandInt(Enchantability / 4) + 1;
+	const auto RandomBonus = 1.0F + (a_Random.RandReal() + a_Random.RandReal() - 1.0F) * 0.15F;
+	const auto FinalEnchantmentLevel = static_cast<unsigned>(ModifiedEnchantmentLevel * RandomBonus + 0.5F);
 
 	cWeightedEnchantments Enchantments;
 	cEnchantments::AddItemEnchantmentWeights(Enchantments, m_ItemType, FinalEnchantmentLevel);

--- a/src/Item.h
+++ b/src/Item.h
@@ -138,12 +138,12 @@ public:
 	static bool IsEnchantable(short a_ItemType, bool a_FromBook = false);  // tolua_export
 
 	/** Returns the enchantability of the item. When the item hasn't a enchantability, it will returns 0 */
-	int GetEnchantability();  // tolua_export
+	unsigned GetEnchantability();  // tolua_export
 
 	/** Randomly enchants the item using the specified number of XP levels.
 	Returns true if the item was enchanted, false if not (not enchantable / too many enchantments already).
 	Randomness is derived from the provided PRNG. */
-	bool EnchantByXPLevels(int a_NumXPLevels, MTRand & a_Random);  // Exported in ManualBindings.cpp
+	bool EnchantByXPLevels(unsigned a_NumXPLevels, MTRand & a_Random);  // Exported in ManualBindings.cpp
 
 	/** Adds this specific enchantment to this item, returning the cost.
 	FromBook specifies whether the enchantment should be treated as coming

--- a/src/Items/ItemFishingRod.h
+++ b/src/Items/ItemFishingRod.h
@@ -175,7 +175,7 @@ public:
 				case 0:
 				{
 					cItem Bow(E_ITEM_BOW, 1, Random.RandInt<short>(50));
-					Bow.EnchantByXPLevels(Random.RandInt(22, 30), GetRandomProvider());
+					Bow.EnchantByXPLevels(Random.RandInt(22U, 30U), GetRandomProvider());
 					Drops.Add(Bow);
 					break;
 				}
@@ -189,7 +189,7 @@ public:
 				case 2:
 				{
 					cItem Rod(E_ITEM_FISHING_ROD, 1, Random.RandInt<short>(50));
-					Rod.EnchantByXPLevels(Random.RandInt(22, 30), GetRandomProvider());
+					Rod.EnchantByXPLevels(Random.RandInt(22U, 30U), GetRandomProvider());
 					Drops.Add(Rod);
 					break;
 				}

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -253,9 +253,7 @@ std::unique_ptr<cProtocol> cMultiVersionProtocol::TryRecognizeLengthedProtocol(c
 			a_Client.GetIPString().c_str(), PacketType
 		);
 
-		throw TriedToJoinWithUnsupportedProtocolException(
-			Printf("Your client isn't supported.\nTry connecting with Minecraft " MCS_CLIENT_VERSIONS, ProtocolVersion)
-		);
+		throw TriedToJoinWithUnsupportedProtocolException("Your client isn't supported.\nTry connecting with Minecraft " MCS_CLIENT_VERSIONS);
 	}
 
 	if (
@@ -270,21 +268,16 @@ std::unique_ptr<cProtocol> cMultiVersionProtocol::TryRecognizeLengthedProtocol(c
 		throw TriedToJoinWithUnsupportedProtocolException("Incorrect amount of data received - hacked client?");
 	}
 
-	cProtocol::State NextState = [&]
+	const auto NextState = [NextStateValue]
+	{
+		switch (NextStateValue)
 		{
-			switch (NextStateValue)
-			{
-				case cProtocol::State::Status: return cProtocol::State::Status;
-				case cProtocol::State::Login: return cProtocol::State::Login;
-				case cProtocol::State::Game: return cProtocol::State::Game;
-				default:
-				{
-					throw TriedToJoinWithUnsupportedProtocolException(
-						fmt::format("Invalid next game state: {}", NextStateValue)
-					);
-				}
-			}
-		}();
+			case 1:  return cProtocol::State::Status;
+			case 2:  return cProtocol::State::Login;
+			case 3:  return cProtocol::State::Game;
+			default: throw TriedToJoinWithUnsupportedProtocolException("Your client isn't supported.\nTry connecting with Minecraft " MCS_CLIENT_VERSIONS);
+		}
+	}();
 
 	// TODO: this should be a protocol property, not ClientHandle:
 	a_Client.SetProtocolVersion(ProtocolVersion);

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -316,9 +316,7 @@ void cProtocol_1_13::HandlePacketSetBeaconEffect(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, Effect1);
 	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, Effect2);
-	m_Client->HandleBeaconSelection(
-		static_cast<int>(Effect1), static_cast<int>(Effect2)
-	);
+	m_Client->HandleBeaconSelection(Effect1, Effect2);
 }
 
 

--- a/src/Protocol/Protocol_1_14.cpp
+++ b/src/Protocol/Protocol_1_14.cpp
@@ -59,7 +59,7 @@ void cProtocol_1_14::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 		Pkt.WriteBEInt32(static_cast<Int32>(a_World.GetDimension()));
 		Pkt.WriteBEUInt8(static_cast<UInt8>(Clamp<size_t>(Server->GetMaxPlayers(), 0, 255)));
 		Pkt.WriteString("default");
-		Pkt.WriteVarInt32(ToUnsigned(a_World.GetMaxViewDistance()));
+		Pkt.WriteVarInt32(a_World.GetMaxViewDistance());
 		Pkt.WriteBool(false);
 	}
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1719,7 +1719,7 @@ void cProtocol_1_8_0::SendWindowProperty(const cWindow & a_Window, size_t a_Prop
 
 bool cProtocol_1_8_0::CompressPacket(const AString & a_Packet, AString & a_CompressedData)
 {
-	const auto UncompressedSize = static_cast<size_t>(a_Packet.size());
+	const auto UncompressedSize = a_Packet.size();
 
 	if (UncompressedSize < CompressionThreshold)
 	{
@@ -1734,8 +1734,7 @@ bool cProtocol_1_8_0::CompressPacket(const AString & a_Packet, AString & a_Compr
 		----------------------------------------------
 		*/
 		const UInt32 DataSize = 0;
-		const auto PacketSize = static_cast<UInt32>(
-			cByteBuffer::GetVarIntSize(DataSize) + UncompressedSize);
+		const auto PacketSize = static_cast<UInt32>(cByteBuffer::GetVarIntSize(DataSize) + UncompressedSize);
 
 		cByteBuffer LengthHeaderBuffer(
 			cByteBuffer::GetVarIntSize(PacketSize) +
@@ -1787,8 +1786,7 @@ bool cProtocol_1_8_0::CompressPacket(const AString & a_Packet, AString & a_Compr
 	}
 
 	const UInt32 DataSize = static_cast<UInt32>(UncompressedSize);
-	const auto PacketSize = static_cast<UInt32>(
-		cByteBuffer::GetVarIntSize(DataSize) + CompressedSize);
+	const auto PacketSize = static_cast<UInt32>(cByteBuffer::GetVarIntSize(DataSize) + CompressedSize);
 
 	cByteBuffer LengthHeaderBuffer(
 		cByteBuffer::GetVarIntSize(PacketSize) +
@@ -2987,8 +2985,8 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 	}
 	else if (a_Channel == "MC|Beacon")
 	{
-		HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, Effect1);
-		HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, Effect2);
+		HANDLE_READ(a_ByteBuffer, ReadBEUInt32, UInt32, Effect1);
+		HANDLE_READ(a_ByteBuffer, ReadBEUInt32, UInt32, Effect2);
 		m_Client->HandleBeaconSelection(Effect1, Effect2);
 		return;
 	}

--- a/src/Root.h
+++ b/src/Root.h
@@ -62,10 +62,10 @@ public:
 	bool Run(cSettingsRepositoryInterface & a_OverridesRepo);
 
 	/** Interrupts the server and stops it, as if "/stop" typed in the console. */
-	void Stop();
+	static void Stop();
 
 	/** Interrupts the server and restarts it, as if "/restart" was typed in the console. */
-	void Restart();
+	static void Restart();
 
 	// tolua_begin
 	cServer * GetServer(void) { return m_Server; }
@@ -208,12 +208,12 @@ private:
 	void HandleInput();
 
 	/** Performs run state transition, enforcing guarantees about state transitions. */
-	void TransitionNextState(NextState a_NextState);
+	static void TransitionNextState(NextState a_NextState);
 
 	cWorld * m_pDefaultWorld;
 	WorldMap m_WorldsByName;
 
-	cEvent m_StopEvent;
+	static cEvent s_StopEvent;
 
 	cServer *        m_Server;
 	cMonsterConfig * m_MonsterConfig;
@@ -249,5 +249,5 @@ private:
 	static cRoot * s_Root;
 
 	/** Indicates the next action of cRoot, whether to run, stop or restart. */
-	std::atomic<NextState> m_NextState;
+	static std::atomic<NextState> s_NextState;
 };  // tolua_export

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -214,16 +214,20 @@ bool cServer::InitServer(cSettingsRepositoryInterface & a_Settings, bool a_Shoul
 	m_ShouldLoadOfflinePlayerData = a_Settings.GetValueSetB("PlayerData", "LoadOfflinePlayerData", false);
 	m_ShouldLoadNamedPlayerData   = a_Settings.GetValueSetB("PlayerData", "LoadNamedPlayerData", true);
 
-	m_ClientViewDistance = a_Settings.GetValueSetI("Server", "DefaultViewDistance", cClientHandle::DEFAULT_VIEW_DISTANCE);
-	if (m_ClientViewDistance < cClientHandle::MIN_VIEW_DISTANCE)
+	const auto ClientViewDistance = a_Settings.GetValueSetI("Server", "DefaultViewDistance", static_cast<int>(cClientHandle::DEFAULT_VIEW_DISTANCE));
+	if (ClientViewDistance < static_cast<int>(cClientHandle::MIN_VIEW_DISTANCE))
 	{
 		m_ClientViewDistance = cClientHandle::MIN_VIEW_DISTANCE;
-		LOGINFO("Setting default viewdistance to the minimum of %d", m_ClientViewDistance);
+		LOGINFO("Setting default view distance to the minimum of %d", m_ClientViewDistance);
 	}
-	if (m_ClientViewDistance > cClientHandle::MAX_VIEW_DISTANCE)
+	else if (ClientViewDistance > static_cast<int>(cClientHandle::MAX_VIEW_DISTANCE))
 	{
 		m_ClientViewDistance = cClientHandle::MAX_VIEW_DISTANCE;
-		LOGINFO("Setting default viewdistance to the maximum of %d", m_ClientViewDistance);
+		LOGINFO("Setting default view distance to the maximum of %d", m_ClientViewDistance);
+	}
+	else
+	{
+		m_ClientViewDistance = static_cast<unsigned>(ClientViewDistance);
 	}
 
 	PrepareKeys();

--- a/src/Server.h
+++ b/src/Server.h
@@ -206,7 +206,7 @@ private:
 	cCriticalSection m_CSPendingCommands;
 	std::vector<std::pair<AString, cCommandOutputCallback *>> m_PendingCommands;
 
-	int m_ClientViewDistance;  // The default view distance for clients; settable in Settings.ini
+	unsigned m_ClientViewDistance;  // The default view distance for clients; settable in Settings.ini
 
 	bool m_bIsConnected;  // true - connected false - not connected
 

--- a/src/Simulator/IncrementalRedstoneSimulator/PressurePlateHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/PressurePlateHandler.h
@@ -12,7 +12,7 @@ namespace PressurePlateHandler
 {
 	inline unsigned char GetPowerLevel(const cChunk & Chunk, const Vector3i Position, const BLOCKTYPE BlockType)
 	{
-		Int64 NumberOfEntities = 0;
+		size_t NumberOfEntities = 0;
 		bool FoundPlayer = false;
 
 		Chunk.ForEachEntityInBox(cBoundingBox(Vector3d(0.5, 0, 0.5) + Position, 0.5, 0.5), [&](cEntity & Entity)
@@ -24,7 +24,8 @@ namespace PressurePlateHandler
 
 			if (Entity.IsPickup())
 			{
-				NumberOfEntities += static_cast<cPickup &>(Entity).GetItem().m_ItemCount;
+				const auto & Pickup = static_cast<cPickup &>(Entity);
+				NumberOfEntities += static_cast<size_t>(Pickup.GetItem().m_ItemCount);
 				return false;
 			}
 			NumberOfEntities++;
@@ -35,11 +36,11 @@ namespace PressurePlateHandler
 		{
 			case E_BLOCK_STONE_PRESSURE_PLATE:
 			{
-				return (FoundPlayer ? 15 : 0);
+				return FoundPlayer ? 15 : 0;
 			}
 			case E_BLOCK_WOODEN_PRESSURE_PLATE:
 			{
-				return (NumberOfEntities > 0 ? 15 : 0);
+				return (NumberOfEntities != 0) ? 15 : 0;
 			}
 			case E_BLOCK_HEAVY_WEIGHTED_PRESSURE_PLATE:
 			{

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -1698,18 +1698,18 @@ void cSlotAreaEnchanting::UpdateResult(cPlayer & a_Player)
 	}
 
 	// Pseudocode found at: https://minecraft.gamepedia.com/Enchanting_mechanics
-	const auto Bookshelves = std::min(static_cast<int>(GetBookshelvesCount(*a_Player.GetWorld())), 15);
+	const auto Bookshelves = std::min(GetBookshelvesCount(*a_Player.GetWorld()), 15U);
 
 	// A PRNG initialised using the player's enchantment seed.
 	auto Random = a_Player.GetEnchantmentRandomProvider();
 
 	// Calculate the levels for the offered enchantment options:
-	const auto Base = (Random.RandInt(1, 8) + (Bookshelves / 2) + Random.RandInt(0, Bookshelves));
-	const std::array<short, 3> OptionLevels
+	const auto Base = (Random.RandInt(1U, 8U) + (Bookshelves / 2) + Random.RandInt(0U, Bookshelves));
+	const std::array<unsigned, 3> OptionLevels
 	{
-		static_cast<short>(std::max(Base / 3, 1)),
-		static_cast<short>((Base * 2) / 3 + 1),
-		static_cast<short>(std::max(Base, Bookshelves * 2))
+		std::max(Base / 3, 1U),
+		(Base * 2) / 3 + 1,
+		std::max(Base, Bookshelves * 2)
 	};
 
 	// Properties set according to: https://wiki.vg/Protocol#Window_Property
@@ -1728,7 +1728,7 @@ void cSlotAreaEnchanting::UpdateResult(cPlayer & a_Player)
 		LOGD("Generated enchanted item %d with enchantments: %s", i, EnchantedItem.m_Enchantments.ToString());
 
 		// Send the level requirement for the enchantment option:
-		m_ParentWindow.SetProperty(i, OptionLevels[i]);
+		m_ParentWindow.SetProperty(i, static_cast<short>(OptionLevels[i]));
 
 		// Get the first enchantment ID, which must exist:
 		ASSERT(EnchantedItem.m_Enchantments.begin() != EnchantedItem.m_Enchantments.end());

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -264,7 +264,8 @@ cWorld::cWorld(
 	m_BroadcastDeathMessages = IniFile.GetValueSetB("Broadcasting", "BroadcastDeathMessages", true);
 	m_BroadcastAchievementMessages = IniFile.GetValueSetB("Broadcasting", "BroadcastAchievementMessages", true);
 
-	SetMaxViewDistance(IniFile.GetValueSetI("SpawnPosition", "MaxViewDistance", 12));
+	const auto ClientViewDistance = IniFile.GetValueSetI("SpawnPosition", "MaxViewDistance", static_cast<int>(cClientHandle::DEFAULT_VIEW_DISTANCE));
+	m_MaxViewDistance = static_cast<unsigned>(std::clamp(ClientViewDistance, static_cast<int>(cClientHandle::MIN_VIEW_DISTANCE), static_cast<int>(cClientHandle::MAX_VIEW_DISTANCE)));
 
 	// Try to find the "SpawnPosition" key and coord values in the world configuration, set the flag if found
 	int KeyNum = IniFile.FindKey("SpawnPosition");
@@ -1841,7 +1842,7 @@ bool cWorld::SetAreaBiome(const cCuboid & a_Area, EMCSBiome a_Biome)
 
 
 
-void cWorld::SetMaxViewDistance(int a_MaxViewDistance)
+void cWorld::SetMaxViewDistance(unsigned a_MaxViewDistance)
 {
 	m_MaxViewDistance = Clamp(a_MaxViewDistance, cClientHandle::MIN_VIEW_DISTANCE, cClientHandle::MAX_VIEW_DISTANCE);
 }

--- a/src/World.h
+++ b/src/World.h
@@ -900,8 +900,8 @@ public:
 	eShrapnelLevel GetTNTShrapnelLevel(void) const { return m_TNTShrapnelLevel; }
 	void SetTNTShrapnelLevel(eShrapnelLevel a_Flag) { m_TNTShrapnelLevel = a_Flag; }
 
-	int GetMaxViewDistance(void) const { return m_MaxViewDistance; }
-	void SetMaxViewDistance(int a_MaxViewDistance);
+	unsigned GetMaxViewDistance(void) const { return m_MaxViewDistance; }
+	void SetMaxViewDistance(unsigned a_MaxViewDistance);
 
 	bool ShouldUseChatPrefixes(void) const { return m_bUseChatPrefixes; }
 	void SetShouldUseChatPrefixes(bool a_Flag) { m_bUseChatPrefixes = a_Flag; }
@@ -1253,7 +1253,7 @@ private:
 	eShrapnelLevel m_TNTShrapnelLevel;
 
 	/** The maximum view distance that a player can have in this world. */
-	int m_MaxViewDistance;
+	unsigned m_MaxViewDistance;
 
 	/** Name of the nether world - where Nether portals should teleport.
 	Only used when this world is an Overworld. */

--- a/src/WorldStorage/StatSerializer.cpp
+++ b/src/WorldStorage/StatSerializer.cpp
@@ -151,13 +151,7 @@ namespace StatSerializer
 
 			if ((FindResult != LegacyMapping.end()) && Entry->isInt())
 			{
-				auto Value = Entry->asInt();
-				if (Value < 0)
-				{
-					FLOGWARNING("Invalid stat value: {0} = {1}", Key, Value);
-					continue;
-				}
-				Manager.SetValue(FindResult->second, ToUnsigned(Value));
+				Manager.SetValue(FindResult->second, Entry->asUInt());
 			}
 		}
 	}
@@ -181,13 +175,7 @@ namespace StatSerializer
 			const auto & StatName = StatInfo.second;
 			try
 			{
-				auto Value = it->asInt();
-				if (Value < 0)
-				{
-					FLOGWARNING("Invalid statistic value: {0} = {1}", Key, Value);
-					continue;
-				}
-				Manager.SetValue(NamespaceSerializer::ToCustomStatistic(StatName), ToUnsigned(Value));
+				Manager.SetValue(NamespaceSerializer::ToCustomStatistic(StatName), it->asUInt());
 			}
 			catch (const std::out_of_range &)
 			{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ static void NonCtrlHandler(int a_Signal)
 		case SIGTERM:
 		{
 			// Server is shutting down, wait for it...
-			cRoot::Get()->Stop();
+			cRoot::Stop();
 			return;
 		}
 #ifdef SIGPIPE
@@ -111,7 +111,7 @@ static void NonCtrlHandler(int a_Signal)
 // Handle CTRL events in windows, including console window close
 static BOOL CtrlHandler(DWORD fdwCtrlType)
 {
-	cRoot::Get()->Stop();
+	cRoot::Stop();
 	LOGD("Terminate event raised from the Windows CtrlHandler");
 
 	// Delay as much as possible to try to get the server to shut down cleanly - 10 seconds given by Windows
@@ -130,7 +130,7 @@ static BOOL CtrlHandler(DWORD fdwCtrlType)
 ////////////////////////////////////////////////////////////////////////////////
 // ParseArguments - Read the startup arguments and store into a settings object
 
-static void ParseArguments(int argc, char ** argv, cMemorySettingsRepository & repo)
+static void ParseArguments(int argc, char ** argv, cMemorySettingsRepository & Settings)
 {
 	// Parse the comand line args:
 	TCLAP::CmdLine cmd("Cuberite");
@@ -151,23 +151,23 @@ static void ParseArguments(int argc, char ** argv, cMemorySettingsRepository & r
 	if (confArg.isSet())
 	{
 		AString conf_file = confArg.getValue();
-		repo.AddValue("Server", "ConfigFile", conf_file);
+		Settings.AddValue("Server", "ConfigFile", conf_file);
 	}
 	if (slotsArg.isSet())
 	{
 		int slots = slotsArg.getValue();
-		repo.AddValue("Server", "MaxPlayers", static_cast<Int64>(slots));
+		Settings.AddValue("Server", "MaxPlayers", static_cast<Int64>(slots));
 	}
 	if (portsArg.isSet())
 	{
 		for (auto port: portsArg.getValue())
 		{
-			repo.AddValue("Server", "Ports", std::to_string(port));
+			Settings.AddValue("Server", "Ports", std::to_string(port));
 		}
 	}
 	if (noFileLogArg.getValue())
 	{
-		repo.AddValue("Server", "DisableLogFile", true);
+		Settings.AddValue("Server", "DisableLogFile", true);
 	}
 	if (commLogArg.getValue())
 	{
@@ -183,7 +183,7 @@ static void ParseArguments(int argc, char ** argv, cMemorySettingsRepository & r
 	{
 		setvbuf(stdout, nullptr, _IONBF, 0);
 	}
-	repo.SetReadOnly();
+	Settings.SetReadOnly();
 
 	if (runAsServiceArg.getValue())
 	{
@@ -230,11 +230,10 @@ static int UniversalMain(int argc, char * argv[], bool RunningAsService)
 
 	try
 	{
-		// Make sure g_RunAsService is set correctly before checking it's value
 		cMemorySettingsRepository Settings;
-		ParseArguments(argc, argv, Settings);
+		ParseArguments(argc, argv, Settings);  // Make sure g_RunAsService is set correctly before checking it's value
 
-		// Attempt to run as a service
+		// Attempt to run as a service:
 		if (!RunningAsService && g_RunAsService)
 		{
 			// This will either fork or call UniversalMain again:


### PR DESCRIPTION
* Turn off global-constructors warning. These are needed to implement cRoot signal handler functionality
* Add Clang flags based on version lookup instead of a compile test. The CMake config process is single threaded and slow enough already
* Reduced GetStackValue verbosity
+ Clarify EnchantmentLevel, StayCount, AlwaysTicked, ViewDistance signedness
+ Give SettingsRepositoryInterface a move constructor to simplify main.cpp code
- Remove do {} while (false) construction in redstone handler