### PR TITLE
Fix lilypad displacing block above

### DIFF
--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -93,14 +93,6 @@ public:
 						return false;
 					}
 					a_CBBlockPos = AddFaceDirection(a_CBBlockPos, BLOCK_FACE_YP);  // Always place pad at top of water block
-					if (
-						!IsBlockWater(a_CBBlockType) &&
-						cBlockInfo::FullyOccupiesVoxel(a_CBBlockType)
-						)
-					{
-						// Can't place lilypad on air / in another block!
-						return true;
-					}
 					m_HasHitFluid = true;
 					m_Pos = a_CBBlockPos;
 					return true;

--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -48,6 +48,24 @@ public:
 		{
 			// Clicked on a face of a submerged block; vanilla allows placement, so should we
 			auto PlacePos = AddFaceDirection(a_ClickedBlockPos, a_ClickedBlockFace);
+
+			// Lilypad should not replace non air and non water blocks
+			auto BlockToReplace = a_World->GetBlock(PlacePos);
+			if ((BlockToReplace != E_BLOCK_AIR) &&
+				(BlockToReplace != E_BLOCK_WATER) &&
+				(BlockToReplace != E_BLOCK_STATIONARY_WATER))
+			{
+				return false;
+			}
+
+			// Lilypad should be placed only if there is a water block below
+			auto BlockBelow = a_World->GetBlock(PlacePos - Vector3i(0, 1, 0));
+			if ((BlockBelow != E_BLOCK_WATER) &&
+				(BlockBelow != E_BLOCK_STATIONARY_WATER))
+			{
+				return false;
+			}
+
 			a_World->SetBlock(PlacePos, E_BLOCK_LILY_PAD, 0);
 			if (!a_Player->IsGameModeCreative())
 			{
@@ -100,6 +118,13 @@ public:
 
 		if (Callbacks.m_HasHitFluid)
 		{
+			// Lilypad should not replace non air blocks
+			auto BlockToReplace = a_World->GetBlock(Callbacks.m_Pos);
+			if (BlockToReplace != E_BLOCK_AIR)
+			{
+				return false;
+			}
+
 			a_World->SetBlock(Callbacks.m_Pos, E_BLOCK_LILY_PAD, 0);
 			if (!a_Player->IsGameModeCreative())
 			{

--- a/src/Items/ItemLilypad.h
+++ b/src/Items/ItemLilypad.h
@@ -44,24 +44,31 @@ public:
 		eBlockFace a_ClickedBlockFace
 	) override
 	{
-		if (a_ClickedBlockFace > BLOCK_FACE_NONE)
-		{
-			// Clicked on a face of a submerged block; vanilla allows placement, so should we
-			auto PlacePos = AddFaceDirection(a_ClickedBlockPos, a_ClickedBlockFace);
+		// The client sends BLOCK_FACE_NONE when it determines it should do a tracing-based placement.
+		// Otherwise, a normal block face is sent.
 
-			// Lilypad should not replace non air and non water blocks
-			auto BlockToReplace = a_World->GetBlock(PlacePos);
-			if ((BlockToReplace != E_BLOCK_AIR) &&
+		if (a_ClickedBlockFace != BLOCK_FACE_NONE)
+		{
+			// The position the client wants the lilypad placed.
+			const auto PlacePos = AddFaceDirection(a_ClickedBlockPos, a_ClickedBlockFace);
+
+			// Lilypad should not replace non air and non water blocks:
+			if (
+				const auto BlockToReplace = a_World->GetBlock(PlacePos);
+				(BlockToReplace != E_BLOCK_AIR) &&
 				(BlockToReplace != E_BLOCK_WATER) &&
-				(BlockToReplace != E_BLOCK_STATIONARY_WATER))
+				(BlockToReplace != E_BLOCK_STATIONARY_WATER)
+			)
 			{
 				return false;
 			}
 
 			// Lilypad should be placed only if there is a water block below
-			auto BlockBelow = a_World->GetBlock(PlacePos - Vector3i(0, 1, 0));
-			if ((BlockBelow != E_BLOCK_WATER) &&
-				(BlockBelow != E_BLOCK_STATIONARY_WATER))
+			if (
+				const auto BlockBelow = a_World->GetBlock(PlacePos.addedY(-1));
+				(BlockBelow != E_BLOCK_WATER) &&
+				(BlockBelow != E_BLOCK_STATIONARY_WATER)
+			)
 			{
 				return false;
 			}
@@ -79,52 +86,50 @@ public:
 		{
 		public:
 
-			cCallbacks():
-				m_HasHitFluid(false)
-			{
-			}
-
 			virtual bool OnNextBlock(Vector3i a_CBBlockPos, BLOCKTYPE a_CBBlockType, NIBBLETYPE a_CBBlockMeta, eBlockFace a_CBEntryFace) override
 			{
-				if (IsBlockWater(a_CBBlockType))
+				if (
+					!IsBlockWater(a_CBBlockType) ||
+					(a_CBBlockMeta != 0)  // The hit block should be a source
+				)
 				{
-					if ((a_CBBlockMeta != 0) || (a_CBEntryFace == BLOCK_FACE_NONE))  // The hit block should be a source. The FACE_NONE check is clicking whilst submerged
-					{
-						return false;
-					}
-					a_CBBlockPos = AddFaceDirection(a_CBBlockPos, BLOCK_FACE_YP);  // Always place pad at top of water block
-					m_HasHitFluid = true;
-					m_Pos = a_CBBlockPos;
-					return true;
+					// TODO: Vanilla stops the trace. However, we need to continue the trace, to work around our lack of block bounding box support
+					// which would otherwise mean we misbehave when clicking through the voxel a (e.g.) button occupies. Now, however, we misbehave
+					// when clicking on a block near water... Nonetheless, the former would cause ghost blocks, so continue for now.
+
+					// Ignore and continue trace:
+					return false;
 				}
-				return false;
+
+				Position = AddFaceDirection(a_CBBlockPos, BLOCK_FACE_YP);  // Always place pad at top of water block
+				return true;
 			}
 
-			Vector3i m_Pos;
-			bool m_HasHitFluid;
+			Vector3i Position;
 
 		} Callbacks;
-		auto Start = a_Player->GetEyePosition() + a_Player->GetLookVector();
-		auto End =   a_Player->GetEyePosition() + a_Player->GetLookVector() * 5;
-		cLineBlockTracer::Trace(*a_Player->GetWorld(), Callbacks, Start, End);
 
-		if (Callbacks.m_HasHitFluid)
+		const auto EyePosition = a_Player->GetEyePosition();
+		const auto End = EyePosition + a_Player->GetLookVector() * 5;
+		if (cLineBlockTracer::Trace(*a_Player->GetWorld(), Callbacks, EyePosition, End))
 		{
-			// Lilypad should not replace non air blocks
-			auto BlockToReplace = a_World->GetBlock(Callbacks.m_Pos);
-			if (BlockToReplace != E_BLOCK_AIR)
-			{
-				return false;
-			}
-
-			a_World->SetBlock(Callbacks.m_Pos, E_BLOCK_LILY_PAD, 0);
-			if (!a_Player->IsGameModeCreative())
-			{
-				a_Player->GetInventory().RemoveOneEquippedItem();
-			}
-			return true;
+			// The line traced to completion; no suitable water was found:
+			return false;
 		}
 
-		return false;
+		const auto BlockToReplace = a_World->GetBlock(Callbacks.Position);
+		if (BlockToReplace != E_BLOCK_AIR)
+		{
+			// Lilypad should not replace non air blocks:
+			return false;
+		}
+
+		a_World->SetBlock(Callbacks.Position, E_BLOCK_LILY_PAD, 0);
+		if (!a_Player->IsGameModeCreative())
+		{
+			a_Player->GetInventory().RemoveOneEquippedItem();
+		}
+
+		return true;
 	}
 };


### PR DESCRIPTION
`cLineBlockTracer` seems to trace diagonally. This means at a certain angle, the player can interact with a water source block even if there is a block above it covering the player's vision. This displaces the block above.

Added a check that only allows air blocks to be replaced when using `cLineBlockTracer`.

This displacement also happens when a player right clicks the side of a block to try to place a lilypad.

Added a similar check that only allows air blocks and water blocks to be replaced. I included water blocks too because you can technically right click on the side of a block and replace a water block in vanilla. 

While fixing the above mentioned issues, I also had to add a check that only allows lilypads to be placed when there is a water block below it (just happened to fix a related issue).

Fixes #4254 
Fixes #4255 (Happened to fix this while fixing 4254)