### PR TITLE
Fix AppVeyor IA32 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,6 @@ for:
       - job_name: Windows-x86
 
   before_build:
-  - del CMakeCache.txt
   - cmake -G "Visual Studio 16 2019" -A "Win32" ..
 
 ################################

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ for:
       - job_name: Windows-x86
 
   before_build:
+	- del CMakeCache.txt
   - cmake -G "Visual Studio 16 2019" -A "Win32" ..
 
 ################################

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ for:
       - job_name: Windows-x86
 
   before_build:
-	- del CMakeCache.txt
+  - del CMakeCache.txt
   - cmake -G "Visual Studio 16 2019" -A "Win32" ..
 
 ################################

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ for:
       - job_name: Windows-x86
 
   before_build:
-  - cmake -G "Visual Studio 16 2019" ..
+  - cmake -G "Visual Studio 16 2019" -A "Win32" ..
 
 ################################
 # Windows 64-bit release build #


### PR DESCRIPTION
> The default target platform name (architecture) is that of the host and is provided in the CMAKE_VS_PLATFORM_NAME_DEFAULT variable.

AppVeyor uses AMD64. Oops.