### PR TITLE
Fix finisher generating invalid pumpkin

### DIFF
--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -931,7 +931,7 @@ void cFinishGenSprinkleFoliage::GenFinish(cChunkDesc & a_ChunkDesc)
 					else if ((val1 > 0.5) && (val2 < -0.5))
 					{
 						float val3 = m_Noise.CubicNoise2D(xx * 0.01f + 10, zz * 0.01f + 10);
-						a_ChunkDesc.SetBlockTypeMeta(x, ++Top, z, E_BLOCK_PUMPKIN, static_cast<int>(val3 * 8) % 4);
+						a_ChunkDesc.SetBlockTypeMeta(x, ++Top, z, E_BLOCK_PUMPKIN, static_cast<unsigned>(val3 * 8) % 4);
 					}
 					break;
 				}  // case E_BLOCK_GRASS


### PR DESCRIPTION
Result was black spot in the ground because the meta exceeded 3 and the client didn't render anything.

Been here since the beginning? http://github.com/cuberite/cuberite/blob/fbabf9ee8c7f0940e6f7d01e0362849bf4f6396b/source/FinishGen.cpp#L159