### PR TITLE
Fix potential destruction crashes

### DIFF
--- a/src/BlockEntities/BeaconEntity.cpp
+++ b/src/BlockEntities/BeaconEntity.cpp
@@ -271,6 +271,20 @@ void cBeaconEntity::CopyFrom(const cBlockEntity & a_Src)
 
 
 
+void cBeaconEntity::OnRemoveFromWorld()
+{
+	const auto Window = GetWindow();
+	if (Window != nullptr)
+	{
+		// Tell window its owner is destroyed:
+		Window->OwnerDestroyed();
+	}
+}
+
+
+
+
+
 void cBeaconEntity::SendTo(cClientHandle & a_Client)
 {
 	a_Client.SendUpdateBlockEntity(*this);
@@ -316,6 +330,3 @@ bool cBeaconEntity::UsedBy(cPlayer * a_Player)
 	}
 	return true;
 }
-
-
-

--- a/src/BlockEntities/BeaconEntity.h
+++ b/src/BlockEntities/BeaconEntity.h
@@ -29,6 +29,7 @@ public:  // tolua_export
 
 	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
+	virtual void OnRemoveFromWorld() override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;

--- a/src/BlockEntities/BlockEntity.cpp
+++ b/src/BlockEntities/BlockEntity.cpp
@@ -28,56 +28,52 @@
 
 
 
-void cBlockEntity::SetPos(Vector3i a_NewPos)
+cBlockEntity::cBlockEntity(const BLOCKTYPE a_BlockType, const NIBBLETYPE a_BlockMeta, const Vector3i a_Pos, cWorld * const a_World) :
+	m_Pos(a_Pos),
+	m_RelX(a_Pos.x - cChunkDef::Width * FAST_FLOOR_DIV(a_Pos.x, cChunkDef::Width)),
+	m_RelZ(a_Pos.z - cChunkDef::Width * FAST_FLOOR_DIV(a_Pos.z, cChunkDef::Width)),
+	m_BlockType(a_BlockType),
+	m_BlockMeta(a_BlockMeta),
+	m_World(a_World)
 {
-	ASSERT(m_World == nullptr);  // Cannot move block entities that represent world blocks (only use this for cBlockArea's BEs)
-	m_Pos = a_NewPos;
 }
 
 
 
 
 
-bool cBlockEntity::IsBlockEntityBlockType(BLOCKTYPE a_BlockType)
+OwnedBlockEntity cBlockEntity::Clone(const Vector3i a_Pos)
 {
-	switch (a_BlockType)
-	{
-		case E_BLOCK_BEACON:
-		case E_BLOCK_BED:
-		case E_BLOCK_BREWING_STAND:
-		case E_BLOCK_CHEST:
-		case E_BLOCK_COMMAND_BLOCK:
-		case E_BLOCK_DISPENSER:
-		case E_BLOCK_DROPPER:
-		case E_BLOCK_ENCHANTMENT_TABLE:
-		case E_BLOCK_ENDER_CHEST:
-		case E_BLOCK_END_PORTAL:
-		case E_BLOCK_FLOWER_POT:
-		case E_BLOCK_FURNACE:
-		case E_BLOCK_HEAD:
-		case E_BLOCK_HOPPER:
-		case E_BLOCK_JUKEBOX:
-		case E_BLOCK_LIT_FURNACE:
-		case E_BLOCK_MOB_SPAWNER:
-		case E_BLOCK_NOTE_BLOCK:
-		case E_BLOCK_SIGN_POST:
-		case E_BLOCK_TRAPPED_CHEST:
-		case E_BLOCK_WALLSIGN:
-		{
-			return true;
-		}
-		default:
-		{
-			return false;
-		}
-	}
+	auto res = CreateByBlockType(m_BlockType, m_BlockMeta, a_Pos, nullptr);
+	res->CopyFrom(*this);
+	return res;
 }
 
 
 
 
 
-OwnedBlockEntity cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World)
+cItems cBlockEntity::ConvertToPickups() const
+{
+	return {};
+}
+
+
+
+
+
+void cBlockEntity::CopyFrom(const cBlockEntity & a_Src)
+{
+	// Nothing to copy, but check that we're copying the right entity:
+	ASSERT(m_BlockType == a_Src.m_BlockType);
+	ASSERT(m_BlockMeta == a_Src.m_BlockMeta);
+}
+
+
+
+
+
+OwnedBlockEntity cBlockEntity::CreateByBlockType(const BLOCKTYPE a_BlockType, const NIBBLETYPE a_BlockMeta, const Vector3i a_Pos, cWorld * const a_World)
 {
 	switch (a_BlockType)
 	{
@@ -117,29 +113,82 @@ OwnedBlockEntity cBlockEntity::CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETY
 
 
 
-OwnedBlockEntity cBlockEntity::Clone(Vector3i a_Pos)
+void cBlockEntity::Destroy()
 {
-	auto res = CreateByBlockType(m_BlockType, m_BlockMeta, a_Pos, nullptr);
-	res->CopyFrom(*this);
-	return res;
 }
 
 
 
 
 
-cItems cBlockEntity::ConvertToPickups() const
+bool cBlockEntity::IsBlockEntityBlockType(const BLOCKTYPE a_BlockType)
 {
-	return {};
+	switch (a_BlockType)
+	{
+		case E_BLOCK_BEACON:
+		case E_BLOCK_BED:
+		case E_BLOCK_BREWING_STAND:
+		case E_BLOCK_CHEST:
+		case E_BLOCK_COMMAND_BLOCK:
+		case E_BLOCK_DISPENSER:
+		case E_BLOCK_DROPPER:
+		case E_BLOCK_ENCHANTMENT_TABLE:
+		case E_BLOCK_ENDER_CHEST:
+		case E_BLOCK_END_PORTAL:
+		case E_BLOCK_FLOWER_POT:
+		case E_BLOCK_FURNACE:
+		case E_BLOCK_HEAD:
+		case E_BLOCK_HOPPER:
+		case E_BLOCK_JUKEBOX:
+		case E_BLOCK_LIT_FURNACE:
+		case E_BLOCK_MOB_SPAWNER:
+		case E_BLOCK_NOTE_BLOCK:
+		case E_BLOCK_SIGN_POST:
+		case E_BLOCK_TRAPPED_CHEST:
+		case E_BLOCK_WALLSIGN:
+		{
+			return true;
+		}
+		default:
+		{
+			return false;
+		}
+	}
 }
 
 
 
 
 
-void cBlockEntity::CopyFrom(const cBlockEntity & a_Src)
+void cBlockEntity::OnRemoveFromWorld()
 {
-	// Nothing to copy, but check that we're copying the right entity:
-	ASSERT(m_BlockType == a_Src.m_BlockType);
-	ASSERT(m_BlockMeta == a_Src.m_BlockMeta);
+}
+
+
+
+
+
+void cBlockEntity::SetPos(const Vector3i a_NewPos)
+{
+	ASSERT(m_World == nullptr);  // Cannot move block entities that represent world blocks (only use this for cBlockArea's BEs)
+	m_Pos = a_NewPos;
+}
+
+
+
+
+
+void cBlockEntity::SetWorld(cWorld * const a_World)
+{
+	m_World = a_World;
+}
+
+
+
+
+
+bool cBlockEntity::Tick(const std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
+{
+	UNUSED(a_Dt);
+	return false;
 }

--- a/src/BlockEntities/BlockEntity.h
+++ b/src/BlockEntities/BlockEntity.h
@@ -24,41 +24,14 @@ using cBlockEntities = std::unordered_map<size_t, OwnedBlockEntity>;
 class cBlockEntity
 {
 protected:
-	cBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World) :
-		m_Pos(a_Pos),
-		m_RelX(a_Pos.x - cChunkDef::Width * FAST_FLOOR_DIV(a_Pos.x, cChunkDef::Width)),
-		m_RelZ(a_Pos.z - cChunkDef::Width * FAST_FLOOR_DIV(a_Pos.z, cChunkDef::Width)),
-		m_BlockType(a_BlockType),
-		m_BlockMeta(a_BlockMeta),
-		m_World(a_World)
-	{
-	}
+
+	cBlockEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
 public:
 
 	// tolua_end
 
-	virtual ~cBlockEntity() {}  // force a virtual destructor in all descendants
-
-	virtual void Destroy() {}
-
-	void SetWorld(cWorld * a_World)
-	{
-		m_World = a_World;
-	}
-
-	/** Updates the internally stored position.
-	Note that this should not ever be used for world-contained block entities, it is meant only for when BEs in a cBlockArea are manipulated.
-	Asserts that the block entity is not assigned to a world. */
-	void SetPos(Vector3i a_NewPos);
-
-	/** Returns true if the specified blocktype is supposed to have an associated block entity. */
-	static bool IsBlockEntityBlockType(BLOCKTYPE a_BlockType);
-
-	/** Creates a new block entity for the specified block type at the specified absolute pos.
-	If a_World is valid, then the entity is created bound to that world
-	Returns nullptr for unknown block types. */
-	static OwnedBlockEntity CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World = nullptr);
+	virtual ~cBlockEntity() = default;  // force a virtual destructor in all descendants
 
 	/** Makes an exact copy of this block entity, except for its m_World (set to nullptr), and at a new position.
 	Uses CopyFrom() to copy the properties. */
@@ -72,6 +45,37 @@ public:
 	Each non-abstract descendant should override to copy its specific properties, and call
 	Super::CopyFrom(a_Src) to copy the common ones. */
 	virtual void CopyFrom(const cBlockEntity & a_Src);
+
+	/** Creates a new block entity for the specified block type at the specified absolute pos.
+	If a_World is valid, then the entity is created bound to that world
+	Returns nullptr for unknown block types. */
+	static OwnedBlockEntity CreateByBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World = nullptr);
+
+	virtual void Destroy();
+
+	/** Returns true if the specified blocktype is supposed to have an associated block entity. */
+	static bool IsBlockEntityBlockType(BLOCKTYPE a_BlockType);
+
+	/** Called when the block entity is removed from a world. */
+	virtual void OnRemoveFromWorld();
+
+	/** Sends the packet defining the block entity to the client specified.
+	To send to all eligible clients, use cWorld::BroadcastBlockEntity() */
+	virtual void SendTo(cClientHandle & a_Client) = 0;
+
+	/** Updates the internally stored position.
+	Note that this should not ever be used for world-contained block entities, it is meant only for when BEs in a cBlockArea are manipulated.
+	Asserts that the block entity is not assigned to a world. */
+	void SetPos(Vector3i a_NewPos);
+
+	void SetWorld(cWorld * a_World);
+
+	/** Ticks the entity; returns true if the chunk should be marked as dirty as a result of this ticking. By default does nothing. */
+	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk);
+
+	/** Called when a player uses this entity; should open the UI window.
+	returns true if the use was successful, return false to use the block as a "normal" block */
+	virtual bool UsedBy(cPlayer * a_Player) = 0;
 
 	// tolua_begin
 
@@ -94,21 +98,6 @@ public:
 	int GetRelZ() const { return m_RelZ; }
 
 	// tolua_end
-
-	/** Called when a player uses this entity; should open the UI window.
-	returns true if the use was successful, return false to use the block as a "normal" block */
-	virtual bool UsedBy( cPlayer * a_Player) = 0;
-
-	/** Sends the packet defining the block entity to the client specified.
-	To send to all eligible clients, use cWorld::BroadcastBlockEntity() */
-	virtual void SendTo(cClientHandle & a_Client) = 0;
-
-	/** Ticks the entity; returns true if the chunk should be marked as dirty as a result of this ticking. By default does nothing. */
-	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
-	{
-		UNUSED(a_Dt);
-		return false;
-	}
 
 
 protected:

--- a/src/BlockEntities/BrewingstandEntity.cpp
+++ b/src/BlockEntities/BrewingstandEntity.cpp
@@ -13,36 +13,11 @@
 
 cBrewingstandEntity::cBrewingstandEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
 	Super(a_BlockType, a_BlockMeta, a_Pos, ContentsWidth, ContentsHeight, a_World),
-	m_IsDestroyed(false),
 	m_IsBrewing(false),
 	m_TimeBrewed(0),
 	m_RemainingFuel(0)
 {
 	m_Contents.AddListener(*this);
-}
-
-
-
-
-
-cBrewingstandEntity::~cBrewingstandEntity()
-{
-	// Tell window its owner is destroyed
-	cWindow * Window = GetWindow();
-	if (Window != nullptr)
-	{
-		Window->OwnerDestroyed();
-	}
-}
-
-
-
-
-
-void cBrewingstandEntity::Destroy()
-{
-	m_IsDestroyed = true;
-	Super::Destroy();
 }
 
 
@@ -64,6 +39,20 @@ void cBrewingstandEntity::CopyFrom(const cBlockEntity & a_Src)
 	}
 	m_TimeBrewed = src.m_TimeBrewed;
 	m_RemainingFuel = src.m_RemainingFuel;
+}
+
+
+
+
+
+void cBrewingstandEntity::OnRemoveFromWorld()
+{
+	const auto Window = GetWindow();
+	if (Window != nullptr)
+	{
+		// Tell window its owner is destroyed:
+		Window->OwnerDestroyed();
+	}
 }
 
 
@@ -205,11 +194,6 @@ void cBrewingstandEntity::BroadcastProgress(size_t a_ProgressbarID, short a_Valu
 void cBrewingstandEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 {
 	Super::OnSlotChanged(a_ItemGrid, a_SlotNum);
-
-	if (m_IsDestroyed)
-	{
-		return;
-	}
 
 	ASSERT(a_ItemGrid == &m_Contents);
 

--- a/src/BlockEntities/BrewingstandEntity.h
+++ b/src/BlockEntities/BrewingstandEntity.h
@@ -8,6 +8,7 @@
 
 
 
+
 class cClientHandle;
 
 
@@ -43,11 +44,9 @@ public:
 	/** Constructor used for normal operation */
 	cBrewingstandEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
-	virtual ~cBrewingstandEntity() override;
-
-	//  cBlockEntity overrides:
-	virtual void Destroy() override;
+	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
+	virtual void OnRemoveFromWorld() override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
@@ -110,11 +109,7 @@ public:
 	/** Gets the recipes. Will be called if the brewing stand gets loaded from the world. */
 	void LoadRecipes(void);
 
-
 protected:
-
-	/** Set to true when the brewing stand entity has been destroyed to prevent the block being set again */
-	bool m_IsDestroyed;
 
 	/** Set to true if the brewing stand is brewing an item */
 	bool m_IsBrewing;

--- a/src/BlockEntities/ChestEntity.cpp
+++ b/src/BlockEntities/ChestEntity.cpp
@@ -32,22 +32,6 @@ cChestEntity::cChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector
 
 
 
-cChestEntity::~cChestEntity()
-{
-	if (m_Neighbour != nullptr)
-	{
-		// Neighbour may share a window with us, force the window shut
-		m_Neighbour->DestroyWindow();
-		m_Neighbour->m_Neighbour = nullptr;
-	}
-
-	DestroyWindow();
-}
-
-
-
-
-
 void cChestEntity::CopyFrom(const cBlockEntity & a_Src)
 {
 	Super::CopyFrom(a_Src);
@@ -57,6 +41,22 @@ void cChestEntity::CopyFrom(const cBlockEntity & a_Src)
 	// Reset the neighbor and player count, there's no sense in copying these:
 	m_Neighbour = nullptr;
 	m_NumActivePlayers = 0;
+}
+
+
+
+
+
+void cChestEntity::OnRemoveFromWorld()
+{
+	if (m_Neighbour != nullptr)
+	{
+		// Neighbour may share a window with us, force the window shut:
+		m_Neighbour->DestroyWindow();
+		m_Neighbour->m_Neighbour = nullptr;
+	}
+
+	DestroyWindow();
 }
 
 
@@ -199,11 +199,10 @@ void cChestEntity::OpenNewWindow(void)
 
 void cChestEntity::DestroyWindow()
 {
-	cWindow * Window = GetWindow();
+	const auto Window = GetWindow();
 	if (Window != nullptr)
 	{
 		Window->OwnerDestroyed();
-		CloseWindow();
 	}
 }
 

--- a/src/BlockEntities/ChestEntity.h
+++ b/src/BlockEntities/ChestEntity.h
@@ -37,10 +37,9 @@ public:
 	/** Constructor used for normal operation */
 	cChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
-	virtual ~cChestEntity() override;
-
 	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
+	virtual void OnRemoveFromWorld() override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 

--- a/src/BlockEntities/DropSpenserEntity.cpp
+++ b/src/BlockEntities/DropSpenserEntity.cpp
@@ -26,20 +26,6 @@ cDropSpenserEntity::cDropSpenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_Block
 
 
 
-cDropSpenserEntity::~cDropSpenserEntity()
-{
-	// Tell window its owner is destroyed
-	cWindow * Window = GetWindow();
-	if (Window != nullptr)
-	{
-		Window->OwnerDestroyed();
-	}
-}
-
-
-
-
-
 void cDropSpenserEntity::AddDropSpenserDir(Vector3i & a_RelCoord, NIBBLETYPE a_Direction)
 {
 	switch (a_Direction & E_META_DROPSPENSER_FACING_MASK)
@@ -126,6 +112,20 @@ void cDropSpenserEntity::CopyFrom(const cBlockEntity & a_Src)
 	auto & src = static_cast<const cDropSpenserEntity &>(a_Src);
 	m_Contents.CopyFrom(src.m_Contents);
 	m_ShouldDropSpense = src.m_ShouldDropSpense;
+}
+
+
+
+
+
+void cDropSpenserEntity::OnRemoveFromWorld()
+{
+	const auto Window = GetWindow();
+	if (Window != nullptr)
+	{
+		// Tell window its owner is destroyed:
+		Window->OwnerDestroyed();
+	}
 }
 
 

--- a/src/BlockEntities/DropSpenserEntity.h
+++ b/src/BlockEntities/DropSpenserEntity.h
@@ -43,10 +43,10 @@ public:
 	// tolua_end
 
 	cDropSpenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
-	virtual ~cDropSpenserEntity() override;
 
 	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
+	virtual void OnRemoveFromWorld() override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;

--- a/src/BlockEntities/EnderChestEntity.cpp
+++ b/src/BlockEntities/EnderChestEntity.cpp
@@ -25,23 +25,23 @@ cEnderChestEntity::cEnderChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMe
 
 
 
-cEnderChestEntity::~cEnderChestEntity()
+void cEnderChestEntity::SendTo(cClientHandle & a_Client)
 {
-	cWindow * Window = GetWindow();
-	if (Window != nullptr)
-	{
-		Window->OwnerDestroyed();
-	}
+	// Send a dummy "number of players with chest open" packet to make the chest visible:
+	a_Client.SendBlockAction(m_Pos.x, m_Pos.y, m_Pos.z, 1, 0, m_BlockType);
 }
 
 
 
 
 
-void cEnderChestEntity::SendTo(cClientHandle & a_Client)
+void cEnderChestEntity::OnRemoveFromWorld()
 {
-	// Send a dummy "number of players with chest open" packet to make the chest visible:
-	a_Client.SendBlockAction(m_Pos.x, m_Pos.y, m_Pos.z, 1, 0, m_BlockType);
+	const auto Window = GetWindow();
+	if (Window != nullptr)
+	{
+		Window->OwnerDestroyed();
+	}
 }
 
 

--- a/src/BlockEntities/EnderChestEntity.h
+++ b/src/BlockEntities/EnderChestEntity.h
@@ -20,9 +20,9 @@ class cEnderChestEntity :
 public:  // tolua_export
 
 	cEnderChestEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
-	virtual ~cEnderChestEntity() override;
 
 	// cBlockEntity overrides:
+	virtual void OnRemoveFromWorld() override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 

--- a/src/BlockEntities/FlowerPotEntity.cpp
+++ b/src/BlockEntities/FlowerPotEntity.cpp
@@ -23,18 +23,9 @@ cFlowerPotEntity::cFlowerPotEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta
 
 
 
-void cFlowerPotEntity::Destroy(void)
+cItems cFlowerPotEntity::ConvertToPickups() const
 {
-	// Drop the contents as pickups:
-	if (!m_Item.IsEmpty())
-	{
-		ASSERT(m_World != nullptr);
-		cItems Pickups;
-		Pickups.Add(m_Item);
-		m_World->SpawnItemPickups(Pickups, Vector3d(0.5, 0.5, 0.5) + m_Pos);
-
-		m_Item.Empty();
-	}
+	return cItem(m_Item);
 }
 
 

--- a/src/BlockEntities/FlowerPotEntity.h
+++ b/src/BlockEntities/FlowerPotEntity.h
@@ -43,7 +43,7 @@ public:  // tolua_export
 	// tolua_end
 
 	// cBlockEntity overrides:
-	virtual void Destroy(void) override;
+	virtual cItems ConvertToPickups() const override;
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
 	virtual void SendTo(cClientHandle & a_Client) override;

--- a/src/BlockEntities/FurnaceEntity.cpp
+++ b/src/BlockEntities/FurnaceEntity.cpp
@@ -25,7 +25,6 @@ enum
 cFurnaceEntity::cFurnaceEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
 	Super(a_BlockType, a_BlockMeta, a_Pos, ContentsWidth, ContentsHeight, a_World),
 	m_CurrentRecipe(nullptr),
-	m_IsDestroyed(false),
 	m_IsCooking(a_BlockType == E_BLOCK_LIT_FURNACE),
 	m_NeedCookTime(0),
 	m_TimeCooked(0),
@@ -41,30 +40,6 @@ cFurnaceEntity::cFurnaceEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Ve
 
 
 
-cFurnaceEntity::~cFurnaceEntity()
-{
-	// Tell window its owner is destroyed
-	cWindow * Window = GetWindow();
-	if (Window != nullptr)
-	{
-		Window->OwnerDestroyed();
-	}
-}
-
-
-
-
-
-void cFurnaceEntity::Destroy()
-{
-	m_IsDestroyed = true;
-	Super::Destroy();
-}
-
-
-
-
-
 void cFurnaceEntity::CopyFrom(const cBlockEntity & a_Src)
 {
 	Super::CopyFrom(a_Src);
@@ -73,12 +48,25 @@ void cFurnaceEntity::CopyFrom(const cBlockEntity & a_Src)
 	m_CurrentRecipe = src.m_CurrentRecipe;
 	m_FuelBurnTime = src.m_FuelBurnTime;
 	m_IsCooking = src.m_IsCooking;
-	m_IsDestroyed = src.m_IsDestroyed;
 	m_IsLoading = src.m_IsLoading;
 	m_LastInput = src.m_LastInput;
 	m_NeedCookTime = src.m_NeedCookTime;
 	m_TimeBurned = src.m_TimeBurned;
 	m_TimeCooked = src.m_TimeCooked;
+}
+
+
+
+
+
+void cFurnaceEntity::OnRemoveFromWorld()
+{
+	const auto Window = GetWindow();
+	if (Window != nullptr)
+	{
+		// Tell window its owner is destroyed:
+		Window->OwnerDestroyed();
+	}
 }
 
 
@@ -258,11 +246,6 @@ void cFurnaceEntity::BurnNewFuel(void)
 void cFurnaceEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 {
 	Super::OnSlotChanged(a_ItemGrid, a_SlotNum);
-
-	if (m_IsDestroyed)
-	{
-		return;
-	}
 
 	if (m_IsLoading)
 	{

--- a/src/BlockEntities/FurnaceEntity.h
+++ b/src/BlockEntities/FurnaceEntity.h
@@ -41,11 +41,9 @@ public:
 	/** Constructor used for normal operation */
 	cFurnaceEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
 
-	virtual ~cFurnaceEntity() override;
-
 	// cBlockEntity overrides:
-	virtual void Destroy() override;
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
+	virtual void OnRemoveFromWorld() override;
 	virtual void SendTo(cClientHandle & a_Client) override;
 	virtual bool Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual bool UsedBy(cPlayer * a_Player) override;
@@ -117,9 +115,6 @@ protected:
 
 	/** The item that is being smelted */
 	cItem m_LastInput;
-
-	/** Set to true when the furnace entity has been destroyed to prevent the block being set again */
-	bool m_IsDestroyed;
 
 	/** Set to true if the furnace is cooking an item */
 	bool m_IsCooking;

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -220,6 +220,12 @@ void cChunk::OnUnload()
 		// Notify the entity:
 		Entity->OnRemoveFromWorld(*Entity->GetWorld());
 	}
+
+	// Notify all block entities of imminent unload:
+	for (auto & BlockEntity : m_BlockEntities)
+	{
+		BlockEntity.second->OnRemoveFromWorld();
+	}
 }
 
 
@@ -452,6 +458,7 @@ void cChunk::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlock
 		if (affectedArea.IsInside(itr->second->GetPos()))
 		{
 			itr->second->Destroy();
+			itr->second->OnRemoveFromWorld();
 			itr = m_BlockEntities.erase(itr);
 		}
 		else
@@ -1267,6 +1274,7 @@ void cChunk::SetBlock(Vector3i a_RelPos, BLOCKTYPE a_BlockType, NIBBLETYPE a_Blo
 	if (BlockEntity != nullptr)
 	{
 		BlockEntity->Destroy();
+		BlockEntity->OnRemoveFromWorld();
 		RemoveBlockEntity(BlockEntity);
 	}
 

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -767,6 +767,7 @@ void cChunk::MoveEntityToNewChunk(OwnedEntity a_Entity)
 	if (Neighbor == nullptr)
 	{
 		LOGWARNING("%s: Failed to move entity, destination chunk unreachable. Entity lost", __FUNCTION__);
+		a_Entity->OnRemoveFromWorld(*m_World);
 		return;
 	}
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -169,7 +169,7 @@ public:
 
 
 	cEntity(eEntityType a_EntityType, Vector3d a_Pos, double a_Width, double a_Height);
-	virtual ~cEntity();
+	virtual ~cEntity() = default;
 
 	/** Spawns the entity in the world; returns true if spawned, false if not (plugin disallowed).
 	Adds the entity to the world. */
@@ -296,7 +296,7 @@ public:
 
 	// tolua_end
 	/** Destroys the entity, schedules it for memory freeing and broadcasts the DestroyEntity packet */
-	virtual void Destroy();
+	void Destroy();
 	// tolua_begin
 
 	/** Makes this pawn take damage from an attack by a_Attacker. Damage values are calculated automatically and DoTakeDamage() called */
@@ -594,9 +594,6 @@ public:
 	/** Removes a mob from the leashed list of mobs. */
 	void RemoveLeashedMob(cMonster * a_Monster);
 
-	/** Removes all mobs from the leashed list of mobs. */
-	void RemoveAllLeashedMobs();
-
 	/** Returs whether the entity has any mob leashed to it. */
 	bool HasAnyMobLeashed() const { return m_LeashedMobs.size() > 0; }
 
@@ -722,8 +719,6 @@ protected:
 	/** Handles the moving of this entity between worlds.
 	Should handle degenerate cases such as moving to the same world. */
 	virtual void DoMoveToWorld(const sWorldChangeInfo & a_WorldChangeInfo);
-
-	virtual void Destroyed(void) {}  // Called after the entity has been destroyed
 
 	/** Applies friction to an entity
 	@param a_Speed The speed vector to apply changes to

--- a/src/Entities/EntityEffect.h
+++ b/src/Entities/EntityEffect.h
@@ -73,7 +73,7 @@ public:
 	@param a_OtherEffect      The other effect to copy */
 	cEntityEffect & operator =(cEntityEffect a_OtherEffect);
 
-	virtual ~cEntityEffect(void) {}
+	virtual ~cEntityEffect(void) = default;
 
 	/** Creates a pointer to the proper entity effect from the effect type
 	@warning This function creates raw pointers that must be manually managed.

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -40,11 +40,11 @@ public:
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 	virtual void HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
-	virtual void Destroyed() override;
+	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
+	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 
 	int LastDamage(void) const { return m_LastDamage; }
 	ePayload GetPayload(void) const { return m_Payload; }
-
 
 protected:
 
@@ -99,7 +99,7 @@ protected:
 
 
 
-class cRideableMinecart :
+class cRideableMinecart final :
 	public cMinecart
 {
 	using Super = cMinecart;
@@ -114,6 +114,7 @@ public:
 	int GetBlockHeight(void) const {return m_Height;}
 
 	// cEntity overrides:
+	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 
 protected:
@@ -127,7 +128,7 @@ protected:
 
 
 
-class cMinecartWithChest :
+class cMinecartWithChest final :
 	public cMinecart,
 	public cItemGrid::cListener,
 	public cEntityWindowOwner
@@ -154,7 +155,6 @@ protected:
 
 	cItemGrid m_Contents;
 	void OpenNewWindow(void);
-	virtual void Destroyed() override;
 
 	// cItemGrid::cListener overrides:
 	virtual void OnSlotChanged(cItemGrid * a_Grid, int a_SlotNum) override
@@ -173,6 +173,8 @@ protected:
 	}
 
 	// cEntity overrides:
+	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
+	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 } ;
 
@@ -180,7 +182,7 @@ protected:
 
 
 
-class cMinecartWithFurnace :
+class cMinecartWithFurnace final :
 	public cMinecart
 {
 	using Super = cMinecart;
@@ -192,6 +194,7 @@ public:
 	cMinecartWithFurnace(Vector3d a_Pos);
 
 	// cEntity overrides:
+	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
@@ -213,22 +216,27 @@ private:
 
 
 
-class cMinecartWithTNT :
+class cMinecartWithTNT final :
 	public cMinecart
 {
 	using Super = cMinecart;
 
 public:
+
 	CLASS_PROTODEF(cMinecartWithTNT)
 
 	cMinecartWithTNT(Vector3d a_Pos);
+
+private:
+
+	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
 } ;
 
 
 
 
 
-class cMinecartWithHopper :
+class cMinecartWithHopper final :
 	public cMinecart
 {
 	using Super = cMinecart;
@@ -238,4 +246,8 @@ public:
 	CLASS_PROTODEF(cMinecartWithHopper)
 
 	cMinecartWithHopper(Vector3d a_Pos);
+
+private:
+
+	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
 } ;

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -28,25 +28,6 @@ cPawn::cPawn(eEntityType a_EntityType, double a_Width, double a_Height) :
 
 
 
-cPawn::~cPawn()
-{
-	ASSERT(m_TargetingMe.size() == 0);
-}
-
-
-
-
-
-void cPawn::Destroyed()
-{
-	StopEveryoneFromTargetingMe();
-	Super::Destroyed();
-}
-
-
-
-
-
 void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	std::vector<cEntityEffect *> EffectsToTick;
@@ -447,6 +428,16 @@ void cPawn::HandleFalling(void)
 	/* Note: it is currently possible to fall through lava and still die from fall damage
 	because of the client skipping an update about the lava block. This can only be resolved by
 	somehow integrating these above checks into the tracer in HandlePhysics. */
+}
+
+
+
+
+
+void cPawn::OnRemoveFromWorld(cWorld & a_World)
+{
+	StopEveryoneFromTargetingMe();
+	Super::OnRemoveFromWorld(a_World);
 }
 
 

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -23,8 +23,6 @@ public:
 	CLASS_PROTODEF(cPawn)
 
 	cPawn(eEntityType a_EntityType, double a_Width, double a_Height);
-	virtual ~cPawn() override;
-	virtual void Destroyed() override;
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
@@ -33,6 +31,7 @@ public:
 	virtual bool IsInvisible() const override;
 	virtual void HandleAir(void) override;
 	virtual void HandleFalling(void);
+	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 
 	/** Tells all pawns which are targeting us to stop targeting us. */
 	void StopEveryoneFromTargetingMe();
@@ -85,7 +84,3 @@ private:
 	/** A list of all monsters that are targeting this pawn. */
 	std::vector<cMonster*> m_TargetingMe;
 } ;  // tolua_export
-
-
-
-

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -280,10 +280,9 @@ cPlayer::~cPlayer(void)
 
 
 
-void cPlayer::Destroyed()
+void cPlayer::OnRemoveFromWorld(cWorld & a_World)
 {
 	CloseWindow(false);
-	Super::Destroyed();
 }
 
 

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -54,6 +54,8 @@ public:
 
 	virtual ~cPlayer() override;
 
+	virtual void OnRemoveFromWorld(cWorld & a_World) override;
+
 	virtual void SpawnOn(cClientHandle & a_Client) override;
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
@@ -783,8 +785,6 @@ protected:
 
 	/** Sets the speed and sends it to the client, so that they are forced to move so. */
 	virtual void DoSetSpeed(double a_SpeedX, double a_SpeedY, double a_SpeedZ) override;
-
-	virtual void Destroyed(void) override;
 
 	/** Filters out damage for creative mode / friendly fire */
 	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;

--- a/src/Mobs/Horse.cpp
+++ b/src/Mobs/Horse.cpp
@@ -32,19 +32,6 @@ cHorse::cHorse(int Type, int Color, int Style, int TameTimes) :
 
 
 
-cHorse::~cHorse()
-{
-	auto Window = GetWindow();
-	if (Window != nullptr)
-	{
-		Window->OwnerDestroyed();
-	}
-}
-
-
-
-
-
 void cHorse::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	Super::Tick(a_Dt, a_Chunk);
@@ -117,6 +104,21 @@ void cHorse::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	{
 		m_World->BroadcastEntityMetadata(*this);
 	}
+}
+
+
+
+
+
+void cHorse::OnRemoveFromWorld(cWorld & a_World)
+{
+	const auto Window = GetWindow();
+	if (Window != nullptr)
+	{
+		Window->OwnerDestroyed();
+	}
+
+	Super::OnRemoveFromWorld(a_World);
 }
 
 

--- a/src/Mobs/Horse.h
+++ b/src/Mobs/Horse.h
@@ -17,7 +17,6 @@ class cHorse:
 public:
 
 	cHorse(int Type, int Color, int Style, int TameTimes);
-	virtual ~cHorse() override;
 
 	CLASS_PROTODEF(cHorse)
 
@@ -25,6 +24,7 @@ public:
 	virtual void InStateIdle(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
+	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 
 	bool IsSaddled      (void) const  {return !m_Saddle.IsEmpty(); }
@@ -66,7 +66,3 @@ private:
 	cItem m_Armor;
 
 } ;
-
-
-
-

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -48,13 +48,9 @@ public:
 	*/
 	cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, double a_Width, double a_Height);
 
-	virtual ~cMonster() override;
+	CLASS_PROTODEF(cMonster)
 
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;
-
-	virtual void Destroyed() override;
-
-	CLASS_PROTODEF(cMonster)
 
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 

--- a/src/Mobs/PassiveMonster.cpp
+++ b/src/Mobs/PassiveMonster.cpp
@@ -37,15 +37,6 @@ bool cPassiveMonster::DoTakeDamage(TakeDamageInfo & a_TDI)
 
 
 
-void cPassiveMonster::Destroyed()
-{
-	Super::Destroyed();
-}
-
-
-
-
-
 void cPassiveMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	Super::Tick(a_Dt, a_Chunk);

--- a/src/Mobs/PassiveMonster.h
+++ b/src/Mobs/PassiveMonster.h
@@ -30,10 +30,4 @@ public:
 
 	/** When hit by someone, run away */
 	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
-
-	virtual void Destroyed(void) override;
 };
-
-
-
-

--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -418,7 +418,6 @@ void cWindow::SetProperty(size_t a_Property, short a_Value)
 
 void cWindow::OwnerDestroyed()
 {
-	m_Owner = nullptr;
 	// Close window for each player. Note that the last one needs special handling
 	while (m_OpenedBy.size() > 1)
 	{


### PR DESCRIPTION
* Fix destructors accessing destroyted objects
* Fix cPlayer not destroying windows (Destroyed never called)
* Tentatively fixes #4608, fixes #3236, fixes #3262
- Remove cEntity::Destroyed() and replace with cEntity::OnRemoveFromWorld()