### PR TITLE
Only enter chase mode if Agressive Mob has los to player.

### DIFF
--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -42,9 +42,19 @@ void cAggressiveMonster::EventSeePlayer(cPlayer * a_Player, cChunk & a_Chunk)
 	{
 		return;
 	}
+	// Check to see if Mob can see the player.
+	Vector3d MyHeadPosition1 = GetPosition() + Vector3d(0, GetHeight(), 0);
+	Vector3d TargetPosition1 = a_Player->GetPosition() + Vector3d(0, a_Player->GetHeight(), 0);
+	if (cLineBlockTracer::LineOfSightTrace(*GetWorld(), MyHeadPosition1, TargetPosition1, cLineBlockTracer::losAirWaterLava))
+	{
+		Super::EventSeePlayer(a_Player, a_Chunk);
+		m_EMState = CHASING;
+	}
+	else
+	{
+		return;
+	}
 
-	Super::EventSeePlayer(a_Player, a_Chunk);
-	m_EMState = CHASING;
 }
 
 


### PR DESCRIPTION
This fixes what imho is the most problematic issue with the game at the moment.  The fact that currently, Mobs have superman vision.  They see you through walls, doors, hiding in a tree, underground.  If there is a mob within it's detection range then it knows exactly where you are and it swarms you regardless.

This causes problems mainly for me because you can't sleep if an Aggressive Mob is around, and this issue causes them to gather around your house.  (Also, if you dare go outside they all jump on you at once.)

I simply added a line of sight check before chase mode is entered into.  I used pre-existing code I modified from elsewhere in the source.

I am not an experienced C++ developer, but I have done what I can and I've been testing it for a while on my Android Phone Server with no issues.  The game is MUCH more enjoyable to play with this one simple change IMHO.

Thanks for your consideration.
(the1robert on forum).

More details here : https://forum.cuberite.org/thread-3331.html

