### PR TITLE
Fix chunk block changes being sent out of order

### DIFF
--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -53,6 +53,9 @@ public:
 	cChunk(const cChunk & Other) = delete;
 	~cChunk();
 
+	/** Flushes the pending block (entity) queue, and clients' outgoing data buffers. */
+	void BroadcastPendingChanges(void);
+
 	/** Returns true iff the chunk block data is valid (loaded / generated) */
 	bool IsValid(void) const {return (m_Presence == cpPresent); }
 
@@ -545,9 +548,6 @@ private:
 
 	/** Wakes up each simulator for its specific blocks; through all the blocks in the chunk */
 	void WakeUpSimulators(void);
-
-	/** Sends m_PendingSendBlocks to all clients */
-	void BroadcastPendingBlockChanges(void);
 
 	/** Checks the block scheduled for checking in m_ToTickBlocks[] */
 	void CheckBlocks();

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1339,9 +1339,17 @@ void cChunkMap::SpawnMobs(cMobSpawner & a_MobSpawner)
 void cChunkMap::Tick(std::chrono::milliseconds a_Dt)
 {
 	cCSLock Lock(m_CSChunks);
+
+	// Do the magic of updating the world:
 	for (auto & Chunk : m_Chunks)
 	{
 		Chunk.second.Tick(a_Dt);
+	}
+
+	// Finally, only after all chunks are ticked, tell the client about all aggregated changes:
+	for (auto & Chunk : m_Chunks)
+	{
+		Chunk.second.BroadcastPendingChanges();
 	}
 }
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -105,6 +105,9 @@ public:  // tolua_export
 	We use Version-3 UUIDs for offline UUIDs, online UUIDs are Version-4, thus we can tell them apart. */
 	static bool IsUUIDOnline(const cUUID & a_UUID);  // Exported in ManualBindings.cpp
 
+	/** Flushes all buffered outgoing data to the network. */
+	void ProcessProtocolOut();
+
 	/** Formats the type of message with the proper color and prefix for sending to the client. */
 	static AString FormatMessageType(bool ShouldAppendChatPrefixes, eMessageType a_ChatPrefix, const AString & a_AdditionalData);
 
@@ -443,12 +446,16 @@ private:
 	/** Protects m_IncomingData against multithreaded access. */
 	cCriticalSection m_CSIncomingData;
 
-	/** Queue for the incoming data received on the link until it is processed in Tick().
+	/** Queue for the incoming data received on the link until it is processed in ProcessProtocolIn().
 	Protected by m_CSIncomingData. */
 	ContiguousByteBuffer m_IncomingData;
 
 	/** Protects m_OutgoingData against multithreaded access. */
 	cCriticalSection m_CSOutgoingData;
+
+	/** Buffer for storing outgoing data from any thread; will get sent in ProcessProtocolOut() at the end of each tick.
+	Protected by m_CSOutgoingData. */
+	ContiguousByteBuffer m_OutgoingData;
 
 	/** A pointer to a World-owned player object, created in FinishAuthenticate when authentication succeeds.
 	The player should only be accessed from the tick thread of the World that owns him.


### PR DESCRIPTION
* Flush out all pending, buffered changes at the end of each tick, after every chunk is ticked. This makes every block update client-side in unison, instead of unlucky ones only being sent 1 tick later.
* Re-add buffer for outgoing network data; IOCP async WSASend has higher overhead than expected... Fixes regression introduced in 054a89dd9