### PR TITLE
Change to Cuboid calculation for splash distance

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -71,6 +71,7 @@ theophriene
 tigerw (Tiger Wang)
 tonibm19
 TooAngel
+tympaniplayer(Nate Palmer)
 UltraCoderRU
 Warmist
 WebFreak001

--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -65,8 +65,11 @@ void cSplashPotionEntity::Splash(Vector3d a_HitPos)
 				return false;
 			}
 
-			double SplashDistance = (a_Entity.GetPosition() - a_HitPos).Length();
-			if (SplashDistance >= 20)
+			Vector3d SplashDistanceCube = (a_Entity.GetPosition() - a_HitPos);
+			double SplashDistance = SplashDistanceCube.Length();
+
+			// Wiki says 8.25 x 8.25 x 4.25 Cuboid.
+			if ((std::max(SplashDistanceCube.x, SplashDistanceCube.z)) > 8.25 || (SplashDistanceCube.y > 4.25))
 			{
 				// Too far away
 				return false;

--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -70,7 +70,6 @@ void cSplashPotionEntity::Splash(Vector3d a_HitPos)
 			}
 
 			// y = -0.25x + 1, where x is the distance from the player. Approximation for potion splash.
-			// TODO: better equation
 			double SplashDistance = (a_Entity.GetPosition() - a_HitPos).Length();
 			double Reduction = -0.25 * SplashDistance + 1.0;
 			Reduction = std::max(Reduction, 0.0);

--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -57,7 +57,11 @@ void cSplashPotionEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos)
 
 void cSplashPotionEntity::Splash(Vector3d a_HitPos)
 {
-	m_World->ForEachEntity([=](cEntity & a_Entity)
+	double XZCalculation = 8.25/2;
+	double YCalculation = 4.25/2;
+	cBoundingBox SplashDistanceBox = cBoundingBox(a_HitPos.x - XZCalculation, a_HitPos.x + XZCalculation, a_HitPos.y - YCalculation, a_HitPos.y + YCalculation, a_HitPos.z - XZCalculation, a_HitPos.z + XZCalculation);
+
+	m_World->ForEachEntityInBox(SplashDistanceBox, [=](cEntity & a_Entity)
 		{
 			if (!a_Entity.IsPawn())
 			{
@@ -65,18 +69,9 @@ void cSplashPotionEntity::Splash(Vector3d a_HitPos)
 				return false;
 			}
 
-			Vector3d SplashDistanceCube = (a_Entity.GetPosition() - a_HitPos);
-			double SplashDistance = SplashDistanceCube.Length();
-
-			// Wiki says 8.25 x 8.25 x 4.25 Cuboid.
-			if ((std::max(SplashDistanceCube.x, SplashDistanceCube.z)) > 8.25 || (SplashDistanceCube.y > 4.25))
-			{
-				// Too far away
-				return false;
-			}
-
 			// y = -0.25x + 1, where x is the distance from the player. Approximation for potion splash.
 			// TODO: better equation
+			double SplashDistance = (a_Entity.GetPosition() - a_HitPos).Length();
 			double Reduction = -0.25 * SplashDistance + 1.0;
 			Reduction = std::max(Reduction, 0.0);
 


### PR DESCRIPTION
This is a fix for #5164 

The wiki mentions that the splash distance for a splash potion is 5 actually 8.25 x 8.25 x 4.25. I updated that instead of using the   20 spheroid distance. Basically everything < 20 was being affected by the splash 6 potion, but with the reduction harming had no effect except visual