### PR TITLE
Added ability to register webadmin pages through Info.lua

### DIFF
--- a/Server/Plugins/InfoReg.lua
+++ b/Server/Plugins/InfoReg.lua
@@ -201,3 +201,133 @@ end
 
 
 
+
+function RegisterWebController(a_Page, a_UrlPath, a_Controller)
+	cWebAdmin:AddWebTab(a_Page, a_UrlPath, function(a_Request, a_UrlPath)
+		local controller = a_Controller:new();
+		local action = a_Request.Params['action'] or 'Index';
+		return controller[a_Request.Method .. action](controller, a_Request, a_UrlPath)
+	end)
+end
+
+
+
+
+
+-- Register all the webadmin pages inside g_PluginInfo.WebAdminPages
+function RegisterPluginInfoWebAdminPages()
+	if (g_PluginInfo.WebAdminPages) then
+		for idx, page in ipairs(g_PluginInfo.WebAdminPages) do
+			RegisterWebController(page.Title, page.UrlPath, page.WebController)
+		end
+	end
+end
+
+
+
+
+
+-- Quick and dirty templating engine.
+-- Allows lua code to be executed by putting it between {={ }=}.
+-- Echoing can be done by putting something between {{ }}
+local function CompileView(a_Content)
+	content = 'return table.concat({[===[' .. a_Content .. ']===]})';
+	content = content:gsub("%{=%{(.-)%}=%}", function(logic)
+		return [[]===], (
+				function() 
+					local __RESULTING_CONTENT__ = {};
+				]] .. logic:gsub("%{%{(.-)%}%}", "table.insert(__RESULTING_CONTENT__, cWebAdmin:GetHTMLEscapedString(%1))") .. [[
+					return table.concat(__RESULTING_CONTENT__)
+				end
+			)(), [===[
+		]];
+	end)
+	
+	content = content:gsub("%{%{(.-)%}%}", 
+		function(match) 
+			return ']===], cWebAdmin:GetHTMLEscapedString(' .. match .. '), [===[' 
+		end
+	)
+	return content;
+end
+
+
+
+
+
+-- A base class for a controller. Other controllers can inherit from it to make use of it's functionality
+WebControllerBase = {}
+
+
+
+
+
+-- Base constructor for the web controller.
+function WebControllerBase:new()
+	local obj = setmetatable({}, WebControllerBase);
+	return obj
+end
+
+
+
+
+
+-- Loads the requested view into Lua bytecode to be executed.
+-- The view should be located inside the plugin's folder in an additional folder called 'webviews'.
+function WebControllerBase:compileView(a_ViewName)
+	local viewPath = cPluginManager:GetCurrentPlugin():GetLocalFolder() .. '/webviews/' .. a_ViewName .. '.html';
+	if (not cFile:IsFile(viewPath)) then
+		error("View does not exist");
+	end
+	
+	local content = cFile:ReadWholeFile(viewPath);
+	content = CompileView(content);
+	
+	local view, err = loadstring(content);
+	if (not view) then
+		error(err)
+	end
+	return view;
+end
+
+
+
+
+
+-- Serializes provided object to json and returns it together with the content type.
+function WebControllerBase:json(a_Obj, a_Options)
+	return cJson:Serialize(a_Obj, a_Options), "application/json";
+end
+
+
+
+
+
+-- Reads the provided path and returns it's content.
+function WebControllerBase:file(a_Path)
+	if (not cFile:IsFile(a_Path)) then
+		error("The requested file does not exist");
+	end
+	return cFile:ReadWholeFile(a_Path);
+end
+
+
+
+
+
+-- Compiles the requested view, executes it and returns it's content.
+function WebControllerBase:view(a_ViewName, a_Model)
+	-- ToDo: cache view so we don't have to recompile it every time.
+	local view = self:compileView(a_ViewName);
+	
+	-- Set the environment of the view to that of the model with the global environment as fallback.
+	-- This way variables inside the model can be accessed directly.
+	setfenv(view, setmetatable(a_Model or {}, {__index = _G}));
+	
+	-- Execute and return the content of the view.
+	return view();
+end
+
+
+
+

--- a/Server/Plugins/InfoReg.lua
+++ b/Server/Plugins/InfoReg.lua
@@ -233,10 +233,14 @@ end
 local function CompileView(a_Content)
 	content = 'return table.concat({[===[' .. a_Content .. ']===]})';
 	content = content:gsub("%{=%{(.-)%}=%}", function(logic)
+		logic = logic
+			:gsub("<>(.-)</>", "table.insert(__RESULTING_CONTENT__, [===[%1]===])")
+			:gsub("%{%{(.-)%}%}", "table.insert(__RESULTING_CONTENT__, cWebAdmin:GetHTMLEscapedString(%1))");
+			
 		return [[]===], (
 				function() 
 					local __RESULTING_CONTENT__ = {};
-				]] .. logic:gsub("%{%{(.-)%}%}", "table.insert(__RESULTING_CONTENT__, cWebAdmin:GetHTMLEscapedString(%1))") .. [[
+				]] .. logic .. [[
 					return table.concat(__RESULTING_CONTENT__)
 				end
 			)(), [===[


### PR DESCRIPTION
This is just something I've thought about for years, but never had the time to actually make. I'd like to get other opinions on this.

I've always felt the way web pages are handled in Cuberite is less than ideal. I've had a few ideas on how to make it a bit better for years. Now I finally have the time to work on it.


## Info.lua
With this PR you can define your webpages inside the `Info.lua` file:
```lua
	WebAdminPages = 
	{
		{
			Title = "Testpage",
			UrlPath = "TestpagePath",
			WebController = TestController,
		}
	}
```


## Controllers
Inside the `Info.lua` you can define all the web pages, but instead of providing a callback function you can provide a class. This class inherits from `WebControllerBase` which i've created inside `InfoReg.lua`. This controller handles the web pages for a single page, but it can have multiple endpoints. The `WebControllerBase` class provides additional functionality to return json, files and views (more on that later).

Currently I have a really simple routing system in place. It takes the HTTP method and puts it in front of the actionname (default is Index). If I want to access a different endpoint I'd have to add a query parameter called `action`.

```lua
-- Inherit from WebControllerBase
TestController = setmetatable({}, {__index = WebControllerBase});
TestController.__index = TestController




-- Constructor for this controller
function TestController:new()
	local obj = setmetatable(WebControllerBase:new(), {__index = TestController});
	return obj;
end



-- Default endpoint.
function TestController:GETIndex(a_Request, a_Path)
	return self:view("testview", 
		{
			TextWhichCanContainHtml = "Hello there<script>alert('TEST')</script>", 
			numbers = { 0, 1, 2, 3, 4, 5, 6 }
		}
	);
end


-- Can be accessed using a get to ?action=Players.
-- Returns a json array containing all active players.
function TestController:GETPlayers(a_Request)
	local playerList = {};
	cRoot:Get():ForEachPlayer(function(a_Player)
		table.insert(playerList, a_Player:GetName());
	end);
	return self:json(playerList);
end


-- Kicks the requested user.
function TestController:POSTKickPlayer(a_Request)
	local playerToKick = a_Request.PostParams['player']
	local success = false;
	cRoot:Get():FindAndDoWithPlayer(playerToKick, function(a_Player)
		a_Player:GetClientHandle():Kick("Bye")
		success = true;
	end);
	return self:json({success = success});
end
```

## Views
Returning the html code is, in my opinion, really clunky at the moment. This PR includes a really simple templating engine that allows you to write Lua code through html. The views are loaded from a subfolder called `webviews` inside the plugin's own folder. For example you can write code like this:
```html
<table>
{={cRoot:Get():ForEachWorld(function(a_World)
	<>
		<tr>
			<td>
				</>{{a_World:GetName()}}<>
			</td>
		</tr>
	</>
end)}=}
</table>
```
It's also possible to pass variables from the controller to the view. For example, using the controller code above:
```html
{{TextWhichCanContainHtml}}

<ul>
{={for i, number in ipairs(numbers) do
	<><li></> {{number}} <></li></>
end}=}
</ul>
```


## Problems
Currently I'm struggling with a few things  in this PR. 
* Errors in views are difficult to debug.
* InfoReg.lua has to be loaded while creating your controllers if you want them to inherit from `WebControllerBase`. This means, to be safe, you'll have to use `dofile` in every file which contains a controller.