### PR TITLE
Enable LOS checks for Hostile Mobs.

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -768,7 +768,7 @@ void cMonster::CheckEventSeePlayer(cChunk & a_Chunk)
 	{
 		EventSeePlayer(&a_Player, a_Chunk);
 		return true;
-	}, false);
+	}, true);
 }
 
 


### PR DESCRIPTION
Fix the problem where Hostile Mobs have superman x-ray vision by enabling the existing Line of Sight checks before the Mob goes into "chase" mode.