### PR TITLE
TNT Changes

### DIFF
--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -136,11 +136,7 @@ bool IsBlockFence(BLOCKTYPE a_BlockType)
 
 bool IsBlockShulkerBox(BLOCKTYPE a_BlockType)
 {
-	if ((a_BlockType >= E_BLOCK_WHITE_SHULKER_BOX) && (a_BlockType <= E_BLOCK_BLACK_SHULKER_BOX))
-	{
-		return true;
-	}
-	return false;
+	return ((a_BlockType >= E_BLOCK_WHITE_SHULKER_BOX) && (a_BlockType <= E_BLOCK_BLACK_SHULKER_BOX));
 }
 
 

--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -134,6 +134,19 @@ bool IsBlockFence(BLOCKTYPE a_BlockType)
 
 
 
+bool IsBlockShulkerBox(BLOCKTYPE a_BlockType)
+{
+	if ((a_BlockType >= E_BLOCK_WHITE_SHULKER_BOX) && (a_BlockType <= E_BLOCK_BLACK_SHULKER_BOX))
+	{
+		return true;
+	}
+	return false;
+}
+
+
+
+
+
 bool IsBlockMaterialWood(BLOCKTYPE a_BlockType)
 {
 	switch (a_BlockType)

--- a/src/BlockInfo.h
+++ b/src/BlockInfo.h
@@ -86,6 +86,8 @@ bool IsBlockTypeOfDirt(BLOCKTYPE a_BlockType);
 
 bool IsBlockFence(BLOCKTYPE a_BlockType);
 
+bool IsBlockShulkerBox(BLOCKTYPE a_BlockType);
+
 bool IsBlockMaterialWood(BLOCKTYPE a_BlockType);
 
 bool IsBlockMaterialPlants(BLOCKTYPE a_BlockType);

--- a/src/Physics/Explodinator.cpp
+++ b/src/Physics/Explodinator.cpp
@@ -83,7 +83,7 @@ namespace Explodinator
 			// Percentage of rays unobstructed.
 			const auto Exposure = CalculateEntityExposure(a_Chunk, Entity, a_Position, SquareRadius);
 			const auto Direction = Entity.GetPosition() - a_Position;
-			const auto Impact = (1 - (static_cast<float>(Direction.Length()) / Radius)) * Exposure;
+			auto Impact = (1 - (static_cast<float>(Direction.Length()) / Radius)) * Exposure;
 
 			// Don't apply damage to other TNT entities and falling blocks, they should be invincible:
 			if (!Entity.IsTNT() && !Entity.IsFallingBlock())
@@ -92,9 +92,12 @@ namespace Explodinator
 				Entity.TakeDamage(dtExplosion, nullptr, FloorC(Damage), 0);
 			}
 
-			// Impact reduced by armour:
-			const auto ReducedImpact = Impact - Impact * Entity.GetEnchantmentBlastKnockbackReduction();  // TODO: call is very expensive, should only apply to Pawns
-			Entity.SetSpeed(Direction.NormalizeCopy() * KnockbackFactor * ReducedImpact);
+			// Impact reduced by armour, expensive call so only apply to Pawns:
+			if (Entity.IsPawn())
+			{
+				Impact *= 1 - Entity.GetEnchantmentBlastKnockbackReduction();
+			}
+			Entity.SetSpeed(Direction.NormalizeCopy() * KnockbackFactor * Impact);
 
 			// Continue iteration:
 			return false;

--- a/src/Physics/Explodinator.cpp
+++ b/src/Physics/Explodinator.cpp
@@ -10,10 +10,6 @@
 #include "LineBlockTracer.h"
 #include "Simulator/SandSimulator.h"
 
-//KingCol13 debugging:
-#include <chrono>
-#include <iostream>
-
 
 
 namespace Explodinator
@@ -297,13 +293,7 @@ namespace Explodinator
 		{
 			LagTheClient(a_Chunk, a_Position, a_Power);
 			DamageEntities(a_Chunk, a_Position, a_Power);
-
-			std::cout << "Starting timer." << std::endl;
-			auto t1 = std::chrono::high_resolution_clock::now();
 			DamageBlocks(a_Chunk, AbsoluteToRelative(a_Position, a_Chunk.GetPos()), a_Power, a_Fiery, a_ExplodingEntity);
-			auto t2 = std::chrono::high_resolution_clock::now();
-			auto duration = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
-			std::cout << "Finished. Time taken: " << duration << std::endl;
 
 			return false;
 		});

--- a/src/Physics/Explodinator.cpp
+++ b/src/Physics/Explodinator.cpp
@@ -10,7 +10,9 @@
 #include "LineBlockTracer.h"
 #include "Simulator/SandSimulator.h"
 
-
+//KingCol13 debugging:
+#include <chrono>
+#include <iostream>
 
 
 
@@ -311,7 +313,12 @@ namespace Explodinator
 		a_World.DoWithChunkAt(a_Position.Floor(), [a_Position, a_Power, a_Fiery, a_ExplodingEntity](cChunk & a_Chunk)
 		{
 			LagTheClient(a_Chunk, a_Position, a_Power);
+			std::cout << "Starting timer." << std::endl;
+			auto t1 = std::chrono::high_resolution_clock::now();
 			DamageEntities(a_Chunk, a_Position, a_Power);
+			auto t2 = std::chrono::high_resolution_clock::now();
+			auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+			std::cout << "Finished. Time taken: " << duration << std::endl;
 			DamageBlocks(a_Chunk, AbsoluteToRelative(a_Position, a_Chunk.GetPos()), a_Power, a_Fiery, a_ExplodingEntity);
 
 			return false;

--- a/src/Physics/Explodinator.cpp
+++ b/src/Physics/Explodinator.cpp
@@ -17,7 +17,7 @@ namespace Explodinator
 	const auto StepUnit = 0.3f;
 	const auto KnockbackFactor = 25U;
 	const auto StepAttenuation = 0.225f;
-	const auto GridPointSpacing = 0.133333333333333333f;  // 16 Ray per cube length
+	const auto GridPointSpacing = 0.133333333333333333f;  // = 2 / 15: 16 rays per cube length
 	const auto BoundingBoxStepUnit = 0.5;
 
 	/** Converts an absolute floating-point Position into a Chunk-relative one. */

--- a/src/Physics/Explodinator.cpp
+++ b/src/Physics/Explodinator.cpp
@@ -111,7 +111,7 @@ namespace Explodinator
 	static bool BlockAlwaysDrops(const BLOCKTYPE a_Block)
 	{
 		// If it's a Shulker box
-		if ((a_Block >= E_BLOCK_WHITE_SHULKER_BOX) && (a_Block <= E_BLOCK_BLACK_SHULKER_BOX))
+		if (IsBlockShulkerBox(a_Block))
 		{
 			return true;
 		}

--- a/src/Physics/Explodinator.cpp
+++ b/src/Physics/Explodinator.cpp
@@ -213,7 +213,7 @@ namespace Explodinator
 		const auto Step = TraceDisplacement.NormalizeCopy() * StepUnit;
 
 		// Loop until we've reached the prescribed destination:
-		while (TraceDisplacement > (Checkpoint - a_Origin))
+		while (true)//(TraceDisplacement > (Checkpoint - a_Origin))
 		{
 			auto Position = Checkpoint.Floor();
 			if (!cChunkDef::IsValidHeight(Position.y))
@@ -264,8 +264,8 @@ namespace Explodinator
 		{
 			for (int OffsetZ = -HalfSide; OffsetZ < HalfSide; OffsetZ++)
 			{
-				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(OffsetX, +ExplosionRadius, OffsetZ), a_Power, a_Fiery, Intensity, a_ExplodingEntity);
-				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(OffsetX, -ExplosionRadius, OffsetZ), a_Power, a_Fiery, Intensity, a_ExplodingEntity);
+				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(OffsetX, +ExplosionRadius, OffsetZ), a_Power, a_Fiery, a_Power * (0.7f + GetRandomProvider().RandReal(0.6f)), a_ExplodingEntity);
+				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(OffsetX, -ExplosionRadius, OffsetZ), a_Power, a_Fiery, a_Power * (0.7f + GetRandomProvider().RandReal(0.6f)), a_ExplodingEntity);
 			}
 		}
 
@@ -291,10 +291,10 @@ namespace Explodinator
 		{
 			for (int OffsetY = -HalfSide + 1; OffsetY < HalfSide - 1; OffsetY++)
 			{
-				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(ExplosionRadius, OffsetY, Offset + 1), a_Power, a_Fiery, Intensity, a_ExplodingEntity);
-				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(-ExplosionRadius, OffsetY, Offset), a_Power, a_Fiery, Intensity, a_ExplodingEntity);
-				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(Offset, OffsetY, ExplosionRadius), a_Power, a_Fiery, Intensity, a_ExplodingEntity);
-				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(Offset + 1, OffsetY, -ExplosionRadius), a_Power, a_Fiery, Intensity, a_ExplodingEntity);
+				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(ExplosionRadius, OffsetY, Offset + 1), a_Power, a_Fiery, a_Power * (0.7f + GetRandomProvider().RandReal(0.6f)), a_ExplodingEntity);
+				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(-ExplosionRadius, OffsetY, Offset), a_Power, a_Fiery, a_Power * (0.7f + GetRandomProvider().RandReal(0.6f)), a_ExplodingEntity);
+				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(Offset, OffsetY, ExplosionRadius), a_Power, a_Fiery, a_Power * (0.7f + GetRandomProvider().RandReal(0.6f)), a_ExplodingEntity);
+				DestructionTrace(&a_Chunk, a_Position, a_Position + Vector3f(Offset + 1, OffsetY, -ExplosionRadius), a_Power, a_Fiery, a_Power * (0.7f + GetRandomProvider().RandReal(0.6f)), a_ExplodingEntity);
 			}
 		}
 	}

--- a/src/Physics/Explodinator.cpp
+++ b/src/Physics/Explodinator.cpp
@@ -21,7 +21,7 @@ namespace Explodinator
 	const auto StepUnit = 0.3f;
 	const auto KnockbackFactor = 25U;
 	const auto StepAttenuation = 0.225f;
-	const auto TraceCubeSideLength = 16U;
+	const auto GridPointSpacing = 0.133333333333333333f;  // 16 Ray per cube length
 	const auto BoundingBoxStepUnit = 0.5;
 
 	/** Converts an absolute floating-point Position into a Chunk-relative one. */
@@ -249,12 +249,9 @@ namespace Explodinator
 
 		// The following loops implement the tracing algorithm described in http://minecraft.gamepedia.com/Explosion
 
-		// Want 16 rays per length so apply lamposts and spaces
-		const float GridPointSpacing = 0.133333333333333333f;
-
 		// Trace rays from the explosion centre to all points in a square of area TraceCubeSideLength * TraceCubeSideLength
 		// Careful to avoid duplicates along edges
-		// top and bottom sides:
+		// Top and bottom sides:
 		for (float OffsetX = -1; OffsetX < 1; OffsetX+=GridPointSpacing)
 		{
 			for (float OffsetZ = -1; OffsetZ < 1; OffsetZ+=GridPointSpacing)
@@ -264,7 +261,7 @@ namespace Explodinator
 			}
 		}
 
-		// left and right sides, avoid duplicates at top and bottom edges
+		// Left and right sides, avoid duplicates at top and bottom edges:
 		for (float OffsetX = -1; OffsetX < 1; OffsetX+=GridPointSpacing)
 		{
 			for (float OffsetY = -1+GridPointSpacing; OffsetY < 1-GridPointSpacing; OffsetY+=GridPointSpacing)
@@ -274,7 +271,7 @@ namespace Explodinator
 			}
 		}
 
-		// front and back sides, avoid all edges
+		// Front and back sides, avoid all edges:
 		for (float OffsetZ = -1+GridPointSpacing; OffsetZ < 1-GridPointSpacing; OffsetZ+=GridPointSpacing)
 		{
 			for (float OffsetY = -1+GridPointSpacing; OffsetY < 1-GridPointSpacing; OffsetY+=GridPointSpacing)

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1390,10 +1390,9 @@ bool cWorld::ForEachFurnaceInChunk(int a_ChunkX, int a_ChunkZ, cFurnaceCallback 
 void cWorld::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, bool a_CanCauseFire, eExplosionSource a_Source, void * a_SourceData)
 {
 	cLock Lock(*this);
-
 	if (!cPluginManager::Get()->CallHookExploding(*this, a_ExplosionSize, a_CanCauseFire, a_BlockX, a_BlockY, a_BlockZ, a_Source, a_SourceData) && (a_ExplosionSize > 0))
 	{
-		// TODO: CanCauseFire gets reset to false for some reason
+		// TODO: CanCauseFire gets reset to false for some reason, (plugin has ability to change it, might be related)
 
 		const cEntity * Entity;
 		switch (a_Source)


### PR DESCRIPTION
Mum said it was my turn to play with the TNT code.

- Make TNT explosions always drop pickups (1.14 behaviour)
- Always drop items that wiki says should always drop
- Get rid of destination and just keep direction and intensity (seems to be wiki behaviour)
- Give each ray in explosion different random intensity
