### PR TITLE
Fixed horse UI desync when taking saddle out

### DIFF
--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -2803,6 +2803,7 @@ void cSlotAreaHorse::Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_C
 					{
 						return;
 					}
+					break;
 				}
 				case ArmorSlot:
 				{
@@ -2810,9 +2811,11 @@ void cSlotAreaHorse::Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_C
 					{
 						return;
 					}
+					break;
 				}
 				default: break;
 			}
+
 		}
 		default: break;
 	}


### PR DESCRIPTION
Overlooked falltrough. The SaddleSlot execution falling into checks for ArmorSlot causes the take out to be ignored, as then it returns because saddle is not an armor and the ::Click is not called/propagated.