### PR TITLE
Introduce cConstexprMap for simple lookup tables.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ target_sources(
 	Color.h
 	CommandOutput.h
 	CompositeChat.h
+	ConstexprMap.h
 	CraftingRecipes.h
 	Cuboid.h
 	DeadlockDetect.h

--- a/src/ConstexprMap.h
+++ b/src/ConstexprMap.h
@@ -1,0 +1,258 @@
+#pragma once
+
+// contexpr copies of std:: algorithms. Remove once we're using C++20.
+namespace ConstexprAlgorithms
+{
+template <typename InIt, typename OutIt>
+constexpr OutIt copy(InIt a_First, InIt a_Last, OutIt a_DestFirst)
+{
+	for (; a_First != a_Last; ++a_First, ++a_DestFirst)
+	{
+		*a_DestFirst = *a_First;
+	}
+	return a_DestFirst;
+}
+
+template <typename T>
+constexpr void swap(T & a, T & b)
+{
+	T Temp = std::move(a);
+	a = std::move(b);
+	b = std::move(Temp);
+}
+
+template <typename It, typename Pred>
+constexpr It adjacent_find(It a_First, It a_Last, Pred a_Pred = std::equal_to<>{})
+{
+	if (a_First == a_Last)
+	{
+		return a_Last;
+	}
+
+	auto Trailer = a_First;
+	++a_First;
+	for (; a_First != a_Last; ++a_First, ++Trailer)
+	{
+		if (a_Pred(*Trailer, *a_First))
+		{
+			return Trailer;
+		}
+	}
+	return a_Last;
+}
+
+template <typename It, typename T, typename Pred>
+constexpr It lower_bound(It a_First, It a_Last, T a_Val, Pred a_Less = std::less<>{})
+{
+	while (a_First != a_Last)
+	{
+		const auto Dist = a_Last - a_First;
+		const auto Middle = a_First + Dist / 2;
+		if (a_Less(*Middle, a_Val))
+		{
+			a_First = Middle + 1;
+		}
+		else
+		{
+			a_Last = Middle;
+		}
+	}
+	return a_First;
+}
+
+template <typename It, typename Pred>
+constexpr It partition(It a_First, It a_Last, Pred a_Pred)
+{
+
+	for (;;)
+	{
+		for (;; ++a_First)
+		{
+			if (a_First == a_Last)
+			{
+				return a_First;
+			}
+
+			if (!a_Pred(*a_First))
+			{
+				break;
+			}
+		}
+
+		for (;;)
+		{
+			--a_Last;
+			if (a_First == a_Last)
+			{
+				return a_First;
+			}
+
+			if (a_Pred(*a_Last))
+			{
+				break;
+			}
+		}
+
+		swap(*a_First, *a_Last);
+		++a_First;
+	}
+}
+
+template <typename It, typename Comp>
+constexpr void InsertionSort(It a_First, It a_Last, Comp a_Less = std::less<>{})
+{
+	if (a_First == a_Last)
+	{
+		return;
+	}
+
+	for (auto i = std::next(a_First); i != a_Last; ++i)
+	{
+		for (auto j = i;;)
+		{
+			auto Prev = std::prev(j);
+			if ((Prev == a_First) || !a_Less(*j, *Prev))
+			{
+				break;
+			}
+			swap(*j, *Prev);
+			j = Prev;
+		}
+	}
+}
+
+template <typename It, typename Pred>
+constexpr void sort(It a_First, It a_Last, Pred a_Less = std::less<>{})
+{
+	// Insertion sort for small ranges
+	auto Dist = a_Last - a_First;
+	if (Dist <= 8)
+	{
+		return ConstexprAlgorithms::InsertionSort(a_First, a_Last, a_Less);
+	}
+
+	// Recursive quicksort for larger ranges
+	auto Pivot = [&]  // Select "median of 3" as pivot
+		{
+			auto Mid = a_First + Dist / 2;
+			std::array<decltype(Mid), 3> Samples{{a_First, Mid, std::prev(a_Last)}};
+			ConstexprAlgorithms::InsertionSort(std::begin(Samples), std::end(Samples),
+				[&](const auto & a_Lhs, const auto & a_Rhs)
+				{
+					return a_Less(*a_Lhs, *a_Rhs);
+				}
+			);
+			return *Samples[1];
+		}();
+
+	const auto LowerBound = ConstexprAlgorithms::partition(a_First, a_Last,
+		[&](const auto & a_Val) { return a_Less(a_Val, Pivot); }
+	);
+	const auto UpperBound = ConstexprAlgorithms::partition(LowerBound, a_Last,
+		[&](const auto & a_Val) { return !a_Less(Pivot, a_Val); }
+	);
+	ConstexprAlgorithms::sort(a_First, LowerBound, a_Less);
+	ConstexprAlgorithms::sort(UpperBound, a_Last, a_Less);
+}
+}  // namespace ConstexprAlgorithms
+
+
+
+
+
+// A flat-map intended for constexpr lookup tables
+template <typename K, typename V, size_t Size, typename Comp=std::less<>>
+class cConstexprMap
+{
+	// NOTE: std::pair assignment isn't constexpr, so need our own type
+	struct sKVPair
+	{
+		K first;
+		V second;
+	};
+	using cStorage = std::array<sKVPair, Size>;
+public:
+
+	using value_type = sKVPair;
+	using size_type = size_t;
+	using const_iterator = typename cStorage::const_iterator;
+	using iterator = const_iterator;
+
+	constexpr cConstexprMap(std::initializer_list<value_type> a_IL):
+		m_Storage{}
+	{
+		if (a_IL.size() != Size)
+		{
+			throw std::invalid_argument("Wrong number of elements");
+		}
+
+		ConstexprAlgorithms::copy(a_IL.begin(), a_IL.end(), std::begin(m_Storage));
+		ConstexprAlgorithms::sort(std::begin(m_Storage), std::end(m_Storage),
+			[](const auto & a_Lhs, const auto & a_Rhs)
+			{
+				return Comp{}(a_Lhs.first, a_Rhs.first);
+			}
+		);
+
+		#ifdef DEBUG
+			for (size_t i = 0; i + 1 < Size; ++i)
+			{
+				// Assert m_Storage is sorted
+				if (Comp{}(m_Storage[i + 1].first, m_Storage[i].first))
+				{
+					throw std::runtime_error("Sorting failed");
+				}
+			}
+		#endif
+
+		auto It = ConstexprAlgorithms::adjacent_find(begin(), end(),
+			[](const auto & a_Lhs, const auto & a_Rhs)
+			{
+				return a_Lhs.first == a_Rhs.first;
+			}
+		);
+
+		if (It != end())
+		{
+			throw std::invalid_argument("Duplicate keys in initializer_list");
+		}
+	}
+
+	constexpr iterator cbegin() const { return std::cbegin(m_Storage); }
+	constexpr iterator cend() const { return std::cend(m_Storage); }
+	constexpr iterator begin() const { return cbegin(); }
+	constexpr iterator end() const { return cend(); }
+	constexpr size_type size() const { return Size; }
+
+	template <typename K2>
+	constexpr iterator lower_bound(const K2 & a_Key) const
+	{
+		return ConstexprAlgorithms::lower_bound(begin(), end(), a_Key,
+			[&](const value_type & a_Lhs, const auto & a_Rhs)
+			{
+				return Comp{}(a_Lhs.first, a_Rhs);
+			}
+		);
+	}
+
+	template <typename K2>
+	constexpr iterator find(const K2 & a_Key) const
+	{
+		auto it = lower_bound(a_Key);
+		return (it->first == a_Key) ? it : end();
+	}
+
+	template <typename K2>
+	constexpr const V & at(const K2 & a_Key) const
+	{
+		auto It = find(a_Key);
+		if (It == end())
+		{
+			throw std::out_of_range("");
+		}
+		return It->second;
+	}
+
+private:
+	cStorage m_Storage;
+};

--- a/src/Generating/PrefabPiecePool.cpp
+++ b/src/Generating/PrefabPiecePool.cpp
@@ -9,6 +9,7 @@
 #include "../Bindings/LuaState.h"
 #include "../WorldStorage/SchematicFileSerializer.h"
 #include "../StringCompression.h"
+#include "../ConstexprMap.h"
 
 
 
@@ -28,22 +29,26 @@
 
 
 /** Returns the map of string => eMergeStrategy used when translating cubeset file merge strategies. */
-static std::map<AString, cBlockArea::eMergeStrategy> & GetMergeStrategyMap(void)
+static std::optional<cBlockArea::eMergeStrategy> GetMergeStrategy(std::string_view a_MS)
 {
-	static std::map<AString, cBlockArea::eMergeStrategy> msmap;
-	if (msmap.empty())
+	static constexpr cConstexprMap<std::string_view, cBlockArea::eMergeStrategy, 8> MSMap
 	{
 		// This is the first use, initialize the map:
-		msmap["msOverwrite"]     = cBlockArea::msOverwrite;
-		msmap["msFillAir"]       = cBlockArea::msFillAir;
-		msmap["msImprint"]       = cBlockArea::msImprint;
-		msmap["msLake"]          = cBlockArea::msLake;
-		msmap["msSpongePrint"]   = cBlockArea::msSpongePrint;
-		msmap["msDifference"]    = cBlockArea::msDifference;
-		msmap["msSimpleCompare"] = cBlockArea::msSimpleCompare;
-		msmap["msMask"]          = cBlockArea::msMask;
+		{"msOverwrite",     cBlockArea::msOverwrite},
+		{"msFillAir",       cBlockArea::msFillAir},
+		{"msImprint",       cBlockArea::msImprint},
+		{"msLake",          cBlockArea::msLake},
+		{"msSpongePrint",   cBlockArea::msSpongePrint},
+		{"msDifference",    cBlockArea::msDifference},
+		{"msSimpleCompare", cBlockArea::msSimpleCompare},
+		{"msMask",          cBlockArea::msMask}
+	};
+	auto It = MSMap.find(a_MS);
+	if (It == MSMap.end())
+	{
+		return std::nullopt;
 	}
-	return msmap;
+	return It->second;
 }
 
 
@@ -552,9 +557,8 @@ bool cPrefabPiecePool::ReadPieceMetadataCubesetVer1(
 	a_Prefab->SetAddWeightIfSame(AddWeightIfSame);
 	a_Prefab->SetDefaultWeight(DefaultWeight);
 	a_Prefab->ParseDepthWeight(DepthWeight.c_str());
-	auto msmap = GetMergeStrategyMap();
-	auto strategy = msmap.find(MergeStrategy);
-	if (strategy == msmap.end())
+	auto StrategyOpt = GetMergeStrategy(MergeStrategy);
+	if (!StrategyOpt)
 	{
 		CONDWARNING(a_LogWarnings, "Unknown merge strategy (\"%s\") specified for piece %s in file %s. Using msSpongePrint instead.",
 			MergeStrategy.c_str(), a_PieceName.c_str(), a_FileName.c_str()
@@ -563,7 +567,7 @@ bool cPrefabPiecePool::ReadPieceMetadataCubesetVer1(
 	}
 	else
 	{
-		a_Prefab->SetMergeStrategy(strategy->second);
+		a_Prefab->SetMergeStrategy(*StrategyOpt);
 	}
 	a_Prefab->SetMoveToGround(MoveToGround != 0);
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -14,6 +14,7 @@ Implements the 1.8 protocol classes:
 #include "Packetizer.h"
 
 #include "../ClientHandle.h"
+#include "../ConstexprMap.h"
 #include "../Root.h"
 #include "../Server.h"
 #include "../World.h"
@@ -1806,7 +1807,7 @@ bool cProtocol_1_8_0::CompressPacket(const AString & a_Packet, AString & a_Compr
 
 int cProtocol_1_8_0::GetParticleID(const AString & a_ParticleName)
 {
-	static const std::unordered_map<AString, int> ParticleMap
+	static constexpr cConstexprMap<std::string_view, int, 49> ParticleMap
 	{
 		// Initialize the ParticleMap:
 		{ "explode",          0 },

--- a/src/WorldStorage/NamespaceSerializer.cpp
+++ b/src/WorldStorage/NamespaceSerializer.cpp
@@ -1,6 +1,7 @@
 #include "Globals.h"
 
 #include "NamespaceSerializer.h"
+#include "../ConstexprMap.h"
 
 namespace NamespaceSerializer
 {
@@ -137,7 +138,7 @@ namespace NamespaceSerializer
 
 	Statistic ToCustomStatistic(const std::string_view ID)
 	{
-		static const std::unordered_map<std::string_view, Statistic> CustomStatistics
+		static constexpr cConstexprMap<std::string_view, Statistic, 109> CustomStatistics
 		{
 			{ "animals_bred",                            Statistic::AnimalsBred },
 			{ "aviate_one_cm",                           Statistic::AviateOneCm },

--- a/src/WorldStorage/StatSerializer.cpp
+++ b/src/WorldStorage/StatSerializer.cpp
@@ -4,6 +4,7 @@
 
 #include "Globals.h"
 #include "../Statistics.h"
+#include "../ConstexprMap.h"
 #include "StatSerializer.h"
 #include "NamespaceSerializer.h"
 
@@ -58,7 +59,7 @@ namespace StatSerializer
 	static void LoadLegacyFromJSON(cStatManager & Manager, const Json::Value & In)
 	{
 		// Upgrade mapping from pre-1.13 names. TODO: remove on 2020-09-18
-		static const std::unordered_map<std::string_view, Statistic> LegacyMapping
+		static constexpr cConstexprMap<std::string_view, Statistic, 82> LegacyMapping
 		{
 			{ "achievement.openInventory", Statistic::AchOpenInventory },
 			{ "achievement.mineWood", Statistic::AchMineWood },


### PR DESCRIPTION
There are a few places we use constant maps from e.g. string to enum value. This adds a `constexpr`-capable map so these mappings can be produced at compile-time and without any dynamic memory allocation. It uses a very simple ordered flat-map (an array of key-value pairs, sorted by key).

No global constructors, no magic-static constructor guards, no memory allocation. Just a simple lookup table. 

Unfortunately, most of the `<algorithm>` header isn't marked `constexpr` until C++20, so I had to reproduce some of the algorithms like `sort` and `lower_bound`. The nice thing about `constexpr` though, if there is a bug in my sorting routine it'll get caught at compile time.