### PR TITLE
Fix Windows XP to 7 compatibility

### DIFF
--- a/Tools/MCADefrag/MCADefrag.cpp
+++ b/Tools/MCADefrag/MCADefrag.cpp
@@ -126,7 +126,7 @@ AString cMCADefrag::GetNextFileName(void)
 // cMCADefrag::cThread:
 
 cMCADefrag::cThread::cThread(cMCADefrag & a_Parent) :
-	super("MCADefrag thread"),
+	super("MCA Defragmentor"),
 	m_Parent(a_Parent),
 	m_IsChunkUncompressed(false),
 	m_Compressor(12)  // Set the highest compression factor

--- a/src/ChunkGeneratorThread.cpp
+++ b/src/ChunkGeneratorThread.cpp
@@ -18,7 +18,7 @@ const size_t QUEUE_SKIP_LIMIT = 500;
 
 
 cChunkGeneratorThread::cChunkGeneratorThread(void) :
-	Super("cChunkGeneratorThread"),
+	Super("Chunk Generator"),
 	m_Generator(nullptr),
 	m_PluginInterface(nullptr),
 	m_ChunkSink(nullptr)

--- a/src/ChunkSender.cpp
+++ b/src/ChunkSender.cpp
@@ -59,7 +59,7 @@ public:
 // cChunkSender:
 
 cChunkSender::cChunkSender(cWorld & a_World) :
-	Super("ChunkSender"),
+	Super("Chunk Sender"),
 	m_World(a_World),
 	m_Serializer(m_World.GetDimension())
 {

--- a/src/DeadlockDetect.cpp
+++ b/src/DeadlockDetect.cpp
@@ -21,7 +21,7 @@ const int CYCLE_MILLISECONDS = 100;
 
 
 cDeadlockDetect::cDeadlockDetect(void) :
-	Super("DeadlockDetect"),
+	Super("Deadlock Detector"),
 	m_IntervalSec(1000)
 {
 }

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -78,22 +78,24 @@
 
 // OS-dependent stuff:
 #ifdef _WIN32
-
+	#define NOMINMAX  // Windows SDK defines min and max macros, messing up with our std::min and std::max usage.
 	#define WIN32_LEAN_AND_MEAN
-	#define _WIN32_WINNT _WIN32_WINNT_WS03  // We want to target Windows XP with Service Pack 2 & Windows Server 2003 with Service Pack 1 and higher
+	#define _WIN32_WINNT 0x0501  // We want to target Windows XP with Service Pack 2 & Windows Server 2003 with Service Pack 1 and higher.
 
-	// Windows SDK defines min and max macros, messing up with our std::min and std::max usage
-	#define NOMINMAX
+	// Use CryptoAPI primitives when targeting a version that supports encrypting with AES-CFB8 smaller than a full block at a time.
+	#define PLATFORM_CRYPTOGRAPHY (_WIN32_WINNT >= 0x0602)
 
 	#include <Windows.h>
 	#include <winsock2.h>
 	#include <Ws2tcpip.h>  // IPv6 stuff
 
-	// Windows SDK defines GetFreeSpace as a constant, probably a Win16 API remnant
+	// Windows SDK defines GetFreeSpace as a constant, probably a Win16 API remnant:
 	#ifdef GetFreeSpace
 		#undef GetFreeSpace
 	#endif  // GetFreeSpace
 #else
+	#define PLATFORM_CRYPTOGRAPHY 0
+
 	#include <arpa/inet.h>
 	#include <unistd.h>
 #endif

--- a/src/LightingThread.cpp
+++ b/src/LightingThread.cpp
@@ -100,7 +100,7 @@ public:
 // cLightingThread:
 
 cLightingThread::cLightingThread(cWorld & a_World):
-	Super("cLightingThread"),
+	Super("Lighting Executor"),
 	m_World(a_World),
 	m_MaxHeight(0),
 	m_NumSeeds(0)

--- a/src/OSSupport/IsThread.h
+++ b/src/OSSupport/IsThread.h
@@ -32,7 +32,7 @@ protected:
 	std::atomic<bool> m_ShouldTerminate;
 
 public:
-	cIsThread(const AString & a_ThreadName);
+	cIsThread(AString && a_ThreadName);
 	virtual ~cIsThread();
 
 	/** Starts the thread; returns without waiting for the actual start. */

--- a/src/OSSupport/NetworkLookup.cpp
+++ b/src/OSSupport/NetworkLookup.cpp
@@ -11,7 +11,7 @@
 
 
 cNetworkLookup::cNetworkLookup() :
-	cIsThread("NetworkLookup")
+	cIsThread("Network Lookup Executor")
 {
 }
 

--- a/src/Protocol/Authenticator.cpp
+++ b/src/Protocol/Authenticator.cpp
@@ -26,7 +26,7 @@
 
 
 cAuthenticator::cAuthenticator(void) :
-	Super("cAuthenticator"),
+	Super("Authenticator"),
 	m_Server(DEFAULT_AUTH_SERVER),
 	m_Address(DEFAULT_AUTH_ADDRESS),
 	m_ShouldAuthenticate(true)

--- a/src/Protocol/MojangAPI.cpp
+++ b/src/Protocol/MojangAPI.cpp
@@ -237,7 +237,7 @@ class cMojangAPI::cUpdateThread:
 public:
 
 	cUpdateThread(cMojangAPI & a_MojangAPI):
-		Super("cMojangAPI::cUpdateThread"),
+		Super("MojangAPI Updater"),
 		m_MojangAPI(a_MojangAPI)
 	{
 	}

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -1046,7 +1046,6 @@ void cRoot::TransitionNextState(NextState a_NextState)
 	s_StopEvent.Set();
 
 #ifdef WIN32
-
 	DWORD Length;
 	INPUT_RECORD Record
 	{

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -71,7 +71,7 @@ public:
 // cServer::cTickThread:
 
 cServer::cTickThread::cTickThread(cServer & a_Server) :
-	Super("ServerTickThread"),
+	Super("Server Ticker"),
 	m_Server(a_Server)
 {
 }

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -96,7 +96,7 @@ cWorld::cLock::cLock(const cWorld & a_World) :
 // cWorld::cTickThread:
 
 cWorld::cTickThread::cTickThread(cWorld & a_World) :
-	Super(Printf("WorldTickThread: %s", a_World.GetName().c_str())),
+	Super(Printf("World Ticker (%s)", a_World.GetName().c_str())),
 	m_World(a_World)
 {
 }

--- a/src/WorldStorage/WorldStorage.cpp
+++ b/src/WorldStorage/WorldStorage.cpp
@@ -38,7 +38,7 @@ protected:
 // cWorldStorage:
 
 cWorldStorage::cWorldStorage(void) :
-	Super("cWorldStorage"),
+	Super("World Storage Executor"),
 	m_World(nullptr),
 	m_SaveSchema(nullptr)
 {

--- a/src/mbedTLS++/AesCfb128Decryptor.cpp
+++ b/src/mbedTLS++/AesCfb128Decryptor.cpp
@@ -13,7 +13,7 @@
 cAesCfb128Decryptor::cAesCfb128Decryptor(void) :
 	m_IsValid(false)
 {
-#ifdef _WIN32
+#if PLATFORM_CRYPTOGRAPHY && defined(_WIN32)
 	if (!CryptAcquireContext(&m_Aes, nullptr, nullptr, PROV_RSA_AES, CRYPT_VERIFYCONTEXT))
 	{
 		throw std::system_error(GetLastError(), std::system_category());
@@ -30,7 +30,7 @@ cAesCfb128Decryptor::cAesCfb128Decryptor(void) :
 cAesCfb128Decryptor::~cAesCfb128Decryptor()
 {
 	// Clear the leftover in-memory data, so that they can't be accessed by a backdoor:
-#ifdef _WIN32
+#if PLATFORM_CRYPTOGRAPHY && defined(_WIN32)
 	CryptReleaseContext(m_Aes, 0);
 #else
 	mbedtls_aes_free(&m_Aes);
@@ -45,7 +45,7 @@ void cAesCfb128Decryptor::Init(const Byte a_Key[16], const Byte a_IV[16])
 {
 	ASSERT(!IsValid());  // Cannot Init twice
 
-#ifdef _WIN32
+#if PLATFORM_CRYPTOGRAPHY && defined(_WIN32)
 	struct Key
 	{
 		PUBLICKEYSTRUC Header;
@@ -77,7 +77,7 @@ void cAesCfb128Decryptor::ProcessData(std::byte * const a_EncryptedIn, const siz
 {
 	ASSERT(IsValid());  // Must Init() first
 
-#ifdef _WIN32
+#if PLATFORM_CRYPTOGRAPHY && defined(_WIN32)
 	ASSERT(a_Length <= std::numeric_limits<DWORD>::max());
 
 	DWORD Length = static_cast<DWORD>(a_Length);

--- a/src/mbedTLS++/AesCfb128Decryptor.h
+++ b/src/mbedTLS++/AesCfb128Decryptor.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef _WIN32
+#if PLATFORM_CRYPTOGRAPHY && defined(_WIN32)
 #include <wincrypt.h>
 #else
 #include "mbedtls/aes.h"
@@ -38,7 +38,7 @@ public:
 
 protected:
 
-#ifdef _WIN32
+#if PLATFORM_CRYPTOGRAPHY && defined(_WIN32)
 	HCRYPTPROV m_Aes;
 	HCRYPTKEY m_Key;
 #else


### PR DESCRIPTION
* Partially reverts 01a4e696b
* Unify thread names
- Remove use of GetThreadId API

Protocol encryption uses AES128 in CFB8 mode as a stream cipher, which in theory would mean it can decrypt one byte at a time. This is important for the network, because any number of bytes can arrive at once, and a packet can start and end anywhere within them. However, the platform's CryptoAPI on <Windows 7 (8/8.1 untested) only accepts decryption of buffers that are multiples of the key size (128 bit / 8 = 16 bytes), which broke the [test server](https://forum.cuberite.org/thread-3261.html) that is running on Windows 7.

![CryptoAPI disassembly](https://user-images.githubusercontent.com/2939130/112733288-f5d03100-8f36-11eb-8f02-0ea72cf3ad70.png)

The multiples check. `div eax,ebx`.

![Backtrace](https://user-images.githubusercontent.com/2939130/112733302-17311d00-8f37-11eb-8dfa-128aea3c8558.png)

EAX = 0x4A = ciphertext length
EBX = 0x10 = IV length

Fix by adding a PLATFORM_CRYPTOGRAPHY macro that is 1 when targeting Windows 8>. It would be good to provide "legacy Windows (XP-7)" and "modern Windows (8+)" official builds because ideally we still want to eventually replace mbedtls with CryptoAPI on Windows.