### PR TITLE
Fixed switch-ups regarding some slab and stair recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Tools/ProtoProxy/ProtoProxy
 Testing/
 ChunkWorxSave.ini
 doxy/
+.vscode/
 Profiling
 Symbols
 cloc-ignored.txt

--- a/Server/Protocol/1.12.2/base.recipes.txt
+++ b/Server/Protocol/1.12.2/base.recipes.txt
@@ -50,8 +50,8 @@
 58 stone_axe
 59 sticky_piston
 60 stick
-61 spruce_stairs
-62 spruce_slab
+61 spruce_slab
+62 spruce_stairs
 63 spruce_planks
 64 spruce_fence_gate
 65 spruce_fence
@@ -150,8 +150,8 @@
 158 orange_bed
 159 orange_banner
 160 observer
-161 oak_stairs
-162 oak_slab
+161 oak_slab
+162 oak_stairs
 163 oak_planks
 164 note_block
 165 nether_wart_block


### PR DESCRIPTION
Fixes #5089

- Spruce and oak wood stairs were switched-up with the slabs in 1.12.2 protocol base recipes.
- Added VS Code files to gitignore.
