### PR TITLE
Fix HUMONGOUS BUG (crashes)

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1981,14 +1981,7 @@ void cClientHandle::Tick(float a_Dt)
 		m_BreakProgress += m_Player->GetMiningProgressPerTick(Block);
 	}
 
-	try
-	{
-		ProcessProtocolIn();
-	}
-	catch (const std::exception & Oops)
-	{
-		Kick(Oops.what());
-	}
+	ProcessProtocolIn();
 
 	if (IsDestroyed())
 	{
@@ -3171,7 +3164,7 @@ void cClientHandle::PacketBufferFull(void)
 {
 	// Too much data in the incoming queue, the server is probably too busy, kick the client:
 	LOGERROR("Too much data in queue for client \"%s\" @ %s, kicking them.", m_Username.c_str(), m_IPString.c_str());
-	SendDisconnect("Server busy");
+	SendDisconnect("The server is busy; please try again later.");
 }
 
 
@@ -3249,9 +3242,18 @@ void cClientHandle::ProcessProtocolIn(void)
 		std::swap(IncomingData, m_IncomingData);
 	}
 
-	if (!IncomingData.empty())
+	if (IncomingData.empty())
+	{
+		return;
+	}
+
+	try
 	{
 		m_Protocol.HandleIncomingData(*this, IncomingData);
+	}
+	catch (const std::exception & Oops)
+	{
+		Kick(Oops.what());
 	}
 }
 

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -47,22 +47,17 @@ public:
 
 private:
 
-	/** Handles data reception in a newly-created client handle that doesn't yet have known protocol.
+	/** Handles data reception in a newly-created client handle that doesn't yet have a known protocol.
 	a_Data contains a view of data that were just received.
-	Calls TryRecognizeProtocol to populate m_Protocol, and transitions to another mode depending on success. */
+	Tries to recognize a protocol, populate m_Protocol, and transitions to another mode depending on success. */
 	void HandleIncomingDataInRecognitionStage(cClientHandle & a_Client, std::string_view a_Data);
 
 	/** Handles and responds to unsupported clients sending pings. */
-	void HandleIncomingDataInOldPingResponseStage(cClientHandle & a_Client, const std::string_view a_Data);
-
-	/* Tries to recognize a protocol based on a_Data and m_Buffer contents.
-	a_Data is replaced with a sub-view, with handshake packet removed. */
-	void TryRecognizeProtocol(cClientHandle & a_Client, std::string_view & a_Data);
+	void HandleIncomingDataInOldPingResponseStage(cClientHandle & a_Client, std::string_view a_Data);
 
 	/** Tries to recognize a protocol in the lengthed family (1.7+), based on m_Buffer.
-	The packet length and type have already been read, type is 0.
 	Returns a cProtocol_XXX instance if recognized. */
-	std::unique_ptr<cProtocol> TryRecognizeLengthedProtocol(cClientHandle & a_Client, std::string_view & a_Data);
+	std::unique_ptr<cProtocol> TryRecognizeLengthedProtocol(cClientHandle & a_Client, std::string_view a_Data);
 
 	/** Sends one packet inside a cByteBuffer.
 	This is used only when handling an outdated server ping. */

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -177,6 +177,13 @@ void cProtocol_1_8_0::DataReceived(cByteBuffer & a_Buffer, const char * a_Data, 
 {
 	if (m_IsEncrypted)
 	{
+		// An artefact of the protocol recogniser, will be removed when decryption done in-place:
+		if (a_Size == 0)
+		{
+			AddReceivedData(a_Buffer, nullptr, 0);
+			return;
+		}
+
 		std::byte Decrypted[512];
 		while (a_Size > 0)
 		{

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -2815,7 +2815,6 @@ void cSlotAreaHorse::Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_C
 				}
 				default: break;
 			}
-
 		}
 		default: break;
 	}


### PR DESCRIPTION
First one: add missing exception handler in ProcessProtocolIn

Second: remove faulty logic dealing with incomplete packets.

`a_Data = a_Data.substr(m_Buffer.GetUsedSpace() - m_Buffer.GetReadableSpace());`

was incorrect; it attempted to apply a length derived from m_Buffer to an unrelated a_Data. Its purpose was to give cProtocol the data the client sent, minus initial handshake bytes. However, we can use the knowledge that during initial handshake, there is no encryption and every byte can be written unchanged into m_Buffer, to just call cProtocol with a data length of zero. This will cause it to parse from m_Buffer - wherein we have already written everything the client sent - with no a_Data manipulation needed.

Additionally, removed UnsupportedButPingableProtocolException (use of exception as control flow) and encode this state as m_Protocol == nullptr, id est "no protocol for this unsupported version", which is then handled by cMultiVersionProtocol itself.