### PR TITLE
Add default value nullptr for parameter a_Digger and added digger to cWorld:DigBlock in lua api

### DIFF
--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -541,28 +541,56 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 			},
 			DigBlock =
 			{
-				Params =
 				{
+					Params =
 					{
-						Name = "X",
-						Type = "number",
+						{
+							Name = "X",
+							Type = "number",
+						},
+						{
+							Name = "Y",
+							Type = "number",
+						},
+						{
+							Name = "Z",
+							Type = "number",
+						},
+						{
+							Name = "Digger",
+							Type = "cEntity",
+							IsOptional = true,
+						},
 					},
+					Returns =
 					{
-						Name = "Y",
-						Type = "number",
+						{
+							Type = "boolean",
+						},
 					},
-					{
-						Name = "Z",
-						Type = "number",
-					},
+					Notes = "Replaces the specified block with air, without dropping the usual pickups for the block. Wakes up the simulators for the block and its neighbors. The optional Digger parameter specifies the entity who dug the block, usually a player. Returns true on success, or false if the chunk is not loaded or invalid coords. See also DropBlockAsPickups() for the version that drops pickups.",
 				},
-				Returns =
 				{
+					Params =
 					{
-						Type = "boolean",
+						{
+							Name = "BlockPos",
+							Type = "Vector3i",
+						},
+						{
+							Name = "Digger",
+							Type = "cEntity",
+							IsOptional = true,
+						},
 					},
+					Returns =
+					{
+						{
+							Type = "boolean",
+						},
+					},
+					Notes = "Replaces the specified block with air, without dropping the usual pickups for the block. Wakes up the simulators for the block and its neighbors. The optional Digger parameter specifies the entity who dug the block, usually a player. Returns true on success, or false if the chunk is not loaded or invalid coords. See also DropBlockAsPickups() for the version that drops pickups.",
 				},
-				Notes = "Replaces the specified block with air, without dropping the usual pickups for the block. Wakes up the simulators for the block and its neighbors. Returns true on success, or false if the chunk is not loaded or invalid coords. See also DropBlockAsPickups() for the version that drops pickups.",
 			},
 			DoExplosionAt =
 			{

--- a/src/World.h
+++ b/src/World.h
@@ -667,14 +667,14 @@ public:
 	/** Replaces the specified block with air, and calls the OnBroken block handler.
 	Wakes up the simulators. Doesn't produce pickups, use DropBlockAsPickups() for that instead.
 	Returns true on success, false if the chunk is not loaded. */
-	bool DigBlock(Vector3i a_BlockPos, const cEntity * a_Digger);
+	bool DigBlock(Vector3i a_BlockPos, const cEntity * a_Digger = nullptr);
 
 	/** OBSOLETE, use the Vector3-based overload instead.
 	Replaces the specified block with air, and calls the apropriate block handlers (OnBreaking(), OnBroken()).
 	Wakes up the simulators.
 	Doesn't produce pickups, use DropBlockAsPickups() for that instead.
 	Returns true on success, false if the chunk is not loaded. */
-	bool DigBlock(int a_X, int a_Y, int a_Z, cEntity * a_Digger)
+	bool DigBlock(int a_X, int a_Y, int a_Z, cEntity * a_Digger = nullptr)
 	{
 		return DigBlock({a_X, a_Y, a_Z}, a_Digger);
 	}


### PR DESCRIPTION
Pull request #4967 broke api function cWorld:DigBlock, by making the digger not optional.
Lua code like:
No digger passed: `cRoot:Get():GetDefaultWorld():DigBlock(1, 1, 1)` fails, but should work
Adding nil for digger: `cRoot:Get():GetDefaultWorld():DigBlock(1, 1, 1, nil)` works
Fixed by adding nullptr to a_Digger.

Also added overloaded function for Vector3i in API Doc.
Copied the sentence `The optional Digger parameter specifies the entity who dug the block, usually a player` from function `DropBlockAsPickups`.

