### PR TITLE
API: Corrected type for param Pos

### DIFF
--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -3312,7 +3312,7 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 				{
 					{
 						Name = "Pos",
-						Type = "Vector3i",
+						Type = "Vector3d",
 					},
 					{
 						Name = "ShowBottom",


### PR DESCRIPTION
The API function `cWorld:SpawnEnderCrystal` has `Vector3i` as type for Pos, but the c++ class requires a `Vector3d`: 
`UInt32 cWorld::SpawnEnderCrystal(Vector3d a_Pos, bool a_ShowBottom);`