### PR TITLE
Include sys/select.h on non-glibc Linux platforms

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -13,6 +13,10 @@
 	#include <signal.h>
 	#if defined(__linux__)
 		#include <fstream>
+
+		#if !defined(__GLIBC__)
+			#include <sys/select.h>
+		#endif
 	#elif defined(__APPLE__)
 		#include <mach/mach.h>
 	#endif


### PR DESCRIPTION
Otherwise fd_set will be unknown for example on Musl libc systems