### PR TITLE
changing cComposite Chat to newer c++ standart

### DIFF
--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -45,6 +45,10 @@ cCompositeChat::~cCompositeChat()
 
 void cCompositeChat::Clear(void)
 {
+	for (const auto Part : m_Parts)
+	{
+		delete Part;
+	}
 	m_Parts.clear();
 }
 

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -45,9 +45,9 @@ cCompositeChat::~cCompositeChat()
 
 void cCompositeChat::Clear(void)
 {
-	for (const auto Part : m_Parts)
+	for (auto & Part : m_Parts)
 	{
-		delete Part;
+		Part.reset();
 	}
 	m_Parts.clear();
 }
@@ -255,7 +255,7 @@ AString cCompositeChat::ExtractText(void) const
 			}
 			case ptUrl:
 			{
-				Msg.append(static_cast<const cUrlPart *>(Part)->m_Url);
+				Msg.append(static_cast<const cUrlPart *>(Part.get())->m_Url);
 				break;
 			}
 			case ptShowAchievement:
@@ -336,7 +336,7 @@ AString cCompositeChat::CreateJsonString(bool a_ShouldUseChatPrefixes) const
 
 			case cCompositeChat::ptClientTranslated:
 			{
-				const auto TranslatedPart = static_cast<const cCompositeChat::cClientTranslatedPart *>(Part);
+				const auto TranslatedPart = static_cast<const cClientTranslatedPart *>(Part.get());
 				JsonPart["translate"] = TranslatedPart->m_Text;
 				Json::Value With;
 				for (const auto & Parameter : TranslatedPart->m_Parameters)
@@ -353,11 +353,10 @@ AString cCompositeChat::CreateJsonString(bool a_ShouldUseChatPrefixes) const
 
 			case cCompositeChat::ptUrl:
 			{
-				const auto UrlPart = static_cast<const cCompositeChat::cUrlPart *>(Part);
+				const auto UrlPart = static_cast<const cUrlPart *>(Part.get());
 				JsonPart["text"] = UrlPart->m_Text;
 				Json::Value Url;
 				Url["action"] = "open_url";
-				LOG(UrlPart->m_Url);
 				Url["value"] = UrlPart->m_Url;
 				JsonPart["clickEvent"] = Url;
 				AddChatPartStyle(JsonPart, UrlPart->m_Style);
@@ -367,7 +366,7 @@ AString cCompositeChat::CreateJsonString(bool a_ShouldUseChatPrefixes) const
 			case cCompositeChat::ptSuggestCommand:
 			case cCompositeChat::ptRunCommand:
 			{
-				const auto CommandPart = static_cast<const cCompositeChat::cCommandPart *>(Part);
+				const auto CommandPart = static_cast<const cCommandPart *>(Part.get());
 				JsonPart["text"] = CommandPart->m_Text;
 				Json::Value Cmd;
 				Cmd["action"] = (CommandPart->m_PartType == cCompositeChat::ptRunCommand) ? "run_command" : "suggest_command";
@@ -379,7 +378,7 @@ AString cCompositeChat::CreateJsonString(bool a_ShouldUseChatPrefixes) const
 
 			case cCompositeChat::ptShowAchievement:
 			{
-				const auto AchievementPart = static_cast<const cCompositeChat::cShowAchievementPart *>(Part);
+				const auto AchievementPart = static_cast<const cShowAchievementPart *>(Part.get());
 				JsonPart["translate"] = "chat.type.achievement";
 
 				Json::Value Ach;

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -45,10 +45,6 @@ cCompositeChat::~cCompositeChat()
 
 void cCompositeChat::Clear(void)
 {
-	for (auto & Part : m_Parts)
-	{
-		Part.reset();
-	}
 	m_Parts.clear();
 }
 
@@ -159,11 +155,11 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 
 			case ':':
 			{
-				static const std::array<AString, 2> LinkPrefixes =
+				static const constexpr std::array<std::string_view , 2> LinkPrefixes =
 				{
 					{
-						AString("http"),
-						AString("https")
+						"http",
+						"https"
 					}
 				};
 				for (const auto & Prefix : LinkPrefixes)
@@ -171,7 +167,7 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 					size_t PrefixLen = Prefix.size();
 					if (
 						(i >= first + PrefixLen) &&  // There is enough space in front of the colon for the prefix
-						(strncmp(a_ParseText.c_str() + i - PrefixLen, Prefix.c_str(), PrefixLen) == 0)  // the prefix matches
+						(std::string_view(a_ParseText).substr(i - PrefixLen, PrefixLen) == Prefix)  // the prefix matches
 					)
 					{
 						// Add everything before this as a text part:

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -155,7 +155,7 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 
 			case ':':
 			{
-				static const constexpr std::array<std::string_view , 2> LinkPrefixes =
+				static const constexpr std::array<std::string_view, 2> LinkPrefixes =
 				{
 					{
 						"http",

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -58,7 +58,7 @@ void cCompositeChat::Clear(void)
 
 void cCompositeChat::AddTextPart(const AString & a_Message, const AString & a_Style)
 {
-	m_Parts.emplace_back(new cTextPart(a_Message, a_Style));
+	m_Parts.emplace_back(std::make_unique<cTextPart>(a_Message, a_Style));
 }
 
 
@@ -67,7 +67,7 @@ void cCompositeChat::AddTextPart(const AString & a_Message, const AString & a_St
 
 void cCompositeChat::AddClientTranslatedPart(const AString & a_TranslationID, const AStringVector & a_Parameters, const AString & a_Style)
 {
-	m_Parts.emplace_back(new cClientTranslatedPart(a_TranslationID, a_Parameters, a_Style));
+	m_Parts.emplace_back(std::make_unique<cClientTranslatedPart>(a_TranslationID, a_Parameters, a_Style));
 }
 
 
@@ -76,7 +76,7 @@ void cCompositeChat::AddClientTranslatedPart(const AString & a_TranslationID, co
 
 void cCompositeChat::AddUrlPart(const AString & a_Text, const AString & a_Url, const AString & a_Style)
 {
-	m_Parts.emplace_back(new cUrlPart(a_Text, a_Url, a_Style));
+	m_Parts.emplace_back(std::make_unique<cUrlPart>(a_Text, a_Url, a_Style));
 }
 
 
@@ -85,7 +85,7 @@ void cCompositeChat::AddUrlPart(const AString & a_Text, const AString & a_Url, c
 
 void cCompositeChat::AddRunCommandPart(const AString & a_Text, const AString & a_Command, const AString & a_Style)
 {
-	m_Parts.emplace_back(new cRunCommandPart(a_Text, a_Command, a_Style));
+	m_Parts.emplace_back(std::make_unique<cRunCommandPart>(a_Text, a_Command, a_Style));
 }
 
 
@@ -94,7 +94,7 @@ void cCompositeChat::AddRunCommandPart(const AString & a_Text, const AString & a
 
 void cCompositeChat::AddSuggestCommandPart(const AString & a_Text, const AString & a_SuggestedCommand, const AString & a_Style)
 {
-	m_Parts.emplace_back(new cSuggestCommandPart(a_Text, a_SuggestedCommand, a_Style));
+	m_Parts.emplace_back(std::make_unique<cSuggestCommandPart>(a_Text, a_SuggestedCommand, a_Style));
 }
 
 
@@ -103,7 +103,7 @@ void cCompositeChat::AddSuggestCommandPart(const AString & a_Text, const AString
 
 void cCompositeChat::AddShowAchievementPart(const AString & a_PlayerName, const AString & a_Achievement, const AString & a_Style)
 {
-	m_Parts.emplace_back(new cShowAchievementPart(a_PlayerName, a_Achievement, a_Style));
+	m_Parts.emplace_back(std::make_unique<cShowAchievementPart>(a_PlayerName, a_Achievement, a_Style));
 }
 
 
@@ -149,7 +149,7 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 					}
 					if (!CurrentText.empty())
 					{
-						m_Parts.emplace_back(new cTextPart(CurrentText, CurrentStyle));
+						m_Parts.emplace_back(std::make_unique<cTextPart>(CurrentText, CurrentStyle));
 						CurrentText.clear();
 					}
 					AddStyle(CurrentStyle, a_ParseText.substr(i - 1, 2));

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -153,7 +153,7 @@ public:
 
 
 	/** the parts have to be allocated with new else the part specific parts are not saved (only the cBasePart members). */
-	using cParts = std::vector<cBasePart *>;
+	using cParts = std::vector<std::unique_ptr<cBasePart>>;
 
 	/** Creates a new empty chat message.
 	Exported manually due to the other overload needing a manual export. */

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -165,6 +165,12 @@ public:
 	Exported manually due to ToLua++ generating extra output parameter. */
 	cCompositeChat(const AString & a_ParseText, eMessageType a_MessageType = mtCustom);
 
+	cCompositeChat(cCompositeChat && a_Other) = default;
+
+	/** Copy constructor is explicitly deleted because m_Parts is not copyable. */
+	cCompositeChat(cCompositeChat & a_Other) = delete;
+	cCompositeChat(const cCompositeChat & a_Other) = delete;
+
 	~cCompositeChat();  // tolua_export
 
 	// The following are exported in ManualBindings in order to support chaining - they return "self" in Lua (#755)

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -152,9 +152,8 @@ public:
 	} ;
 
 
-
+	/** the parts have to be allocated with new else the part specific parts are not saved (only the cBasePart members). */
 	using cParts = std::vector<cBasePart *>;
-
 
 	/** Creates a new empty chat message.
 	Exported manually due to the other overload needing a manual export. */

--- a/tests/CompositeChat/CompositeChatTest.cpp
+++ b/tests/CompositeChat/CompositeChatTest.cpp
@@ -96,6 +96,19 @@ static void TestParser5(void)
 
 
 
+static void TestParser6(void)
+{
+	cCompositeChat Msg;
+	Msg.ParseText("Hello World");
+	const cCompositeChat::cParts & Parts = Msg.GetParts();
+	TEST_EQUAL(Parts.size(), 1);
+	TEST_EQUAL(Parts[0]->m_PartType, cCompositeChat::ptText);
+	TEST_EQUAL(Parts[0]->m_Style, "");
+}
+
+
+
+
 
 IMPLEMENT_TEST_MAIN("CompositeChat",
 	TestParser1();
@@ -103,4 +116,5 @@ IMPLEMENT_TEST_MAIN("CompositeChat",
 	TestParser3();
 	TestParser4();
 	TestParser5();
+	TestParser6();
 )


### PR DESCRIPTION
upgraded to new C++ for loops and fixed errors in previous redition which made it possible to copy the object and cause errors.

Fixes: #5027

Todo:
- [ ] add move constructor