### PR TITLE
Clarify cClientHandle, cPlayer ownership semantics

### DIFF
--- a/src/ChunkSender.cpp
+++ b/src/ChunkSender.cpp
@@ -104,13 +104,13 @@ void cChunkSender::QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Prior
 				m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
 				info.m_Priority = a_Priority;
 			}
-			info.m_Clients.insert(a_Client);
+			info.m_Clients.insert(a_Client->shared_from_this());
 		}
 		else
 		{
 			m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
 			auto info = sSendChunk{Chunk, a_Priority};
-			info.m_Clients.insert(a_Client);
+			info.m_Clients.insert(a_Client->shared_from_this());
 			m_ChunkInfo.emplace(Chunk, info);
 		}
 	}
@@ -135,35 +135,23 @@ void cChunkSender::QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Prior
 				m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
 				info.m_Priority = a_Priority;
 			}
-			info.m_Clients.insert(a_Clients.begin(), a_Clients.end());
+			for (const auto & Client : a_Clients)
+			{
+				info.m_Clients.insert(Client->shared_from_this());
+			}
 		}
 		else
 		{
 			m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
 			auto info = sSendChunk{Chunk, a_Priority};
-			info.m_Clients.insert(a_Clients.begin(), a_Clients.end());
+			for (const auto & Client : a_Clients)
+			{
+				info.m_Clients.insert(Client->shared_from_this());
+			}
 			m_ChunkInfo.emplace(Chunk, info);
 		}
 	}
 	m_evtQueue.Set();
-}
-
-
-
-
-
-void cChunkSender::RemoveClient(cClientHandle * a_Client)
-{
-	{
-		cCSLock Lock(m_CS);
-		for (auto && pair : m_ChunkInfo)
-		{
-			auto && clients = pair.second.m_Clients;
-			clients.erase(a_Client);  // nop for sets that do not contain a_Client
-		}
-	}
-	m_evtQueue.Set();
-	m_evtRemoved.Wait();  // Wait for all remaining instances of a_Client to be processed (Execute() makes a copy of m_ChunkInfo)
 }
 
 
@@ -189,16 +177,13 @@ void cChunkSender::Execute(void)
 					continue;
 				}
 
-				std::unordered_set<cClientHandle *> clients;
-				std::swap(itr->second.m_Clients, clients);
+				auto clients = std::move(itr->second.m_Clients);
 				m_ChunkInfo.erase(itr);
 
 				cCSUnlock Unlock(Lock);
 				SendChunk(Chunk.m_ChunkX, Chunk.m_ChunkZ, clients);
 			}
 		}
-
-		m_evtRemoved.SetAll();  // Notify all waiting threads that all clients are processed and thus safe to destroy
 	}  // while (!m_ShouldTerminate)
 }
 
@@ -206,19 +191,25 @@ void cChunkSender::Execute(void)
 
 
 
-void cChunkSender::SendChunk(int a_ChunkX, int a_ChunkZ, std::unordered_set<cClientHandle *> a_Clients)
+void cChunkSender::SendChunk(int a_ChunkX, int a_ChunkZ, const WeakClients & a_Clients)
 {
+	// Contains strong pointers to clienthandles.
+	std::vector<std::shared_ptr<cClientHandle>> Clients;
+
 	// Ask the client if it still wants the chunk:
-	for (auto itr = a_Clients.begin(); itr != a_Clients.end();)
+	for (const auto & WeakClient : a_Clients)
 	{
-		if (!(*itr)->WantsSendChunk(a_ChunkX, a_ChunkZ))
+		auto Client = WeakClient.lock();
+		if ((Client != nullptr) && Client->WantsSendChunk(a_ChunkX, a_ChunkZ))
 		{
-			itr = a_Clients.erase(itr);
+			Clients.push_back(std::move(Client));
 		}
-		else
-		{
-			itr++;
-		}
+	}
+
+	// Bail early if every requester disconnected:
+	if (Clients.empty())
+	{
+		return;
 	}
 
 	// If the chunk has no clients, no need to packetize it:
@@ -247,9 +238,9 @@ void cChunkSender::SendChunk(int a_ChunkX, int a_ChunkZ, std::unordered_set<cCli
 	}
 
 	// Send:
-	m_Serializer.SendToClients(a_ChunkX, a_ChunkZ, m_Data, m_BiomeMap, a_Clients);
+	m_Serializer.SendToClients(a_ChunkX, a_ChunkZ, m_Data, m_BiomeMap, Clients);
 
-	for (const auto Client : a_Clients)
+	for (const auto & Client : Clients)
 	{
 		// Send block-entity packets:
 		for (const auto & Pos : m_BlockEntities)
@@ -270,7 +261,17 @@ void cChunkSender::SendChunk(int a_ChunkX, int a_ChunkZ, std::unordered_set<cCli
 					Client->GetUsername().c_str()
 				);
 				*/
-				a_Entity.SpawnOn(*Client);
+
+				/* This check looks highly suspect.
+				Its purpose is to check the client still has a valid player object associated,
+				since the player destroys itself when the client is destroyed.
+				It's done within the world lock to ensure correctness.
+				A better way involves fixing chunk sending (GH #3696) to obviate calling SpawnOn from this thread in the first place. */
+				if (!Client->IsDestroyed())
+				{
+					a_Entity.SpawnOn(*Client);
+				}
+
 				return true;
 			});
 		}

--- a/src/ChunkSender.h
+++ b/src/ChunkSender.h
@@ -74,10 +74,9 @@ public:
 	void QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Priority, cClientHandle * a_Client);
 	void QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Priority, cChunkClientHandles a_Client);
 
-	/** Removes the a_Client from all waiting chunk send operations */
-	void RemoveClient(cClientHandle * a_Client);
-
 protected:
+
+	using WeakClients = std::set<std::weak_ptr<cClientHandle>, std::owner_less<std::weak_ptr<cClientHandle>>>;
 
 	struct sChunkQueue
 	{
@@ -96,7 +95,7 @@ protected:
 	struct sSendChunk
 	{
 		cChunkCoords m_Chunk;
-		std::unordered_set<cClientHandle *> m_Clients;
+		WeakClients m_Clients;
 		Priority m_Priority;
 		sSendChunk(cChunkCoords a_Chunk, Priority a_Priority) :
 			m_Chunk(a_Chunk),
@@ -114,7 +113,6 @@ protected:
 	std::priority_queue<sChunkQueue> m_SendChunks;
 	std::unordered_map<cChunkCoords, sSendChunk, cChunkCoordsHash> m_ChunkInfo;
 	cEvent m_evtQueue;  // Set when anything is added to m_ChunksReady
-	cEvent m_evtRemoved;  // Set when removed clients are safe to be deleted
 
 	// Data about the chunk that is being sent:
 	// NOTE that m_BlockData[] is inherited from the cChunkDataCollector
@@ -132,7 +130,7 @@ protected:
 	virtual void BlockEntity  (cBlockEntity * a_Entity) override;
 
 	/** Sends the specified chunk to all the specified clients */
-	void SendChunk(int a_ChunkX, int a_ChunkZ, std::unordered_set<cClientHandle *> a_Clients);
+	void SendChunk(int a_ChunkX, int a_ChunkZ, const WeakClients & a_Clients);
 } ;
 
 

--- a/src/CircularBufferCompressor.h
+++ b/src/CircularBufferCompressor.h
@@ -7,6 +7,12 @@
 
 
 
+class cByteBuffer;
+
+
+
+
+
 class CircularBufferCompressor
 {
 public:

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -45,7 +45,7 @@ typedef std::shared_ptr<cClientHandle> cClientHandlePtr;
 
 
 class cClientHandle  // tolua_export
-	: public cTCPLink::cCallbacks
+	: public cTCPLink::cCallbacks, public std::enable_shared_from_this<cClientHandle>
 {  // tolua_export
 public:  // tolua_export
 
@@ -136,7 +136,6 @@ public:  // tolua_export
 
 	bool IsPlaying   (void) const { return (m_State == csPlaying); }
 	bool IsDestroyed (void) const { return (m_State == csDestroyed); }
-	bool IsDestroying(void) const { return (m_State == csDestroying); }
 
 	// The following functions send the various packets:
 	// (Please keep these alpha-sorted)
@@ -197,7 +196,7 @@ public:  // tolua_export
 	void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID);
 	void SendResourcePack               (const AString & a_ResourcePackUrl);
 	void SendResetTitle                 (void);  // tolua_export
-	void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks = false);
+	void SendRespawn                    (eDimension a_Dimension, bool a_ShouldIgnoreDimensionChecks);
 	void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode);
 	void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode);
 	void SendSetSubTitle                (const cCompositeChat & a_SubTitle);  // tolua_export
@@ -401,9 +400,6 @@ public:  // tolua_export
 	bool IsPlayerChunkSent();
 
 private:
-	/** The dimension that was last sent to a player in a Respawn or Login packet.
-	Used to avoid Respawning into the same dimension, which confuses the client. */
-	eDimension m_LastSentDimension;
 
 	friend class cServer;  // Needs access to SetSelf()
 
@@ -447,16 +443,11 @@ private:
 	/** Protects m_OutgoingData against multithreaded access. */
 	cCriticalSection m_CSOutgoingData;
 
-	/** Buffer for storing outgoing data from any thread; will get sent in Tick() (to prevent deadlocks).
-	Protected by m_CSOutgoingData. */
-	ContiguousByteBuffer m_OutgoingData;
-
-	Vector3d m_ConfirmPosition;
-
+	/** A pointer to a World-owned player object, created in FinishAuthenticate when authentication succeeds.
+	The player should only be accessed from the tick thread of the World that owns him.
+	After the player object is handed off to the World, lifetime is managed automatically, guaranteed to outlast this client handle.
+	The player self-destructs some time after the client handle enters the Destroyed state. */
 	cPlayer * m_Player;
-
-	// Temporary (#3115-will-fix): maintain temporary ownership of created cPlayer objects while they are in limbo
-	std::unique_ptr<cPlayer> m_PlayerPtr;
 
 	/** This is an optimization which saves you an iteration of m_SentChunks if you just want to know
 	whether or not the player is standing at a sent chunk.
@@ -500,12 +491,8 @@ private:
 	{
 		csConnected,             ///< The client has just connected, waiting for their handshake / login
 		csAuthenticating,        ///< The client has logged in, waiting for external authentication
-		csAuthenticated,         ///< The client has been authenticated, will start streaming chunks in the next tick
 		csDownloadingWorld,      ///< The client is waiting for chunks, we're waiting for the loader to provide and send them
 		csPlaying,               ///< Normal gameplay
-		csKicked,                ///< Disconnect packet sent, awaiting connection closure
-		csQueuedForDestruction,  ///< The client will be destroyed in the next tick (flag set when socket closed)
-		csDestroying,            ///< The client is being destroyed, don't queue any more packets / don't add to chunks
 		csDestroyed,             ///< The client has been destroyed, the destructor is to be called from the owner thread
 	} ;
 
@@ -555,9 +542,6 @@ private:
 	m_CSOutgoingData is used to synchronize access for sending data. */
 	cTCPLinkPtr m_Link;
 
-	/** Shared pointer to self, so that this instance can keep itself alive when needed. */
-	cClientHandlePtr m_Self;
-
 	/** The fraction between 0 and 1 (or above), of how far through mining the currently mined block is.
 	0 for just started, 1 and above for broken. Used for anti-cheat. */
 	float m_BreakProgress;
@@ -592,16 +576,13 @@ private:
 	/** Called when the network socket has been closed. */
 	void SocketClosed(void);
 
-	/** Called right after the instance is created to store its SharedPtr inside. */
-	void SetSelf(cClientHandlePtr a_Self);
-
 	/** Called to update m_State.
 	Only succeeds if a_NewState > m_State, otherwise returns false. */
 	bool SetState(eState a_NewState);
 
-	/** Processes the data in the network input and output buffers.
+	/** Processes the data in the network input buffer.
 	Called by both Tick() and ServerTick(). */
-	void ProcessProtocolInOut(void);
+	void ProcessProtocolIn(void);
 
 	// cTCPLink::cCallbacks overrides:
 	virtual void OnLinkCreated(cTCPLinkPtr a_Link) override;

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -81,7 +81,6 @@ protected:
 		cWorld * m_NewWorld;
 		Vector3d m_NewPosition;
 		bool m_SetPortalCooldown;
-		bool m_SendRespawn;
 	};
 
 public:
@@ -173,7 +172,7 @@ public:
 
 	/** Spawns the entity in the world; returns true if spawned, false if not (plugin disallowed).
 	Adds the entity to the world. */
-	virtual bool Initialize(OwnedEntity a_Self, cWorld & a_EntityWorld);
+	bool Initialize(OwnedEntity a_Self, cWorld & a_EntityWorld);
 
 	/** Called when the entity is added to a world.
 	e.g after first spawning or after successfuly moving between worlds.
@@ -469,13 +468,6 @@ public:
 	/** Teleports to the coordinates specified */
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ);
 
-	/** Schedules a MoveToWorld call to occur on the next Tick of the entity */
-	[[deprecated]] void ScheduleMoveToWorld(cWorld & a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true)
-	{
-		LOGWARNING("ScheduleMoveToWorld is deprecated, use MoveToWorld instead");
-		MoveToWorld(a_World, a_NewPosition, a_ShouldSetPortalCooldown, a_ShouldSendRespawn);
-	}
-
 	bool MoveToWorld(cWorld & a_World, Vector3d a_NewPosition, bool a_ShouldSetPortalCooldown = false, bool a_ShouldSendRespawn = true);
 
 	bool MoveToWorld(cWorld & a_World, bool a_ShouldSendRespawn, Vector3d a_NewPosition)
@@ -718,7 +710,7 @@ protected:
 
 	/** Handles the moving of this entity between worlds.
 	Should handle degenerate cases such as moving to the same world. */
-	virtual void DoMoveToWorld(const sWorldChangeInfo & a_WorldChangeInfo);
+	void DoMoveToWorld(const sWorldChangeInfo & a_WorldChangeInfo);
 
 	/** Applies friction to an entity
 	@param a_Speed The speed vector to apply changes to

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -598,20 +598,6 @@ bool cMonster::DoTakeDamage(TakeDamageInfo & a_TDI)
 
 
 
-void cMonster::DoMoveToWorld(const cEntity::sWorldChangeInfo & a_WorldChangeInfo)
-{
-	// Stop all mobs from targeting this entity
-	// Stop this entity from targeting other mobs
-	SetTarget(nullptr);
-	StopEveryoneFromTargetingMe();
-
-	Super::DoMoveToWorld(a_WorldChangeInfo);
-}
-
-
-
-
-
 void cMonster::KilledBy(TakeDamageInfo & a_TDI)
 {
 	Super::KilledBy(a_TDI);

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -358,8 +358,6 @@ protected:
 	/** Adds weapon that is equipped with the chance saved in m_DropChance[...] (this will be greter than 1 if picked up or 0.085 + (0.01 per LootingLevel) if born with) to the drop */
 	void AddRandomWeaponDropItem(cItems & a_Drops, unsigned int a_LootingLevel);
 
-	virtual void DoMoveToWorld(const cEntity::sWorldChangeInfo & a_WorldChangeInfo) override;
-
 	/* The breeding processing */
 
 	/** The monster's breeding partner. */

--- a/src/Protocol/ChunkDataSerializer.cpp
+++ b/src/Protocol/ChunkDataSerializer.cpp
@@ -74,7 +74,7 @@ cChunkDataSerializer::cChunkDataSerializer(const eDimension a_Dimension) :
 
 void cChunkDataSerializer::SendToClients(const int a_ChunkX, const int a_ChunkZ, const cChunkData & a_Data, const unsigned char * a_BiomeData, const ClientHandles & a_SendTo)
 {
-	for (const auto Client : a_SendTo)
+	for (const auto & Client : a_SendTo)
 	{
 		switch (static_cast<cProtocol::Version>(Client->GetProtocolVersion()))
 		{
@@ -133,7 +133,7 @@ void cChunkDataSerializer::SendToClients(const int a_ChunkX, const int a_ChunkZ,
 
 
 
-inline void cChunkDataSerializer::Serialize(cClientHandle * a_Client, const int a_ChunkX, const int a_ChunkZ, const cChunkData & a_Data, const unsigned char * a_BiomeData, const CacheVersion a_CacheVersion)
+inline void cChunkDataSerializer::Serialize(const ClientHandles::value_type & a_Client, const int a_ChunkX, const int a_ChunkZ, const cChunkData & a_Data, const unsigned char * a_BiomeData, const CacheVersion a_CacheVersion)
 {
 	auto & Cache = m_Cache[static_cast<size_t>(a_CacheVersion)];
 	if (Cache.Engaged)

--- a/src/Protocol/ChunkDataSerializer.h
+++ b/src/Protocol/ChunkDataSerializer.h
@@ -21,7 +21,7 @@ Caches the serialized data for as long as this object lives, so that the same da
 other clients using the same protocol. */
 class cChunkDataSerializer
 {
-	using ClientHandles = std::unordered_set<cClientHandle *>;
+	using ClientHandles = std::vector<std::shared_ptr<cClientHandle>>;
 
 	/** Enum to collapse protocol versions into a contiguous index. */
 	enum class CacheVersion
@@ -55,7 +55,7 @@ private:
 
 	/** Serialises the given chunk, storing the result into the given cache entry, and sends the data.
 	If the cache entry is already present, simply re-uses it. */
-	inline void Serialize(cClientHandle * a_Client, int a_ChunkX, int a_ChunkZ, const cChunkData & a_Data, const unsigned char * a_BiomeData, CacheVersion a_CacheVersion);
+	inline void Serialize(const ClientHandles::value_type & a_Client, int a_ChunkX, int a_ChunkZ, const cChunkData & a_Data, const unsigned char * a_BiomeData, CacheVersion a_CacheVersion);
 
 	inline void Serialize47 (int a_ChunkX, int a_ChunkZ, const cChunkData & a_Data, const unsigned char * a_BiomeData);  // Release 1.8
 	inline void Serialize107(int a_ChunkX, int a_ChunkZ, const cChunkData & a_Data, const unsigned char * a_BiomeData);  // Release 1.9

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -670,8 +670,7 @@ void cProtocol_1_8_0::SendHeldItemChange(int a_ItemIndex)
 	ASSERT((a_ItemIndex >= 0) && (a_ItemIndex <= 8));  // Valid check
 
 	cPacketizer Pkt(*this, pktHeldItemChange);
-	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteBEInt8(static_cast<Int8>(Player->GetInventory().GetEquippedSlotNum()));
+	Pkt.WriteBEInt8(static_cast<Int8>(a_ItemIndex));
 }
 
 
@@ -1021,15 +1020,11 @@ void cProtocol_1_8_0::SendPlayerListUpdatePing(const cPlayer & a_Player)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	auto ClientHandle = a_Player.GetClientHandlePtr();
-	if (ClientHandle != nullptr)
-	{
-		cPacketizer Pkt(*this, pktPlayerList);
-		Pkt.WriteVarInt32(2);
-		Pkt.WriteVarInt32(1);
-		Pkt.WriteUUID(a_Player.GetUUID());
-		Pkt.WriteVarInt32(static_cast<UInt32>(ClientHandle->GetPing()));
-	}
+	cPacketizer Pkt(*this, pktPlayerList);
+	Pkt.WriteVarInt32(2);
+	Pkt.WriteVarInt32(1);
+	Pkt.WriteUUID(a_Player.GetUUID());
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_Player.GetClientHandle()->GetPing()));
 }
 
 

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -500,7 +500,7 @@ void cRoot::QueueExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCall
 		cRoot::Get()->ForEachPlayer(
 			[&](cPlayer & a_Player)
 			{
-				a_Player.GetClientHandlePtr()->Kick(m_Server->GetShutdownMessage());
+				a_Player.GetClientHandle()->Kick(m_Server->GetShutdownMessage());
 				SentDisconnect = true;
 				return false;
 			}

--- a/src/StringCompression.h
+++ b/src/StringCompression.h
@@ -9,8 +9,6 @@
 
 
 
-class cByteBuffer;
-
 struct libdeflate_compressor;
 struct libdeflate_decompressor;
 


### PR DESCRIPTION
+ A cPlayer, once created, has a strong pointer to the cClientHandle. The player ticks the clienthandle. If he finds the handle destroyed, he destroys himself in turn. Nothing else can kill the player.
* The client handle has a pointer to the player. Once a player is created, the client handle never outlasts the player, nor does it manage the player's lifetime. The pointer is always safe to use after FinishAuthenticate, which is also the point where cProtocol is put into the Game state that allows player manipulation.
+ Entities are once again never lost by constructing a chunk when they try to move into one that doesn't exist.
* Fixed a forgotten Super invocation in cPlayer::OnRemoveFromWorld.
* Fix SaveToDisk usage in destructor by only saving things cPlayer owns, instead of accessing cWorld.