### PR TITLE
Ignore CanFly flag sent by the client

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -835,12 +835,11 @@ void cClientHandle::HandleEnchantItem(UInt8 a_WindowID, UInt8 a_Enchantment)
 
 
 
-void cClientHandle::HandlePlayerAbilities(bool a_CanFly, bool a_IsFlying, float FlyingSpeed, float WalkingSpeed)
+void cClientHandle::HandlePlayerAbilities(bool a_IsFlying, float FlyingSpeed, float WalkingSpeed)
 {
 	UNUSED(FlyingSpeed);  // Ignore the client values for these
 	UNUSED(WalkingSpeed);
 
-	m_Player->SetCanFly(a_CanFly);
 	m_Player->SetFlying(a_IsFlying);
 }
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -350,7 +350,7 @@ public:  // tolua_export
 	void HandleOpenHorseInventory(UInt32 a_EntityID);
 
 	void HandlePing             (void);
-	void HandlePlayerAbilities  (bool a_CanFly, bool a_IsFlying, float FlyingSpeed, float WalkingSpeed);
+	void HandlePlayerAbilities  (bool a_IsFlying, float FlyingSpeed, float WalkingSpeed);
 	void HandlePlayerLook       (float a_Rotation, float a_Pitch, bool a_IsOnGround);
 	void HandlePlayerMoveLook   (double a_PosX, double a_PosY, double a_PosZ, double a_Stance, float a_Rotation, float a_Pitch, bool a_IsOnGround);  // While m_bPositionConfirmed (normal gameplay)
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -2643,17 +2643,13 @@ void cProtocol_1_8_0::HandlePacketPlayerAbilities(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, WalkingSpeed);
 
 	// COnvert the bitfield into individual boolean flags:
-	bool IsFlying = false, CanFly = false;
+	bool IsFlying = false;
 	if ((Flags & 2) != 0)
 	{
 		IsFlying = true;
 	}
-	if ((Flags & 4) != 0)
-	{
-		CanFly = true;
-	}
 
-	m_Client->HandlePlayerAbilities(CanFly, IsFlying, FlyingSpeed, WalkingSpeed);
+	m_Client->HandlePlayerAbilities(IsFlying, FlyingSpeed, WalkingSpeed);
 }
 
 


### PR DESCRIPTION
In Minecraft 1.16, the Player Abilities packet was modified to only include a flag specifying if the player is flying or not. This broke flying when connected to a Cuberite server through ViaVersion on a 1.16 client, as CanFly defaults to false in the code.

Since flying works just fine on a vanilla 1.12.2 server with ViaVersion, and only the IsFlying flag remains in 1.16, I think it's safe to assume that the vanilla server has been ignoring the CanFly flag for a while.