### PR TITLE
Fix Android builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,13 +88,10 @@ endif()
 # Selectively disable warnings in the level where the target is created:
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	# Generated file has old-style casts, missing prototypes, and deprecated declarations
-	set_source_files_properties("${CMAKE_SOURCE_DIR}/src/Bindings/Bindings.cpp" PROPERTIES COMPILE_OPTIONS -Wno-everything)
+	set_source_files_properties("${PROJECT_SOURCE_DIR}/src/Bindings/Bindings.cpp" PROPERTIES COMPILE_OPTIONS -Wno-everything)
 
 	# File failed to follow NHS guidelines on handwashing and has not maintained good hygiene
-	set_source_files_properties("${CMAKE_SOURCE_DIR}/src/IniFile.cpp" PROPERTIES COMPILE_OPTIONS -Wno-header-hygiene)
-
-	# Enforce BlockHandler handling all blocks in switch statements
-	set_source_files_properties("${CMAKE_SOURCE_DIR}/src/Blocks/BlockHandler.cpp" PROPERTIES COMPILE_OPTIONS -Werror=switch)
+	set_source_files_properties("${PROJECT_SOURCE_DIR}/src/IniFile.cpp" PROPERTIES COMPILE_OPTIONS -Wno-header-hygiene)
 endif()
 
 if(${BUILD_TOOLS})

--- a/android/compile.sh
+++ b/android/compile.sh
@@ -40,7 +40,7 @@ if [ -z "$THREADS" ]; then
 	THREADS="4"
 fi
 
-cd $BASEDIR
+cd "$BASEDIR"
 
 case "$1" in
 
@@ -93,9 +93,9 @@ case "$1" in
 	;;
 esac
 
-mkdir -p $BUILDDIR
-cd $BUILDDIR
-"$CMAKE" $BASEDIR/../android -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
+mkdir -p "$BUILDDIR"
+cd "$BUILDDIR"
+"$CMAKE" "$BASEDIR/../android" -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="$1" \
     -DANDROID_NATIVE_API_LEVEL="$APILEVEL" \
     -DCMAKE_BUILD_TYPE="$TYPE" \

--- a/tests/BlockTypeRegistry/CMakeLists.txt
+++ b/tests/BlockTypeRegistry/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Threads REQUIRED)
-include_directories(${CMAKE_SOURCE_DIR}/src/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
 
 # Define individual test executables:
 
@@ -7,21 +7,21 @@ include_directories(${CMAKE_SOURCE_DIR}/src/)
 add_executable(BlockStateTest
 	BlockStateTest.cpp
 	../TestHelpers.h
-	${CMAKE_SOURCE_DIR}/src/BlockState.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockState.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
 )
 target_link_libraries(BlockStateTest fmt::fmt)
 
 add_executable(BlockTypePaletteTest
 	BlockTypePaletteTest.cpp
 	../TestHelpers.h
-	${CMAKE_SOURCE_DIR}/src/BlockState.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockTypePalette.cpp
-	${CMAKE_SOURCE_DIR}/src/JsonUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockState.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockTypePalette.cpp
+	${PROJECT_SOURCE_DIR}/src/JsonUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.cpp
 )
 target_link_libraries(BlockTypePaletteTest fmt::fmt jsoncpp_lib)
 
@@ -29,9 +29,9 @@ target_link_libraries(BlockTypePaletteTest fmt::fmt jsoncpp_lib)
 add_executable(BlockTypeRegistryTest
 	BlockTypeRegistryTest.cpp
 	../TestHelpers.h
-	${CMAKE_SOURCE_DIR}/src/BlockTypeRegistry.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockTypeRegistry.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
 )
 target_link_libraries(BlockTypeRegistryTest fmt::fmt Threads::Threads)
 
@@ -39,14 +39,14 @@ target_link_libraries(BlockTypeRegistryTest fmt::fmt Threads::Threads)
 add_executable(PalettedBlockAreaTest
 	PalettedBlockAreaTest.cpp
 	../TestHelpers.h
-	${CMAKE_SOURCE_DIR}/src/BlockState.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockTypeRegistry.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockTypePalette.cpp
-	${CMAKE_SOURCE_DIR}/src/Cuboid.cpp
-	${CMAKE_SOURCE_DIR}/src/JsonUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/PalettedBlockArea.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockState.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockTypeRegistry.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockTypePalette.cpp
+	${PROJECT_SOURCE_DIR}/src/Cuboid.cpp
+	${PROJECT_SOURCE_DIR}/src/JsonUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/PalettedBlockArea.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
 )
 target_link_libraries(PalettedBlockAreaTest fmt::fmt jsoncpp_lib)
 

--- a/tests/BoundingBox/CMakeLists.txt
+++ b/tests/BoundingBox/CMakeLists.txt
@@ -1,15 +1,15 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/BoundingBox.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
+	${PROJECT_SOURCE_DIR}/src/BoundingBox.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
 )
 
 set (SHARED_HDRS
-	${CMAKE_SOURCE_DIR}/src/BoundingBox.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
+	${PROJECT_SOURCE_DIR}/src/BoundingBox.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
 )
 
 set (SRCS

--- a/tests/ByteBuffer/CMakeLists.txt
+++ b/tests/ByteBuffer/CMakeLists.txt
@@ -1,14 +1,14 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/ByteBuffer.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/ByteBuffer.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 )
 
 set (SHARED_HDRS
 	../TestHelpers.h
-	${CMAKE_SOURCE_DIR}/src/ByteBuffer.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/ByteBuffer.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 )
 
 set (SRCS

--- a/tests/ChunkData/CMakeLists.txt
+++ b/tests/ChunkData/CMakeLists.txt
@@ -1,6 +1,6 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
 
-add_library(ChunkBuffer ${CMAKE_SOURCE_DIR}/src/ChunkData.cpp ${CMAKE_SOURCE_DIR}/src/StringUtils.cpp)
+add_library(ChunkBuffer ${PROJECT_SOURCE_DIR}/src/ChunkData.cpp ${PROJECT_SOURCE_DIR}/src/StringUtils.cpp)
 
 target_link_libraries(ChunkBuffer PUBLIC fmt::fmt)
 

--- a/tests/CompositeChat/CMakeLists.txt
+++ b/tests/CompositeChat/CMakeLists.txt
@@ -1,18 +1,18 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-include_directories(${CMAKE_SOURCE_DIR}/lib/jsoncpp/include)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
+include_directories(${PROJECT_SOURCE_DIR}/lib/jsoncpp/include)
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/CompositeChat.cpp
-	${CMAKE_SOURCE_DIR}/src/JsonUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/CompositeChat.cpp
+	${PROJECT_SOURCE_DIR}/src/JsonUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 )
 
 set (SHARED_HDRS
 	../TestHelpers.h
-	${CMAKE_SOURCE_DIR}/src/CompositeChat.h
-	${CMAKE_SOURCE_DIR}/src/JsonUtils.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/CompositeChat.h
+	${PROJECT_SOURCE_DIR}/src/JsonUtils.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 )
 
 set (SRCS

--- a/tests/FastRandom/CMakeLists.txt
+++ b/tests/FastRandom/CMakeLists.txt
@@ -1,14 +1,14 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/FastRandom.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/FastRandom.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 )
 
 set (SHARED_HDRS
 	../TestHelpers.h
-	${CMAKE_SOURCE_DIR}/src/FastRandom.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/FastRandom.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 )
 
 set (SRCS

--- a/tests/Generating/CMakeLists.txt
+++ b/tests/Generating/CMakeLists.txt
@@ -1,139 +1,139 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/mbedtls/include)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/)
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/mbedtls/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockArea.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockInfo.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockType.cpp
-	${CMAKE_SOURCE_DIR}/src/Cuboid.cpp
-	${CMAKE_SOURCE_DIR}/src/ChunkData.cpp
-	${CMAKE_SOURCE_DIR}/src/Defines.cpp
-	${CMAKE_SOURCE_DIR}/src/Enchantments.cpp
-	${CMAKE_SOURCE_DIR}/src/FastRandom.cpp
-	${CMAKE_SOURCE_DIR}/src/IniFile.cpp
-	${CMAKE_SOURCE_DIR}/src/ProbabDistrib.cpp
-	${CMAKE_SOURCE_DIR}/src/StringCompression.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
-	${CMAKE_SOURCE_DIR}/src/VoronoiMap.cpp
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockArea.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockInfo.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockType.cpp
+	${PROJECT_SOURCE_DIR}/src/Cuboid.cpp
+	${PROJECT_SOURCE_DIR}/src/ChunkData.cpp
+	${PROJECT_SOURCE_DIR}/src/Defines.cpp
+	${PROJECT_SOURCE_DIR}/src/Enchantments.cpp
+	${PROJECT_SOURCE_DIR}/src/FastRandom.cpp
+	${PROJECT_SOURCE_DIR}/src/IniFile.cpp
+	${PROJECT_SOURCE_DIR}/src/ProbabDistrib.cpp
+	${PROJECT_SOURCE_DIR}/src/StringCompression.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/VoronoiMap.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.cpp  # Needed for PrefabPiecePool loading
+	${PROJECT_SOURCE_DIR}/src/Bindings/LuaState.cpp  # Needed for PrefabPiecePool loading
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.cpp
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.cpp
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp  # Needed for LuaState
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp  # Needed for LuaState
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
 )
 
 set (GENERATING_SRCS
-	${CMAKE_SOURCE_DIR}/src/Generating/BioGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Caves.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkGenerator.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/CompoGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/CompoGenBiomal.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/ComposableGenerator.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/DistortedHeightmap.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/DungeonRoomsFinisher.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/EndGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/FinishGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/GridStructGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/HeiGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/MineShafts.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Noise3DGenerator.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PieceStructuresGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabStructure.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Ravines.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/RoughRavines.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/SinglePieceStructuresGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/StructGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Trees.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/TwoHeights.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VillageGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/BioGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/Caves.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkGenerator.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/CompoGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/CompoGenBiomal.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/ComposableGenerator.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/DistortedHeightmap.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/DungeonRoomsFinisher.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/EndGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/FinishGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/GridStructGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/HeiGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/MineShafts.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/Noise3DGenerator.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PiecePool.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PieceStructuresGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/Prefab.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabStructure.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/Ravines.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/RoughRavines.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/SinglePieceStructuresGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/StructGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/Trees.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/TwoHeights.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/VillageGen.cpp
 )
 
 set (SHARED_HDRS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.h
-	${CMAKE_SOURCE_DIR}/src/BlockArea.h
-	${CMAKE_SOURCE_DIR}/src/BlockInfo.h
-	${CMAKE_SOURCE_DIR}/src/BlockType.h
-	${CMAKE_SOURCE_DIR}/src/Cuboid.h
-	${CMAKE_SOURCE_DIR}/src/ChunkData.h
-	${CMAKE_SOURCE_DIR}/src/ChunkDef.h
-	${CMAKE_SOURCE_DIR}/src/Defines.h
-	${CMAKE_SOURCE_DIR}/src/Enchantments.h
-	${CMAKE_SOURCE_DIR}/src/FastRandom.h
-	${CMAKE_SOURCE_DIR}/src/Globals.h
-	${CMAKE_SOURCE_DIR}/src/IniFile.h
-	${CMAKE_SOURCE_DIR}/src/ProbabDistrib.h
-	${CMAKE_SOURCE_DIR}/src/StringCompression.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
-	${CMAKE_SOURCE_DIR}/src/VoronoiMap.h
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.h
+	${PROJECT_SOURCE_DIR}/src/BlockArea.h
+	${PROJECT_SOURCE_DIR}/src/BlockInfo.h
+	${PROJECT_SOURCE_DIR}/src/BlockType.h
+	${PROJECT_SOURCE_DIR}/src/Cuboid.h
+	${PROJECT_SOURCE_DIR}/src/ChunkData.h
+	${PROJECT_SOURCE_DIR}/src/ChunkDef.h
+	${PROJECT_SOURCE_DIR}/src/Defines.h
+	${PROJECT_SOURCE_DIR}/src/Enchantments.h
+	${PROJECT_SOURCE_DIR}/src/FastRandom.h
+	${PROJECT_SOURCE_DIR}/src/Globals.h
+	${PROJECT_SOURCE_DIR}/src/IniFile.h
+	${PROJECT_SOURCE_DIR}/src/ProbabDistrib.h
+	${PROJECT_SOURCE_DIR}/src/StringCompression.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/VoronoiMap.h
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.h
+	${PROJECT_SOURCE_DIR}/src/Bindings/LuaState.h
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.h
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.h
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.h
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
 )
 
 set (GENERATING_HDRS
-	${CMAKE_SOURCE_DIR}/src/Generating/BioGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Caves.h
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.h
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkGenerator.h
-	${CMAKE_SOURCE_DIR}/src/Generating/CompoGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/CompoGenBiomal.h
-	${CMAKE_SOURCE_DIR}/src/Generating/ComposableGenerator.h
-	${CMAKE_SOURCE_DIR}/src/Generating/CompositedHeiGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/DistortedHeightmap.h
-	${CMAKE_SOURCE_DIR}/src/Generating/DungeonRoomsFinisher.h
-	${CMAKE_SOURCE_DIR}/src/Generating/EndGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/FinishGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/GridStructGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/HeiGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/IntGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/MineShafts.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Noise3DGenerator.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PieceStructuresGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabStructure.h
-	${CMAKE_SOURCE_DIR}/src/Generating/ProtIntGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Ravines.h
-	${CMAKE_SOURCE_DIR}/src/Generating/RoughRavines.h
-	${CMAKE_SOURCE_DIR}/src/Generating/ShapeGen.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/SinglePieceStructuresGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/StructGen.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Trees.h
-	${CMAKE_SOURCE_DIR}/src/Generating/TwoHeights.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VillageGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/BioGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Caves.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkDesc.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkGenerator.h
+	${PROJECT_SOURCE_DIR}/src/Generating/CompoGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/CompoGenBiomal.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ComposableGenerator.h
+	${PROJECT_SOURCE_DIR}/src/Generating/CompositedHeiGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/DistortedHeightmap.h
+	${PROJECT_SOURCE_DIR}/src/Generating/DungeonRoomsFinisher.h
+	${PROJECT_SOURCE_DIR}/src/Generating/EndGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/FinishGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/GridStructGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/HeiGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/IntGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/MineShafts.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Noise3DGenerator.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PieceGeneratorBFSTree.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PieceStructuresGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Prefab.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabStructure.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ProtIntGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Ravines.h
+	${PROJECT_SOURCE_DIR}/src/Generating/RoughRavines.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ShapeGen.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/SinglePieceStructuresGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/StructGen.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Trees.h
+	${PROJECT_SOURCE_DIR}/src/Generating/TwoHeights.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalLimit.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalStrategy.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VillageGen.h
 )
 
 set (STUBS
@@ -169,11 +169,11 @@ source_group("Generating" FILES ${GENERATING_HDRS} ${GENERATING_SRCS})
 # BasicGeneratingTest:
 add_executable(BasicGeneratorTest
 	BasicGeneratorTest.cpp
-	${CMAKE_SOURCE_DIR}/src/IniFile.cpp
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/Sha1Checksum.cpp
+	${PROJECT_SOURCE_DIR}/src/IniFile.cpp
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/Sha1Checksum.cpp
 )
 target_link_libraries(BasicGeneratorTest GeneratorTestingSupport mbedtls)
-file(COPY "${CMAKE_SOURCE_DIR}/Server/items.ini" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+file(COPY "${PROJECT_SOURCE_DIR}/Server/items.ini" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 add_test(
 	NAME BasicGeneratorTest
 	COMMAND BasicGeneratorTest
@@ -223,7 +223,7 @@ add_executable(PieceGeneratorBFSTree
 target_link_libraries(PieceGeneratorBFSTree GeneratorTestingSupport)
 add_test(
 	NAME PieceGeneratorBFSTree-test
-	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Server/Prefabs/PieceStructures
+	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Server/Prefabs/PieceStructures
 	COMMAND PieceGeneratorBFSTree
 )
 

--- a/tests/HTTP/CMakeLists.txt
+++ b/tests/HTTP/CMakeLists.txt
@@ -1,33 +1,33 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/mbedtls/include)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/mbedtls/include)
 
 # Create a single HTTP library that contains all the HTTP code:
 set (HTTP_SRCS
-	${CMAKE_SOURCE_DIR}/src/HTTP/EnvelopeParser.cpp
-	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessage.cpp
-	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessageParser.cpp
-	${CMAKE_SOURCE_DIR}/src/HTTP/TransferEncodingParser.cpp
-	${CMAKE_SOURCE_DIR}/src/HTTP/UrlClient.cpp
-	${CMAKE_SOURCE_DIR}/src/HTTP/UrlParser.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/HTTP/EnvelopeParser.cpp
+	${PROJECT_SOURCE_DIR}/src/HTTP/HTTPMessage.cpp
+	${PROJECT_SOURCE_DIR}/src/HTTP/HTTPMessageParser.cpp
+	${PROJECT_SOURCE_DIR}/src/HTTP/TransferEncodingParser.cpp
+	${PROJECT_SOURCE_DIR}/src/HTTP/UrlClient.cpp
+	${PROJECT_SOURCE_DIR}/src/HTTP/UrlParser.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 )
 
 set (HTTP_HDRS
-	${CMAKE_SOURCE_DIR}/src/HTTP/EnvelopeParser.h
-	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessage.h
-	${CMAKE_SOURCE_DIR}/src/HTTP/HTTPMessageParser.h
-	${CMAKE_SOURCE_DIR}/src/HTTP/TransferEncodingParser.h
-	${CMAKE_SOURCE_DIR}/src/HTTP/UrlClient.h
-	${CMAKE_SOURCE_DIR}/src/HTTP/UrlParser.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/HTTP/EnvelopeParser.h
+	${PROJECT_SOURCE_DIR}/src/HTTP/HTTPMessage.h
+	${PROJECT_SOURCE_DIR}/src/HTTP/HTTPMessageParser.h
+	${PROJECT_SOURCE_DIR}/src/HTTP/TransferEncodingParser.h
+	${PROJECT_SOURCE_DIR}/src/HTTP/UrlClient.h
+	${PROJECT_SOURCE_DIR}/src/HTTP/UrlParser.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 )
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.cpp
 )
 
 add_library(HTTP

--- a/tests/LoadablePieces/CMakeLists.txt
+++ b/tests/LoadablePieces/CMakeLists.txt
@@ -1,64 +1,64 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockArea.cpp
-	${CMAKE_SOURCE_DIR}/src/Cuboid.cpp
-	${CMAKE_SOURCE_DIR}/src/ChunkData.cpp
-	${CMAKE_SOURCE_DIR}/src/StringCompression.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockArea.cpp
+	${PROJECT_SOURCE_DIR}/src/Cuboid.cpp
+	${PROJECT_SOURCE_DIR}/src/ChunkData.cpp
+	${PROJECT_SOURCE_DIR}/src/StringCompression.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.cpp
+	${PROJECT_SOURCE_DIR}/src/Bindings/LuaState.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PiecePool.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/Prefab.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.cpp
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.cpp
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
 )
 
 set (SHARED_HDRS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.h
-	${CMAKE_SOURCE_DIR}/src/BlockArea.h
-	${CMAKE_SOURCE_DIR}/src/Cuboid.h
-	${CMAKE_SOURCE_DIR}/src/ChunkData.h
-	${CMAKE_SOURCE_DIR}/src/Globals.h
-	${CMAKE_SOURCE_DIR}/src/StringCompression.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.h
+	${PROJECT_SOURCE_DIR}/src/BlockArea.h
+	${PROJECT_SOURCE_DIR}/src/Cuboid.h
+	${PROJECT_SOURCE_DIR}/src/ChunkData.h
+	${PROJECT_SOURCE_DIR}/src/Globals.h
+	${PROJECT_SOURCE_DIR}/src/StringCompression.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.h
+	${PROJECT_SOURCE_DIR}/src/Bindings/LuaState.h
 
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkDesc.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Prefab.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalLimit.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalStrategy.h
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.h
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.h
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.h
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.h
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
 )
 
 set (SRCS
@@ -78,8 +78,8 @@ endif()
 
 if (MSVC)
 	# Add the MSVC-specific LeakFinder sources:
-	list (APPEND SHARED_SRCS ${CMAKE_SOURCE_DIR}/src/LeakFinder.cpp ${CMAKE_SOURCE_DIR}/src/StackWalker.cpp)
-	list (APPEND SHARED_HDRS ${CMAKE_SOURCE_DIR}/src/LeakFinder.h   ${CMAKE_SOURCE_DIR}/src/StackWalker.h)
+	list (APPEND SHARED_SRCS ${PROJECT_SOURCE_DIR}/src/LeakFinder.cpp ${PROJECT_SOURCE_DIR}/src/StackWalker.cpp)
+	list (APPEND SHARED_HDRS ${PROJECT_SOURCE_DIR}/src/LeakFinder.h   ${PROJECT_SOURCE_DIR}/src/StackWalker.h)
 endif()
 
 source_group("Shared" FILES ${SHARED_SRCS} ${SHARED_HDRS})

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -1,67 +1,67 @@
 find_package(Threads REQUIRED)
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockArea.cpp
-	${CMAKE_SOURCE_DIR}/src/Cuboid.cpp
-	${CMAKE_SOURCE_DIR}/src/ChunkData.cpp
-	${CMAKE_SOURCE_DIR}/src/StringCompression.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockArea.cpp
+	${PROJECT_SOURCE_DIR}/src/Cuboid.cpp
+	${PROJECT_SOURCE_DIR}/src/ChunkData.cpp
+	${PROJECT_SOURCE_DIR}/src/StringCompression.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.cpp
+	${PROJECT_SOURCE_DIR}/src/Bindings/LuaState.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkDesc.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PiecePool.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/Prefab.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabPiecePool.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalLimit.cpp
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalStrategy.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.cpp
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.cpp
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
 )
 
 set (SHARED_HDRS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.h
-	${CMAKE_SOURCE_DIR}/src/BlockArea.h
-	${CMAKE_SOURCE_DIR}/src/Cuboid.h
-	${CMAKE_SOURCE_DIR}/src/ChunkData.h
-	${CMAKE_SOURCE_DIR}/src/Globals.h
-	${CMAKE_SOURCE_DIR}/src/StringCompression.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.h
+	${PROJECT_SOURCE_DIR}/src/BlockArea.h
+	${PROJECT_SOURCE_DIR}/src/Cuboid.h
+	${PROJECT_SOURCE_DIR}/src/ChunkData.h
+	${PROJECT_SOURCE_DIR}/src/Globals.h
+	${PROJECT_SOURCE_DIR}/src/StringCompression.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.h
+	${PROJECT_SOURCE_DIR}/src/Bindings/LuaState.h
 
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkDesc.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Prefab.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalLimit.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalStrategy.h
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.h
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.h
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.h
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
 )
 
 set (SRCS

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -1,53 +1,53 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/mbedtls/include)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/mbedtls/include)
 
 find_package(Threads REQUIRED)
 
 # Create a single Network library that contains all the networking code:
 set (Network_SRCS
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/HostnameLookup.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/IPLookup.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/IsThread.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkInterfaceEnum.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkLookup.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkSingleton.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CtrDrbgContext.cpp
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CryptoKey.cpp
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/EntropyContext.cpp
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/SslConfig.cpp
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/SslContext.cpp
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/X509Cert.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/HostnameLookup.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/IPLookup.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/IsThread.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/NetworkInterfaceEnum.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/NetworkLookup.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/NetworkSingleton.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/CtrDrbgContext.cpp
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/CryptoKey.cpp
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/EntropyContext.cpp
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/SslConfig.cpp
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/SslContext.cpp
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/X509Cert.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 )
 
 set (Network_HDRS
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GetAddressInfoError.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/HostnameLookup.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/IPLookup.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/IsThread.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Network.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkLookup.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/NetworkSingleton.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Queue.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CtrDrbgContext.h
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/CryptoKey.h
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/EntropyContext.h
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/SslConfig.h
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/SslContext.h
-	${CMAKE_SOURCE_DIR}/src/mbedTLS++/X509Cert.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GetAddressInfoError.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/HostnameLookup.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/IPLookup.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/IsThread.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Network.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/NetworkLookup.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/NetworkSingleton.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/ServerHandleImpl.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/TCPLinkImpl.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Queue.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/CtrDrbgContext.h
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/CryptoKey.h
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/EntropyContext.h
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/SslConfig.h
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/SslContext.h
+	${PROJECT_SOURCE_DIR}/src/mbedTLS++/X509Cert.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 )
 
 add_library(Network

--- a/tests/OSSupport/CMakeLists.txt
+++ b/tests/OSSupport/CMakeLists.txt
@@ -1,17 +1,17 @@
 find_package(Threads REQUIRED)
-include_directories(${CMAKE_SOURCE_DIR}/src/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
 
 # Create a single OSSupport library that contains all the OSSupport code used in the tests:
 set (OSSupport_SRCS
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 )
 set (OSSupport_HDRS
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
-	${CMAKE_SOURCE_DIR}/src/Globals.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/Globals.h
 )
 add_library(OSSupport
 	${OSSupport_SRCS}

--- a/tests/SchematicFileSerializer/CMakeLists.txt
+++ b/tests/SchematicFileSerializer/CMakeLists.txt
@@ -1,57 +1,57 @@
-include_directories(${CMAKE_SOURCE_DIR}/src/)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/lib/)
+include_directories(${PROJECT_SOURCE_DIR}/src/)
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.cpp
-	${CMAKE_SOURCE_DIR}/src/BlockArea.cpp
-	${CMAKE_SOURCE_DIR}/src/Cuboid.cpp
-	${CMAKE_SOURCE_DIR}/src/ChunkData.cpp
-	${CMAKE_SOURCE_DIR}/src/StringCompression.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.cpp
+	${PROJECT_SOURCE_DIR}/src/BlockArea.cpp
+	${PROJECT_SOURCE_DIR}/src/Cuboid.cpp
+	${PROJECT_SOURCE_DIR}/src/ChunkData.cpp
+	${PROJECT_SOURCE_DIR}/src/StringCompression.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.cpp
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.cpp
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.cpp
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.cpp
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.cpp
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.cpp
 )
 
 set (SHARED_HDRS
-	${CMAKE_SOURCE_DIR}/src/BiomeDef.h
-	${CMAKE_SOURCE_DIR}/src/BlockArea.h
-	${CMAKE_SOURCE_DIR}/src/Cuboid.h
-	${CMAKE_SOURCE_DIR}/src/ChunkData.h
-	${CMAKE_SOURCE_DIR}/src/Globals.h
-	${CMAKE_SOURCE_DIR}/src/StringCompression.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/BiomeDef.h
+	${PROJECT_SOURCE_DIR}/src/BlockArea.h
+	${PROJECT_SOURCE_DIR}/src/Cuboid.h
+	${PROJECT_SOURCE_DIR}/src/ChunkData.h
+	${PROJECT_SOURCE_DIR}/src/Globals.h
+	${PROJECT_SOURCE_DIR}/src/StringCompression.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 
-	${CMAKE_SOURCE_DIR}/src/Bindings/LuaState.h
+	${PROJECT_SOURCE_DIR}/src/Bindings/LuaState.h
 
-	${CMAKE_SOURCE_DIR}/src/Generating/ChunkDesc.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/Prefab.h
-	${CMAKE_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalLimit.h
-	${CMAKE_SOURCE_DIR}/src/Generating/VerticalStrategy.h
+	${PROJECT_SOURCE_DIR}/src/Generating/ChunkDesc.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/Prefab.h
+	${PROJECT_SOURCE_DIR}/src/Generating/PrefabPiecePool.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalLimit.h
+	${PROJECT_SOURCE_DIR}/src/Generating/VerticalStrategy.h
 
-	${CMAKE_SOURCE_DIR}/src/Noise/Noise.h
+	${PROJECT_SOURCE_DIR}/src/Noise/Noise.h
 
-	${CMAKE_SOURCE_DIR}/src/OSSupport/CriticalSection.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/Event.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/File.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/GZipFile.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/StackTrace.h
-	${CMAKE_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/CriticalSection.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/Event.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/File.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/GZipFile.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/StackTrace.h
+	${PROJECT_SOURCE_DIR}/src/OSSupport/WinStackWalker.h
 
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/FastNBT.h
-	${CMAKE_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/FastNBT.h
+	${PROJECT_SOURCE_DIR}/src/WorldStorage/SchematicFileSerializer.h
 )
 
 set (SRCS

--- a/tests/UUID/CMakeLists.txt
+++ b/tests/UUID/CMakeLists.txt
@@ -1,11 +1,11 @@
 set (SHARED_SRCS
-	${CMAKE_SOURCE_DIR}/src/UUID.cpp
-	${CMAKE_SOURCE_DIR}/src/StringUtils.cpp
+	${PROJECT_SOURCE_DIR}/src/UUID.cpp
+	${PROJECT_SOURCE_DIR}/src/StringUtils.cpp
 )
 
 set (SHARED_HDRS
-	${CMAKE_SOURCE_DIR}/src/UUID.h
-	${CMAKE_SOURCE_DIR}/src/StringUtils.h
+	${PROJECT_SOURCE_DIR}/src/UUID.h
+	${PROJECT_SOURCE_DIR}/src/StringUtils.h
 )
 
 set (SRCS
@@ -19,8 +19,8 @@ add_executable(UUIDTest ${SRCS} ${SHARED_SRCS} ${SHARED_HDRS})
 target_link_libraries(UUIDTest mbedcrypto fmt::fmt)
 target_compile_definitions(UUIDTest PRIVATE TEST_GLOBALS=1)
 target_include_directories(UUIDTest PRIVATE
-	${CMAKE_SOURCE_DIR}/src/
-	${CMAKE_SOURCE_DIR}/lib/mbedtls/include
+	${PROJECT_SOURCE_DIR}/src/
+	${PROJECT_SOURCE_DIR}/lib/mbedtls/include
 )
 
 add_test(NAME UUID-test COMMAND UUIDTest)


### PR DESCRIPTION
Construct paths relative to the Cuberite sources with PROJECT_SOURCE_DIR, instead of wherever the first CMakeLists.txt file happened to be with CMAKE_SOURCE_DIR.

In Android's case, the latter was in a folder called android/ but that's not the root of the source tree, so any file path built off that root was wrong. This caused file-specific warnings exclusions to fail to apply.