### PR TITLE
2021-04 Cumulative Quality Rollup for Cuberite

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -71,7 +71,7 @@ theophriene
 tigerw (Tiger Wang)
 tonibm19
 TooAngel
-tympaniplayer(Nate Palmer)
+tympaniplayer (Nate Palmer)
 UltraCoderRU
 Warmist
 WebFreak001

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -10781,16 +10781,6 @@ a_Player:OpenWindow(Window);
 					},
 					Notes = "Returns true if the player is satiated (cannot eat).",
 				},
-				IsVisible =
-				{
-					Returns =
-					{
-						{
-							Type = "boolean",
-						},
-					},
-					Notes = "Returns true if the player is visible to other players",
-				},
 				LoadRank =
 				{
 					Notes = "Reloads the player's rank, message visuals and permissions from the {{cRankManager}}, based on the player's current rank.",

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -3831,6 +3831,16 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "(<b>DEPRECATED</b>) Please use cEntity:IsTicking().",
 				},
+				IsElytraFlying =
+				{
+					Returns =
+					{
+						{
+							Type = "boolean",
+						},
+					},
+					Notes = "Returns true if the entity is flying with an elytra. Entities that cannot fly with an elytra return always false.",
+				},
 				IsEnderCrystal =
 				{
 					Returns =
@@ -3881,6 +3891,16 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 					},
 					Notes = "Returns true if the entity represents a fishing rod floater",
 				},
+				IsHeadInWater =
+				{
+					Returns =
+					{
+						{
+							Type = "boolean",
+						},
+					},
+					Notes = "Returns true if the entity's head is in a water block",
+				},
 				IsInvisible =
 				{
 					Returns =
@@ -3889,7 +3909,7 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 							Type = "boolean",
 						},
 					},
-					Notes = "Returns true if the entity is invisible",
+					Notes = "Returns true if the entity is invisible.",
 				},
 				IsInFire =
 				{
@@ -3920,16 +3940,6 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 						},
 					},
 					Notes = "Returns true if any part of the entity is in a water block",
-				},
-				IsHeadInWater =
-				{
-					Returns =
-					{
-						{
-							Type = "boolean",
-						},
-					},
-					Notes = "Returns true if the entity's head is in a water block",
 				},
 				IsItemFrame =
 				{
@@ -4070,16 +4080,6 @@ local Hash = cCryptoHash.sha1HexString("DataToHash")
 						},
 					},
 					Notes = "Returns true if the entity is sprinting. Entities that cannot sprint return always false",
-				},
-				IsElytraFlying =
-				{
-					Returns =
-					{
-						{
-							Type = "boolean",
-						},
-					},
-					Notes = "Returns true if the entity is flying with an elytra. Entities that cannot fly with an elytra return always false",
 				},
 				IsSubmerged =
 				{
@@ -10449,16 +10449,6 @@ a_Player:OpenWindow(Window);
 					},
 					Notes = "Returns the player's current maximum speed, relative to the game default speed. Takes into account the sprinting / flying status.",
 				},
-				GetMainHand =
-				{
-					Returns =
-					{
-						{
-							Type = "eMainHand",
-						},
-					},
-					Notes = "Returns the player's main hand.",
-				},
 				GetName =
 				{
 					Returns =
@@ -10770,6 +10760,16 @@ a_Player:OpenWindow(Window);
 						},
 					},
 					Notes = "Returns true if the player is currently lying in a bed.",
+				},
+				IsLeftHanded =
+				{
+					Returns =
+					{
+						{
+							Type = "boolean",
+						},
+					},
+					Notes = "Returns true if the player's left hand is dominant.",
 				},
 				IsSatiated =
 				{
@@ -11101,6 +11101,17 @@ a_Player:OpenWindow(Window);
 					},
 					Notes = "Sets the item that the player is dragging in a UI window. If no UI window is open, this function does nothing."
 				},
+				SetElytraFlight =
+				{
+					Params =
+					{
+						{
+							Name = "IsElytraFlying",
+							Type = "boolean",
+						},
+					},
+					Notes = "Sets whether the player is elytra flying or not.",
+				},
 				SetFlying =
 				{
 					Params =
@@ -11194,16 +11205,16 @@ a_Player:OpenWindow(Window);
 					},
 					Notes = "Sets the 'IsFishing' flag for the player. The floater entity ID is expected for the true variant, it can be omitted when IsFishing is false. FIXME: Undefined behavior when multiple fishing rods are used simultanously",
 				},
-				SetMainHand =
+				SetLeftHanded =
 				{
 					Params =
 					{
 						{
-							Name = "Hand",
-							Type = "eMainHand",
+							Name = "IsLeftHanded",
+							Type = "boolean",
 						},
 					},
-					Notes = "Sets the main hand of the player.",
+					Notes = "Sets the dominant hand of the player.",
 				},
 				SetName =
 				{
@@ -11248,17 +11259,6 @@ a_Player:OpenWindow(Window);
 						},
 					},
 					Notes = "Sets the skin part flags of the player.  The value should be a bitwise OR of several {{Globals#eSkinPart|eSkinPart}} constants.",
-				},
-				SetElytraFlight =
-				{
-					Params =
-					{
-						{
-							Name = "IsElytraFlying",
-							Type = "boolean",
-						},
-					},
-					Notes = "Sets whether the player is elytra flying or not.",
 				},
 				SetSprintingMaxSpeed =
 				{
@@ -17923,32 +17923,6 @@ end
 					TextBefore = [[
 						The following constants are used for the gamemode - survival, creative or adventure. Use the
 						gmXXX constants, the eGameMode_ constants are deprecated and will be removed from the API.
-					]],
-				},
-				eHand =
-				{
-					Include =
-					{
-						"hMain",
-						"hOff",
-					},
-					TextBefore = [[
-						These constants represent the main and off hand.  Currently, these constants are not used, but
-						are provided for future use when dual-wielding is functional.  An action or item can be in the
-						main hand or the off hand.  The main hand can be either the left or the right hand - use
-						{{cPlayer}}:GetMainHand() to determine which (see {{Globals#eMainHand|eMainHand}}).
-					]],
-				},
-				eMainHand =
-				{
-					Include =
-					{
-						"^mh.*",
-					},
-					TextBefore = [[
-						These constants identify which hand is the main hand.  The main hand can either be the left hand
-						or the right hand.  Note that this is only visual, as the client behaves the same regardless of the
-						main hand setting.  See {{cPlayer}}:GetMainHand().
 					]],
 				},
 				EMCSBiome =

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -9138,24 +9138,6 @@ a_Player:OpenWindow(Window);
 					},
 					Notes = "Returns the relative walk speed of this mob. Standard is 1.0",
 				},
-				GetSpawnDelay =
-				{
-					IsStatic = true,
-					Params =
-					{
-						{
-							Name = "MobFamily",
-							Type = "cMonster#eFamily",
-						},
-					},
-					Returns =
-					{
-						{
-							Type = "number",
-						},
-					},
-					Notes = "Returns the spawn delay  - the number of game ticks between spawn attempts - for the specified mob family.",
-				},
 				HasCustomName =
 				{
 					Returns =
@@ -11392,10 +11374,6 @@ a_Player:OpenWindow(Window);
 			},
 			Constants =
 			{
-				EATING_TICKS =
-				{
-					Notes = "Number of ticks required for consuming an item.",
-				},
 				MAX_FOOD_LEVEL =
 				{
 					Notes = "The maximum food level value. When the food level is at this value, the player cannot eat.",

--- a/Server/Plugins/APIDump/Classes/BlockEntities.lua
+++ b/Server/Plugins/APIDump/Classes/BlockEntities.lua
@@ -1076,10 +1076,6 @@ World:ForEachChestInChunk(Player:GetChunkX(), Player:GetChunkZ(),
 			{
 				Notes = "Width (X) of the internal {{cItemGrid}} representing the hopper contents.",
 			},
-			TICKS_PER_TRANSFER =
-			{
-				Notes = "Number of ticks between when the hopper transfers items.",
-			},
 		},
 		Inherits = "cBlockEntityWithItems",
 	},

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -2338,6 +2338,36 @@ static int tolua_cClientHandle_SendPluginMessage(lua_State * L)
 
 
 
+static int tolua_cClientHandle_SendTimeUpdate(lua_State * L)
+{
+	cLuaState S(L);
+	if (
+		!S.CheckParamSelf("cClientHandle") ||
+		!S.CheckParamNumber(2, 3) ||
+		!S.CheckParamBool(4) ||
+		!S.CheckParamEnd(5)
+	)
+	{
+		return 0;
+	}
+
+	cClientHandle * Client;
+	cTickTimeLong::rep WorldAge, WorldDate;
+	bool DoDayLightCycle;
+	S.GetStackValues(1, Client, WorldAge, WorldDate, DoDayLightCycle);
+	if (Client == nullptr)
+	{
+		return S.ApiParamError("Invalid 'self'");
+	}
+
+	Client->SendTimeUpdate(cTickTimeLong(WorldAge), cTickTimeLong(WorldDate), DoDayLightCycle);
+	return 0;
+}
+
+
+
+
+
 static int tolua_cClientHandle_GetForgeMods(lua_State * L)
 {
 	cLuaState S(L);
@@ -4361,6 +4391,7 @@ void cManualBindings::Bind(lua_State * tolua_S)
 
 			tolua_function(tolua_S, "GetForgeMods", tolua_cClientHandle_GetForgeMods);
 			tolua_function(tolua_S, "SendPluginMessage",   tolua_cClientHandle_SendPluginMessage);
+			tolua_function(tolua_S, "SendTimeUpdate",      tolua_cClientHandle_SendTimeUpdate);
 			tolua_function(tolua_S, "GetUUID",             tolua_cClientHandle_GetUUID);
 			tolua_function(tolua_S, "GenerateOfflineUUID", tolua_cClientHandle_GenerateOfflineUUID);
 			tolua_function(tolua_S, "IsUUIDOnline",        tolua_cClientHandle_IsUUIDOnline);

--- a/src/Bindings/ManualBindings_World.cpp
+++ b/src/Bindings/ManualBindings_World.cpp
@@ -1266,6 +1266,70 @@ static int tolua_cWorld_GetSignLines(lua_State * tolua_S)
 
 
 
+static int tolua_cWorld_GetTimeOfDay(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (
+		!L.CheckParamSelf("cWorld") ||
+		!L.CheckParamEnd(2)
+	)
+	{
+		return 0;
+	}
+
+	// Get params:
+	cWorld * Self = nullptr;
+	L.GetStackValues(1, Self);
+	if (Self == nullptr)
+	{
+		return L.ApiParamError("Invalid 'self'");
+	}
+
+	// Call the function:
+	const auto Time = Self->GetTimeOfDay();
+
+	// Push the returned value:
+	L.Push(Time.count());
+	return 1;
+}
+
+
+
+
+
+static int tolua_cWorld_GetWorldAge(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (
+		!L.CheckParamSelf("cWorld") ||
+		!L.CheckParamEnd(2)
+	)
+	{
+		return 0;
+	}
+
+	// Get params:
+	cWorld * Self = nullptr;
+	L.GetStackValues(1, Self);
+	if (Self == nullptr)
+	{
+		return L.ApiParamError("Invalid 'self'");
+	}
+
+	// Call the function:
+	const auto Time = Self->GetWorldAge();
+
+	// Push the returned value:
+	L.Push(static_cast<lua_Number>(Time.count()));
+	return 1;
+}
+
+
+
+
+
 static int tolua_cWorld_PrepareChunk(lua_State * tolua_S)
 {
 	/* Function signature:
@@ -1459,6 +1523,37 @@ static int tolua_cWorld_SetSignLines(lua_State * tolua_S)
 
 
 
+static int tolua_cWorld_SetTimeOfDay(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (
+		!L.CheckParamSelf("cWorld") ||
+		!L.CheckParamNumber(2) ||
+		!L.CheckParamEnd(3)
+	)
+	{
+		return 0;
+	}
+
+	// Get params:
+	cWorld * Self = nullptr;
+	cTickTime::rep Time;
+	L.GetStackValues(1, Self, Time);
+	if (Self == nullptr)
+	{
+		return L.ApiParamError("Invalid 'self'");
+	}
+
+	// Call the function:
+	Self->SetTimeOfDay(cTickTime(Time));
+	return 0;
+}
+
+
+
+
+
 static int tolua_cWorld_ScheduleTask(lua_State * tolua_S)
 {
 	// Function signature:
@@ -1490,7 +1585,7 @@ static int tolua_cWorld_ScheduleTask(lua_State * tolua_S)
 		return cManualBindings::lua_do_error(tolua_S, "Error in function call '#funcname#': Could not store the callback parameter");
 	}
 
-	World->ScheduleTask(NumTicks, [Task](cWorld & a_World)
+	World->ScheduleTask(cTickTime(NumTicks), [Task](cWorld & a_World)
 		{
 			Task->Call(&a_World);
 		}
@@ -1624,17 +1719,16 @@ void cManualBindings::BindWorld(lua_State * tolua_S)
 			tolua_function(tolua_S, "GetBlockSkyLight",             tolua_cWorld_GetBlockSkyLight);
 			tolua_function(tolua_S, "GetBlockTypeMeta",             tolua_cWorld_GetBlockTypeMeta);
 			tolua_function(tolua_S, "GetSignLines",                 tolua_cWorld_GetSignLines);
+			tolua_function(tolua_S, "GetTimeOfDay",                 tolua_cWorld_GetTimeOfDay);
+			tolua_function(tolua_S, "GetWorldAge",                  tolua_cWorld_GetWorldAge);
 			tolua_function(tolua_S, "PrepareChunk",                 tolua_cWorld_PrepareChunk);
 			tolua_function(tolua_S, "QueueTask",                    tolua_cWorld_QueueTask);
 			tolua_function(tolua_S, "ScheduleTask",                 tolua_cWorld_ScheduleTask);
 			tolua_function(tolua_S, "SetBlock",                     tolua_cWorld_SetBlock);
 			tolua_function(tolua_S, "SetSignLines",                 tolua_cWorld_SetSignLines);
+			tolua_function(tolua_S, "SetTimeOfDay",                 tolua_cWorld_SetTimeOfDay);
 			tolua_function(tolua_S, "SpawnSplitExperienceOrbs",     tolua_cWorld_SpawnSplitExperienceOrbs);
 			tolua_function(tolua_S, "TryGetHeight",                 tolua_cWorld_TryGetHeight);
 		tolua_endmodule(tolua_S);
 	tolua_endmodule(tolua_S);
 }
-
-
-
-

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -541,7 +541,7 @@ bool cPluginManager::CallHookExecuteCommand(cPlayer * a_Player, const AStringVec
 		if (world != nullptr)
 		{
 			worldName = world->GetName();
-			worldAge = world->GetWorldAge();
+			worldAge = world->GetWorldAge().count();
 		}
 		else
 		{

--- a/src/BlockEntities/BeaconEntity.cpp
+++ b/src/BlockEntities/BeaconEntity.cpp
@@ -296,8 +296,10 @@ void cBeaconEntity::SendTo(cClientHandle & a_Client)
 
 bool cBeaconEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
-	// Update the beacon every 4 seconds
-	if ((GetWorld()->GetWorldAge() % 80) == 0)
+	using namespace std::chrono_literals;
+
+	// Update the beacon every 4 seconds:
+	if ((GetWorld()->GetWorldTickAge() % 4s) == 0s)
 	{
 		UpdateBeacon();
 		GiveEffects();

--- a/src/BlockEntities/BrewingstandEntity.cpp
+++ b/src/BlockEntities/BrewingstandEntity.cpp
@@ -288,8 +288,8 @@ void cBrewingstandEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 
 void cBrewingstandEntity::UpdateProgressBars(bool a_ForceUpdate)
 {
-	/** Sending an update every 3th tick, using a higher value lets look the progressbar ugly */
-	if (!a_ForceUpdate && (m_World->GetWorldAge() % 3 != 0))
+	// Send an update every 3rd tick, using a higher value makes the progressbar look ugly:
+	if (!a_ForceUpdate && ((m_World->GetWorldTickAge() % 3_tick) != 0_tick))
 	{
 		return;
 	}

--- a/src/BlockEntities/FurnaceEntity.cpp
+++ b/src/BlockEntities/FurnaceEntity.cpp
@@ -388,8 +388,8 @@ bool cFurnaceEntity::CanCookInputToOutput(void) const
 
 void cFurnaceEntity::UpdateProgressBars(bool a_ForceUpdate)
 {
-	// In order to preserve bandwidth, an update is sent only every 10th tick
-	if (!a_ForceUpdate && (m_World->GetWorldAge() % 10 != 0))
+	// In order to preserve bandwidth, an update is sent only every 10th tick:
+	if (!a_ForceUpdate && ((m_World->GetWorldTickAge() % 10_tick) != 0_tick))
 	{
 		return;
 	}

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -17,6 +17,13 @@
 
 
 
+// How many ticks at minimum between two item transfers to or from the hopper.
+#define TICKS_PER_TRANSFER 8_tick
+
+
+
+
+
 cHopperEntity::cHopperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World):
 	Super(a_BlockType, a_BlockMeta, a_Pos, ContentsWidth, ContentsHeight, a_World),
 	m_LastMoveItemsInTick(0),
@@ -76,14 +83,14 @@ void cHopperEntity::CopyFrom(const cBlockEntity & a_Src)
 bool cHopperEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	UNUSED(a_Dt);
-	Int64 CurrentTick = a_Chunk.GetWorld()->GetWorldAge();
 
 	bool isDirty = false;
 	if (!m_Locked)
 	{
-		isDirty = MoveItemsIn  (a_Chunk, CurrentTick) || isDirty;
-		isDirty = MovePickupsIn(a_Chunk, CurrentTick) || isDirty;
-		isDirty = MoveItemsOut (a_Chunk, CurrentTick) || isDirty;
+		const auto CurrentTick = a_Chunk.GetWorld()->GetWorldAge();
+		isDirty = MoveItemsIn(a_Chunk, CurrentTick) || isDirty;
+		isDirty = MovePickupsIn(a_Chunk) || isDirty;
+		isDirty = MoveItemsOut(a_Chunk, CurrentTick) || isDirty;
 	}
 	return isDirty;
 }
@@ -147,7 +154,7 @@ void cHopperEntity::OpenNewWindow(void)
 
 
 
-bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
+bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, const cTickTimeLong a_CurrentTick)
 {
 	if (m_Pos.y >= cChunkDef::Height)
 	{
@@ -155,7 +162,7 @@ bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 		return false;
 	}
 
-	if (a_CurrentTick - m_LastMoveItemsInTick < TICKS_PER_TRANSFER)
+	if ((a_CurrentTick - m_LastMoveItemsInTick) < TICKS_PER_TRANSFER)
 	{
 		// Too early after the previous transfer
 		return false;
@@ -201,10 +208,8 @@ bool cHopperEntity::MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 
 
 
-bool cHopperEntity::MovePickupsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
+bool cHopperEntity::MovePickupsIn(cChunk & a_Chunk)
 {
-	UNUSED(a_CurrentTick);
-
 	class cHopperPickupSearchCallback
 	{
 	public:
@@ -290,9 +295,9 @@ bool cHopperEntity::MovePickupsIn(cChunk & a_Chunk, Int64 a_CurrentTick)
 
 
 
-bool cHopperEntity::MoveItemsOut(cChunk & a_Chunk, Int64 a_CurrentTick)
+bool cHopperEntity::MoveItemsOut(cChunk & a_Chunk, const cTickTimeLong a_CurrentTick)
 {
-	if (a_CurrentTick - m_LastMoveItemsOutTick < TICKS_PER_TRANSFER)
+	if ((a_CurrentTick - m_LastMoveItemsOutTick) < TICKS_PER_TRANSFER)
 	{
 		// Too early after the previous transfer
 		return false;

--- a/src/BlockEntities/HopperEntity.h
+++ b/src/BlockEntities/HopperEntity.h
@@ -30,8 +30,7 @@ public:
 	enum
 	{
 		ContentsHeight = 1,
-		ContentsWidth  = 5,
-		TICKS_PER_TRANSFER = 8,  ///< How many ticks at minimum between two item transfers to or from the hopper
+		ContentsWidth  = 5
 	} ;
 
 	// tolua_end
@@ -48,8 +47,8 @@ public:
 
 protected:
 
-	Int64 m_LastMoveItemsInTick;
-	Int64 m_LastMoveItemsOutTick;
+	cTickTimeLong m_LastMoveItemsInTick;
+	cTickTimeLong m_LastMoveItemsOutTick;
 
 	// cBlockEntity overrides:
 	virtual void CopyFrom(const cBlockEntity & a_Src) override;
@@ -61,13 +60,13 @@ protected:
 	void OpenNewWindow(void);
 
 	/** Moves items from the container above it into this hopper. Returns true if the contents have changed. */
-	bool MoveItemsIn(cChunk & a_Chunk, Int64 a_CurrentTick);
+	bool MoveItemsIn(cChunk & a_Chunk, cTickTimeLong a_CurrentTick);
 
 	/** Moves pickups from above this hopper into it. Returns true if the contents have changed. */
-	bool MovePickupsIn(cChunk & a_Chunk, Int64 a_CurrentTick);
+	bool MovePickupsIn(cChunk & a_Chunk);
 
 	/** Moves items out from this hopper into the destination. Returns true if the contents have changed. */
-	bool MoveItemsOut(cChunk & a_Chunk, Int64 a_CurrentTick);
+	bool MoveItemsOut(cChunk & a_Chunk, cTickTimeLong a_CurrentTick);
 
 	/** Moves items from a chest (dblchest) above the hopper into this hopper. Returns true if contents have changed. */
 	bool MoveItemsFromChest(cChunk & a_Chunk);

--- a/src/BlockEntities/MobSpawnerEntity.cpp
+++ b/src/BlockEntities/MobSpawnerEntity.cpp
@@ -92,8 +92,10 @@ void cMobSpawnerEntity::UpdateActiveState(void)
 
 bool cMobSpawnerEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
-	// Update the active flag every 5 seconds
-	if ((m_World->GetWorldAge() % 100) == 0)
+	using namespace std::chrono_literals;
+
+	// Update the active flag every 5 seconds:
+	if ((m_World->GetWorldTickAge() % 5s) == 0s)
 	{
 		UpdateActiveState();
 	}

--- a/src/Blocks/BlockBed.cpp
+++ b/src/Blocks/BlockBed.cpp
@@ -75,7 +75,7 @@ bool cBlockBedHandler::OnUse(
 
 	// Sleeping is allowed only during night and thunderstorms:
 	if (
-		!(((a_WorldInterface.GetTimeOfDay() > 12541) && (a_WorldInterface.GetTimeOfDay() < 23458)) ||
+		!(((a_WorldInterface.GetTimeOfDay() > 12541_tick) && (a_WorldInterface.GetTimeOfDay() < 23458_tick)) ||
 		(a_Player.GetWorld()->GetWeather() == wThunderstorm))
 	)  // Source: https://minecraft.gamepedia.com/Bed#Sleeping
 	{
@@ -146,7 +146,7 @@ bool cBlockBedHandler::OnUse(
 				return false;
 			}
 		);
-		a_WorldInterface.SetTimeOfDay(0);
+		a_WorldInterface.SetTimeOfDay(0_tick);
 		a_ChunkInterface.SetBlockMeta(a_BlockPos, Meta & 0x0b);  // Clear the "occupied" bit of the bed's block
 	}
 	return true;

--- a/src/Blocks/BlockBed.cpp
+++ b/src/Blocks/BlockBed.cpp
@@ -60,11 +60,13 @@ bool cBlockBedHandler::OnUse(
 	cChunkInterface & a_ChunkInterface,
 	cWorldInterface & a_WorldInterface,
 	cPlayer & a_Player,
-	const Vector3i a_BlockPos,
+	Vector3i a_BlockPos,
 	eBlockFace a_BlockFace,
 	const Vector3i a_CursorPos
 ) const
 {
+	// Source: https://minecraft.gamepedia.com/Bed#Sleeping
+
 	// Sleeping in bed only allowed in Overworld, beds explode elsewhere:
 	if (a_WorldInterface.GetDimension() != dimOverworld)
 	{
@@ -73,82 +75,82 @@ bool cBlockBedHandler::OnUse(
 		return true;
 	}
 
+	auto Meta = a_ChunkInterface.GetBlockMeta(a_BlockPos);
+
+	if ((Meta & 0x8) == 0)
+	{
+		// Clicked on the foot of the bed, adjust to the head:
+		a_BlockPos += MetaDataToDirection(Meta & 0x03);
+
+		BLOCKTYPE Type;
+		a_ChunkInterface.GetBlockTypeMeta(a_BlockPos, Type, Meta);
+		if (Type != E_BLOCK_BED)
+		{
+			// Bed was incomplete, bail:
+			return true;
+		}
+	}
+
+	// Set the bed position to the pillow block:
+	a_Player.SetBedPos(a_BlockPos);
+
 	// Sleeping is allowed only during night and thunderstorms:
 	if (
 		!(((a_WorldInterface.GetTimeOfDay() > 12541_tick) && (a_WorldInterface.GetTimeOfDay() < 23458_tick)) ||
 		(a_Player.GetWorld()->GetWeather() == wThunderstorm))
-	)  // Source: https://minecraft.gamepedia.com/Bed#Sleeping
+	)
 	{
 		a_Player.SendAboveActionBarMessage("You can only sleep at night and during thunderstorms");
-
-		// Try to set home position anyway:
-		SetBedPos(a_Player, a_BlockPos);
 		return true;
 	}
 
 	// Check if the bed is occupied:
-	auto Meta = a_ChunkInterface.GetBlockMeta(a_BlockPos);
 	if ((Meta & 0x04) == 0x04)
 	{
-		a_Player.SendMessageFailure("This bed is occupied");
+		a_Player.SendAboveActionBarMessage("This bed is occupied");
 		return true;
 	}
 
 	// Cannot sleep if there are hostile mobs nearby:
-	auto FindMobs = [](cEntity & a_Entity)
-	{
-		return (
-			(a_Entity.GetEntityType() == cEntity::etMonster) &&
-			(static_cast<cMonster&>(a_Entity).GetMobFamily() == cMonster::mfHostile)
-		);
-	};
-	if (!a_Player.GetWorld()->ForEachEntityInBox(cBoundingBox(a_Player.GetPosition() - Vector3i(0, 5, 0), 8, 10), FindMobs))
+	if (
+		!a_Player.GetWorld()->ForEachEntityInBox({ a_Player.GetPosition().addedY(-5), 8, 10 }, [](cEntity & a_Entity)
+		{
+			return a_Entity.IsMob() && (static_cast<cMonster&>(a_Entity).GetMobFamily() == cMonster::mfHostile);
+		})
+	)
 	{
 		a_Player.SendAboveActionBarMessage("You may not rest now, there are monsters nearby");
 		return true;
 	}
 
-	// Broadcast the "Use bed" for the pillow block:
-	if ((Meta & 0x8) == 0x8)
-	{
-		// Is pillow
-		a_WorldInterface.GetBroadcastManager().BroadcastUseBed(a_Player, a_BlockPos);
-	}
-	else
-	{
-		// Is foot end
-		VERIFY((Meta & 0x04) != 0x04);  // Occupied flag should never be set, else our compilator (intended) is broken
-
-		auto PillowPos = a_BlockPos + MetaDataToDirection(Meta & 0x03);
-		if (a_ChunkInterface.GetBlock(PillowPos) == E_BLOCK_BED)  // Must always use pillow location for sleeping
-		{
-			a_WorldInterface.GetBroadcastManager().BroadcastUseBed(a_Player, PillowPos);
-		}
-	}
-
-	// Occupy the bed:
-	SetBedPos(a_Player, a_BlockPos);
-	SetBedOccupationState(a_ChunkInterface, a_Player.GetLastBedPos(), true);
+	// This will broadcast "use bed" for the pillow block, if the player can sleep:
 	a_Player.SetIsInBed(true);
+
+	// Check sleeping was successful, if not, bail:
+	if (!a_Player.IsInBed())
+	{
+		return true;
+	}
+
+	// Occupy the bed, where 0x4 = occupied bit:
+	a_ChunkInterface.SetBlockMeta(a_BlockPos, Meta | 0x04);
 	a_Player.GetStatManager().AddValue(Statistic::SleepInBed);
 
+	// When sleeping, the player's bounding box moves to approximately where his head is.
+	// Set the player's position to somewhere close to the edge of the pillow block:
+	a_Player.SetPosition(Vector3f(0.4f, 1, 0.4f) * MetaDataToDirection(Meta & 0x03) + Vector3f(0.5f, 0.6875, 0.5f) + a_BlockPos);
+
 	// Fast-forward the time if all players in the world are in their beds:
-	auto TimeFastForwardTester = [](cPlayer & a_OtherPlayer)
+	if (a_WorldInterface.ForEachPlayer([](cPlayer & a_OtherPlayer) { return !a_OtherPlayer.IsInBed(); }))
 	{
-		return !a_OtherPlayer.IsInBed();
-	};
-	if (a_WorldInterface.ForEachPlayer(TimeFastForwardTester))
-	{
-		a_WorldInterface.ForEachPlayer([&](cPlayer & a_OtherPlayer)
-			{
-				cBlockBedHandler::SetBedOccupationState(a_ChunkInterface, a_OtherPlayer.GetLastBedPos(), false);
-				a_OtherPlayer.SetIsInBed(false);
-				return false;
-			}
-		);
+		a_WorldInterface.ForEachPlayer([&a_ChunkInterface](cPlayer & a_OtherPlayer)
+		{
+			VacateBed(a_ChunkInterface, a_OtherPlayer);
+			return false;
+		});
 		a_WorldInterface.SetTimeOfDay(0_tick);
-		a_ChunkInterface.SetBlockMeta(a_BlockPos, Meta & 0x0b);  // Clear the "occupied" bit of the bed's block
 	}
+
 	return true;
 }
 
@@ -174,17 +176,4 @@ cItems cBlockBedHandler::ConvertToPickups(const NIBBLETYPE a_BlockMeta, const cI
 {
 	// Drops handled by the block entity:
 	return {};
-}
-
-
-
-
-
-void cBlockBedHandler::SetBedPos(cPlayer & a_Player, const Vector3i a_BedPosition)
-{
-	if (a_Player.GetLastBedPos() != a_BedPosition)
-	{
-		a_Player.SetBedPos(a_BedPosition);
-		a_Player.SendMessageSuccess("Home position set successfully");
-	}
 }

--- a/src/Blocks/BlockButton.h
+++ b/src/Blocks/BlockButton.h
@@ -193,7 +193,7 @@ private:
 	The given block type is checked when the task is executed to ensure the position still contains a button. */
 	static void QueueButtonRelease(cWorld & a_ButtonWorld, const Vector3i a_Position, const BLOCKTYPE a_BlockType)
 	{
-		const auto TickDelay = (a_BlockType == E_BLOCK_STONE_BUTTON) ? 20 : 30;
+		const auto TickDelay = (a_BlockType == E_BLOCK_STONE_BUTTON) ? 20_tick : 30_tick;
 		a_ButtonWorld.ScheduleTask(
 			TickDelay,
 			[a_Position, a_BlockType](cWorld & a_World)

--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -56,7 +56,7 @@ void cBlockPistonHandler::ExtendPiston(Vector3i a_BlockPos, cWorld & a_World)
 	// However, we don't confuse animation with the underlying state of the world, so emulate by delaying 1 tick
 	// (Probably why vanilla has so many dupe glitches with sand and pistons lolol)
 
-	a_World.ScheduleTask(1, [a_BlockPos](cWorld & World)
+	a_World.ScheduleTask(1_tick, [a_BlockPos](cWorld & World)
 		{
 			BLOCKTYPE pistonBlock;
 			NIBBLETYPE pistonMeta;
@@ -108,7 +108,7 @@ void cBlockPistonHandler::RetractPiston(Vector3i a_BlockPos, cWorld & a_World)
 		a_World.BroadcastBlockAction(a_BlockPos, PistonRetractAction, pistonMeta, pistonBlock);
 	}
 
-	a_World.ScheduleTask(1, [a_BlockPos](cWorld & World)
+	a_World.ScheduleTask(1_tick, [a_BlockPos](cWorld & World)
 		{
 			BLOCKTYPE pistonBlock;
 			NIBBLETYPE pistonMeta;

--- a/src/Blocks/BroadcastInterface.h
+++ b/src/Blocks/BroadcastInterface.h
@@ -42,9 +42,8 @@ public:
 	virtual void BroadcastEntityLook                 (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastEntityMetadata             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastEntityPosition             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) = 0;
-	virtual void BroadcastEntityStatus               (const cEntity & a_Entity, Int8 a_Status, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastEntityVelocity             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) = 0;
-	virtual void BroadcastEntityAnimation            (const cEntity & a_Entity, Int8 a_Animation, const cClientHandle * a_Exclude = nullptr) = 0;
+	virtual void BroadcastEntityAnimation            (const cEntity & a_Entity, EntityAnimation a_Animation, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) = 0;
 	virtual void BroadcastParticleEffect             (const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastParticleEffect             (const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, std::array<int, 2> a_Data, const cClientHandle * a_Exclude = nullptr) = 0;
@@ -64,6 +63,5 @@ public:
 	virtual void BroadcastThunderbolt                (Vector3i a_BlockPos, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastTimeUpdate                 (const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastUnleashEntity              (const cEntity & a_Entity) = 0;
-	virtual void BroadcastUseBed                     (const cEntity & a_Entity, Vector3i a_BedPos) = 0;
 	virtual void BroadcastWeather                    (eWeather a_Weather, const cClientHandle * a_Exclude = nullptr) = 0;
 };

--- a/src/Blocks/WorldInterface.h
+++ b/src/Blocks/WorldInterface.h
@@ -21,8 +21,8 @@ class cWorldInterface
 public:
 	virtual ~cWorldInterface() {}
 
-	virtual int GetTimeOfDay(void) const = 0;
-	virtual Int64 GetWorldAge(void)  const = 0;
+	virtual cTickTime GetTimeOfDay(void) const = 0;
+	virtual cTickTimeLong GetWorldAge(void)  const = 0;
 
 	virtual eDimension GetDimension(void) const = 0;
 
@@ -70,7 +70,7 @@ public:
 	If any chunk in the box is missing, ignores the entities in that chunk silently. */
 	virtual bool ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback a_Callback) = 0;
 
-	virtual void SetTimeOfDay(int a_TimeOfDay) = 0;
+	virtual void SetTimeOfDay(cTickTime a_TimeOfDay) = 0;
 
 	/** Returns true if it is raining or storming at the specified location. This takes into account biomes. */
 	virtual bool IsWeatherWetAt(int a_BlockX, int a_BlockZ) = 0;

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -596,7 +596,7 @@ void cWorld::BroadcastTimeUpdate(const cClientHandle * a_Exclude)
 {
 	ForClientsInWorld(*this, a_Exclude, [&](cClientHandle & a_Client)
 		{
-			a_Client.SendTimeUpdate(GetWorldAge(), std::chrono::duration_cast<cTickTimeLong>(m_WorldDate).count(), IsDaylightCycleEnabled());
+			a_Client.SendTimeUpdate(GetWorldAge(), GetWorldDate(), IsDaylightCycleEnabled());
 		}
 	);
 }

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -345,6 +345,19 @@ void cWorld::BroadcastEntityPosition(const cEntity & a_Entity, const cClientHand
 
 
 
+void cWorld::BroadcastEntityProperties(const cEntity & a_Entity)
+{
+	ForClientsWithEntity(a_Entity, *this, nullptr, [&](cClientHandle & a_Client)
+		{
+			a_Client.SendEntityProperties(a_Entity);
+		}
+	);
+}
+
+
+
+
+
 void cWorld::BroadcastEntityStatus(const cEntity & a_Entity, Int8 a_Status, const cClientHandle * a_Exclude)
 {
 	ForClientsWithEntity(a_Entity, *this, a_Exclude, [&](cClientHandle & a_Client)

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -358,19 +358,6 @@ void cWorld::BroadcastEntityProperties(const cEntity & a_Entity)
 
 
 
-void cWorld::BroadcastEntityStatus(const cEntity & a_Entity, Int8 a_Status, const cClientHandle * a_Exclude)
-{
-	ForClientsWithEntity(a_Entity, *this, a_Exclude, [&](cClientHandle & a_Client)
-		{
-			a_Client.SendEntityStatus(a_Entity, a_Status);
-		}
-	);
-}
-
-
-
-
-
 void cWorld::BroadcastEntityVelocity(const cEntity & a_Entity, const cClientHandle * a_Exclude)
 {
 	ForClientsWithEntity(a_Entity, *this, a_Exclude, [&](cClientHandle & a_Client)
@@ -384,7 +371,7 @@ void cWorld::BroadcastEntityVelocity(const cEntity & a_Entity, const cClientHand
 
 
 
-void cWorld::BroadcastEntityAnimation(const cEntity & a_Entity, Int8 a_Animation, const cClientHandle * a_Exclude)
+void cWorld::BroadcastEntityAnimation(const cEntity & a_Entity, EntityAnimation a_Animation, const cClientHandle * a_Exclude)
 {
 	ForClientsWithEntity(a_Entity, *this, a_Exclude, [&](cClientHandle & a_Client)
 		{
@@ -623,19 +610,6 @@ void cWorld::BroadcastUnleashEntity(const cEntity & a_Entity)
 	ForClientsWithEntity(a_Entity, *this, nullptr, [&](cClientHandle & a_Client)
 		{
 			a_Client.SendUnleashEntity(a_Entity);
-		}
-	);
-}
-
-
-
-
-
-void cWorld::BroadcastUseBed(const cEntity & a_Entity, Vector3i a_BedPos)
-{
-	ForClientsWithChunkAtPos(a_BedPos, *this, nullptr, [&](cClientHandle & a_Client)
-		{
-			a_Client.SendUseBed(a_Entity, a_BedPos.x, a_BedPos.y, a_BedPos.z);
 		}
 	);
 }

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -552,7 +552,7 @@ private:
 	/** Checks the block scheduled for checking in m_ToTickBlocks[] */
 	void CheckBlocks();
 
-	/** Ticks several random blocks in the chunk */
+	/** Ticks several random blocks in the chunk. */
 	void TickBlocks(void);
 
 	/** Adds snow to the top of snowy biomes and hydrates farmland / fills cauldrons in rainy biomes */

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2528,6 +2528,15 @@ void cClientHandle::SendEntityPosition(const cEntity & a_Entity)
 
 
 
+void cClientHandle::SendEntityProperties(const cEntity & a_Entity)
+{
+	m_Protocol->SendEntityProperties(a_Entity);
+}
+
+
+
+
+
 void cClientHandle::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 {
 	m_Protocol->SendEntityStatus(a_Entity, a_Status);
@@ -2731,15 +2740,6 @@ void cClientHandle::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
 void cClientHandle::SendPlayerListUpdatePing()
 {
 	m_Protocol->SendPlayerListUpdatePing();
-}
-
-
-
-
-
-void cClientHandle::SendPlayerMaxSpeed(void)
-{
-	m_Protocol->SendPlayerMaxSpeed();
 }
 
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1857,8 +1857,7 @@ bool cClientHandle::HandleHandshake(const AString & a_Username)
 void cClientHandle::HandleLeaveBed()
 {
 	cChunkInterface Interface(m_Player->GetWorld()->GetChunkMap());
-	cBlockBedHandler::SetBedOccupationState(Interface, m_Player->GetLastBedPos(), false);
-	m_Player->SetIsInBed(false);
+	cBlockBedHandler::VacateBed(Interface, *m_Player);
 }
 
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -538,6 +538,8 @@ void cClientHandle::UnloadOutOfRangeChunks(void)
 		m_Player->GetWorld()->RemoveChunkClient(itr->m_ChunkX, itr->m_ChunkZ, this);
 		SendUnloadChunk(itr->m_ChunkX, itr->m_ChunkZ);
 	}
+
+	m_LastUnloadCheck = m_Player->GetWorld()->GetWorldAge();
 }
 
 
@@ -1981,6 +1983,8 @@ bool cClientHandle::CheckBlockInteractionsRate(void)
 
 void cClientHandle::Tick(float a_Dt)
 {
+	using namespace std::chrono_literals;
+
 	// anticheat fastbreak
 	if (m_HasStartedDigging)
 	{
@@ -2069,8 +2073,8 @@ void cClientHandle::Tick(float a_Dt)
 		}
 	}
 
-	// Unload all chunks that are out of the view distance (every 5 seconds)
-	if ((m_Player->GetWorld()->GetWorldAge() % 100) == 0)
+	// Unload all chunks that are out of the view distance (every 5 seconds):
+	if ((m_Player->GetWorld()->GetWorldAge() - m_LastUnloadCheck) > 5s)
 	{
 		UnloadOutOfRangeChunks();
 	}
@@ -3012,7 +3016,7 @@ void cClientHandle::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int a_
 
 
 
-void cClientHandle::SendTimeUpdate(Int64 a_WorldAge, Int64 a_WorldDate, bool a_DoDaylightCycle)
+void cClientHandle::SendTimeUpdate(const cTickTimeLong a_WorldAge, const cTickTimeLong a_WorldDate, const bool a_DoDaylightCycle)
 {
 	m_Protocol->SendTimeUpdate(a_WorldAge, a_WorldDate, a_DoDaylightCycle);
 }

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2537,15 +2537,6 @@ void cClientHandle::SendEntityProperties(const cEntity & a_Entity)
 
 
 
-void cClientHandle::SendEntityStatus(const cEntity & a_Entity, char a_Status)
-{
-	m_Protocol->SendEntityStatus(a_Entity, a_Status);
-}
-
-
-
-
-
 void cClientHandle::SendEntityVelocity(const cEntity & a_Entity)
 {
 	m_Protocol->SendEntityVelocity(a_Entity);
@@ -2674,7 +2665,7 @@ void cClientHandle::SendPaintingSpawn(const cPainting & a_Painting)
 
 
 
-void cClientHandle::SendEntityAnimation(const cEntity & a_Entity, char a_Animation)
+void cClientHandle::SendEntityAnimation(const cEntity & a_Entity, EntityAnimation a_Animation)
 {
 	m_Protocol->SendEntityAnimation(a_Entity, a_Animation);
 }
@@ -3058,15 +3049,6 @@ void cClientHandle::SendUpdateSign(
 		a_BlockX, a_BlockY, a_BlockZ,
 		a_Line1, a_Line2, a_Line3, a_Line4
 	);
-}
-
-
-
-
-
-void cClientHandle::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
-{
-	m_Protocol->SendUseBed(a_Entity, a_BlockX, a_BlockY, a_BlockZ);
 }
 
 

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1309,7 +1309,7 @@ void cClientHandle::HandleBlockDigFinished(int a_BlockX, int a_BlockY, int a_Blo
 		World->DigBlock(absPos, m_Player);
 	}
 
-	World->BroadcastSoundParticleEffect(EffectID::PARTICLE_SMOKE, absPos, DugBlock, this);
+	World->BroadcastSoundParticleEffect(EffectID::PARTICLE_BLOCK_BREAK, absPos, DugBlock, this);
 	cRoot::Get()->GetPluginManager()->CallHookPlayerBrokenBlock(*m_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, DugBlock, DugMeta);
 }
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -216,7 +216,7 @@ public:  // tolua_export
 	void SendTabCompletionResults       (const AStringVector & a_Results);
 	void SendThunderbolt                (int a_BlockX, int a_BlockY, int a_BlockZ);
 	void SendTitleTimes                 (int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks);  // tolua_export
-	void SendTimeUpdate                 (Int64 a_WorldAge, Int64 a_WorldDate, bool a_DoDaylightCycle);  // tolua_export
+	void SendTimeUpdate                 (cTickTimeLong a_WorldAge, cTickTimeLong a_WorldDate, bool a_DoDaylightCycle);
 	void SendUnleashEntity              (const cEntity & a_Entity);
 	void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ);
 	void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity);
@@ -477,6 +477,9 @@ private:
 	// Chunk position when the last StreamChunks() was called; used to avoid re-streaming while in the same chunk
 	int m_LastStreamedChunkX;
 	int m_LastStreamedChunkZ;
+
+	/** The last time UnloadOutOfRangeChunks was called. */
+	cTickTimeLong m_LastUnloadCheck;
 
 	/** Number of ticks since the last network packet was received (increased in Tick(), reset in OnReceivedData()) */
 	std::atomic<int> m_TicksSinceLastPacket;

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -162,7 +162,7 @@ public:  // tolua_export
 	void SendDisconnect                 (const AString & a_Reason);
 	void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display);
 	void SendEditSign                   (int a_BlockX, int a_BlockY, int a_BlockZ);
-	void SendEntityAnimation            (const cEntity & a_Entity, char a_Animation);  // tolua_export
+	void SendEntityAnimation            (const cEntity & a_Entity, EntityAnimation a_Animation);  // tolua_export
 	void SendEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, int a_Duration);
 	void SendEntityEquipment            (const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item);
 	void SendEntityHeadLook             (const cEntity & a_Entity);
@@ -170,7 +170,6 @@ public:  // tolua_export
 	void SendEntityMetadata             (const cEntity & a_Entity);
 	void SendEntityPosition             (const cEntity & a_Entity);
 	void SendEntityProperties           (const cEntity & a_Entity);
-	void SendEntityStatus               (const cEntity & a_Entity, char a_Status);
 	void SendEntityVelocity             (const cEntity & a_Entity);
 	void SendExperience                 (void);
 	void SendExperienceOrb              (const cExpOrb & a_ExpOrb);
@@ -221,7 +220,6 @@ public:  // tolua_export
 	void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ);
 	void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity);
 	void SendUpdateSign                 (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4);
-	void SendUseBed                     (const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ);
 
 	/** Send a newly discovered recipe to show the notification and unlock in the recipe book */
 	void SendUnlockRecipe               (UInt32 a_RecipeId);

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -169,6 +169,7 @@ public:  // tolua_export
 	void SendEntityLook                 (const cEntity & a_Entity);
 	void SendEntityMetadata             (const cEntity & a_Entity);
 	void SendEntityPosition             (const cEntity & a_Entity);
+	void SendEntityProperties           (const cEntity & a_Entity);
 	void SendEntityStatus               (const cEntity & a_Entity, char a_Status);
 	void SendEntityVelocity             (const cEntity & a_Entity);
 	void SendExperience                 (void);
@@ -191,7 +192,6 @@ public:  // tolua_export
 	void SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName);
 	void SendPlayerListUpdateGameMode   (const cPlayer & a_Player);
 	void SendPlayerListUpdatePing       ();
-	void SendPlayerMaxSpeed             (void);  ///< Informs the client of the maximum player speed (1.6.1+)
 	void SendPlayerMoveLook             (void);
 	void SendPlayerPosition             (void);
 	void SendPlayerSpawn                (const cPlayer & a_Player);

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -294,8 +294,8 @@ public:  // tolua_export
 	void PacketUnknown(UInt32 a_PacketType);
 	void PacketError(UInt32 a_PacketType);
 
-	// Calls that cProtocol descendants use for handling packets:
-	void HandleAnimation(int a_Animation);
+	/** Called when the protocol receives a (hand swing) animation packet. */
+	void HandleAnimation(bool a_SwingMainHand);
 
 	/** Called when the protocol receives a MC|ItemName plugin message, indicating that the player named
 	an item in the anvil UI. */
@@ -352,18 +352,18 @@ public:  // tolua_export
 	void HandlePing             (void);
 	void HandlePlayerAbilities  (bool a_IsFlying, float FlyingSpeed, float WalkingSpeed);
 	void HandlePlayerLook       (float a_Rotation, float a_Pitch, bool a_IsOnGround);
-	void HandlePlayerMoveLook   (double a_PosX, double a_PosY, double a_PosZ, float a_Rotation, float a_Pitch, bool a_IsOnGround);  // While m_bPositionConfirmed (normal gameplay)
 
-	/** Verifies and sets player position, performing relevant checks
-	Calls relevant methods to process movement related statistics
-	Requires state of previous position and on-ground status, so must be called when these are still intact
-	*/
-	void HandlePlayerPos(double a_PosX, double a_PosY, double a_PosZ, bool a_IsOnGround);
+	/** Verifies and sets player position, performing relevant checks.
+	Calls relevant methods to process movement related statistics.
+	Requires state of previous position and on-ground status, so must be called when these are still intact. */
+	void HandlePlayerMove(double a_PosX, double a_PosY, double a_PosZ, bool a_IsOnGround);
+
+	void HandlePlayerMoveLook(double a_PosX, double a_PosY, double a_PosZ, float a_Rotation, float a_Pitch, bool a_IsOnGround);
 
 
 	void HandlePluginMessage    (const AString & a_Channel, ContiguousByteBufferView a_Message);
 	void HandleRespawn          (void);
-	void HandleRightClick       (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, int a_CursorX, int a_CursorY, int a_CursorZ, eHand a_Hand);
+	void HandleRightClick       (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, int a_CursorX, int a_CursorY, int a_CursorZ, bool a_UsedMainHand);
 	void HandleSlotSelected     (Int16 a_SlotNum);
 	void HandleSpectate         (const cUUID & a_PlayerUUID);
 
@@ -382,7 +382,7 @@ public:  // tolua_export
 	);
 	void HandleUnmount          (void);
 	void HandleUseEntity        (UInt32 a_TargetEntityID, bool a_IsLeftClick);
-	void HandleUseItem          (eHand a_Hand);
+	void HandleUseItem          (bool a_UsedMainHand);
 	void HandleWindowClick      (UInt8 a_WindowID, Int16 a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem);
 	void HandleWindowClose      (UInt8 a_WindowID);
 

--- a/src/DeadlockDetect.cpp
+++ b/src/DeadlockDetect.cpp
@@ -103,11 +103,10 @@ void cDeadlockDetect::Execute(void)
 	{
 		// Check the world ages:
 		cRoot::Get()->ForEachWorld([=](cWorld & a_World)
-			{
-				CheckWorldAge(a_World.GetName(), a_World.GetWorldAge());
-				return false;
-			}
-		);
+		{
+			CheckWorldAge(a_World.GetName(), a_World.GetWorldAge());
+			return false;
+		});
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(CYCLE_MILLISECONDS));
 	}  // while (should run)
@@ -117,7 +116,7 @@ void cDeadlockDetect::Execute(void)
 
 
 
-void cDeadlockDetect::SetWorldAge(const AString & a_WorldName, Int64 a_Age)
+void cDeadlockDetect::SetWorldAge(const AString & a_WorldName, const cTickTimeLong a_Age)
 {
 	m_WorldAges[a_WorldName].m_Age = a_Age;
 	m_WorldAges[a_WorldName].m_NumCyclesSame = 0;
@@ -127,7 +126,7 @@ void cDeadlockDetect::SetWorldAge(const AString & a_WorldName, Int64 a_Age)
 
 
 
-void cDeadlockDetect::CheckWorldAge(const AString & a_WorldName, Int64 a_Age)
+void cDeadlockDetect::CheckWorldAge(const AString & a_WorldName, const cTickTimeLong a_Age)
 {
 	WorldAges::iterator itr = m_WorldAges.find(a_WorldName);
 	if (itr == m_WorldAges.end())
@@ -157,14 +156,14 @@ void cDeadlockDetect::CheckWorldAge(const AString & a_WorldName, Int64 a_Age)
 
 
 
-void cDeadlockDetect::DeadlockDetected(const AString & a_WorldName, Int64 a_WorldAge)
+void cDeadlockDetect::DeadlockDetected(const AString & a_WorldName, const cTickTimeLong a_WorldAge)
 {
 	LOGERROR("Deadlock detected: world %s has been stuck at age %lld. Aborting the server.",
-		a_WorldName.c_str(), static_cast<long long>(a_WorldAge)
+		a_WorldName.c_str(), static_cast<long long>(a_WorldAge.count())
 	);
 	ListTrackedCSs();
 	ASSERT(!"Deadlock detected");
-	abort();
+	std::abort();
 }
 
 
@@ -182,7 +181,3 @@ void cDeadlockDetect::ListTrackedCSs(void)
 		);
 	}
 }
-
-
-
-

--- a/src/DeadlockDetect.h
+++ b/src/DeadlockDetect.h
@@ -46,7 +46,7 @@ protected:
 	struct sWorldAge
 	{
 		/** Last m_WorldAge that has been detected in this world */
-		Int64 m_Age;
+		cTickTimeLong m_Age;
 
 		/** Number of cycles for which the age has been the same */
 		int m_NumCyclesSame;
@@ -71,16 +71,16 @@ protected:
 	// cIsThread overrides:
 	virtual void Execute(void) override;
 
-	/** Sets the initial world age */
-	void SetWorldAge(const AString & a_WorldName, Int64 a_Age);
+	/** Sets the initial world age. */
+	void SetWorldAge(const AString & a_WorldName, cTickTimeLong a_Age);
 
-	/** Checks if the world's age has changed, updates the world's stats; calls DeadlockDetected() if deadlock detected */
-	void CheckWorldAge(const AString & a_WorldName, Int64 a_Age);
+	/** Checks if the world's age has changed, updates the world's stats; calls DeadlockDetected() if deadlock detected. */
+	void CheckWorldAge(const AString & a_WorldName, cTickTimeLong a_Age);
 
 	/** Called when a deadlock is detected in a world. Aborts the server.
 	a_WorldName is the name of the world whose age has triggered the detection.
 	a_WorldAge is the age (in ticks) in which the world is stuck. */
-	[[noreturn]] void DeadlockDetected(const AString & a_WorldName, Int64 a_WorldAge);
+	[[noreturn]] void DeadlockDetected(const AString & a_WorldName, cTickTimeLong a_WorldAge);
 
 	/** Outputs a listing of the tracked CSs, together with their name and state. */
 	void ListTrackedCSs();

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -211,26 +211,6 @@ enum eMobHeadRotation
 
 
 
-enum eHand
-{
-	hMain = 0,
-	hOff = 1,
-} ;
-
-
-
-
-
-enum eMainHand
-{
-	mhLeft = 0,
-	mhRight = 1,
-} ;
-
-
-
-
-
 enum eSkinPart
 {
 	spCape = 0x01,

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -467,9 +467,91 @@ enum class BossBarDivisionType
 	TwentyNotches
 };
 
+// tolua_end
 
 
 
+
+
+enum class EntityAnimation
+{
+	AnimalFallsInLove,
+	ArmorStandGetsHit,
+	ArrowTipSparkles,
+	DolphinShowsHappiness,
+	EggCracks,
+	EntityGetsCriticalHit,
+	EntityGetsMagicalCriticalHit,
+	EntityTrailsHoney,
+	EvokerFangsAttacks,
+	FireworkRocketExplodes,
+	// FishingHookReels,
+	FoxChews,
+	GuardianAttacks,
+	HoglinAttacks,
+	HorseTamingFails,
+	HorseTamingSucceeds,
+	IronGolemAttacks,
+	IronGolemOffersGift,
+	IronGolemStashesGift,
+	MinecartSpawnerDelayResets,
+	MinecartTNTIgnites,
+	MobSpawns,
+	OcelotTrusts,
+	OcelotDistrusts,
+	PawnBerryBushPricks,
+	PawnBurns,
+	PawnChestEquipmentBreaks,
+	PawnDies,
+	PawnDrowns,
+	PawnFeetEquipmentBreaks,
+	PawnHandItemSwaps,
+	PawnHeadEquipmentBreaks,
+	PawnHurts,
+	PawnLegsEquipmentBreaks,
+	PawnMainHandEquipmentBreaks,
+	PawnOffHandEquipmentBreaks,
+	PawnShieldBlocks,
+	PawnShieldBreaks,
+	PawnTeleports,
+	PawnThornsPricks,
+	PawnTotemActivates,
+	PlayerBadOmenActivates,
+	PlayerEntersBed,
+	PlayerFinishesEating,
+	PlayerLeavesBed,
+	PlayerMainHandSwings,
+	// PlayerReducedDebugScreenDisables,
+	// PlayerReducedDebugScreenEnables,
+	// PlayerSetsOperatorLevelFour,
+	// PlayerSetsOperatorLevelOne,
+	// PlayerSetsOperatorLevelThree,
+	// PlayerSetsOperatorLevelTwo,
+	// PlayerSetsOperatorLevelZero,
+	PlayerOffHandSwings,
+	RabbitJumps,
+	RavagerAttacks,
+	RavagerBecomesStunned,
+	SheepEatsGrass,
+	SnowballPoofs,
+	// SquidResetsRotation,
+	VillagerKisses,
+	VillagerShowsAnger,
+	VillagerShowsHappiness,
+	VillagerSweats,
+	WitchMagicks,
+	WolfShakesWater,
+	WolfTamingFails,
+	WolfTamingSucceeds,
+	ZoglinAttacks,
+	ZombieVillagerCureFinishes
+};
+
+
+
+
+
+// tolua_begin
 
 /** Returns a textual representation of the click action. */
 const char * ClickActionToString(int a_ClickAction);

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -10,7 +10,7 @@
 
 
 cArrowEntity::cArrowEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkArrow, a_Creator, a_Pos, a_Speed, 0.5, 0.5),
+	Super(pkArrow, a_Creator, a_Pos, a_Speed, 0.5f, 0.5f),
 	m_PickupState(psNoPickup),
 	m_DamageCoeff(2),
 	m_IsCritical(false),

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -15,7 +15,7 @@
 
 
 cBoat::cBoat(Vector3d a_Pos, eMaterial a_Material) :
-	Super(etBoat, a_Pos, 0.98, 0.7),
+	Super(etBoat, a_Pos, 1.375f, 0.5625f),
 	m_LastDamage(0), m_ForwardDirection(0),
 	m_DamageTaken(0.0f), m_Material(a_Material),
 	m_RightPaddleUsed(false), m_LeftPaddleUsed(false)

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -46,8 +46,8 @@ void cBoat::BroadcastMovementUpdate(const cClientHandle * a_Exclude)
 	// Cannot use super::BroadcastMovementUpdate here, broadcasting position when not
 	// expected by the client breaks things. See https://github.com/cuberite/cuberite/pull/4488
 
-	// Process packet sending every two ticks
-	if (GetWorld()->GetWorldAge() % 2 != 0)
+	// Process packet sending every two ticks:
+	if ((GetWorld()->GetWorldTickAge() % 2_tick) != 0_tick)
 	{
 		return;
 	}

--- a/src/Entities/EnderCrystal.cpp
+++ b/src/Entities/EnderCrystal.cpp
@@ -20,7 +20,7 @@ cEnderCrystal::cEnderCrystal(Vector3d a_Pos, bool a_ShowBottom) :
 
 
 cEnderCrystal::cEnderCrystal(Vector3d a_Pos, Vector3i a_BeamTarget, bool a_DisplayBeam, bool a_ShowBottom) :
-	Super(etEnderCrystal, a_Pos, 1.0, 1.0),
+	Super(etEnderCrystal, a_Pos, 2.0f, 2.0f),
 	m_BeamTarget(a_BeamTarget),
 	m_DisplayBeam(a_DisplayBeam),
 	m_ShowBottom(a_ShowBottom)
@@ -92,7 +92,7 @@ void cEnderCrystal::KilledBy(TakeDamageInfo & a_TDI)
 	// Destroy first so the Explodinator doesn't find us (when iterating through entities):
 	Destroy();
 
-	m_World->DoExplosionAt(6.0, GetPosX(), GetPosY() + (GetHeight() / 2.0), GetPosZ(), true, esEnderCrystal, this);
+	m_World->DoExplosionAt(6.0, GetPosX(), GetPosY() + GetHeight() / 2, GetPosZ(), true, esEnderCrystal, this);
 
 	const auto Position = GetPosition().Floor();
 	if (cChunkDef::IsValidHeight(Position.y))

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -525,7 +525,15 @@ bool cEntity::DoTakeDamage(TakeDamageInfo & a_TDI)
 		SetSpeed(a_TDI.Knockback);
 	}
 
-	m_World->BroadcastEntityStatus(*this, esGenericHurt);
+	m_World->BroadcastEntityAnimation(*this, [&a_TDI]
+	{
+		switch (a_TDI.DamageType)
+		{
+			case eDamageType::dtBurning: return EntityAnimation::PawnBurns;
+			case eDamageType::dtDrowning: return EntityAnimation::PawnDrowns;
+			default: return EntityAnimation::PawnHurts;
+		}
+	}());
 
 	m_InvulnerableTicks = 10;
 
@@ -797,7 +805,7 @@ void cEntity::KilledBy(TakeDamageInfo & a_TDI)
 	// If the victim is a player the hook is handled by the cPlayer class
 	if (!IsPlayer())
 	{
-		AString emptystring = AString("");
+		AString emptystring;
 		cRoot::Get()->GetPluginManager()->CallHookKilled(*this, a_TDI, emptystring);
 	}
 
@@ -813,7 +821,7 @@ void cEntity::KilledBy(TakeDamageInfo & a_TDI)
 		m_World->SpawnItemPickups(Drops, GetPosX(), GetPosY(), GetPosZ());
 	}
 
-	m_World->BroadcastEntityStatus(*this, esGenericDead);
+	m_World->BroadcastEntityAnimation(*this, EntityAnimation::PawnDies);
 }
 
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1884,8 +1884,8 @@ void cEntity::TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ)
 
 void cEntity::BroadcastMovementUpdate(const cClientHandle * a_Exclude)
 {
-	// Process packet sending every two ticks
-	if (GetWorld()->GetWorldAge() % 2 != 0)
+	// Process packet sending every two ticks:
+	if ((GetWorld()->GetWorldTickAge() % 2_tick) != 0_tick)
 	{
 		return;
 	}

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -122,7 +122,7 @@ bool cEntity::Initialize(OwnedEntity a_Self, cWorld & a_EntityWorld)
 	*/
 
 
-	ASSERT(m_World == nullptr);
+	ASSERT(a_Self->IsPlayer() || (m_World == nullptr));  // Players' worlds are loaded from disk.
 	ASSERT(GetParentChunk() == nullptr);
 	SetWorld(&a_EntityWorld);
 	a_EntityWorld.AddEntity(std::move(a_Self));

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -33,7 +33,7 @@ static UInt32 GetNextUniqueID(void)
 ////////////////////////////////////////////////////////////////////////////////
 // cEntity:
 
-cEntity::cEntity(eEntityType a_EntityType, Vector3d a_Pos, double a_Width, double a_Height):
+cEntity::cEntity(eEntityType a_EntityType, Vector3d a_Pos, float a_Width, float a_Height):
 	m_UniqueID(GetNextUniqueID()),
 	m_Health(1),
 	m_MaxHealth(1),
@@ -59,8 +59,6 @@ cEntity::cEntity(eEntityType a_EntityType, Vector3d a_Pos, double a_Width, doubl
 	m_IsInLava(false),
 	m_IsInWater(false),
 	m_IsHeadInWater(false),
-	m_Width(a_Width),
-	m_Height(a_Height),
 	m_AirLevel(MAX_AIR_LEVEL),
 	m_AirTickTimer(DROWNING_TICKS),
 	m_TicksAlive(0),
@@ -71,6 +69,8 @@ cEntity::cEntity(eEntityType a_EntityType, Vector3d a_Pos, double a_Width, doubl
 	m_Position(a_Pos),
 	m_WaterSpeed(0, 0, 0),
 	m_Mass (0.001),  // Default 1g
+	m_Width(a_Width),
+	m_Height(a_Height),
 	m_InvulnerableTicks(0)
 {
 	m_WorldChangeInfo.m_NewWorld = nullptr;
@@ -1098,7 +1098,7 @@ void cEntity::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			NextPos = HitCoords;
 
 			// Avoid movement in the direction of the blockface that has been hit and correct for collision box:
-			double HalfWidth = GetWidth() / 2.0;
+			const auto HalfWidth = GetWidth() / 2;
 			switch (HitBlockFace)
 			{
 				case BLOCK_FACE_XM:
@@ -1708,6 +1708,16 @@ void cEntity::SetIsTicking(bool a_IsTicking)
 {
 	m_IsTicking = a_IsTicking;
 	ASSERT(!(m_IsTicking && (m_ParentChunk == nullptr)));  // We shouldn't be ticking if we have no parent chunk
+}
+
+
+
+
+
+void cEntity::SetSize(const float a_Width, const float a_Height)
+{
+	m_Width = a_Width;
+	m_Height = a_Height;
 }
 
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -109,47 +109,6 @@ public:
 
 	// tolua_end
 
-	enum eEntityStatus
-	{
-		// TODO: Investigate 0, 1, and 5 as Wiki.vg is not certain
-
-		// Entity becomes coloured red
-		esGenericHurt            = 2,
-		// Entity plays death animation (entity falls to ground)
-		esGenericDead            = 3,
-		// Iron Golem plays attack animation (arms lift and fall)
-		esIronGolemAttacking     = 4,
-		// Wolf taming particles spawn (smoke)
-		esWolfTaming             = 6,
-		// Wolf tamed particles spawn (hearts)
-		esWolfTamed              = 7,
-		// Wolf plays water removal animation (shaking and water particles)
-		esWolfDryingWater        = 8,
-		// Informs client that eating was accepted
-		esPlayerEatingAccepted   = 9,
-		// Sheep plays eating animation (head lowers to ground)
-		esSheepEating            = 10,
-		// Iron Golem holds gift to villager children
-		esIronGolemGivingPlant   = 11,
-		// Villager spawns heart particles
-		esVillagerBreeding       = 12,
-		// Villager spawns thunderclound particles
-		esVillagerAngry          = 13,
-		// Villager spawns green crosses
-		esVillagerHappy          = 14,
-		// Witch spawns magic particle (TODO: investigation into what this is)
-		esWitchMagicking         = 15,
-
-		// It seems 16 (zombie conversion) is now done with metadata
-
-		// Informs client to explode a firework based on its metadata
-		esFireworkExploding      = 17,
-		// Passive mob is in "love mode"
-		esMobInLove              = 18,
-		// Plays totem of undying animation and sound
-		esTotemOfUndying         = 35,
-	} ;
-
 	static const int FIRE_TICKS_PER_DAMAGE = 10;   ///< Ticks to wait between damaging an entity when it stands in fire
 	static const int FIRE_DAMAGE           = 1;    ///< Damage to deal when standing in fire
 	static const int LAVA_TICKS_PER_DAMAGE = 10;   ///< Ticks to wait between damaging an entity when it stands in lava

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -169,7 +169,7 @@ public:
 	static const UInt32 INVALID_ID = 0;  // Exported to Lua in ManualBindings.cpp, ToLua doesn't parse initialized constants.
 
 
-	cEntity(eEntityType a_EntityType, Vector3d a_Pos, double a_Width, double a_Height);
+	cEntity(eEntityType a_EntityType, Vector3d a_Pos, float a_Width, float a_Height);
 	virtual ~cEntity() = default;
 
 	/** Spawns the entity in the world; returns true if spawned, false if not (plugin disallowed).
@@ -225,7 +225,7 @@ public:
 	cWorld * GetWorld(void) const { return m_World; }
 
 	double           GetHeadYaw   (void) const { return m_HeadYaw; }  // In degrees
-	double           GetHeight    (void) const { return m_Height;  }
+	float            GetHeight    (void) const { return m_Height;  }
 	double           GetMass      (void) const { return m_Mass;    }
 	double           GetPosX      (void) const { return m_Position.x; }
 	double           GetPosY      (void) const { return m_Position.y; }
@@ -237,7 +237,7 @@ public:
 	double           GetSpeedX    (void) const { return m_Speed.x; }
 	double           GetSpeedY    (void) const { return m_Speed.y; }
 	double           GetSpeedZ    (void) const { return m_Speed.z; }
-	double           GetWidth     (void) const { return m_Width;   }
+	float            GetWidth     (void) const { return m_Width;   }
 
 	int GetChunkX(void) const { return FloorC(m_Position.x / cChunkDef::Width); }
 	int GetChunkZ(void) const { return FloorC(m_Position.z / cChunkDef::Width); }
@@ -579,6 +579,9 @@ public:
 	/** Set the entity's status to either ticking or not ticking. */
 	void SetIsTicking(bool a_IsTicking);
 
+	/** Update an entity's size, for example, on body stance changes. */
+	void SetSize(float a_Width, float a_Height);
+
 	/** Adds a mob to the leashed list of mobs. */
 	void AddLeashedMob(cMonster * a_Monster);
 
@@ -686,12 +689,6 @@ protected:
 	/** If the entity's head is in a water block */
 	bool m_IsHeadInWater;
 
-	/** Width of the entity, in the XZ plane. Since entities are represented as cylinders, this is more of a diameter. */
-	double m_Width;
-
-	/** Height of the entity (Y axis). */
-	double m_Height;
-
 	/** Air level of a mobile */
 	int m_AirLevel;
 	int m_AirTickTimer;
@@ -747,6 +744,12 @@ private:
 
 	/** Measured in Kilograms (Kg) */
 	double m_Mass;
+
+	/** Width of the entity, in the XZ plane. Since entities are represented as cylinders, this is more of a diameter. */
+	float m_Width;
+
+	/** Height of the entity (Y axis). */
+	float m_Height;
 
 	/** If a player hit a entity, the entity receive a invulnerable of 10 ticks.
 	While this ticks, a player can't hit this entity. */

--- a/src/Entities/ExpBottleEntity.cpp
+++ b/src/Entities/ExpBottleEntity.cpp
@@ -9,7 +9,7 @@
 
 
 cExpBottleEntity::cExpBottleEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed) :
-	Super(pkExpBottle, a_Creator, a_Pos, 0.25, 0.25)
+	Super(pkExpBottle, a_Creator, a_Pos, 0.25f, 0.25f)
 {
 	SetSpeed(a_Speed);
 }

--- a/src/Entities/ExpOrb.cpp
+++ b/src/Entities/ExpOrb.cpp
@@ -6,7 +6,7 @@
 
 
 cExpOrb::cExpOrb(Vector3d a_Pos, int a_Reward):
-	Super(etExpOrb, a_Pos, 0.98, 0.98),  // TODO: Check size
+	Super(etExpOrb, a_Pos, 0.5f, 0.5f),
 	m_Reward(a_Reward),
 	m_Timer(0)
 {

--- a/src/Entities/FallingBlock.cpp
+++ b/src/Entities/FallingBlock.cpp
@@ -12,7 +12,7 @@
 
 
 cFallingBlock::cFallingBlock(Vector3d a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta):
-	Super(etFallingBlock, a_Position, 0.98, 0.98),
+	Super(etFallingBlock, a_Position, 0.98f, 0.98f),
 	m_BlockType(a_BlockType),
 	m_BlockMeta(a_BlockMeta)
 {

--- a/src/Entities/FireChargeEntity.cpp
+++ b/src/Entities/FireChargeEntity.cpp
@@ -8,7 +8,7 @@
 
 
 cFireChargeEntity::cFireChargeEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkFireCharge, a_Creator, a_Pos, 0.3125, 0.3125)
+	Super(pkFireCharge, a_Creator, a_Pos, 0.3125f, 0.3125f)
 {
 	SetSpeed(a_Speed);
 	SetGravity(0);

--- a/src/Entities/FireworkEntity.cpp
+++ b/src/Entities/FireworkEntity.cpp
@@ -9,7 +9,7 @@
 
 
 cFireworkEntity::cFireworkEntity(cEntity * a_Creator, Vector3d a_Pos, const cItem & a_Item) :
-	Super(pkFirework, a_Creator, a_Pos, 0.25, 0.25),
+	Super(pkFirework, a_Creator, a_Pos, 0.25f, 0.25f),
 	m_TicksToExplosion(a_Item.m_FireworkItem.m_FlightTimeInTicks),
 	m_FireworkItem(a_Item)
 {

--- a/src/Entities/FireworkEntity.cpp
+++ b/src/Entities/FireworkEntity.cpp
@@ -74,7 +74,7 @@ void cFireworkEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	if (m_TicksToExplosion <= 0)
 	{
 		// TODO: Notify the plugins
-		m_World->BroadcastEntityStatus(*this, esFireworkExploding);
+		m_World->BroadcastEntityAnimation(*this, EntityAnimation::FireworkRocketExplodes);
 		Destroy();
 		return;
 	}

--- a/src/Entities/Floater.cpp
+++ b/src/Entities/Floater.cpp
@@ -75,7 +75,7 @@ protected:
 
 
 cFloater::cFloater(Vector3d a_Pos, Vector3d a_Speed, UInt32 a_PlayerID, int a_CountDownTime) :
-	Super(etFloater, a_Pos, 0.2, 0.2),
+	Super(etFloater, a_Pos, 0.25f, 0.25f),
 	m_BitePos(a_Pos),
 	m_CanPickupItem(false),
 	m_PickupCountDown(0),

--- a/src/Entities/HangingEntity.cpp
+++ b/src/Entities/HangingEntity.cpp
@@ -10,7 +10,7 @@
 
 
 cHangingEntity::cHangingEntity(eEntityType a_EntityType, eBlockFace a_Facing, Vector3d a_Pos) :
-	Super(a_EntityType, a_Pos, 0.8, 0.8),
+	Super(a_EntityType, a_Pos, 0.5f, 0.5f),
 	m_Facing(cHangingEntity::BlockFaceToProtocolFace(a_Facing))
 {
 	SetMaxHealth(1);

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -95,7 +95,7 @@ protected:
 // cMinecart:
 
 cMinecart::cMinecart(ePayload a_Payload, Vector3d a_Pos):
-	Super(etMinecart, a_Pos, 0.98, 0.7),
+	Super(etMinecart, a_Pos, 0.98f, 0.7f),
 	m_Payload(a_Payload),
 	m_LastDamage(0),
 	m_DetectorRailPosition(0, 0, 0),

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -425,15 +425,18 @@ void cPawn::HandleFalling(void)
 
 			TakeDamage(dtFalling, nullptr, Damage, static_cast<float>(Damage), 0);
 
-			// Fall particles
-			GetWorld()->BroadcastParticleEffect(
-				"blockdust",
-				GetPosition(),
-				{ 0, 0, 0 },
-				(Damage - 1.f) * ((0.3f - 0.1f) / (15.f - 1.f)) + 0.1f,  // Map damage (1 - 15) to particle speed (0.1 - 0.3)
-				static_cast<int>((Damage - 1.f) * ((50.f - 20.f) / (15.f - 1.f)) + 20.f),  // Map damage (1 - 15) to particle quantity (20 - 50)
-				{ { GetWorld()->GetBlock(POS_TOINT - Vector3i(0, 1, 0)), 0 } }
-			);
+			// Fall particles:
+			if (const auto Below = POS_TOINT.addedY(-1); Below.y >= 0)
+			{
+				GetWorld()->BroadcastParticleEffect(
+					"blockdust",
+					GetPosition(),
+					{ 0, 0, 0 },
+					(Damage - 1.f) * ((0.3f - 0.1f) / (15.f - 1.f)) + 0.1f,  // Map damage (1 - 15) to particle speed (0.1 - 0.3)
+					static_cast<int>((Damage - 1.f) * ((50.f - 20.f) / (15.f - 1.f)) + 20.f),  // Map damage (1 - 15) to particle quantity (20 - 50)
+					{ { GetWorld()->GetBlock(Below), 0 } }
+				);
+			}
 		}
 
 		m_bTouchGround = true;

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -115,7 +115,7 @@ void cPawn::KilledBy(TakeDamageInfo & a_TDI)
 	// Is death eligible for totem reanimation?
 	if (DeductTotem(a_TDI.DamageType))
 	{
-		m_World->BroadcastEntityStatus(*this, esTotemOfUndying);
+		m_World->BroadcastEntityAnimation(*this, EntityAnimation::PawnTotemActivates);
 
 		AddEntityEffect(cEntityEffect::effAbsorption, 100, 1);
 		AddEntityEffect(cEntityEffect::effRegeneration, 900, 1);

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -14,7 +14,7 @@
 
 
 
-cPawn::cPawn(eEntityType a_EntityType, double a_Width, double a_Height) :
+cPawn::cPawn(eEntityType a_EntityType, float a_Width, float a_Height) :
 	Super(a_EntityType, Vector3d(), a_Width, a_Height),
 	m_EntityEffects(tEffectMap()),
 	m_LastGroundHeight(0),

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -22,7 +22,7 @@ public:
 
 	CLASS_PROTODEF(cPawn)
 
-	cPawn(eEntityType a_EntityType, double a_Width, double a_Height);
+	cPawn(eEntityType a_EntityType, float a_Width, float a_Height);
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void KilledBy(TakeDamageInfo & a_TDI) override;

--- a/src/Entities/Pickup.cpp
+++ b/src/Entities/Pickup.cpp
@@ -94,7 +94,7 @@ protected:
 // cPickup:
 
 cPickup::cPickup(Vector3d a_Pos, const cItem & a_Item, bool IsPlayerCreated, Vector3f a_Speed, int a_LifetimeTicks, bool a_CanCombine):
-	Super(etPickup, a_Pos, 0.2, 0.2),
+	Super(etPickup, a_Pos, 0.25f, 0.25f),
 	m_Timer(0),
 	m_Item(a_Item),
 	m_bCollected(false),

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1410,9 +1410,11 @@ void cPlayer::TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ)
 	//  ask plugins to allow teleport to the new position.
 	if (!cRoot::Get()->GetPluginManager()->CallHookEntityTeleport(*this, m_LastPosition, Vector3d(a_PosX, a_PosY, a_PosZ)))
 	{
+		m_IsTeleporting = true;
+
+		Detach();
 		SetPosition({a_PosX, a_PosY, a_PosZ});
 		FreezeInternal(GetPosition(), false);
-		m_IsTeleporting = true;
 
 		m_ClientHandle->SendPlayerMoveLook();
 	}
@@ -2589,22 +2591,13 @@ void cPlayer::AttachTo(cEntity * a_AttachTo)
 
 void cPlayer::Detach()
 {
-	Detach(false);
-}
-
-
-
-
-
-void cPlayer::Detach(bool a_IsTeleporting)
-{
 	if (m_AttachedTo == nullptr)
 	{
 		// The player is not attached to anything. Bail out.
 		return;
 	}
 
-	// Different detach, if this is a spectator
+	// Different detach, if this is a spectator:
 	if (IsGameModeSpectator())
 	{
 		GetClientHandle()->SendCameraSetTo(*this);
@@ -2615,8 +2608,8 @@ void cPlayer::Detach(bool a_IsTeleporting)
 
 	Super::Detach();
 
-	// If they are teleporting, no need to figure out position
-	if (a_IsTeleporting)
+	// If they are teleporting, no need to figure out position:
+	if (m_IsTeleporting)
 	{
 		return;
 	}

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -59,8 +59,8 @@ const int cPlayer::MAX_HEALTH = 20;
 
 const int cPlayer::MAX_FOOD_LEVEL = 20;
 
-/** Number of ticks it takes to eat an item */
-const int cPlayer::EATING_TICKS = 30;
+// Number of ticks it takes to eat an item.
+#define EATING_TICKS 30_tick
 
 
 
@@ -530,7 +530,7 @@ void cPlayer::StartEating(void)
 void cPlayer::FinishEating(void)
 {
 	// Reset the timer:
-	m_EatingFinishTick = -1;
+	m_EatingFinishTick = -1_tick;
 
 	// Send the packets:
 	m_ClientHandle->SendEntityStatus(*this, esPlayerEatingAccepted);
@@ -553,7 +553,7 @@ void cPlayer::FinishEating(void)
 
 void cPlayer::AbortEating(void)
 {
-	m_EatingFinishTick = -1;
+	m_EatingFinishTick = -1_tick;
 	m_World->BroadcastEntityMetadata(*this);
 }
 
@@ -2929,7 +2929,7 @@ void cPlayer::TickFreezeCode()
 				}
 			}
 		}
-		else if (GetWorld()->GetWorldAge() % 100 == 0)
+		else if ((GetWorld()->GetWorldTickAge() % 100_tick) == 0_tick)
 		{
 			// Despite the client side freeze, the player may be able to move a little by
 			// Jumping or canceling flight. Re-freeze every now and then
@@ -3115,7 +3115,7 @@ void cPlayer::OnAddToWorld(cWorld & a_World)
 	m_ClientHandle->SendWeather(a_World.GetWeather());
 
 	// Send time:
-	m_ClientHandle->SendTimeUpdate(a_World.GetWorldAge(), a_World.GetTimeOfDay(), a_World.IsDaylightCycleEnabled());
+	m_ClientHandle->SendTimeUpdate(a_World.GetWorldAge(), a_World.GetWorldDate(), a_World.IsDaylightCycleEnabled());
 
 	// Finally, deliver the notification hook:
 	cRoot::Get()->GetPluginManager()->CallHookPlayerSpawned(*this);
@@ -3298,7 +3298,7 @@ void cPlayer::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	{
 		m_World->CollectPickupsByPlayer(*this);
 
-		if ((m_EatingFinishTick >= 0) && (m_EatingFinishTick <= m_World->GetWorldAge()))
+		if ((m_EatingFinishTick >= 0_tick) && (m_EatingFinishTick <= m_World->GetWorldAge()))
 		{
 			FinishEating();
 		}

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -481,11 +481,12 @@ void cPlayer::SetIsInBed(const bool a_GoToBed)
 	if (a_GoToBed && IsStanding())
 	{
 		m_BodyStance = BodyStanceSleeping(*this);
+		m_World->BroadcastEntityAnimation(*this, EntityAnimation::PlayerEntersBed);
 	}
 	else if (!a_GoToBed && IsInBed())
 	{
 		m_BodyStance = BodyStanceStanding(*this);
-		GetWorld()->BroadcastEntityAnimation(*this, 2);
+		m_World->BroadcastEntityAnimation(*this, EntityAnimation::PlayerLeavesBed);
 	}
 }
 
@@ -3250,6 +3251,14 @@ void cPlayer::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		if (IsOnGround() || IsInWater() || IsRiding() || (GetEquippedChestplate().m_ItemType != E_ITEM_ELYTRA))
 		{
 			SetElytraFlight(false);
+		}
+	}
+	else if (IsInBed())
+	{
+		// Check if sleeping is still possible:
+		if ((GetPosition().Floor() != m_LastBedPos) || (m_World->GetBlock(m_LastBedPos) != E_BLOCK_BED))
+		{
+			m_ClientHandle->HandleLeaveBed();
 		}
 	}
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -123,6 +123,7 @@ cPlayer::cPlayer(const std::shared_ptr<cClientHandle> & a_Client) :
 	m_IsFlightCapable(false),
 	m_IsFlying(false),
 	m_IsFrozen(false),
+	m_IsLeftHanded(false),
 	m_IsTeleporting(false),
 	m_IsVisible(true),
 	m_EatingFinishTick(-1),
@@ -132,8 +133,7 @@ cPlayer::cPlayer(const std::shared_ptr<cClientHandle> & a_Client) :
 	m_FloaterID(cEntity::INVALID_ID),
 	m_Team(nullptr),
 	m_TicksUntilNextSave(PLAYER_INVENTORY_SAVE_INTERVAL),
-	m_SkinParts(0),
-	m_MainHand(mhRight)
+	m_SkinParts(0)
 {
 	ASSERT(GetName().length() <= 16);  // Otherwise this player could crash many clients...
 
@@ -449,6 +449,15 @@ bool cPlayer::IsInBed(void) const
 
 
 
+bool cPlayer::IsLeftHanded() const
+{
+	return m_IsLeftHanded;
+}
+
+
+
+
+
 bool cPlayer::IsStanding() const
 {
 	return std::holds_alternative<BodyStanceStanding>(m_BodyStance);
@@ -686,6 +695,16 @@ void cPlayer::SetFlying(const bool a_ShouldFly)
 		// If we are frozen, we do not send this yet. We send when unfreeze() is called
 		m_ClientHandle->SendPlayerAbilities();
 	}
+}
+
+
+
+
+
+void cPlayer::SetLeftHanded(const bool a_IsLeftHanded)
+{
+	m_IsLeftHanded = a_IsLeftHanded;
+	m_World->BroadcastEntityMetadata(*this);
 }
 
 
@@ -2537,16 +2556,6 @@ bool cPlayer::PlaceBlocks(const sSetBlockVector & a_Blocks)
 void cPlayer::SetSkinParts(int a_Parts)
 {
 	m_SkinParts = a_Parts & spMask;
-	m_World->BroadcastEntityMetadata(*this, m_ClientHandle.get());
-}
-
-
-
-
-
-void cPlayer::SetMainHand(eMainHand a_Hand)
-{
-	m_MainHand = a_Hand;
 	m_World->BroadcastEntityMetadata(*this, m_ClientHandle.get());
 }
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -498,8 +498,7 @@ void cPlayer::StartEating(void)
 	// Set the timer:
 	m_EatingFinishTick = m_World->GetWorldAge() + EATING_TICKS;
 
-	// Send the packets:
-	m_World->BroadcastEntityAnimation(*this, 3);
+	// Send the packet:
 	m_World->BroadcastEntityMetadata(*this);
 }
 
@@ -513,7 +512,7 @@ void cPlayer::FinishEating(void)
 	m_EatingFinishTick = -1_tick;
 
 	// Send the packets:
-	m_ClientHandle->SendEntityStatus(*this, esPlayerEatingAccepted);
+	m_ClientHandle->SendEntityAnimation(*this, EntityAnimation::PlayerFinishesEating);
 	m_World->BroadcastEntityMetadata(*this);
 
 	// consume the item:

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -104,7 +104,7 @@ cPlayer::BodyStanceGliding::BodyStanceGliding(cPlayer & a_Player) :
 
 
 cPlayer::cPlayer(const std::shared_ptr<cClientHandle> & a_Client) :
-	Super(etPlayer, 0.6, 1.8),
+	Super(etPlayer, 0.6f, 1.8f),
 	m_BodyStance(BodyStanceStanding(*this)),
 	m_FoodLevel(MAX_FOOD_LEVEL),
 	m_FoodSaturationLevel(5.0),
@@ -2815,16 +2815,6 @@ void cPlayer::AddKnownItem(const cItem & a_Item)
 	{
 		AddKnownRecipe(RecipeId);
 	}
-}
-
-
-
-
-
-void cPlayer::SetSize(const float a_Width, const float a_Height)
-{
-	m_Width = a_Width;
-	m_Height = a_Height;
 }
 
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -31,8 +31,9 @@
 
 #include "../CraftingRecipes.h"
 
-// 6000 ticks or 5 minutes
-#define PLAYER_INVENTORY_SAVE_INTERVAL 6000
+
+
+
 
 namespace
 {
@@ -61,6 +62,13 @@ const int cPlayer::MAX_FOOD_LEVEL = 20;
 
 // Number of ticks it takes to eat an item.
 #define EATING_TICKS 30_tick
+
+// 6000 ticks or 5 minutes
+#define PLAYER_INVENTORY_SAVE_INTERVAL 6000
+
+#define XP_TO_LEVEL15 255
+#define XP_PER_LEVEL_TO15 17
+#define XP_TO_LEVEL30 825
 
 
 

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -592,9 +592,6 @@ public:
 	If the item is already known, does nothing. */
 	void AddKnownItem(const cItem & a_Item);
 
-	/** Update a player's size, for example, on body stance changes. */
-	void SetSize(float a_Width, float a_Height);
-
 	// cEntity overrides:
 	virtual void AttachTo(cEntity * a_AttachTo) override;
 	virtual void Detach(void) override;

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -376,6 +376,9 @@ public:
 	/** Returns true if a player is sleeping in a bed. */
 	bool IsInBed(void) const;
 
+	/** Returns true if the player's left hand is dominant. */
+	bool IsLeftHanded() const;
+
 	/** Returns true if the player has thrown out a floater */
 	bool IsFishing(void) const { return m_IsFishing; }
 
@@ -491,6 +494,9 @@ public:
 	/** Starts or stops flying, broadcasting the state change. */
 	void SetFlying(bool a_ShouldFly);
 
+	/** Sets the dominant hand of the player. */
+	void SetLeftHanded(bool a_IsLeftHanded);
+
 	/** Starts or stops sprinting, if our current body stance permits, broadcasting the state change. */
 	void SetSprint(bool a_ShouldSprint);
 
@@ -556,9 +562,6 @@ public:
 	bool HasSkinPart(eSkinPart a_Part) const { return (m_SkinParts & a_Part) != 0; }
 	int GetSkinParts(void) const { return m_SkinParts; }
 	void SetSkinParts(int a_Parts);
-
-	eMainHand GetMainHand(void) const { return m_MainHand; }
-	void SetMainHand(eMainHand a_Hand);
 
 	// tolua_end
 
@@ -715,6 +718,9 @@ private:
 	/** If true, we are locking m_Position to m_FrozenPosition. */
 	bool m_IsFrozen;
 
+	/** Whether the player is left-handed, or right-handed. */
+	bool m_IsLeftHanded;
+
 	/** Was the player frozen manually by a plugin or automatically by the server? */
 	bool m_IsManuallyFrozen;
 
@@ -748,9 +754,6 @@ private:
 
 	/** Displayed skin part bit mask */
 	int m_SkinParts;
-
-	/** The main hand of the player */
-	eMainHand m_MainHand;
 
 	/** List on known recipes as Ids */
 	std::set<UInt32> m_KnownRecipes;

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -163,8 +163,8 @@ public:
 
 	virtual void TeleportToCoords(double a_PosX, double a_PosY, double a_PosZ) override;
 
-	// Updates player's capabilities - flying, visibility, etc. from their gamemode.
-	void SetCapabilities();
+	/** Updates player's capabilities - flying, visibility, etc. from their gamemode. */
+	void UpdateCapabilities();
 
 	// tolua_begin
 
@@ -412,21 +412,18 @@ public:
 	void Respawn(void);  // tolua_export
 
 	void SetVisible( bool a_bVisible);  // tolua_export
-	bool IsVisible(void) const { return m_IsVisible; }  // tolua_export
 
 	/** Saves all player data, such as inventory, to JSON. */
 	void SaveToDisk(void);
 
-	typedef cWorld * cWorldPtr;
-
 	/** Loads the player data from the disk file.
-	Sets a_World to the world where the player will spawn, based on the stored world name or the default world by calling LoadFromFile(). */
-	void LoadFromDisk(cWorldPtr & a_World);
+	Sets m_World to the world where the player will spawn, based on the stored world name or the default world by calling LoadFromFile(). */
+	void LoadFromDisk();
 
 	/** Loads the player data from the specified file.
-	Sets a_World to the world where the player will spawn, based on the stored world name or the default world.
+	Sets m_World to the world where the player will spawn, based on the stored world name or the default world.
 	Returns true on success, false if the player wasn't found, and excepts with base std::runtime_error if the data couldn't be read or parsed. */
-	bool LoadFromFile(const AString & a_FileName, cWorldPtr & a_World);
+	bool LoadFromFile(const AString & a_FileName);
 
 	const AString & GetLoadedWorldName() const { return m_CurrentWorldName; }
 
@@ -805,6 +802,7 @@ private:
 	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
 	virtual float GetEnchantmentBlastKnockbackReduction() override;
 	virtual void HandlePhysics(std::chrono::milliseconds a_Dt, cChunk &) override { UNUSED(a_Dt); }
+	virtual bool IsInvisible() const override;
 	virtual bool IsRclking(void) const override { return IsEating() || IsChargingBow(); }
 	virtual void OnAddToWorld(cWorld & a_World) override;
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -598,7 +598,6 @@ public:
 	// cEntity overrides:
 	virtual void AttachTo(cEntity * a_AttachTo) override;
 	virtual void Detach(void) override;
-	virtual void Detach(bool a_IsTeleporting);
 	virtual cItem GetEquippedWeapon(void) const override { return m_Inventory.GetEquippedItem(); }
 	virtual cItem GetEquippedHelmet(void) const override { return m_Inventory.GetEquippedHelmet(); }
 	virtual cItem GetEquippedChestplate(void) const override { return m_Inventory.GetEquippedChestplate(); }

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -612,14 +612,6 @@ public:
 
 private:
 
-	/** Xp Level stuff */
-	enum
-	{
-		XP_TO_LEVEL15 = 255,
-		XP_PER_LEVEL_TO15 = 17,
-		XP_TO_LEVEL30 = 825
-	} ;
-
 	typedef std::vector<std::vector<AString> > AStringVectorVector;
 
 	/** The current body stance the player has adopted. */

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -86,9 +86,6 @@ public:
 
 	static const int MAX_FOOD_LEVEL;
 
-	/** Number of ticks it takes to eat an item */
-	static const int EATING_TICKS;
-
 	// tolua_end
 
 	CLASS_PROTODEF(cPlayer)
@@ -371,7 +368,7 @@ public:
 	void AddFoodExhaustion(double a_Exhaustion);
 
 	/** Returns true if the player is currently in the process of eating the currently equipped item */
-	bool IsEating(void) const { return (m_EatingFinishTick >= 0); }
+	bool IsEating(void) const { return m_EatingFinishTick >= 0_tick; }
 
 	/** Returns true if the player is currently flying */
 	bool IsFlying(void) const { return m_IsFlying; }
@@ -734,7 +731,7 @@ private:
 	bool m_IsVisible;
 
 	/** The world tick in which eating will be finished. -1 if not eating */
-	Int64 m_EatingFinishTick;
+	cTickTimeLong m_EatingFinishTick;
 
 	/** Player Xp level */
 	int m_LifetimeTotalXp;

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -219,7 +219,7 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 // cProjectileEntity:
 
-cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, double a_Width, double a_Height):
+cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, float a_Width, float a_Height):
 	Super(etProjectile, a_Pos, a_Width, a_Height),
 	m_ProjectileKind(a_Kind),
 	m_CreatorData(
@@ -237,7 +237,7 @@ cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d
 
 
 
-cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed, double a_Width, double a_Height):
+cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed, float a_Width, float a_Height):
 	cProjectileEntity(a_Kind, a_Creator, a_Pos, a_Width, a_Height)
 {
 	SetSpeed(a_Speed);

--- a/src/Entities/ProjectileEntity.h
+++ b/src/Entities/ProjectileEntity.h
@@ -48,8 +48,8 @@ public:
 
 	CLASS_PROTODEF(cProjectileEntity)
 
-	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, double a_Width, double a_Height);
-	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed, double a_Width, double a_Height);
+	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, float a_Width, float a_Height);
+	cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed, float a_Width, float a_Height);
 
 	/** Creates a new instance of the specified projectile entity.
 	a_Item is the item from which the projectile originated (such as firework or arrow). */

--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -17,7 +17,7 @@ cSplashPotionEntity::cSplashPotionEntity(
 	Vector3d a_Speed,
 	const cItem & a_Item
 ):
-	Super(pkSplashPotion, a_Creator, a_Pos, 0.25, 0.25),
+	Super(pkSplashPotion, a_Creator, a_Pos, 0.25f, 0.25f),
 	m_Item(a_Item),
 	m_DestroyTimer(-1)
 {

--- a/src/Entities/SplashPotionEntity.cpp
+++ b/src/Entities/SplashPotionEntity.cpp
@@ -17,11 +17,9 @@ cSplashPotionEntity::cSplashPotionEntity(
 	Vector3d a_Speed,
 	const cItem & a_Item
 ):
-	Super(pkSplashPotion, a_Creator, a_Pos, 0.25f, 0.25f),
-	m_Item(a_Item),
-	m_DestroyTimer(-1)
+	Super(pkSplashPotion, a_Creator, a_Pos, a_Speed, 0.25f, 0.25f),
+	m_Item(a_Item)
 {
-	SetSpeed(a_Speed);
 	m_EntityEffectType = cEntityEffect::GetPotionEffectType(a_Item.m_ItemDamage);
 	m_EntityEffect = cEntityEffect(
 		cEntityEffect::GetPotionEffectDuration(a_Item.m_ItemDamage),
@@ -34,10 +32,30 @@ cSplashPotionEntity::cSplashPotionEntity(
 
 
 
-void cSplashPotionEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
+void cSplashPotionEntity::Splash(Vector3d a_HitPos)
 {
-	Splash(a_HitPos);
-	m_DestroyTimer = 2;
+	// Look for entities in 8.25 (width) x 4.25 (height) cuboid _centred_ on hit position:
+	m_World->ForEachEntityInBox({ a_HitPos.addedY(-4.25 / 2), 8.25 / 2, 4.25 }, [this, a_HitPos](cEntity & a_Entity)
+	{
+		if (!a_Entity.IsPawn())
+		{
+			// Not an entity that can take effects
+			return false;
+		}
+
+		double SplashDistance = (a_Entity.GetPosition() - a_HitPos).Length();
+		double Reduction = -0.25 * SplashDistance + 1.0;  // y = -0.25x + 1, where x is the distance from the player. Approximation for potion splash.
+		Reduction = std::max(Reduction, 0.0);
+
+		static_cast<cPawn &>(a_Entity).AddEntityEffect(m_EntityEffectType, m_EntityEffect.GetDuration(), m_EntityEffect.GetIntensity(), Reduction);
+		return false;
+	});
+
+	m_World->BroadcastSoundParticleEffect(
+		EffectID::PARTICLE_SPLASH_POTION,
+		a_HitPos.Floor(),
+		m_PotionColor
+	);
 }
 
 
@@ -46,42 +64,21 @@ void cSplashPotionEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFac
 
 void cSplashPotionEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos)
 {
+	Super::OnHitEntity(a_EntityHit, a_HitPos);
+
 	a_EntityHit.TakeDamage(dtRangedAttack, this, 0, 1);
 	Splash(a_HitPos);
-	m_DestroyTimer = 5;
+	Destroy();
 }
 
 
 
 
 
-void cSplashPotionEntity::Splash(Vector3d a_HitPos)
+void cSplashPotionEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
-	double XZCalculation = 8.25/2;
-	double YCalculation = 4.25/2;
-	cBoundingBox SplashDistanceBox = cBoundingBox(a_HitPos.x - XZCalculation, a_HitPos.x + XZCalculation, a_HitPos.y - YCalculation, a_HitPos.y + YCalculation, a_HitPos.z - XZCalculation, a_HitPos.z + XZCalculation);
+	Super::OnHitSolidBlock(a_HitPos, a_HitFace);
 
-	m_World->ForEachEntityInBox(SplashDistanceBox, [=](cEntity & a_Entity)
-		{
-			if (!a_Entity.IsPawn())
-			{
-				// Not an entity that can take effects
-				return false;
-			}
-
-			// y = -0.25x + 1, where x is the distance from the player. Approximation for potion splash.
-			double SplashDistance = (a_Entity.GetPosition() - a_HitPos).Length();
-			double Reduction = -0.25 * SplashDistance + 1.0;
-			Reduction = std::max(Reduction, 0.0);
-
-			static_cast<cPawn &>(a_Entity).AddEntityEffect(m_EntityEffectType, m_EntityEffect.GetDuration(), m_EntityEffect.GetIntensity(), Reduction);
-			return false;
-		}
-	);
-
-	m_World->BroadcastSoundParticleEffect(
-		EffectID::PARTICLE_SPLASH_POTION,
-		a_HitPos.Floor(),
-		m_PotionColor
-	);
+	Splash(a_HitPos);
+	Destroy();
 }

--- a/src/Entities/SplashPotionEntity.h
+++ b/src/Entities/SplashPotionEntity.h
@@ -52,43 +52,18 @@ public:  // tolua_export
 	cEntityEffect        GetEntityEffect(void)     const { return m_EntityEffect; }
 	void SetEntityEffect(cEntityEffect a_EntityEffect) { m_EntityEffect = a_EntityEffect; }
 
-protected:
+private:
 
 	cEntityEffect::eType m_EntityEffectType;
 	cEntityEffect m_EntityEffect;
 	int m_PotionColor;
 	cItem m_Item;
 
-
-	// cProjectileEntity overrides:
-	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
-	virtual void OnHitEntity    (cEntity & a_EntityHit, Vector3d a_HitPos) override;
-	virtual void Tick           (std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override
-	{
-		if (m_DestroyTimer > 0)
-		{
-			m_DestroyTimer--;
-			if (m_DestroyTimer == 0)
-			{
-				Destroy();
-				return;
-			}
-		}
-		else
-		{
-			Super::Tick(a_Dt, a_Chunk);
-		}
-	}
-
 	/** Splashes the potion, fires its particle effects and sounds
 	@param a_HitPos     The position where the potion will splash */
 	void Splash(Vector3d a_HitPos);
 
-private:
-	/** Time in ticks to wait for the hit animation to begin before destroying */
-	int m_DestroyTimer;
+	// cProjectileEntity overrides:
+	virtual void OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos) override;
+	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
 } ;  // tolua_export
-
-
-
-

--- a/src/Entities/TNTEntity.cpp
+++ b/src/Entities/TNTEntity.cpp
@@ -9,7 +9,7 @@
 
 
 cTNTEntity::cTNTEntity(Vector3d a_Pos, unsigned a_FuseTicks) :
-	Super(etTNT, a_Pos, 0.98, 0.98),
+	Super(etTNT, a_Pos, 0.98f, 0.98f),
 	m_FuseTicks(a_FuseTicks)
 {
 	SetGravity(-16.0f);

--- a/src/Entities/ThrownEggEntity.cpp
+++ b/src/Entities/ThrownEggEntity.cpp
@@ -8,21 +8,8 @@
 
 
 cThrownEggEntity::cThrownEggEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkEgg, a_Creator, a_Pos, 0.25f, 0.25f),
-	m_DestroyTimer(-1)
+	Super(pkEgg, a_Creator, a_Pos, a_Speed, 0.25f, 0.25f)
 {
-	SetSpeed(a_Speed);
-}
-
-
-
-
-
-void cThrownEggEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
-{
-	TrySpawnChicken(a_HitPos);
-
-	m_DestroyTimer = 2;
 }
 
 
@@ -31,41 +18,39 @@ void cThrownEggEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 
 void cThrownEggEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos)
 {
-	int TotalDamage = 0;
-	// If entity is an Ender Dragon or Ender Crystal, it is damaged.
-	if (
-		(a_EntityHit.IsMob() && (static_cast<cMonster &>(a_EntityHit).GetMobType() == mtEnderDragon)) ||
-		a_EntityHit.IsEnderCrystal()
-	)
+	Super::OnHitEntity(a_EntityHit, a_HitPos);
+
+	int Damage = 0;
+	if (a_EntityHit.IsMob() && (static_cast<cMonster &>(a_EntityHit).GetMobType() == mtEnderDragon))
 	{
-		TotalDamage = 1;
+		// Enderdragons take 1 damage:
+		Damage = 1;
+	}
+	else if (a_EntityHit.IsEnderCrystal())
+	{
+		// Endercrystals are destroyed:
+		Damage = CeilC(a_EntityHit.GetHealth());
 	}
 
-	TrySpawnChicken(a_HitPos);
-	a_EntityHit.TakeDamage(dtRangedAttack, this, TotalDamage, 1);
+	a_EntityHit.TakeDamage(dtRangedAttack, GetCreatorUniqueID(), Damage, 1);
+	m_World->BroadcastEntityAnimation(*this, EntityAnimation::EggCracks);
 
-	m_DestroyTimer = 5;
+	TrySpawnChicken(a_HitPos);
+	Destroy();
 }
 
 
 
 
 
-void cThrownEggEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
+void cThrownEggEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
-	if (m_DestroyTimer > 0)
-	{
-		m_DestroyTimer--;
-		if (m_DestroyTimer == 0)
-		{
-			Destroy();
-			return;
-		}
-	}
-	else
-	{
-		Super::Tick(a_Dt, a_Chunk);
-	}
+	Super::OnHitSolidBlock(a_HitPos, a_HitFace);
+
+	m_World->BroadcastEntityAnimation(*this, EntityAnimation::EggCracks);
+
+	TrySpawnChicken(a_HitPos);
+	Destroy();
 }
 
 
@@ -87,7 +72,3 @@ void cThrownEggEntity::TrySpawnChicken(Vector3d a_HitPos)
 		m_World->SpawnMob(a_HitPos.x, a_HitPos.y, a_HitPos.z, mtChicken, true);
 	}
 }
-
-
-
-

--- a/src/Entities/ThrownEggEntity.cpp
+++ b/src/Entities/ThrownEggEntity.cpp
@@ -8,7 +8,7 @@
 
 
 cThrownEggEntity::cThrownEggEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkEgg, a_Creator, a_Pos, 0.25, 0.25),
+	Super(pkEgg, a_Creator, a_Pos, 0.25f, 0.25f),
 	m_DestroyTimer(-1)
 {
 	SetSpeed(a_Speed);

--- a/src/Entities/ThrownEggEntity.h
+++ b/src/Entities/ThrownEggEntity.h
@@ -30,23 +30,13 @@ public:  // tolua_export
 
 	cThrownEggEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
-protected:
-
-	// cProjectileEntity overrides:
-	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
-	virtual void OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos) override;
-	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
-
-	// Randomly decides whether to spawn a chicken where the egg lands.
-	void TrySpawnChicken(Vector3d a_HitPos);
-
 private:
 
-	/** Time in ticks to wait for the hit animation to begin before destroying */
-	int m_DestroyTimer;
+	/** Randomly decides whether to spawn a chicken where the egg lands. */
+	void TrySpawnChicken(Vector3d a_HitPos);
+
+	// cProjectileEntity overrides:
+	virtual void OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos) override;
+	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
 
 } ;  // tolua_export
-
-
-
-

--- a/src/Entities/ThrownEnderPearlEntity.cpp
+++ b/src/Entities/ThrownEnderPearlEntity.cpp
@@ -9,7 +9,7 @@
 
 
 cThrownEnderPearlEntity::cThrownEnderPearlEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkEnderPearl, a_Creator, a_Pos, 0.25, 0.25),
+	Super(pkEnderPearl, a_Creator, a_Pos, 0.25f, 0.25f),
 	m_DestroyTimer(-1)
 {
 	SetSpeed(a_Speed);

--- a/src/Entities/ThrownEnderPearlEntity.cpp
+++ b/src/Entities/ThrownEnderPearlEntity.cpp
@@ -9,22 +9,8 @@
 
 
 cThrownEnderPearlEntity::cThrownEnderPearlEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkEnderPearl, a_Creator, a_Pos, 0.25f, 0.25f),
-	m_DestroyTimer(-1)
+	Super(pkEnderPearl, a_Creator, a_Pos, a_Speed, 0.25f, 0.25f)
 {
-	SetSpeed(a_Speed);
-}
-
-
-
-
-
-void cThrownEnderPearlEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
-{
-	// TODO: Tweak a_HitPos based on block face.
-	TeleportCreator(a_HitPos);
-
-	m_DestroyTimer = 2;
 }
 
 
@@ -33,51 +19,30 @@ void cThrownEnderPearlEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_Hi
 
 void cThrownEnderPearlEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos)
 {
-	int TotalDamage = 0;
+	Super::OnHitEntity(a_EntityHit, a_HitPos);
 
-	bool isAttachedEntity = GetWorld()->FindAndDoWithPlayer(m_CreatorData.m_Name, [& a_EntityHit](cPlayer & a_Entity)
-		{
-			const cEntity * attachedEntity = a_Entity.GetAttached();
-			if (attachedEntity == nullptr)
-			{
-				// nothing attached
-				return false;
-			}
-
-			return attachedEntity->GetUniqueID() == a_EntityHit.GetUniqueID();
-		}
-	);
-	// TODO: If entity is Ender Crystal, destroy it
-
-
-	if (!isAttachedEntity)
+	int Damage = 0;
+	if (a_EntityHit.IsEnderCrystal())
 	{
-		TeleportCreator(a_HitPos);
-		a_EntityHit.TakeDamage(dtRangedAttack, this, TotalDamage, 1);
-		m_DestroyTimer = 5;
+		// Endercrystals are destroyed:
+		Damage = CeilC(a_EntityHit.GetHealth());
 	}
 
+	a_EntityHit.TakeDamage(dtRangedAttack, this, Damage, 1);
+	TeleportCreator(a_HitPos);
+	Destroy();
 }
 
 
 
 
 
-void cThrownEnderPearlEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
+void cThrownEnderPearlEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
-	if (m_DestroyTimer > 0)
-	{
-		m_DestroyTimer--;
-		if (m_DestroyTimer == 0)
-		{
-			Destroy();
-			return;
-		}
-	}
-	else
-	{
-		Super::Tick(a_Dt, a_Chunk);
-	}
+	Super::OnHitSolidBlock(a_HitPos, a_HitFace);
+
+	TeleportCreator(a_HitPos);
+	Destroy();
 }
 
 
@@ -92,12 +57,10 @@ void cThrownEnderPearlEntity::TeleportCreator(Vector3d a_HitPos)
 	}
 
 	GetWorld()->FindAndDoWithPlayer(m_CreatorData.m_Name, [=](cPlayer & a_Entity)
-		{
-			// Teleport the creator here, make them take 5 damage:
-			a_Entity.TeleportToCoords(a_HitPos.x, a_HitPos.y + 0.2, a_HitPos.z);
-			a_Entity.TakeDamage(dtEnderPearl, this, 5, 0);
-			a_Entity.Detach(true);
-			return true;
-		}
-	);
+	{
+		// Teleport the creator here, make them take 5 damage:
+		a_Entity.TeleportToCoords(a_HitPos.x, a_HitPos.y + 0.2, a_HitPos.z);
+		a_Entity.TakeDamage(dtEnderPearl, this, 5, 0);
+		return false;
+	});
 }

--- a/src/Entities/ThrownEnderPearlEntity.h
+++ b/src/Entities/ThrownEnderPearlEntity.h
@@ -30,23 +30,13 @@ public:  // tolua_export
 
 	cThrownEnderPearlEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
-protected:
-
-	// cProjectileEntity overrides:
-	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
-	virtual void OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos) override;
-	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
+private:
 
 	/** Teleports the creator where the ender pearl lands */
 	void TeleportCreator(Vector3d a_HitPos);
 
-private:
-
-	/** Time in ticks to wait for the hit animation to begin before destroying */
-	int m_DestroyTimer;
+	// cProjectileEntity overrides:
+	virtual void OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos) override;
+	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
 
 } ;  // tolua_export
-
-
-
-

--- a/src/Entities/ThrownSnowballEntity.cpp
+++ b/src/Entities/ThrownSnowballEntity.cpp
@@ -8,19 +8,8 @@
 
 
 cThrownSnowballEntity::cThrownSnowballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkSnowball, a_Creator, a_Pos, 0.25f, 0.25f),
-	m_DestroyTimer(-1)
+	Super(pkSnowball, a_Creator, a_Pos, a_Speed, 0.25f, 0.25f)
 {
-	SetSpeed(a_Speed);
-}
-
-
-
-
-
-void cThrownSnowballEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
-{
-	m_DestroyTimer = 2;
 }
 
 
@@ -31,42 +20,31 @@ void cThrownSnowballEntity::OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos
 {
 	Super::OnHitEntity(a_EntityHit, a_HitPos);
 
-	int TotalDamage = 0;
-	if (a_EntityHit.IsMob())
+	int Damage = 0;
+	if (a_EntityHit.IsMob() && (static_cast<cMonster &>(a_EntityHit).GetMobType() == mtBlaze))
 	{
-		eMonsterType MobType = static_cast<cMonster &>(a_EntityHit).GetMobType();
-		if (MobType == mtBlaze)
-		{
-			TotalDamage = 3;
-		}
+		// Blazes take 3 damage:
+		Damage = 3;
 	}
-	// TODO: If entity is Ender Crystal, destroy it
-	a_EntityHit.TakeDamage(dtRangedAttack, GetCreatorUniqueID(), TotalDamage, 1);
+	else if (a_EntityHit.IsEnderCrystal())
+	{
+		// Endercrystals are destroyed:
+		Damage = CeilC(a_EntityHit.GetHealth());
+	}
 
-	m_DestroyTimer = 5;
+	a_EntityHit.TakeDamage(dtRangedAttack, GetCreatorUniqueID(), Damage, 1);
+	m_World->BroadcastEntityAnimation(*this, EntityAnimation::SnowballPoofs);
+	Destroy();
 }
 
 
 
 
 
-void cThrownSnowballEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
+void cThrownSnowballEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 {
-	if (m_DestroyTimer > 0)
-	{
-		m_DestroyTimer--;
-		if (m_DestroyTimer == 0)
-		{
-			Destroy();
-			return;
-		}
-	}
-	else
-	{
-		Super::Tick(a_Dt, a_Chunk);
-	}
+	Super::OnHitSolidBlock(a_HitPos, a_HitFace);
+
+	m_World->BroadcastEntityAnimation(*this, EntityAnimation::SnowballPoofs);
+	Destroy();
 }
-
-
-
-

--- a/src/Entities/ThrownSnowballEntity.cpp
+++ b/src/Entities/ThrownSnowballEntity.cpp
@@ -8,7 +8,7 @@
 
 
 cThrownSnowballEntity::cThrownSnowballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkSnowball, a_Creator, a_Pos, 0.25, 0.25),
+	Super(pkSnowball, a_Creator, a_Pos, 0.25f, 0.25f),
 	m_DestroyTimer(-1)
 {
 	SetSpeed(a_Speed);

--- a/src/Entities/ThrownSnowballEntity.h
+++ b/src/Entities/ThrownSnowballEntity.h
@@ -30,20 +30,10 @@ public:  // tolua_export
 
 	cThrownSnowballEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed);
 
-protected:
-
-	// cProjectileEntity overrides:
-	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
-	virtual void OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos) override;
-	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
-
 private:
 
-	/** Time in ticks to wait for the hit animation to begin before destroying */
-	int m_DestroyTimer;
+	// cProjectileEntity overrides:
+	virtual void OnHitEntity(cEntity & a_EntityHit, Vector3d a_HitPos) override;
+	virtual void OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace) override;
 
 } ;  // tolua_export
-
-
-
-

--- a/src/Entities/WitherSkullEntity.cpp
+++ b/src/Entities/WitherSkullEntity.cpp
@@ -13,7 +13,7 @@
 
 
 cWitherSkullEntity::cWitherSkullEntity(cEntity * a_Creator, Vector3d a_Pos, Vector3d a_Speed):
-	Super(pkWitherSkull, a_Creator, a_Pos, 0.25, 0.25)
+	Super(pkWitherSkull, a_Creator, a_Pos, 0.3125f, 0.3125f)
 {
 	SetSpeed(a_Speed);
 	SetGravity(0);

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -338,14 +338,14 @@ T Clamp(T a_Value, T a_Min, T a_Max)
 
 
 
-/** Floors a value, then casts it to C (an int by default) */
+/** Floors a value, then casts it to C (an int by default). */
 template <typename C = int, typename T>
 typename std::enable_if<std::is_arithmetic<T>::value, C>::type FloorC(T a_Value)
 {
 	return static_cast<C>(std::floor(a_Value));
 }
 
-/** Ceils a value, then casts it to C (an int by default) */
+/** Ceils a value, then casts it to C (an int by default). */
 template <typename C = int, typename T>
 typename std::enable_if<std::is_arithmetic<T>::value, C>::type CeilC(T a_Value)
 {
@@ -356,9 +356,17 @@ typename std::enable_if<std::is_arithmetic<T>::value, C>::type CeilC(T a_Value)
 
 
 
-// a tick is 50 ms
-using cTickTime = std::chrono::duration<int,  std::ratio_multiply<std::chrono::milliseconds::period, std::ratio<50>>>;
-using cTickTimeLong = std::chrono::duration<Int64,  cTickTime::period>;
+// A time duration representing a Minecraft tick (50 ms), capable of storing at least 32'767 ticks.
+using cTickTime = std::chrono::duration<signed int, std::ratio_multiply<std::chrono::milliseconds::period, std::ratio<50>>>;
+
+// A time duration representing a Minecraft tick (50 ms), capable of storing at least a 64 bit signed duration.
+using cTickTimeLong = std::chrono::duration<signed long long int, cTickTime::period>;
+
+/** Converts a literal to a tick time. */
+constexpr cTickTimeLong operator ""_tick(const unsigned long long a_Ticks)
+{
+	return cTickTimeLong(a_Ticks);
+}
 
 using ContiguousByteBuffer = std::basic_string<std::byte>;
 using ContiguousByteBufferView = std::basic_string_view<std::byte>;

--- a/src/MobCensus.cpp
+++ b/src/MobCensus.cpp
@@ -39,7 +39,6 @@ int cMobCensus::GetCapMultiplier(cMonster::eFamily a_MobFamily)
 		case cMonster::mfAmbient: return 16;
 		case cMonster::mfWater:   return 5;
 		case cMonster::mfNoSpawn:
-		case cMonster::mfUnhandled:
 		{
 			break;
 		}

--- a/src/Mobs/AggressiveMonster.cpp
+++ b/src/Mobs/AggressiveMonster.cpp
@@ -11,7 +11,7 @@
 
 
 
-cAggressiveMonster::cAggressiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, double a_Width, double a_Height) :
+cAggressiveMonster::cAggressiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, float a_Width, float a_Height) :
 	Super(a_ConfigName, a_MobType, a_SoundHurt, a_SoundDeath, a_SoundAmbient, a_Width, a_Height)
 {
 	m_EMPersonality = AGGRESSIVE;

--- a/src/Mobs/AggressiveMonster.h
+++ b/src/Mobs/AggressiveMonster.h
@@ -20,8 +20,8 @@ public:
 		const AString & a_SoundHurt,
 		const AString & a_SoundDeath,
 		const AString & a_SoundAmbient,
-		double a_Width,
-		double a_Height
+		float a_Width,
+		float a_Height
 	);
 
 	virtual void Tick          (std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;

--- a/src/Mobs/Bat.cpp
+++ b/src/Mobs/Bat.cpp
@@ -6,7 +6,7 @@
 
 
 cBat::cBat(void) :
-	Super("Bat", mtBat, "entity.bat.hurt", "entity.bat.death", "entity.bat.ambient", 0.5, 0.9)
+	Super("Bat", mtBat, "entity.bat.hurt", "entity.bat.death", "entity.bat.ambient", 0.5f, 0.9f)
 {
 	SetGravity(-2.0f);
 	SetAirDrag(0.05f);

--- a/src/Mobs/Blaze.cpp
+++ b/src/Mobs/Blaze.cpp
@@ -9,7 +9,7 @@
 
 
 cBlaze::cBlaze(void) :
-	Super("Blaze", mtBlaze, "entity.blaze.hurt", "entity.blaze.death", "entity.blaze.ambient", 0.6, 1.8),
+	Super("Blaze", mtBlaze, "entity.blaze.hurt", "entity.blaze.death", "entity.blaze.ambient", 0.6f, 1.8f),
 	m_IsCharging(false),
 	m_ChargeTimer(0)
 {

--- a/src/Mobs/CaveSpider.cpp
+++ b/src/Mobs/CaveSpider.cpp
@@ -8,7 +8,7 @@
 
 
 cCaveSpider::cCaveSpider(void) :
-	Super("CaveSpider", mtCaveSpider, "entity.spider.hurt", "entity.spider.death", "entity.spider.ambient", 0.7, 0.5)
+	Super("CaveSpider", mtCaveSpider, "entity.spider.hurt", "entity.spider.death", "entity.spider.ambient", 0.7f, 0.5f)
 {
 }
 

--- a/src/Mobs/CaveSpider.cpp
+++ b/src/Mobs/CaveSpider.cpp
@@ -25,7 +25,7 @@ void cCaveSpider::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		return;
 	}
 
-	m_EMPersonality = (GetWorld()->GetTimeOfDay() < (12000 + 1000)) ? PASSIVE : AGGRESSIVE;
+	m_EMPersonality = (GetWorld()->GetTimeOfDay() < 13000_tick) ? PASSIVE : AGGRESSIVE;
 }
 
 

--- a/src/Mobs/Chicken.cpp
+++ b/src/Mobs/Chicken.cpp
@@ -8,7 +8,7 @@
 
 
 cChicken::cChicken(void) :
-	Super("Chicken", mtChicken, "entity.chicken.hurt", "entity.chicken.death", "entity.chicken.ambient", 0.4, 0.7),
+	Super("Chicken", mtChicken, "entity.chicken.hurt", "entity.chicken.death", "entity.chicken.ambient", 0.4f, 0.7f),
 	m_EggDropTimer(0)
 {
 	SetGravity(-2.0f);

--- a/src/Mobs/Cow.cpp
+++ b/src/Mobs/Cow.cpp
@@ -9,7 +9,7 @@
 
 
 cCow::cCow(void) :
-	Super("Cow", mtCow, "entity.cow.hurt", "entity.cow.death", "entity.cow.ambient", 0.9, 1.3)
+	Super("Cow", mtCow, "entity.cow.hurt", "entity.cow.death", "entity.cow.ambient", 0.9f, 1.4f)
 {
 }
 

--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -11,7 +11,7 @@
 
 
 cCreeper::cCreeper(void) :
-	Super("Creeper", mtCreeper, "entity.creeper.hurt", "entity.creeper.death", "entity.creeper.ambient", 0.6, 1.8),
+	Super("Creeper", mtCreeper, "entity.creeper.hurt", "entity.creeper.death", "entity.creeper.ambient", 0.6f, 1.7f),
 	m_bIsBlowing(false),
 	m_bIsCharged(false),
 	m_BurnedWithFlintAndSteel(false),

--- a/src/Mobs/EnderDragon.cpp
+++ b/src/Mobs/EnderDragon.cpp
@@ -10,8 +10,7 @@
 
 
 cEnderDragon::cEnderDragon(void) :
-	// TODO: Vanilla source says this, but is it right? Dragons fly, they don't stand
-	Super("EnderDragon", mtEnderDragon, "entity.enderdragon.hurt", "entity.enderdragon.death", "entity.enderdragon.ambient", 16.0, 8.0)
+	Super("EnderDragon", mtEnderDragon, "entity.enderdragon.hurt", "entity.enderdragon.death", "entity.enderdragon.ambient", 16, 8)
 {
 }
 

--- a/src/Mobs/Enderman.cpp
+++ b/src/Mobs/Enderman.cpp
@@ -79,7 +79,7 @@ protected:
 
 
 cEnderman::cEnderman(void) :
-	Super("Enderman", mtEnderman, "entity.endermen.hurt", "entity.endermen.death", "entity.endermen.ambient", 0.5, 2.9),
+	Super("Enderman", mtEnderman, "entity.endermen.hurt", "entity.endermen.death", "entity.endermen.ambient", 0.6f, 2.9f),
 	m_bIsScreaming(false),
 	m_CarriedBlock(E_BLOCK_AIR),
 	m_CarriedMeta(0)

--- a/src/Mobs/Giant.cpp
+++ b/src/Mobs/Giant.cpp
@@ -8,7 +8,7 @@
 
 
 cGiant::cGiant(void) :
-	Super("Giant", mtGiant, "entity.zombie.hurt", "entity.zombie.death", "entity.zombie.ambient", 3.6, 10.8)
+	Super("Giant", mtGiant, "entity.zombie.hurt", "entity.zombie.death", "entity.zombie.ambient", 3.6f, 12)
 {
 
 }

--- a/src/Mobs/Guardian.cpp
+++ b/src/Mobs/Guardian.cpp
@@ -9,7 +9,7 @@
 
 
 cGuardian::cGuardian(void) :
-	Super("Guardian", mtGuardian, "entity.guardian.hurt", "entity.guardian.death", "entity.guardian.ambient", 0.875, 0.8)
+	Super("Guardian", mtGuardian, "entity.guardian.hurt", "entity.guardian.death", "entity.guardian.ambient", 0.85f, 0.85f)
 {
 }
 

--- a/src/Mobs/Horse.cpp
+++ b/src/Mobs/Horse.cpp
@@ -11,7 +11,7 @@
 
 
 cHorse::cHorse(int Type, int Color, int Style, int TameTimes) :
-	Super("Horse", mtHorse, "entity.horse.hurt", "entity.horse.death", "entity.horse.ambient", 1.4, 1.6),
+	Super("Horse", mtHorse, "entity.horse.hurt", "entity.horse.death", "entity.horse.ambient", 1.4f, 1.6f),
 	cEntityWindowOwner(this),
 	m_bHasChest(false),
 	m_bIsEating(false),

--- a/src/Mobs/IronGolem.cpp
+++ b/src/Mobs/IronGolem.cpp
@@ -8,7 +8,7 @@
 
 
 cIronGolem::cIronGolem(void) :
-	Super("IronGolem", mtIronGolem, "entity.irongolem.hurt", "entity.irongolem.death", "entity.irongolem.ambient", 1.4, 2.9)
+	Super("IronGolem", mtIronGolem, "entity.irongolem.hurt", "entity.irongolem.death", "entity.irongolem.ambient", 1.4f, 2.7f)
 {
 }
 

--- a/src/Mobs/MagmaCube.cpp
+++ b/src/Mobs/MagmaCube.cpp
@@ -7,7 +7,15 @@
 
 
 cMagmaCube::cMagmaCube(int a_Size) :
-	Super("MagmaCube", mtMagmaCube, Printf("entity.%smagmacube.hurt", GetSizeName(a_Size).c_str()), Printf("entity.%smagmacube.death", GetSizeName(a_Size).c_str()), "", 0.6 * a_Size, 0.6 * a_Size),
+	Super(
+		"MagmaCube",
+		mtMagmaCube,
+		Printf("entity.%smagmacube.hurt", GetSizeName(a_Size).c_str()),
+		Printf("entity.%smagmacube.death", GetSizeName(a_Size).c_str()),
+		"",
+		0.51f * a_Size,
+		0.51f * a_Size
+	),
 	m_Size(a_Size)
 {
 }

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -80,7 +80,7 @@ static const struct
 ////////////////////////////////////////////////////////////////////////////////
 // cMonster:
 
-cMonster::cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, double a_Width, double a_Height)
+cMonster::cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, float a_Width, float a_Height)
 	: Super(etMonster, a_Width, a_Height)
 	, m_EMState(IDLE)
 	, m_EMPersonality(AGGRESSIVE)

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1150,34 +1150,26 @@ cMonster::eFamily cMonster::FamilyFromType(eMonsterType a_Type)
 		case mtZombieHorse:     return mfPassive;
 		case mtZombiePigman:    return mfHostile;
 		case mtZombieVillager:  return mfHostile;
-
-		default:
-		{
-			ASSERT(!"Unhandled mob type");
-			return mfUnhandled;
-		}
+		case mtInvalidType:     break;
 	}
+	UNREACHABLE("Unhandled mob type");
 }
 
 
 
 
 
-int cMonster::GetSpawnDelay(cMonster::eFamily a_MobFamily)
+cTickTime cMonster::GetSpawnDelay(cMonster::eFamily a_MobFamily)
 {
 	switch (a_MobFamily)
 	{
-		case mfHostile:   return 40;
-		case mfPassive:   return 40;
-		case mfAmbient:   return 40;
-		case mfWater:     return 400;
-		case mfNoSpawn:   return -1;
-		default:
-		{
-			ASSERT(!"Unhandled mob family");
-			return -1;
-		}
+		case mfHostile:   return 40_tick;
+		case mfPassive:   return 40_tick;
+		case mfAmbient:   return 40_tick;
+		case mfWater:     return 400_tick;
+		case mfNoSpawn:   return -1_tick;
 	}
+	UNREACHABLE("Unhandled mob family");
 }
 
 
@@ -1654,7 +1646,7 @@ bool cMonster::WouldBurnAt(Vector3d a_Location, cChunk & a_Chunk)
 
 	if (
 		(Chunk->GetBlock(Rel) != E_BLOCK_SOULSAND) &&   // Not on soulsand
-		(GetWorld()->GetTimeOfDay() < 12000 + 1000) &&  // Daytime
+		(GetWorld()->GetTimeOfDay() < 13000_tick) &&    // Daytime
 		Chunk->IsWeatherSunnyAt(Rel.x, Rel.z) &&        // Not raining
 		!IsInWater()                                    // Isn't swimming
 	)

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1463,7 +1463,7 @@ void cMonster::RightClickFeed(cPlayer & a_Player)
 				a_Player.GetInventory().RemoveOneEquippedItem();
 			}
 			m_LoveTimer = TPS * 30;  // half a minute
-			m_World->BroadcastEntityStatus(*this, esMobInLove);
+			m_World->BroadcastEntityAnimation(*this, EntityAnimation::AnimalFallsInLove);
 		}
 	}
 	// If a player holding my spawn egg right-clicked me, spawn a new baby

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -32,8 +32,7 @@ public:
 		mfAmbient  = 2,  // Bats
 		mfWater    = 3,  // Squid, Guardian
 
-		mfNoSpawn,
-		mfUnhandled,  // Nothing. Be sure this is the last and the others are in order
+		mfNoSpawn
 	} ;
 
 	// tolua_end
@@ -187,10 +186,10 @@ public:
 	/** Returns the mob family based on the type */
 	static eFamily FamilyFromType(eMonsterType a_MobType);
 
-	/** Returns the spawn delay (number of game ticks between spawn attempts) for the given mob family */
-	static int GetSpawnDelay(cMonster::eFamily a_MobFamily);
-
 	// tolua_end
+
+	/** Returns the spawn delay (number of game ticks between spawn attempts) for the given mob family */
+	static cTickTime GetSpawnDelay(cMonster::eFamily a_MobFamily);
 
 	/**  Translates the MobType enum to the vanilla nbt name */
 	static AString MobTypeToVanillaNBT(eMonsterType a_MobType);

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -45,7 +45,7 @@ public:
 	a_MobType is the type of the mob (also used in the protocol ( http://wiki.vg/Entities#Mobs 2012_12_22))
 	a_SoundHurt and a_SoundDeath are assigned into m_SoundHurt and m_SoundDeath, respectively
 	*/
-	cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, double a_Width, double a_Height);
+	cMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, float a_Width, float a_Height);
 
 	CLASS_PROTODEF(cMonster)
 

--- a/src/Mobs/Mooshroom.cpp
+++ b/src/Mobs/Mooshroom.cpp
@@ -9,7 +9,7 @@
 
 
 cMooshroom::cMooshroom(void) :
-	Super("Mooshroom", mtMooshroom, "entity.cow.hurt", "entity.cow.death", "entity.cow.ambient", 0.9, 1.3)
+	Super("Mooshroom", mtMooshroom, "entity.cow.hurt", "entity.cow.death", "entity.cow.ambient", 0.9f, 1.4f)
 {
 }
 

--- a/src/Mobs/Ocelot.cpp
+++ b/src/Mobs/Ocelot.cpp
@@ -21,7 +21,7 @@
 */
 
 cOcelot::cOcelot(void) :
-	Super("Ocelot", mtOcelot, "entity.cat.hurt", "entity.cat.death", "entity.cat.ambient", 0.6, 0.8),
+	Super("Ocelot", mtOcelot, "entity.cat.hurt", "entity.cat.death", "entity.cat.ambient", 0.6f, 0.7f),
 	m_IsSitting(false),
 	m_IsTame(false),
 	m_IsBegging(false),

--- a/src/Mobs/Ocelot.cpp
+++ b/src/Mobs/Ocelot.cpp
@@ -166,14 +166,12 @@ void cOcelot::OnRightClicked(cPlayer & a_Player)
 					SetIsTame(true);
 					SetOwner(a_Player.GetName(), a_Player.GetUUID());
 					SetCatType(static_cast<eCatType>(Random.RandInt<int>(1, 3)));
-					m_World->BroadcastEntityStatus(*this, esWolfTamed);
-					m_World->BroadcastParticleEffect("heart", static_cast<Vector3f>(GetPosition()), Vector3f{}, 0, 5);
+					m_World->BroadcastEntityAnimation(*this, EntityAnimation::OcelotTrusts);
 				}
 				else
 				{
 					// Taming failed
-					m_World->BroadcastEntityStatus(*this, esWolfTaming);
-					m_World->BroadcastParticleEffect("smoke", static_cast<Vector3f>(GetPosition()), Vector3f{}, 0, 5);
+					m_World->BroadcastEntityAnimation(*this, EntityAnimation::OcelotDistrusts);
 				}
 			}
 		}

--- a/src/Mobs/PassiveAggressiveMonster.cpp
+++ b/src/Mobs/PassiveAggressiveMonster.cpp
@@ -9,7 +9,7 @@
 
 
 
-cPassiveAggressiveMonster::cPassiveAggressiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, double a_Width, double a_Height) :
+cPassiveAggressiveMonster::cPassiveAggressiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, float a_Width, float a_Height) :
 	Super(a_ConfigName, a_MobType, a_SoundHurt, a_SoundDeath, a_SoundAmbient, a_Width, a_Height)
 {
 	m_EMPersonality = PASSIVE;

--- a/src/Mobs/PassiveAggressiveMonster.h
+++ b/src/Mobs/PassiveAggressiveMonster.h
@@ -20,8 +20,8 @@ public:
 		const AString & a_SoundHurt,
 		const AString & a_SoundDeath,
 		const AString & a_SoundAmbient,
-		double a_Width,
-		double a_Height
+		float a_Width,
+		float a_Height
 	);
 
 	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;

--- a/src/Mobs/PassiveMonster.cpp
+++ b/src/Mobs/PassiveMonster.cpp
@@ -10,7 +10,7 @@
 
 
 
-cPassiveMonster::cPassiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, double a_Width, double a_Height) :
+cPassiveMonster::cPassiveMonster(const AString & a_ConfigName, eMonsterType a_MobType, const AString & a_SoundHurt, const AString & a_SoundDeath, const AString & a_SoundAmbient, float a_Width, float a_Height) :
 	Super(a_ConfigName, a_MobType, a_SoundHurt, a_SoundDeath, a_SoundAmbient, a_Width, a_Height)
 {
 	m_EMPersonality = PASSIVE;

--- a/src/Mobs/PassiveMonster.h
+++ b/src/Mobs/PassiveMonster.h
@@ -21,8 +21,8 @@ public:
 		const AString & a_SoundHurt,
 		const AString & a_SoundDeath,
 		const AString & a_SoundAmbient,
-		double a_Width,
-		double a_Height
+		float a_Width,
+		float a_Height
 	);
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;

--- a/src/Mobs/PathFinder.cpp
+++ b/src/Mobs/PathFinder.cpp
@@ -8,13 +8,12 @@
 
 
 
-cPathFinder::cPathFinder(double a_MobWidth, double a_MobHeight) :
-	m_Path(),
+cPathFinder::cPathFinder(float a_MobWidth, float a_MobHeight) :
+	m_Width(a_MobWidth),
+	m_Height(a_MobHeight),
 	m_GiveUpCounter(0),
 	m_NotFoundCooldown(0)
 {
-	m_Width = a_MobWidth;
-	m_Height = a_MobHeight;
 }
 
 

--- a/src/Mobs/PathFinder.h
+++ b/src/Mobs/PathFinder.h
@@ -16,7 +16,7 @@ public:
 	@param a_MobWidth The mob width.
 	@param a_MobHeight The mob height.
 	*/
-	cPathFinder(double a_MobWidth, double a_MobHeight);
+	cPathFinder(float a_MobWidth, float a_MobHeight);
 
 	/** Updates the PathFinder's internal state and returns a waypoint.
 	A waypoint is a coordinate which the mob can safely move to from its current position in a straight line.
@@ -41,10 +41,10 @@ public:
 private:
 
 	/** The width of the Mob which owns this PathFinder. */
-	double m_Width;
+	float m_Width;
 
 	/** The height of the Mob which owns this PathFinder. */
-	double m_Height;
+	float m_Height;
 
 	/** The current cPath instance we have. This is discarded and recreated when a path recalculation is needed. */
 	std::unique_ptr<cPath> m_Path;

--- a/src/Mobs/Pig.cpp
+++ b/src/Mobs/Pig.cpp
@@ -10,7 +10,7 @@
 
 
 cPig::cPig(void) :
-	Super("Pig", mtPig, "entity.pig.hurt", "entity.pig.death", "entity.pig.ambient", 0.9, 0.9),
+	Super("Pig", mtPig, "entity.pig.hurt", "entity.pig.death", "entity.pig.ambient", 0.9f, 0.9f),
 	m_bIsSaddled(false)
 {
 }

--- a/src/Mobs/Rabbit.cpp
+++ b/src/Mobs/Rabbit.cpp
@@ -21,7 +21,7 @@ cRabbit::cRabbit(void) :
 
 
 cRabbit::cRabbit(eRabbitType Type, int MoreCarrotTicks) :
-	Super("Rabbit", mtRabbit, "entity.rabbit.hurt", "entity.rabbit.death", "entity.rabbit.ambient", 0.82, 0.68),
+	Super("Rabbit", mtRabbit, "entity.rabbit.hurt", "entity.rabbit.death", "entity.rabbit.ambient", 0.4f, 0.5f),
 	m_Type(Type),
 	m_MoreCarrotTicks(MoreCarrotTicks)
 {

--- a/src/Mobs/Sheep.cpp
+++ b/src/Mobs/Sheep.cpp
@@ -12,7 +12,7 @@
 
 
 cSheep::cSheep(int a_Color) :
-	Super("Sheep", mtSheep, "entity.sheep.hurt", "entity.sheep.death", "entity.sheep.ambient", 0.6, 1.3),
+	Super("Sheep", mtSheep, "entity.sheep.hurt", "entity.sheep.death", "entity.sheep.ambient", 0.9f, 1.3f),
 	m_IsSheared(false),
 	m_WoolColor(a_Color),
 	m_TimeToStopEating(-1)

--- a/src/Mobs/Sheep.cpp
+++ b/src/Mobs/Sheep.cpp
@@ -129,7 +129,7 @@ void cSheep::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		{
 			if (m_World->GetBlock({ PosX, PosY, PosZ }) == E_BLOCK_GRASS)
 			{
-				m_World->BroadcastEntityStatus(*this, esSheepEating);
+				m_World->BroadcastEntityAnimation(*this, EntityAnimation::SheepEatsGrass);
 				m_TimeToStopEating = 40;
 			}
 		}

--- a/src/Mobs/Silverfish.cpp
+++ b/src/Mobs/Silverfish.cpp
@@ -12,6 +12,15 @@
 
 
 
+cSilverfish::cSilverfish() :
+	Super("Silverfish", mtSilverfish, "entity.silverfish.hurt", "entity.silverfish.death", "entity.silverfish.ambient", 0.4f, 0.3f)
+{
+}
+
+
+
+
+
 bool cSilverfish::DoTakeDamage(TakeDamageInfo &a_TDI)
 {
 	// Call on our brethren to attack!

--- a/src/Mobs/Silverfish.h
+++ b/src/Mobs/Silverfish.h
@@ -14,10 +14,7 @@ class cSilverfish:
 
 public:
 
-	cSilverfish():
-		Super("Silverfish", mtSilverfish, "entity.silverfish.hurt", "entity.silverfish.death", "entity.silverfish.ambient", 0.3, 0.4)
-	{
-	}
+	cSilverfish();
 
 	CLASS_PROTODEF(cSilverfish)
 

--- a/src/Mobs/Skeleton.cpp
+++ b/src/Mobs/Skeleton.cpp
@@ -10,7 +10,7 @@
 
 
 cSkeleton::cSkeleton(void) :
-	Super("Skeleton", mtSkeleton, "entity.skeleton.hurt", "entity.skeleton.death", "entity.skeleton.ambient", 0.6, 1.8)
+	Super("Skeleton", mtSkeleton, "entity.skeleton.hurt", "entity.skeleton.death", "entity.skeleton.ambient", 0.6f, 1.99f)
 {
 }
 

--- a/src/Mobs/Slime.cpp
+++ b/src/Mobs/Slime.cpp
@@ -15,8 +15,8 @@ cSlime::cSlime(int a_Size) :
 		Printf("entity.%sslime.hurt", GetSizeName(a_Size).c_str()),
 		Printf("entity.%sslime.death", GetSizeName(a_Size).c_str()),
 		"",
-		0.6 * a_Size,
-		0.6 * a_Size
+		0.51f * a_Size,
+		0.51f * a_Size
 	),
 	m_Size(a_Size)
 {

--- a/src/Mobs/SnowGolem.cpp
+++ b/src/Mobs/SnowGolem.cpp
@@ -11,7 +11,7 @@
 
 
 cSnowGolem::cSnowGolem(void) :
-	Super("SnowGolem", mtSnowGolem, "entity.snowman.hurt", "entity.snowman.death", "entity.snowman.ambient", 0.4, 1.8)
+	Super("SnowGolem", mtSnowGolem, "entity.snowman.hurt", "entity.snowman.death", "entity.snowman.ambient", 0.7f, 1.9f)
 {
 }
 

--- a/src/Mobs/Spider.cpp
+++ b/src/Mobs/Spider.cpp
@@ -9,7 +9,7 @@
 
 
 cSpider::cSpider(void) :
-	Super("Spider", mtSpider, "entity.spider.hurt", "entity.spider.death", "entity.spider.ambient", 1.4, 0.9)
+	Super("Spider", mtSpider, "entity.spider.hurt", "entity.spider.death", "entity.spider.ambient", 1.4f, 0.9f)
 {
 }
 

--- a/src/Mobs/Squid.cpp
+++ b/src/Mobs/Squid.cpp
@@ -9,7 +9,7 @@
 
 
 cSquid::cSquid(void) :
-	Super("Squid", mtSquid, "entity.squid.hurt", "entity.squid.death", "entity.squid.ambient", 0.95, 0.95)
+	Super("Squid", mtSquid, "entity.squid.hurt", "entity.squid.death", "entity.squid.ambient", 0.8f, 0.8f)
 {
 }
 

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -12,7 +12,7 @@
 
 
 cVillager::cVillager(eVillagerType VillagerType) :
-	Super("Villager", mtVillager, "entity.villager.hurt", "entity.villager.death", "entity.villager.ambient", 0.6, 1.8),
+	Super("Villager", mtVillager, "entity.villager.hurt", "entity.villager.death", "entity.villager.ambient", 0.6f, 1.95f),
 	m_ActionCountDown(-1),
 	m_Type(VillagerType),
 	m_VillagerAction(false)

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -34,7 +34,7 @@ bool cVillager::DoTakeDamage(TakeDamageInfo & a_TDI)
 	{
 		if (GetRandomProvider().RandBool(1.0 / 6.0))
 		{
-			m_World->BroadcastEntityStatus(*this, esVillagerAngry);
+			m_World->BroadcastEntityAnimation(*this, EntityAnimation::VillagerShowsAnger);
 		}
 	}
 

--- a/src/Mobs/Witch.cpp
+++ b/src/Mobs/Witch.cpp
@@ -9,7 +9,7 @@
 
 
 cWitch::cWitch(void) :
-	Super("Witch", mtWitch, "entity.witch.hurt", "entity.witch.death", "entity.witch.ambient", 0.6, 1.8)
+	Super("Witch", mtWitch, "entity.witch.hurt", "entity.witch.death", "entity.witch.ambient", 0.6f, 1.95f)
 {
 }
 

--- a/src/Mobs/Wither.cpp
+++ b/src/Mobs/Wither.cpp
@@ -13,7 +13,7 @@
 
 
 cWither::cWither(void) :
-	Super("Wither", mtWither, "entity.wither.hurt", "entity.wither.death", "entity.wither.ambient", 0.9, 4.0),
+	Super("Wither", mtWither, "entity.wither.hurt", "entity.wither.death", "entity.wither.ambient", 0.9f, 3.5f),
 	m_WitherInvulnerableTicks(220)
 {
 	SetMaxHealth(300);

--- a/src/Mobs/WitherSkeleton.cpp
+++ b/src/Mobs/WitherSkeleton.cpp
@@ -9,7 +9,7 @@
 
 
 cWitherSkeleton::cWitherSkeleton(void) :
-	Super("WitherSkeleton", mtWitherSkeleton, "entity.wither_skeleton.hurt", "entity.wither_skeleton.death", "entity.wither_skeleton.ambient", 0.7, 2.4)
+	Super("WitherSkeleton", mtWitherSkeleton, "entity.wither_skeleton.hurt", "entity.wither_skeleton.death", "entity.wither_skeleton.ambient", 0.7f, 2.4f)
 {
 }
 

--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -12,7 +12,7 @@
 
 
 cWolf::cWolf(void) :
-	Super("Wolf", mtWolf, "entity.wolf.hurt", "entity.wolf.death", "entity.wolf.ambient", 0.6, 0.8),
+	Super("Wolf", mtWolf, "entity.wolf.hurt", "entity.wolf.death", "entity.wolf.ambient", 0.6f, 0.85f),
 	m_IsSitting(false),
 	m_IsTame(false),
 	m_IsBegging(false),

--- a/src/Mobs/Wolf.cpp
+++ b/src/Mobs/Wolf.cpp
@@ -185,14 +185,12 @@ void cWolf::OnRightClicked(cPlayer & a_Player)
 				SetMaxHealth(20);
 				SetIsTame(true);
 				SetOwner(a_Player.GetName(), a_Player.GetUUID());
-				m_World->BroadcastEntityStatus(*this, esWolfTamed);
-				m_World->BroadcastParticleEffect("heart", static_cast<Vector3f>(GetPosition()), Vector3f{}, 0, 5);
+				m_World->BroadcastEntityAnimation(*this, EntityAnimation::WolfTamingSucceeds);
 			}
 			else
 			{
 				// Taming failed
-				m_World->BroadcastEntityStatus(*this, esWolfTaming);
-				m_World->BroadcastParticleEffect("smoke", static_cast<Vector3f>(GetPosition()), Vector3f{}, 0, 5);
+				m_World->BroadcastEntityAnimation(*this, EntityAnimation::WolfTamingFails);
 			}
 		}
 	}

--- a/src/Mobs/Zombie.cpp
+++ b/src/Mobs/Zombie.cpp
@@ -10,7 +10,7 @@
 
 
 cZombie::cZombie() :
-	Super("Zombie", mtZombie, "entity.zombie.hurt", "entity.zombie.death", "entity.zombie.ambient", 0.6, 1.8)
+	Super("Zombie", mtZombie, "entity.zombie.hurt", "entity.zombie.death", "entity.zombie.ambient", 0.6f, 1.95f)
 {
 }
 

--- a/src/Mobs/ZombiePigman.cpp
+++ b/src/Mobs/ZombiePigman.cpp
@@ -9,7 +9,7 @@
 
 
 cZombiePigman::cZombiePigman(void) :
-	Super("ZombiePigman", mtZombiePigman, "entity.zombie_pig.hurt", "entity.zombie_pig.death", "entity.zombie_pig.ambient", 0.6, 1.8)
+	Super("ZombiePigman", mtZombiePigman, "entity.zombie_pig.hurt", "entity.zombie_pig.death", "entity.zombie_pig.ambient", 0.6f, 1.95f)
 {
 }
 

--- a/src/Mobs/ZombieVillager.cpp
+++ b/src/Mobs/ZombieVillager.cpp
@@ -11,7 +11,7 @@
 
 
 cZombieVillager::cZombieVillager(cVillager::eVillagerType a_Profession) :
-	Super("ZombieVillager", mtZombieVillager, "entity.zombie_villager.hurt", "entity.zombie_villager.death", "entity.ambient", 0.6, 1.8),
+	Super("ZombieVillager", mtZombieVillager, "entity.zombie_villager.hurt", "entity.zombie_villager.death", "entity.ambient", 0.6f, 1.95f),
 	m_ConversionTime(-1),
 	m_Profession(a_Profession)
 {

--- a/src/Protocol/Packetizer.cpp
+++ b/src/Protocol/Packetizer.cpp
@@ -99,7 +99,6 @@ AString cPacketizer::PacketTypeToStr(cProtocol::ePacketType a_PacketType)
 		case cProtocol::pktPlayerAbilities:        return "pktPlayerAbilities";
 		case cProtocol::pktPlayerList:             return "pktPlayerList";
 		case cProtocol::pktPlayerListHeaderFooter: return "pktPlayerListHeaderFooter";
-		case cProtocol::pktPlayerMaxSpeed:         return "pktPlayerMaxSpeed";
 		case cProtocol::pktPlayerMoveLook:         return "pktPlayerMoveLook";
 		case cProtocol::pktPluginMessage:          return "pktPluginMessage";
 		case cProtocol::pktRemoveEntityEffect:     return "pktRemoveEntityEffect";

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -105,7 +105,6 @@ public:
 		pktPlayerAbilities,
 		pktPlayerList,
 		pktPlayerListHeaderFooter,
-		pktPlayerMaxSpeed,
 		pktPlayerMoveLook,
 		pktPluginMessage,
 		pktRemoveEntityEffect,
@@ -412,7 +411,6 @@ public:
 	virtual void SendPlayerListUpdateGameMode   (const cPlayer & a_Player) = 0;
 	virtual void SendPlayerListUpdatePing       () = 0;
 	virtual void SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName) = 0;
-	virtual void SendPlayerMaxSpeed             (void) = 0;  ///< Informs the client of the maximum player speed (1.6.1+)
 	virtual void SendPlayerMoveLook             (void) = 0;
 	virtual void SendPlayerPosition             (void) = 0;
 	virtual void SendPlayerSpawn                (const cPlayer & a_Player) = 0;

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -438,7 +438,7 @@ public:
 	virtual void SendTabCompletionResults       (const AStringVector & a_Results) = 0;
 	virtual void SendThunderbolt                (int a_BlockX, int a_BlockY, int a_BlockZ) = 0;
 	virtual void SendTitleTimes                 (int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks) = 0;
-	virtual void SendTimeUpdate                 (Int64 a_WorldAge, Int64 a_WorldDate, bool a_DoDaylightCycle) = 0;
+	virtual void SendTimeUpdate                 (cTickTimeLong a_WorldAge, cTickTimeLong a_WorldDate, bool a_DoDaylightCycle) = 0;
 	virtual void SendUnleashEntity              (const cEntity & a_Entity) = 0;
 	virtual void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ) = 0;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) = 0;

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -381,14 +381,13 @@ public:
 	virtual void SendDisconnect                 (const AString & a_Reason) = 0;
 	virtual void SendEditSign                   (int a_BlockX, int a_BlockY, int a_BlockZ) = 0;  ///< Request the client to open up the sign editor for the sign (1.6+)
 	virtual void SendEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, int a_Duration) = 0;
-	virtual void SendEntityAnimation            (const cEntity & a_Entity, char a_Animation) = 0;
+	virtual void SendEntityAnimation            (const cEntity & a_Entity, EntityAnimation a_Animation) = 0;
 	virtual void SendEntityEquipment            (const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item) = 0;
 	virtual void SendEntityHeadLook             (const cEntity & a_Entity) = 0;
 	virtual void SendEntityLook                 (const cEntity & a_Entity) = 0;
 	virtual void SendEntityMetadata             (const cEntity & a_Entity) = 0;
 	virtual void SendEntityPosition             (const cEntity & a_Entity) = 0;
 	virtual void SendEntityProperties           (const cEntity & a_Entity) = 0;
-	virtual void SendEntityStatus               (const cEntity & a_Entity, char a_Status) = 0;
 	virtual void SendEntityVelocity             (const cEntity & a_Entity) = 0;
 	virtual void SendExplosion                  (Vector3f a_Position, float a_Power) = 0;
 	virtual void SendGameMode                   (eGameMode a_GameMode) = 0;
@@ -441,7 +440,6 @@ public:
 	virtual void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ) = 0;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) = 0;
 	virtual void SendUpdateSign                 (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) = 0;
-	virtual void SendUseBed                     (const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ) = 0;
 	virtual void SendUnlockRecipe               (UInt32 a_RecipeID) = 0;
 	virtual void SendInitRecipes                (UInt32 a_RecipeID) = 0;
 	virtual void SendWeather                    (eWeather a_Weather) = 0;

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -25,21 +25,12 @@ class cExpOrb;
 class cPlayer;
 class cEntity;
 class cWindow;
-class cPickup;
 class cPainting;
 class cWorld;
 class cMonster;
-class cChunkDataSerializer;
-class cFallingBlock;
 class cCompositeChat;
 class cStatManager;
 class cPacketizer;
-
-
-
-
-
-typedef unsigned char Byte;
 
 
 
@@ -469,10 +460,10 @@ protected:
 	cByteBuffer m_OutPacketLenBuffer;
 
 	/** Returns the protocol-specific packet ID given the protocol-agnostic packet enum. */
-	virtual UInt32 GetPacketID(ePacketType a_Packet) = 0;
+	virtual UInt32 GetPacketID(ePacketType a_Packet) const = 0;
 
 	/** Returns the current protocol's version, for handling status requests. */
-	virtual Version GetProtocolVersion() = 0;
+	virtual Version GetProtocolVersion() const = 0;
 
 	/** A generic data-sending routine, all outgoing packet data needs to be routed through this so that descendants may override it. */
 	virtual void SendData(ContiguousByteBufferView a_Data) = 0;

--- a/src/Protocol/Protocol_1_10.cpp
+++ b/src/Protocol/Protocol_1_10.cpp
@@ -329,22 +329,22 @@ void cProtocol_1_10_0::SendSoundEffect(const AString & a_SoundName, double a_X, 
 
 
 
-cProtocol::Version cProtocol_1_10_0::GetProtocolVersion()
-{
-	return Version::v1_10_0;
-}
-
-
-
-
-
-UInt32 cProtocol_1_10_0::GetProtocolMobType(const eMonsterType a_MobType)
+UInt32 cProtocol_1_10_0::GetProtocolMobType(const eMonsterType a_MobType) const
 {
 	switch (a_MobType)
 	{
 		case mtPolarBear: return 102;
 		default:          return Super::GetProtocolMobType(a_MobType);
 	}
+}
+
+
+
+
+
+cProtocol::Version cProtocol_1_10_0::GetProtocolVersion() const
+{
+	return Version::v1_10_0;
 }
 
 
@@ -360,7 +360,7 @@ void cProtocol_1_10_0::HandlePacketResourcePackStatus(cByteBuffer & a_ByteBuffer
 
 
 
-void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const
 {
 	using namespace Metadata;
 
@@ -413,7 +413,7 @@ void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEUInt8(PLAYER_MAIN_HAND);
 			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetMainHand()));
+			a_Pkt.WriteBEUInt8(Player.IsLeftHanded() ? 0 : 1);
 			break;
 		}
 		case cEntity::etPickup:
@@ -581,7 +581,7 @@ void cProtocol_1_10_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 
 
-void cProtocol_1_10_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_10_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const
 {
 	using namespace Metadata;
 

--- a/src/Protocol/Protocol_1_10.h
+++ b/src/Protocol/Protocol_1_10.h
@@ -32,9 +32,11 @@ protected:
 
 	virtual void SendSoundEffect(const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch) override;
 
-	virtual Version GetProtocolVersion() override;
-	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) override;
+	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) const override;
+	virtual Version GetProtocolVersion() const override;
+
 	virtual void HandlePacketResourcePackStatus(cByteBuffer & a_ByteBuffer) override;
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) override;
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override;
+
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const override;
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const override;
 };

--- a/src/Protocol/Protocol_1_11.cpp
+++ b/src/Protocol/Protocol_1_11.cpp
@@ -492,16 +492,24 @@ void cProtocol_1_11_0::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 
 
 
-cProtocol::Version cProtocol_1_11_0::GetProtocolVersion()
+signed char cProtocol_1_11_0::GetProtocolEntityStatus(const EntityAnimation a_Animation) const
 {
-	return Version::v1_11_0;
+	switch (a_Animation)
+	{
+		case EntityAnimation::EggCracks: return 3;
+		case EntityAnimation::EvokerFangsAttacks: return 4;
+		case EntityAnimation::IronGolemStashesGift: return 34;
+		case EntityAnimation::PawnTotemActivates: return 35;
+		case EntityAnimation::SnowballPoofs: return 3;
+		default: return Super::GetProtocolEntityStatus(a_Animation);
+	}
 }
 
 
 
 
 
-UInt32 cProtocol_1_11_0::GetProtocolMobType(const eMonsterType a_MobType)
+UInt32 cProtocol_1_11_0::GetProtocolMobType(const eMonsterType a_MobType) const
 {
 	switch (a_MobType)
 	{
@@ -561,17 +569,9 @@ UInt32 cProtocol_1_11_0::GetProtocolMobType(const eMonsterType a_MobType)
 
 
 
-signed char cProtocol_1_11_0::GetProtocolEntityStatus(const EntityAnimation a_Animation) const
+cProtocol::Version cProtocol_1_11_0::GetProtocolVersion() const
 {
-	switch (a_Animation)
-	{
-		case EntityAnimation::EggCracks: return 3;
-		case EntityAnimation::EvokerFangsAttacks: return 4;
-		case EntityAnimation::IronGolemStashesGift: return 34;
-		case EntityAnimation::PawnTotemActivates: return 35;
-		case EntityAnimation::SnowballPoofs: return 3;
-		default: return Super::GetProtocolEntityStatus(a_Animation);
-	}
+	return Version::v1_11_0;
 }
 
 
@@ -592,14 +592,14 @@ void cProtocol_1_11_0::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, CursorY);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, CursorZ);
 
-	m_Client->HandleRightClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), FloorC(CursorX * 16), FloorC(CursorY * 16), FloorC(CursorZ * 16), HandIntToEnum(Hand));
+	m_Client->HandleRightClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), FloorC(CursorX * 16), FloorC(CursorY * 16), FloorC(CursorZ * 16), Hand == 0);
 }
 
 
 
 
 
-void cProtocol_1_11_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity)
+void cProtocol_1_11_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) const
 {
 	a_Writer.AddInt("x", a_BlockEntity.GetPosX());
 	a_Writer.AddInt("y", a_BlockEntity.GetPosY());
@@ -632,7 +632,7 @@ void cProtocol_1_11_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockE
 
 
 
-void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const
 {
 	using namespace Metadata_1_11;
 
@@ -685,7 +685,7 @@ void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 			a_Pkt.WriteBEUInt8(PLAYER_MAIN_HAND);
 			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetMainHand()));
+			a_Pkt.WriteBEUInt8(Player.IsLeftHanded() ? 0 : 1);
 			break;
 		}
 		case cEntity::etPickup:
@@ -855,7 +855,7 @@ void cProtocol_1_11_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 
 
 
-void cProtocol_1_11_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_11_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const
 {
 	using namespace Metadata_1_11;
 
@@ -1273,7 +1273,7 @@ void cProtocol_1_11_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_11_1:
 
-cProtocol::Version cProtocol_1_11_1::GetProtocolVersion()
+cProtocol::Version cProtocol_1_11_1::GetProtocolVersion() const
 {
 	return Version::v1_11_1;
 }

--- a/src/Protocol/Protocol_1_11.h
+++ b/src/Protocol/Protocol_1_11.h
@@ -33,6 +33,7 @@ public:
 protected:
 
 	virtual void SendCollectEntity    (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count) override;
+	virtual void SendEntityAnimation  (const cEntity & a_Entity, EntityAnimation a_Animation) override;
 	virtual void SendHideTitle        (void) override;
 	virtual void SendResetTitle       (void) override;
 	virtual void SendSpawnMob         (const cMonster & a_Mob) override;
@@ -44,6 +45,7 @@ protected:
 
 	/** Converts eMonsterType to protocol-specific mob IDs */
 	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) override;
+	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
 
 	virtual void HandlePacketBlockPlace   (cByteBuffer & a_ByteBuffer) override;
 

--- a/src/Protocol/Protocol_1_11.h
+++ b/src/Protocol/Protocol_1_11.h
@@ -40,18 +40,15 @@ protected:
 	virtual void SendTitleTimes       (int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks) override;
 	virtual void SendUpdateBlockEntity(cBlockEntity & a_BlockEntity) override;
 
-	/** Returns 1.11. */
-	virtual Version GetProtocolVersion() override;
-
-	/** Converts eMonsterType to protocol-specific mob IDs */
-	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) override;
 	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
+	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) const override;
+	virtual Version GetProtocolVersion() const override;
 
-	virtual void HandlePacketBlockPlace   (cByteBuffer & a_ByteBuffer) override;
+	virtual void HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer) override;
 
-	virtual void WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) override;
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) override;
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override;
+	virtual void WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) const override;
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const override;
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const override;
 };
 
 
@@ -69,5 +66,5 @@ public:
 
 protected:
 
-	virtual Version GetProtocolVersion() override;
+	virtual Version GetProtocolVersion() const override;
 };

--- a/src/Protocol/Protocol_1_12.cpp
+++ b/src/Protocol/Protocol_1_12.cpp
@@ -1070,6 +1070,20 @@ cProtocol::Version cProtocol_1_12::GetProtocolVersion()
 
 
 
+signed char cProtocol_1_12::GetProtocolEntityStatus(EntityAnimation a_Animation) const
+{
+	switch (a_Animation)
+	{
+		case EntityAnimation::PawnBurns: return 37;
+		case EntityAnimation::PawnDrowns: return 36;
+		default: return Super::GetProtocolEntityStatus(a_Animation);
+	}
+}
+
+
+
+
+
 UInt32 cProtocol_1_12::GetProtocolMobType(const eMonsterType a_MobType)
 {
 	switch (a_MobType)

--- a/src/Protocol/Protocol_1_12.cpp
+++ b/src/Protocol/Protocol_1_12.cpp
@@ -323,7 +323,7 @@ namespace Metadata_1_12
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_12:
 
-void cProtocol_1_12::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_12::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const
 {
 	using namespace Metadata_1_12;
 
@@ -380,7 +380,7 @@ void cProtocol_1_12::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_
 
 			a_Pkt.WriteBEUInt8(PLAYER_MAIN_HAND);
 			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetMainHand()));
+			a_Pkt.WriteBEUInt8(Player.IsLeftHanded() ? 0 : 1);
 			break;
 		}
 		case cEntity::etPickup:
@@ -550,7 +550,7 @@ void cProtocol_1_12::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_
 
 
 
-void cProtocol_1_12::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_12::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const
 {
 	using namespace Metadata_1_12;
 
@@ -982,7 +982,7 @@ void cProtocol_1_12::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mo
 
 
 
-UInt32 cProtocol_1_12::GetPacketID(cProtocol::ePacketType a_Packet)
+UInt32 cProtocol_1_12::GetPacketID(cProtocol::ePacketType a_Packet) const
 {
 	switch (a_Packet)
 	{
@@ -1061,15 +1061,6 @@ void cProtocol_1_12::HandlePacketAdvancementTab(cByteBuffer & a_ByteBuffer)
 
 
 
-cProtocol::Version cProtocol_1_12::GetProtocolVersion()
-{
-	return Version::v1_12;
-}
-
-
-
-
-
 signed char cProtocol_1_12::GetProtocolEntityStatus(EntityAnimation a_Animation) const
 {
 	switch (a_Animation)
@@ -1084,7 +1075,7 @@ signed char cProtocol_1_12::GetProtocolEntityStatus(EntityAnimation a_Animation)
 
 
 
-UInt32 cProtocol_1_12::GetProtocolMobType(const eMonsterType a_MobType)
+UInt32 cProtocol_1_12::GetProtocolMobType(const eMonsterType a_MobType) const
 {
 	switch (a_MobType)
 	{
@@ -1092,6 +1083,15 @@ UInt32 cProtocol_1_12::GetProtocolMobType(const eMonsterType a_MobType)
 		case mtParrot:     return 105;
 		default:           return Super::GetProtocolMobType(a_MobType);
 	}
+}
+
+
+
+
+
+cProtocol::Version cProtocol_1_12::GetProtocolVersion() const
+{
+	return Version::v1_12;
 }
 
 
@@ -1176,7 +1176,7 @@ bool cProtocol_1_12::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketTyp
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_12_1:
 
-UInt32 cProtocol_1_12_1::GetPacketID(ePacketType a_Packet)
+UInt32 cProtocol_1_12_1::GetPacketID(ePacketType a_Packet) const
 {
 	switch (a_Packet)
 	{
@@ -1219,7 +1219,7 @@ UInt32 cProtocol_1_12_1::GetPacketID(ePacketType a_Packet)
 
 
 
-cProtocol::Version cProtocol_1_12_1::GetProtocolVersion()
+cProtocol::Version cProtocol_1_12_1::GetProtocolVersion() const
 {
 	return Version::v1_12_1;
 }
@@ -1305,7 +1305,7 @@ bool cProtocol_1_12_1::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketT
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_12_2::
 
-cProtocol::Version cProtocol_1_12_2::GetProtocolVersion()
+cProtocol::Version cProtocol_1_12_2::GetProtocolVersion() const
 {
 	return Version::v1_12_2;
 }

--- a/src/Protocol/Protocol_1_12.cpp
+++ b/src/Protocol/Protocol_1_12.cpp
@@ -1003,7 +1003,6 @@ UInt32 cProtocol_1_12::GetPacketID(cProtocol::ePacketType a_Packet)
 		case pktExperience:          return 0x3f;
 		case pktHeldItemChange:      return 0x39;
 		case pktLeashEntity:         return 0x3c;
-		case pktPlayerMaxSpeed:      return 0x4d;
 		case pktRemoveEntityEffect:  return 0x32;
 		case pktResourcePack:        return 0x33;
 		case pktRespawn:             return 0x34;
@@ -1184,7 +1183,6 @@ UInt32 cProtocol_1_12_1::GetPacketID(ePacketType a_Packet)
 		case pktPlayerList:             return 0x2e;
 		case pktPlayerListHeaderFooter: return 0x4a;
 		case pktPlayerAbilities:        return 0x2c;
-		case pktPlayerMaxSpeed:         return 0x4e;
 		case pktPlayerMoveLook:         return 0x2f;
 		case pktRemoveEntityEffect:     return 0x33;
 		case pktResourcePack:           return 0x34;

--- a/src/Protocol/Protocol_1_12.h
+++ b/src/Protocol/Protocol_1_12.h
@@ -34,16 +34,18 @@ public:
 
 protected:
 
-	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
-	virtual Version GetProtocolVersion() override;
+	virtual UInt32 GetPacketID(ePacketType a_Packet) const override;
 	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
-	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) override;
+	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) const override;
+	virtual Version GetProtocolVersion() const override;
+
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 	virtual void HandlePacketAdvancementTab(cByteBuffer & a_ByteBuffer);
 	virtual void HandleCraftRecipe(cByteBuffer & a_ByteBuffer);
 	virtual void HandlePacketCraftingBookData(cByteBuffer & a_ByteBuffer);
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) override;
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override;
+
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const override;
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const override;
 };
 
 
@@ -61,8 +63,9 @@ public:
 
 protected:
 
-	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
-	virtual Version GetProtocolVersion() override;
+	virtual UInt32 GetPacketID(ePacketType a_Packet) const override;
+	virtual Version GetProtocolVersion() const override;
+
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 };
 
@@ -81,8 +84,10 @@ public:
 
 protected:
 
-	virtual Version GetProtocolVersion() override;
+	virtual Version GetProtocolVersion() const override;
+
 	virtual void HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer) override;
+
 	virtual void SendKeepAlive(UInt32 a_PingID) override;
 	virtual void SendUnlockRecipe(UInt32 a_RecipeID) override;
 	virtual void SendInitRecipes(UInt32 a_RecipeID) override;

--- a/src/Protocol/Protocol_1_12.h
+++ b/src/Protocol/Protocol_1_12.h
@@ -36,6 +36,7 @@ protected:
 
 	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
 	virtual Version GetProtocolVersion() override;
+	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
 	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) override;
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 	virtual void HandlePacketAdvancementTab(cByteBuffer & a_ByteBuffer);

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -238,257 +238,7 @@ void cProtocol_1_13::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 
 
 
-bool cProtocol_1_13::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
-{
-	if (m_State != 3)
-	{
-		return Super::HandlePacket(a_ByteBuffer, a_PacketType);
-	}
-
-	// Game
-	switch (a_PacketType)
-	{
-		case 0x00: HandleConfirmTeleport(a_ByteBuffer); return true;
-		case 0x05: HandlePacketTabComplete(a_ByteBuffer); return true;
-		case 0x02: HandlePacketChatMessage(a_ByteBuffer); return true;
-		case 0x03: HandlePacketClientStatus(a_ByteBuffer); return true;
-		case 0x04: HandlePacketClientSettings(a_ByteBuffer); return true;
-		case 0x06: break;  // Confirm transaction - not used in Cuberite
-		case 0x07: HandlePacketEnchantItem(a_ByteBuffer); return true;
-		case 0x08: HandlePacketWindowClick(a_ByteBuffer); return true;
-		case 0x09: HandlePacketWindowClose(a_ByteBuffer); return true;
-		case 0x0a: HandlePacketPluginMessage(a_ByteBuffer); return true;
-		case 0x0d: HandlePacketUseEntity(a_ByteBuffer); return true;
-		case 0x0e: HandlePacketKeepAlive(a_ByteBuffer); return true;
-		case 0x0f: HandlePacketPlayer(a_ByteBuffer); return true;
-		case 0x10: HandlePacketPlayerPos(a_ByteBuffer); return true;
-		case 0x11: HandlePacketPlayerPosLook(a_ByteBuffer); return true;
-		case 0x12: HandlePacketPlayerLook(a_ByteBuffer); return true;
-		case 0x13: HandlePacketVehicleMove(a_ByteBuffer); return true;
-		case 0x14: HandlePacketBoatSteer(a_ByteBuffer); return true;
-		case 0x15: break;  // Pick item - not yet implemented
-		case 0x16: break;  // Craft Recipe Request - not yet implemented
-		case 0x17: HandlePacketPlayerAbilities(a_ByteBuffer); return true;
-		case 0x18: HandlePacketBlockDig(a_ByteBuffer); return true;
-		case 0x19: HandlePacketEntityAction(a_ByteBuffer); return true;
-		case 0x1a: HandlePacketSteerVehicle(a_ByteBuffer); return true;
-		case 0x1b: HandlePacketCraftingBookData(a_ByteBuffer); return true;
-		case 0x1d: break;  // Resource pack status - not yet implemented
-		case 0x1e: HandlePacketAdvancementTab(a_ByteBuffer); return true;
-		case 0x20: HandlePacketSetBeaconEffect(a_ByteBuffer); return true;
-		case 0x21: HandlePacketSlotSelect(a_ByteBuffer); return true;
-		case 0x24: HandlePacketCreativeInventoryAction(a_ByteBuffer); return true;
-		case 0x26: HandlePacketUpdateSign(a_ByteBuffer); return true;
-		case 0x27: HandlePacketAnimation(a_ByteBuffer); return true;
-		case 0x28: HandlePacketSpectate(a_ByteBuffer); return true;
-		case 0x29: HandlePacketBlockPlace(a_ByteBuffer); return true;
-		case 0x2a: HandlePacketUseItem(a_ByteBuffer); return true;
-	}
-
-	return Super::HandlePacket(a_ByteBuffer, a_PacketType);
-}
-
-
-
-
-
-void cProtocol_1_13::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
-{
-	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Channel);
-
-	// If the plugin channel is recognized vanilla, handle it directly:
-	if (Channel.substr(0, 15) == "minecraft:brand")
-	{
-		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Brand);
-		m_Client->SetClientBrand(Brand);
-
-		// Send back our brand, including the length:
-		m_Client->SendPluginMessage("minecraft:brand", "\x08""Cuberite");
-		return;
-	}
-
-	ContiguousByteBuffer Data;
-
-	// Read the plugin message and relay to clienthandle:
-	VERIFY(a_ByteBuffer.ReadSome(Data, a_ByteBuffer.GetReadableSpace()));  // Always succeeds
-	m_Client->HandlePluginMessage(Channel, Data);
-}
-
-
-
-
-
-void cProtocol_1_13::HandlePacketSetBeaconEffect(cByteBuffer & a_ByteBuffer)
-{
-	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, Effect1);
-	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, Effect2);
-	m_Client->HandleBeaconSelection(Effect1, Effect2);
-}
-
-
-
-
-
-cProtocol::Version cProtocol_1_13::GetProtocolVersion()
-{
-	return Version::v1_13;
-}
-
-
-
-
-
-UInt32 cProtocol_1_13::GetPacketID(ePacketType a_PacketType)
-{
-	switch (a_PacketType)
-	{
-		case pktAttachEntity:           return 0x46;
-		case pktBlockChanges:           return 0x0f;
-		case pktCameraSetTo:            return 0x3c;
-		case pktChatRaw:                return 0x0e;
-		case pktCollectEntity:          return 0x4f;
-		case pktDestroyEntity:          return 0x35;
-		case pktDisconnectDuringGame:   return 0x1b;
-		case pktEditSign:               return 0x2c;
-		case pktEntityEffect:           return 0x53;
-		case pktEntityEquipment:        return 0x42;
-		case pktEntityHeadLook:         return 0x39;
-		case pktEntityLook:             return 0x2a;
-		case pktEntityMeta:             return 0x3f;
-		case pktEntityProperties:       return 0x52;
-		case pktEntityRelMove:          return 0x28;
-		case pktEntityRelMoveLook:      return 0x29;
-		case pktEntityStatus:           return 0x1c;
-		case pktEntityVelocity:         return 0x41;
-		case pktExperience:             return 0x43;
-		case pktExplosion:              return 0x1e;
-		case pktGameMode:               return 0x20;
-		case pktHeldItemChange:         return 0x3d;
-		case pktInventorySlot:          return 0x17;
-		case pktJoinGame:               return 0x25;
-		case pktKeepAlive:              return 0x21;
-		case pktLeashEntity:            return 0x40;
-		case pktMapData:                return 0x26;
-		case pktParticleEffect:         return 0x24;
-		case pktPlayerAbilities:        return 0x2e;
-		case pktPlayerList:             return 0x30;
-		case pktPlayerListHeaderFooter: return 0x4e;
-		case pktPlayerMoveLook:         return 0x32;
-		case pktPluginMessage:          return 0x19;
-		case pktRemoveEntityEffect:     return 0x36;
-		case pktRespawn:                return 0x38;
-		case pktScoreboardObjective:    return 0x45;
-		case pktSoundEffect:            return 0x1a;
-		case pktSoundParticleEffect:    return 0x23;
-		case pktSpawnPosition:          return 0x49;
-		case pktTabCompletionResults:   return 0x10;
-		case pktTeleportEntity:         return 0x50;
-		case pktTimeUpdate:             return 0x4a;
-		case pktTitle:                  return 0x4b;
-		case pktUnloadChunk:            return 0x1f;
-		case pktUnlockRecipe:           return 0x32;
-		case pktUpdateHealth:           return 0x44;
-		case pktUpdateScore:            return 0x48;
-		case pktUpdateSign:             return GetPacketID(pktUpdateBlockEntity);
-		case pktUseBed:                 return 0x33;
-		case pktWindowClose:            return 0x13;
-		case pktWindowItems:            return 0x15;
-		case pktWindowOpen:             return 0x14;
-		case pktWindowProperty:         return 0x16;
-		default: return Super::GetPacketID(a_PacketType);
-	}
-}
-
-
-
-
-
-signed char cProtocol_1_13::GetProtocolEntityStatus(const EntityAnimation a_Animation) const
-{
-	switch (a_Animation)
-	{
-		case EntityAnimation::DolphinShowsHappiness: return 38;
-		default: return Super::GetProtocolEntityStatus(a_Animation);
-	}
-}
-
-
-
-
-
-UInt32 cProtocol_1_13::GetProtocolMobType(eMonsterType a_MobType)
-{
-	switch (a_MobType)
-	{
-		// Map invalid type to Giant for easy debugging (if this ever spawns, something has gone very wrong)
-		case mtInvalidType:           return 27;
-		case mtBat:                   return 3;
-		case mtCat:                   return 48;
-		case mtBlaze:                 return 4;
-		case mtCaveSpider:            return 6;
-		case mtChicken:               return 7;
-		case mtCod:                   return 8;
-		case mtCow:                   return 9;
-		case mtCreeper:               return 10;
-		case mtDonkey:                return 11;
-		case mtDolphin:               return 12;
-		case mtDrowned:               return 14;
-		case mtElderGuardian:         return 15;
-		case mtEnderDragon:           return 17;
-		case mtEnderman:              return 18;
-		case mtEndermite:             return 19;
-		case mtEvoker:                return 21;
-		case mtGhast:                 return 26;
-		case mtGiant:                 return 27;
-		case mtGuardian:              return 28;
-		case mtHorse:                 return 29;
-		case mtHusk:                  return 30;
-		case mtIllusioner:            return 31;
-		case mtIronGolem:             return 80;
-		case mtLlama:                 return 36;
-		case mtMagmaCube:             return 38;
-		case mtMule:                  return 46;
-		case mtMooshroom:             return 47;
-		case mtOcelot:                return 48;
-		case mtParrot:                return 50;
-		case mtPhantom:               return 90;
-		case mtPig:                   return 51;
-		case mtPufferfish:            return 52;
-		case mtPolarBear:             return 54;
-		case mtRabbit:                return 56;
-		case mtSalmon:                return 57;
-		case mtSheep:                 return 58;
-		case mtShulker:               return 59;
-		case mtSilverfish:            return 61;
-		case mtSkeleton:              return 62;
-		case mtSkeletonHorse:         return 63;
-		case mtSlime:                 return 64;
-		case mtSnowGolem:             return 66;
-		case mtSpider:                return 69;
-		case mtSquid:                 return 70;
-		case mtStray:                 return 71;
-		case mtTropicalFish:          return 72;
-		case mtTurtle:                return 73;
-		case mtVex:                   return 78;
-		case mtVillager:              return 79;
-		case mtVindicator:            return 81;
-		case mtWitch:                 return 82;
-		case mtWither:                return 83;
-		case mtWitherSkeleton:        return 84;
-		case mtWolf:                  return 86;
-		case mtZombie:                return 87;
-		case mtZombiePigman:          return 53;
-		case mtZombieHorse:           return 88;
-		case mtZombieVillager:        return 89;
-		default:                      return 0;
-	}
-}
-
-
-
-
-
-UInt8 cProtocol_1_13::GetEntityMetadataID(EntityMetadata a_Metadata)
+UInt8 cProtocol_1_13::GetEntityMetadataID(EntityMetadata a_Metadata) const
 {
 	const UInt8 Entity = 6;
 	const UInt8 Living = Entity + 5;
@@ -621,7 +371,7 @@ UInt8 cProtocol_1_13::GetEntityMetadataID(EntityMetadata a_Metadata)
 
 
 
-UInt8 cProtocol_1_13::GetEntityMetadataID(EntityMetadataType a_FieldType)
+UInt8 cProtocol_1_13::GetEntityMetadataID(EntityMetadataType a_FieldType) const
 {
 	switch (a_FieldType)
 	{
@@ -652,7 +402,7 @@ UInt8 cProtocol_1_13::GetEntityMetadataID(EntityMetadataType a_FieldType)
 
 
 
-std::pair<short, short> cProtocol_1_13::GetItemFromProtocolID(UInt32 a_ProtocolID)
+std::pair<short, short> cProtocol_1_13::GetItemFromProtocolID(UInt32 a_ProtocolID) const
 {
 	return PaletteUpgrade::ToItem(Palette_1_13::ToItem(a_ProtocolID));
 }
@@ -661,7 +411,72 @@ std::pair<short, short> cProtocol_1_13::GetItemFromProtocolID(UInt32 a_ProtocolI
 
 
 
-UInt32 cProtocol_1_13::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta)
+UInt32 cProtocol_1_13::GetPacketID(ePacketType a_PacketType) const
+{
+	switch (a_PacketType)
+	{
+		case pktAttachEntity:           return 0x46;
+		case pktBlockChanges:           return 0x0f;
+		case pktCameraSetTo:            return 0x3c;
+		case pktChatRaw:                return 0x0e;
+		case pktCollectEntity:          return 0x4f;
+		case pktDestroyEntity:          return 0x35;
+		case pktDisconnectDuringGame:   return 0x1b;
+		case pktEditSign:               return 0x2c;
+		case pktEntityEffect:           return 0x53;
+		case pktEntityEquipment:        return 0x42;
+		case pktEntityHeadLook:         return 0x39;
+		case pktEntityLook:             return 0x2a;
+		case pktEntityMeta:             return 0x3f;
+		case pktEntityProperties:       return 0x52;
+		case pktEntityRelMove:          return 0x28;
+		case pktEntityRelMoveLook:      return 0x29;
+		case pktEntityStatus:           return 0x1c;
+		case pktEntityVelocity:         return 0x41;
+		case pktExperience:             return 0x43;
+		case pktExplosion:              return 0x1e;
+		case pktGameMode:               return 0x20;
+		case pktHeldItemChange:         return 0x3d;
+		case pktInventorySlot:          return 0x17;
+		case pktJoinGame:               return 0x25;
+		case pktKeepAlive:              return 0x21;
+		case pktLeashEntity:            return 0x40;
+		case pktMapData:                return 0x26;
+		case pktParticleEffect:         return 0x24;
+		case pktPlayerAbilities:        return 0x2e;
+		case pktPlayerList:             return 0x30;
+		case pktPlayerListHeaderFooter: return 0x4e;
+		case pktPlayerMoveLook:         return 0x32;
+		case pktPluginMessage:          return 0x19;
+		case pktRemoveEntityEffect:     return 0x36;
+		case pktRespawn:                return 0x38;
+		case pktScoreboardObjective:    return 0x45;
+		case pktSoundEffect:            return 0x1a;
+		case pktSoundParticleEffect:    return 0x23;
+		case pktSpawnPosition:          return 0x49;
+		case pktTabCompletionResults:   return 0x10;
+		case pktTeleportEntity:         return 0x50;
+		case pktTimeUpdate:             return 0x4a;
+		case pktTitle:                  return 0x4b;
+		case pktUnloadChunk:            return 0x1f;
+		case pktUnlockRecipe:           return 0x32;
+		case pktUpdateHealth:           return 0x44;
+		case pktUpdateScore:            return 0x48;
+		case pktUpdateSign:             return GetPacketID(pktUpdateBlockEntity);
+		case pktUseBed:                 return 0x33;
+		case pktWindowClose:            return 0x13;
+		case pktWindowItems:            return 0x15;
+		case pktWindowOpen:             return 0x14;
+		case pktWindowProperty:         return 0x16;
+		default: return Super::GetPacketID(a_PacketType);
+	}
+}
+
+
+
+
+
+UInt32 cProtocol_1_13::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) const
 {
 	return Palette_1_13::From(PaletteUpgrade::FromBlock(a_BlockType, a_Meta));
 }
@@ -670,7 +485,20 @@ UInt32 cProtocol_1_13::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_
 
 
 
-UInt32 cProtocol_1_13::GetProtocolItemType(short a_ItemID, short a_ItemDamage)
+signed char cProtocol_1_13::GetProtocolEntityStatus(const EntityAnimation a_Animation) const
+{
+	switch (a_Animation)
+	{
+		case EntityAnimation::DolphinShowsHappiness: return 38;
+		default: return Super::GetProtocolEntityStatus(a_Animation);
+	}
+}
+
+
+
+
+
+UInt32 cProtocol_1_13::GetProtocolItemType(short a_ItemID, short a_ItemDamage) const
 {
 	return Palette_1_13::From(PaletteUpgrade::FromItem(a_ItemID, a_ItemDamage));
 }
@@ -679,7 +507,79 @@ UInt32 cProtocol_1_13::GetProtocolItemType(short a_ItemID, short a_ItemDamage)
 
 
 
-UInt32 cProtocol_1_13::GetProtocolStatisticType(Statistic a_Statistic)
+UInt32 cProtocol_1_13::GetProtocolMobType(eMonsterType a_MobType) const
+{
+	switch (a_MobType)
+	{
+		// Map invalid type to Giant for easy debugging (if this ever spawns, something has gone very wrong)
+		case mtInvalidType:           return 27;
+		case mtBat:                   return 3;
+		case mtCat:                   return 48;
+		case mtBlaze:                 return 4;
+		case mtCaveSpider:            return 6;
+		case mtChicken:               return 7;
+		case mtCod:                   return 8;
+		case mtCow:                   return 9;
+		case mtCreeper:               return 10;
+		case mtDonkey:                return 11;
+		case mtDolphin:               return 12;
+		case mtDrowned:               return 14;
+		case mtElderGuardian:         return 15;
+		case mtEnderDragon:           return 17;
+		case mtEnderman:              return 18;
+		case mtEndermite:             return 19;
+		case mtEvoker:                return 21;
+		case mtGhast:                 return 26;
+		case mtGiant:                 return 27;
+		case mtGuardian:              return 28;
+		case mtHorse:                 return 29;
+		case mtHusk:                  return 30;
+		case mtIllusioner:            return 31;
+		case mtIronGolem:             return 80;
+		case mtLlama:                 return 36;
+		case mtMagmaCube:             return 38;
+		case mtMule:                  return 46;
+		case mtMooshroom:             return 47;
+		case mtOcelot:                return 48;
+		case mtParrot:                return 50;
+		case mtPhantom:               return 90;
+		case mtPig:                   return 51;
+		case mtPufferfish:            return 52;
+		case mtPolarBear:             return 54;
+		case mtRabbit:                return 56;
+		case mtSalmon:                return 57;
+		case mtSheep:                 return 58;
+		case mtShulker:               return 59;
+		case mtSilverfish:            return 61;
+		case mtSkeleton:              return 62;
+		case mtSkeletonHorse:         return 63;
+		case mtSlime:                 return 64;
+		case mtSnowGolem:             return 66;
+		case mtSpider:                return 69;
+		case mtSquid:                 return 70;
+		case mtStray:                 return 71;
+		case mtTropicalFish:          return 72;
+		case mtTurtle:                return 73;
+		case mtVex:                   return 78;
+		case mtVillager:              return 79;
+		case mtVindicator:            return 81;
+		case mtWitch:                 return 82;
+		case mtWither:                return 83;
+		case mtWitherSkeleton:        return 84;
+		case mtWolf:                  return 86;
+		case mtZombie:                return 87;
+		case mtZombiePigman:          return 53;
+		case mtZombieHorse:           return 88;
+		case mtZombieVillager:        return 89;
+		default:                      return 0;
+	}
+}
+
+
+
+
+
+UInt32 cProtocol_1_13::GetProtocolStatisticType(Statistic a_Statistic) const
 {
 	return Palette_1_13::From(a_Statistic);
 }
@@ -688,7 +588,107 @@ UInt32 cProtocol_1_13::GetProtocolStatisticType(Statistic a_Statistic)
 
 
 
-bool cProtocol_1_13::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes)
+cProtocol::Version cProtocol_1_13::GetProtocolVersion() const
+{
+	return Version::v1_13;
+}
+
+
+
+
+
+bool cProtocol_1_13::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType)
+{
+	if (m_State != 3)
+	{
+		return Super::HandlePacket(a_ByteBuffer, a_PacketType);
+	}
+
+	// Game
+	switch (a_PacketType)
+	{
+		case 0x00: HandleConfirmTeleport(a_ByteBuffer); return true;
+		case 0x05: HandlePacketTabComplete(a_ByteBuffer); return true;
+		case 0x02: HandlePacketChatMessage(a_ByteBuffer); return true;
+		case 0x03: HandlePacketClientStatus(a_ByteBuffer); return true;
+		case 0x04: HandlePacketClientSettings(a_ByteBuffer); return true;
+		case 0x06: break;  // Confirm transaction - not used in Cuberite
+		case 0x07: HandlePacketEnchantItem(a_ByteBuffer); return true;
+		case 0x08: HandlePacketWindowClick(a_ByteBuffer); return true;
+		case 0x09: HandlePacketWindowClose(a_ByteBuffer); return true;
+		case 0x0a: HandlePacketPluginMessage(a_ByteBuffer); return true;
+		case 0x0d: HandlePacketUseEntity(a_ByteBuffer); return true;
+		case 0x0e: HandlePacketKeepAlive(a_ByteBuffer); return true;
+		case 0x0f: HandlePacketPlayer(a_ByteBuffer); return true;
+		case 0x10: HandlePacketPlayerPos(a_ByteBuffer); return true;
+		case 0x11: HandlePacketPlayerPosLook(a_ByteBuffer); return true;
+		case 0x12: HandlePacketPlayerLook(a_ByteBuffer); return true;
+		case 0x13: HandlePacketVehicleMove(a_ByteBuffer); return true;
+		case 0x14: HandlePacketBoatSteer(a_ByteBuffer); return true;
+		case 0x15: break;  // Pick item - not yet implemented
+		case 0x16: break;  // Craft Recipe Request - not yet implemented
+		case 0x17: HandlePacketPlayerAbilities(a_ByteBuffer); return true;
+		case 0x18: HandlePacketBlockDig(a_ByteBuffer); return true;
+		case 0x19: HandlePacketEntityAction(a_ByteBuffer); return true;
+		case 0x1a: HandlePacketSteerVehicle(a_ByteBuffer); return true;
+		case 0x1b: HandlePacketCraftingBookData(a_ByteBuffer); return true;
+		case 0x1d: break;  // Resource pack status - not yet implemented
+		case 0x1e: HandlePacketAdvancementTab(a_ByteBuffer); return true;
+		case 0x20: HandlePacketSetBeaconEffect(a_ByteBuffer); return true;
+		case 0x21: HandlePacketSlotSelect(a_ByteBuffer); return true;
+		case 0x24: HandlePacketCreativeInventoryAction(a_ByteBuffer); return true;
+		case 0x26: HandlePacketUpdateSign(a_ByteBuffer); return true;
+		case 0x27: HandlePacketAnimation(a_ByteBuffer); return true;
+		case 0x28: HandlePacketSpectate(a_ByteBuffer); return true;
+		case 0x29: HandlePacketBlockPlace(a_ByteBuffer); return true;
+		case 0x2a: HandlePacketUseItem(a_ByteBuffer); return true;
+	}
+
+	return Super::HandlePacket(a_ByteBuffer, a_PacketType);
+}
+
+
+
+
+
+void cProtocol_1_13::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
+{
+	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Channel);
+
+	// If the plugin channel is recognized vanilla, handle it directly:
+	if (Channel.substr(0, 15) == "minecraft:brand")
+	{
+		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Brand);
+		m_Client->SetClientBrand(Brand);
+
+		// Send back our brand, including the length:
+		m_Client->SendPluginMessage("minecraft:brand", "\x08""Cuberite");
+		return;
+	}
+
+	ContiguousByteBuffer Data;
+
+	// Read the plugin message and relay to clienthandle:
+	VERIFY(a_ByteBuffer.ReadSome(Data, a_ByteBuffer.GetReadableSpace()));  // Always succeeds
+	m_Client->HandlePluginMessage(Channel, Data);
+}
+
+
+
+
+
+void cProtocol_1_13::HandlePacketSetBeaconEffect(cByteBuffer & a_ByteBuffer)
+{
+	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, Effect1);
+	HANDLE_READ(a_ByteBuffer, ReadVarInt32, UInt32, Effect2);
+	m_Client->HandleBeaconSelection(Effect1, Effect2);
+}
+
+
+
+
+
+bool cProtocol_1_13::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) const
 {
 	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt16, Int16, ItemID);
 	if (ItemID == -1)
@@ -724,35 +724,7 @@ bool cProtocol_1_13::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t
 
 
 
-void cProtocol_1_13::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
-{
-	short ItemType = a_Item.m_ItemType;
-	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime
-	if (ItemType <= 0)
-	{
-		// Fix, to make sure no invalid values are sent.
-		ItemType = -1;
-	}
-
-	if (a_Item.IsEmpty())
-	{
-		a_Pkt.WriteBEInt16(-1);
-		return;
-	}
-
-	// Normal item
-	a_Pkt.WriteBEInt16(static_cast<Int16>(GetProtocolItemType(a_Item.m_ItemType, a_Item.m_ItemDamage)));
-	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
-
-	// TODO: NBT
-	a_Pkt.WriteBEInt8(0);
-}
-
-
-
-
-
-void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const EntityMetadata a_Metadata, const EntityMetadataType a_FieldType)
+void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const EntityMetadata a_Metadata, const EntityMetadataType a_FieldType) const
 {
 	a_Pkt.WriteBEUInt8(GetEntityMetadataID(a_Metadata));  // Index
 	a_Pkt.WriteBEUInt8(GetEntityMetadataID(a_FieldType));  // Type
@@ -762,7 +734,7 @@ void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const EntityMetada
 
 
 
-void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const
 {
 	// Common metadata:
 	Int8 Flags = 0;
@@ -809,7 +781,7 @@ void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_
 			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetSkinParts()));
 
 			WriteEntityMetadata(a_Pkt, EntityMetadata::PlayerMainHand, EntityMetadataType::Byte);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetMainHand()));
+			a_Pkt.WriteBEUInt8(Player.IsLeftHanded() ? 0 : 1);
 			break;
 		}
 		case cEntity::etPickup:
@@ -953,7 +925,35 @@ void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_
 
 
 
-void cProtocol_1_13::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_13::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const
+{
+	short ItemType = a_Item.m_ItemType;
+	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime
+	if (ItemType <= 0)
+	{
+		// Fix, to make sure no invalid values are sent.
+		ItemType = -1;
+	}
+
+	if (a_Item.IsEmpty())
+	{
+		a_Pkt.WriteBEInt16(-1);
+		return;
+	}
+
+	// Normal item
+	a_Pkt.WriteBEInt16(static_cast<Int16>(GetProtocolItemType(a_Item.m_ItemType, a_Item.m_ItemDamage)));
+	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
+
+	// TODO: NBT
+	a_Pkt.WriteBEInt8(0);
+}
+
+
+
+
+
+void cProtocol_1_13::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const
 {
 	// Living Enitiy Metadata
 	if (a_Mob.HasCustomName())
@@ -1444,16 +1444,7 @@ void cProtocol_1_13_1::SendBossBarUpdateFlags(UInt32 a_UniqueID, bool a_DarkenSk
 
 
 
-cProtocol::Version cProtocol_1_13_1::GetProtocolVersion()
-{
-	return Version::v1_13_1;
-}
-
-
-
-
-
-std::pair<short, short> cProtocol_1_13_1::GetItemFromProtocolID(UInt32 a_ProtocolID)
+std::pair<short, short> cProtocol_1_13_1::GetItemFromProtocolID(UInt32 a_ProtocolID) const
 {
 	return PaletteUpgrade::ToItem(Palette_1_13_1::ToItem(a_ProtocolID));
 }
@@ -1462,7 +1453,7 @@ std::pair<short, short> cProtocol_1_13_1::GetItemFromProtocolID(UInt32 a_Protoco
 
 
 
-UInt32 cProtocol_1_13_1::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta)
+UInt32 cProtocol_1_13_1::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) const
 {
 	return Palette_1_13_1::From(PaletteUpgrade::FromBlock(a_BlockType, a_Meta));
 }
@@ -1471,7 +1462,7 @@ UInt32 cProtocol_1_13_1::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE 
 
 
 
-UInt32 cProtocol_1_13_1::GetProtocolItemType(short a_ItemID, short a_ItemDamage)
+UInt32 cProtocol_1_13_1::GetProtocolItemType(short a_ItemID, short a_ItemDamage) const
 {
 	return Palette_1_13_1::From(PaletteUpgrade::FromItem(a_ItemID, a_ItemDamage));
 }
@@ -1480,9 +1471,18 @@ UInt32 cProtocol_1_13_1::GetProtocolItemType(short a_ItemID, short a_ItemDamage)
 
 
 
-UInt32 cProtocol_1_13_1::GetProtocolStatisticType(Statistic a_Statistic)
+UInt32 cProtocol_1_13_1::GetProtocolStatisticType(Statistic a_Statistic) const
 {
 	return Palette_1_13_1::From(a_Statistic);
+}
+
+
+
+
+
+cProtocol::Version cProtocol_1_13_1::GetProtocolVersion() const
+{
+	return Version::v1_13_1;
 }
 
 
@@ -1492,7 +1492,7 @@ UInt32 cProtocol_1_13_1::GetProtocolStatisticType(Statistic a_Statistic)
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_13_2:
 
-cProtocol::Version cProtocol_1_13_2::GetProtocolVersion()
+cProtocol::Version cProtocol_1_13_2::GetProtocolVersion() const
 {
 	return Version::v1_13_2;
 }
@@ -1501,7 +1501,7 @@ cProtocol::Version cProtocol_1_13_2::GetProtocolVersion()
 
 
 
-bool cProtocol_1_13_2::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes)
+bool cProtocol_1_13_2::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) const
 {
 	HANDLE_PACKET_READ(a_ByteBuffer, ReadBool, bool, Present);
 	if (!Present)
@@ -1538,7 +1538,7 @@ bool cProtocol_1_13_2::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size
 
 
 
-void cProtocol_1_13_2::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
+void cProtocol_1_13_2::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const
 {
 	short ItemType = a_Item.m_ItemType;
 	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -403,6 +403,19 @@ UInt32 cProtocol_1_13::GetPacketID(ePacketType a_PacketType)
 
 
 
+signed char cProtocol_1_13::GetProtocolEntityStatus(const EntityAnimation a_Animation) const
+{
+	switch (a_Animation)
+	{
+		case EntityAnimation::DolphinShowsHappiness: return 38;
+		default: return Super::GetProtocolEntityStatus(a_Animation);
+	}
+}
+
+
+
+
+
 UInt32 cProtocol_1_13::GetProtocolMobType(eMonsterType a_MobType)
 {
 	switch (a_MobType)

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -372,8 +372,7 @@ UInt32 cProtocol_1_13::GetPacketID(ePacketType a_PacketType)
 		case pktParticleEffect:         return 0x24;
 		case pktPlayerAbilities:        return 0x2e;
 		case pktPlayerList:             return 0x30;
-		case pktPlayerListHeaderFooter: return 0x4E;
-		case pktPlayerMaxSpeed:         return 0x52;
+		case pktPlayerListHeaderFooter: return 0x4e;
 		case pktPlayerMoveLook:         return 0x32;
 		case pktPluginMessage:          return 0x19;
 		case pktRemoveEntityEffect:     return 0x36;

--- a/src/Protocol/Protocol_1_13.h
+++ b/src/Protocol/Protocol_1_13.h
@@ -49,6 +49,8 @@ protected:
 	/** Translates outgoing packet types. */
 	virtual UInt32 GetPacketID(ePacketType a_PacketType) override;
 
+	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
+
 	/** Returns 1.13. */
 	virtual Version GetProtocolVersion() override;
 

--- a/src/Protocol/Protocol_1_13.h
+++ b/src/Protocol/Protocol_1_13.h
@@ -46,33 +46,26 @@ protected:
 	virtual void SendTabCompletionResults       (const AStringVector & a_Results) override;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) override;
 
-	/** Translates outgoing packet types. */
-	virtual UInt32 GetPacketID(ePacketType a_PacketType) override;
-
+	virtual UInt8 GetEntityMetadataID(EntityMetadata a_Metadata) const;
+	virtual UInt8 GetEntityMetadataID(EntityMetadataType a_FieldType) const;
+	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID) const;
+	virtual UInt32 GetPacketID(ePacketType a_PacketType) const override;
+	virtual UInt32 GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) const;
 	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
-
-	/** Returns 1.13. */
-	virtual Version GetProtocolVersion() override;
-
-	/** Converts eMonsterType to protocol-specific mob types */
-	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) override;
-
-	virtual UInt8 GetEntityMetadataID(EntityMetadata a_Metadata);
-	virtual UInt8 GetEntityMetadataID(EntityMetadataType a_FieldType);
-	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID);
-	virtual UInt32 GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta);
-	virtual UInt32 GetProtocolItemType(short a_ItemID, short a_ItemDamage);
-	virtual UInt32 GetProtocolStatisticType(Statistic a_Statistic);
+	virtual UInt32 GetProtocolItemType(short a_ItemID, short a_ItemDamage) const;
+	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) const override;
+	virtual UInt32 GetProtocolStatisticType(Statistic a_Statistic) const;
+	virtual Version GetProtocolVersion() const override;
 
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 	virtual void HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer) override;
 	virtual void HandlePacketSetBeaconEffect(cByteBuffer & a_ByteBuffer);
 
-	virtual bool ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) override;
-	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) override;
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, EntityMetadata a_Metadata, EntityMetadataType a_FieldType);
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) override;
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override;
+	virtual bool ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) const override;
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, EntityMetadata a_Metadata, EntityMetadataType a_FieldType) const;
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const override;
+	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const override;
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const override;
 };
 
 
@@ -93,11 +86,11 @@ protected:
 	virtual void SendBossBarAdd(UInt32 a_UniqueID, const cCompositeChat & a_Title, float a_FractionFilled, BossBarColor a_Color, BossBarDivisionType a_DivisionType, bool a_DarkenSky, bool a_PlayEndMusic, bool a_CreateFog) override;
 	virtual void SendBossBarUpdateFlags(UInt32 a_UniqueID, bool a_DarkenSky, bool a_PlayEndMusic, bool a_CreateFog) override;
 
-	virtual Version GetProtocolVersion() override;
-	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID) override;
-	virtual UInt32 GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) override;
-	virtual UInt32 GetProtocolItemType(short a_ItemID, short a_ItemDamage) override;
-	virtual UInt32 GetProtocolStatisticType(Statistic a_Statistic) override;
+	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID) const override;
+	virtual UInt32 GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) const override;
+	virtual UInt32 GetProtocolItemType(short a_ItemID, short a_ItemDamage) const override;
+	virtual UInt32 GetProtocolStatisticType(Statistic a_Statistic) const override;
+	virtual Version GetProtocolVersion() const override;
 };
 
 
@@ -115,7 +108,7 @@ public:
 
 protected:
 
-	virtual Version GetProtocolVersion() override;
-	virtual bool ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) override;
-	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) override;
+	virtual Version GetProtocolVersion() const override;
+	virtual bool ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) const override;
+	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const override;
 };

--- a/src/Protocol/Protocol_1_14.cpp
+++ b/src/Protocol/Protocol_1_14.cpp
@@ -131,7 +131,7 @@ void cProtocol_1_14::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, co
 
 
 
-UInt32 cProtocol_1_14::GetPacketID(ePacketType a_PacketType)
+UInt32 cProtocol_1_14::GetPacketID(ePacketType a_PacketType) const
 {
 	switch (a_PacketType)
 	{
@@ -184,16 +184,7 @@ UInt32 cProtocol_1_14::GetPacketID(ePacketType a_PacketType)
 
 
 
-cProtocol::Version cProtocol_1_14::GetProtocolVersion()
-{
-	return Version::v1_14;
-}
-
-
-
-
-
-std::pair<short, short> cProtocol_1_14::GetItemFromProtocolID(UInt32 a_ProtocolID)
+std::pair<short, short> cProtocol_1_14::GetItemFromProtocolID(UInt32 a_ProtocolID) const
 {
 	return PaletteUpgrade::ToItem(Palette_1_14::ToItem(a_ProtocolID));
 }
@@ -202,7 +193,7 @@ std::pair<short, short> cProtocol_1_14::GetItemFromProtocolID(UInt32 a_ProtocolI
 
 
 
-UInt32 cProtocol_1_14::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta)
+UInt32 cProtocol_1_14::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) const
 {
 	return Palette_1_14::From(PaletteUpgrade::FromBlock(a_BlockType, a_Meta));
 }
@@ -238,7 +229,7 @@ signed char cProtocol_1_14::GetProtocolEntityStatus(EntityAnimation a_Animation)
 
 
 
-UInt32 cProtocol_1_14::GetProtocolItemType(short a_ItemID, short a_ItemDamage)
+UInt32 cProtocol_1_14::GetProtocolItemType(short a_ItemID, short a_ItemDamage) const
 {
 	return Palette_1_14::From(PaletteUpgrade::FromItem(a_ItemID, a_ItemDamage));
 }
@@ -247,9 +238,18 @@ UInt32 cProtocol_1_14::GetProtocolItemType(short a_ItemID, short a_ItemDamage)
 
 
 
-UInt32 cProtocol_1_14::GetProtocolStatisticType(Statistic a_Statistic)
+UInt32 cProtocol_1_14::GetProtocolStatisticType(Statistic a_Statistic) const
 {
 	return Palette_1_14::From(a_Statistic);
+}
+
+
+
+
+
+cProtocol::Version cProtocol_1_14::GetProtocolVersion() const
+{
+	return Version::v1_14;
 }
 
 

--- a/src/Protocol/Protocol_1_14.cpp
+++ b/src/Protocol/Protocol_1_14.cpp
@@ -48,6 +48,22 @@ void cProtocol_1_14::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
 
 
 
+void cProtocol_1_14::SendEntityAnimation(const cEntity & a_Entity, EntityAnimation a_Animation)
+{
+	if (a_Animation == EntityAnimation::PlayerEntersBed)
+	{
+		// Use Bed packet removed, through metadata instead:
+		SendEntityMetadata(a_Entity);
+		return;
+	}
+
+	Super::SendEntityAnimation(a_Entity, a_Animation);
+}
+
+
+
+
+
 void cProtocol_1_14::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 {
 	// Send the Join Game packet:
@@ -108,14 +124,6 @@ void cProtocol_1_14::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 
 
 void cProtocol_1_14::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4)
-{
-}
-
-
-
-
-
-void cProtocol_1_14::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 }
 
@@ -197,6 +205,33 @@ std::pair<short, short> cProtocol_1_14::GetItemFromProtocolID(UInt32 a_ProtocolI
 UInt32 cProtocol_1_14::GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta)
 {
 	return Palette_1_14::From(PaletteUpgrade::FromBlock(a_BlockType, a_Meta));
+}
+
+
+
+
+
+signed char cProtocol_1_14::GetProtocolEntityStatus(EntityAnimation a_Animation) const
+{
+	switch (a_Animation)
+	{
+		case EntityAnimation::FoxChews: return 45;
+		case EntityAnimation::OcelotTrusts: return 40;
+		case EntityAnimation::OcelotDistrusts: return 41;
+		case EntityAnimation::PawnBerryBushPricks: return 44;
+		case EntityAnimation::PawnChestEquipmentBreaks: return 50;
+		case EntityAnimation::PawnFeetEquipmentBreaks: return 52;
+		case EntityAnimation::PawnHeadEquipmentBreaks: return 49;
+		case EntityAnimation::PawnLegsEquipmentBreaks: return 51;
+		case EntityAnimation::PawnMainHandEquipmentBreaks: return 47;
+		case EntityAnimation::PawnOffHandEquipmentBreaks: return 48;
+		case EntityAnimation::PawnTeleports: return 46;
+		case EntityAnimation::PlayerBadOmenActivates: return 43;
+		case EntityAnimation::RavagerAttacks: return 4;
+		case EntityAnimation::RavagerBecomesStunned: return 39;
+		case EntityAnimation::VillagerSweats: return 42;
+		default: return Super::GetProtocolEntityStatus(a_Animation);
+	}
 }
 
 

--- a/src/Protocol/Protocol_1_14.h
+++ b/src/Protocol/Protocol_1_14.h
@@ -33,17 +33,18 @@ protected:
 	virtual void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType) override;
 	virtual void SendBlockBreakAnim             (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) override;
 	virtual void SendEditSign                   (int a_BlockX, int a_BlockY, int a_BlockZ) override;  ///< Request the client to open up the sign editor for the sign (1.6+)
+	virtual void SendEntityAnimation            (const cEntity & a_Entity, EntityAnimation a_Animation) override;
 	virtual void SendLogin                      (const cPlayer & a_Player, const cWorld & a_World) override;
 	virtual void SendPaintingSpawn              (const cPainting & a_Painting) override;
 	virtual void SendSoundParticleEffect        (const EffectID a_EffectID, int a_SrcX, int a_SrcY, int a_SrcZ, int a_Data) override;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) override;
 	virtual void SendUpdateSign                 (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) override;
-	virtual void SendUseBed                     (const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ) override;
 
 	virtual UInt32 GetPacketID(ePacketType a_PacketType) override;
 	virtual Version GetProtocolVersion() override;
 	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID) override;
 	virtual UInt32 GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) override;
+	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
 	virtual UInt32 GetProtocolItemType(short a_ItemID, short a_ItemDamage) override;
 	virtual UInt32 GetProtocolStatisticType(Statistic a_Statistic) override;
 

--- a/src/Protocol/Protocol_1_14.h
+++ b/src/Protocol/Protocol_1_14.h
@@ -40,19 +40,19 @@ protected:
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) override;
 	virtual void SendUpdateSign                 (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) override;
 
-	virtual UInt32 GetPacketID(ePacketType a_PacketType) override;
-	virtual Version GetProtocolVersion() override;
-	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID) override;
-	virtual UInt32 GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) override;
+	virtual UInt32 GetPacketID(ePacketType a_PacketType) const override;
+	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID) const override;
+	virtual UInt32 GetProtocolBlockType(BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta) const override;
 	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
-	virtual UInt32 GetProtocolItemType(short a_ItemID, short a_ItemDamage) override;
-	virtual UInt32 GetProtocolStatisticType(Statistic a_Statistic) override;
+	virtual UInt32 GetProtocolItemType(short a_ItemID, short a_ItemDamage) const override;
+	virtual UInt32 GetProtocolStatisticType(Statistic a_Statistic) const override;
+	virtual Version GetProtocolVersion() const override;
 
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 	virtual void HandlePacketBlockDig(cByteBuffer & a_ByteBuffer) override;
 	virtual void HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer) override;
 	virtual void HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer) override;
 
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) override {}
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override {}
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const override {}
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const override {}
 };

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1004,10 +1004,6 @@ void cProtocol_1_8_0::SendParticleEffect(const AString & a_ParticleName, Vector3
 			Pkt.WriteVarInt32(static_cast<UInt32>(a_Data[0]));
 			break;
 		}
-		default:
-		{
-			break;
-		}
 	}
 }
 
@@ -1832,7 +1828,27 @@ void cProtocol_1_8_0::CompressPacket(CircularBufferCompressor & a_Packet, Contig
 
 
 
-UInt32 cProtocol_1_8_0::GetPacketID(ePacketType a_PacketType)
+eBlockFace cProtocol_1_8_0::FaceIntToBlockFace(const Int32 a_BlockFace)
+{
+	// Normalize the blockface values returned from the protocol
+	// Anything known gets mapped 1:1, everything else returns BLOCK_FACE_NONE
+	switch (a_BlockFace)
+	{
+		case BLOCK_FACE_XM: return BLOCK_FACE_XM;
+		case BLOCK_FACE_XP: return BLOCK_FACE_XP;
+		case BLOCK_FACE_YM: return BLOCK_FACE_YM;
+		case BLOCK_FACE_YP: return BLOCK_FACE_YP;
+		case BLOCK_FACE_ZM: return BLOCK_FACE_ZM;
+		case BLOCK_FACE_ZP: return BLOCK_FACE_ZP;
+		default: return BLOCK_FACE_NONE;
+	}
+}
+
+
+
+
+
+UInt32 cProtocol_1_8_0::GetPacketID(ePacketType a_PacketType) const
 {
 	switch (a_PacketType)
 	{
@@ -1923,15 +1939,6 @@ UInt32 cProtocol_1_8_0::GetPacketID(ePacketType a_PacketType)
 
 
 
-cProtocol::Version cProtocol_1_8_0::GetProtocolVersion()
-{
-	return Version::v1_8_0;
-}
-
-
-
-
-
 unsigned char cProtocol_1_8_0::GetProtocolEntityAnimation(const EntityAnimation a_Animation) const
 {
 	switch (a_Animation)
@@ -1990,7 +1997,7 @@ signed char cProtocol_1_8_0::GetProtocolEntityStatus(const EntityAnimation a_Ani
 
 
 
-UInt32 cProtocol_1_8_0::GetProtocolMobType(const eMonsterType a_MobType)
+UInt32 cProtocol_1_8_0::GetProtocolMobType(const eMonsterType a_MobType) const
 {
 	switch (a_MobType)
 	{
@@ -2042,6 +2049,15 @@ UInt32 cProtocol_1_8_0::GetProtocolMobType(const eMonsterType a_MobType)
 
 		default:                      return 0;
 	}
+}
+
+
+
+
+
+cProtocol::Version cProtocol_1_8_0::GetProtocolVersion() const
+{
+	return Version::v1_8_0;
 }
 
 
@@ -2275,7 +2291,7 @@ void cProtocol_1_8_0::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 
 void cProtocol_1_8_0::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 {
-	m_Client->HandleAnimation(0);  // Packet exists solely for arm-swing notification
+	m_Client->HandleAnimation(true);  // Packet exists solely for arm-swing notification (main hand).
 }
 
 
@@ -2293,6 +2309,7 @@ void cProtocol_1_8_0::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 	}
 
 	HANDLE_READ(a_ByteBuffer, ReadBEInt8, Int8, Face);
+
 	m_Client->HandleLeftClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), Status);
 }
 
@@ -2316,14 +2333,15 @@ void cProtocol_1_8_0::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorX);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorY);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorZ);
+
 	eBlockFace blockFace = FaceIntToBlockFace(Face);
 	if (blockFace == eBlockFace::BLOCK_FACE_NONE)
 	{
-		m_Client->HandleUseItem(eHand::hMain);
+		m_Client->HandleUseItem(true);
 	}
 	else
 	{
-		m_Client->HandleRightClick(BlockX, BlockY, BlockZ, blockFace, CursorX, CursorY, CursorZ, eHand::hMain);
+		m_Client->HandleRightClick(BlockX, BlockY, BlockZ, blockFace, CursorX, CursorY, CursorZ, true);
 	}
 }
 
@@ -2334,6 +2352,7 @@ void cProtocol_1_8_0::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 void cProtocol_1_8_0::HandlePacketChatMessage(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Message);
+
 	m_Client->HandleChat(Message);
 }
 
@@ -2362,6 +2381,7 @@ void cProtocol_1_8_0::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
 void cProtocol_1_8_0::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, ActionID);
+
 	switch (ActionID)
 	{
 		case 0:
@@ -2394,6 +2414,7 @@ void cProtocol_1_8_0::HandlePacketClientStatus(cByteBuffer & a_ByteBuffer)
 void cProtocol_1_8_0::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
+
 	cItem Item;
 	if (!ReadItem(a_ByteBuffer, Item))
 	{
@@ -2436,6 +2457,7 @@ void cProtocol_1_8_0::HandlePacketEntityAction(cByteBuffer & a_ByteBuffer)
 void cProtocol_1_8_0::HandlePacketKeepAlive(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, KeepAliveID);
+
 	m_Client->HandleKeepAlive(KeepAliveID);
 }
 
@@ -2478,6 +2500,7 @@ void cProtocol_1_8_0::HandlePacketPlayerLook(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Yaw);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat, float, Pitch);
 	HANDLE_READ(a_ByteBuffer, ReadBool,    bool,  IsOnGround);
+
 	m_Client->HandlePlayerLook(Yaw, Pitch, IsOnGround);
 }
 
@@ -2491,7 +2514,8 @@ void cProtocol_1_8_0::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosY);
 	HANDLE_READ(a_ByteBuffer, ReadBEDouble, double, PosZ);
 	HANDLE_READ(a_ByteBuffer, ReadBool,     bool,   IsOnGround);
-	m_Client->HandlePlayerPos(PosX, PosY, PosZ, IsOnGround);
+
+	m_Client->HandlePlayerMove(PosX, PosY, PosZ, IsOnGround);
 }
 
 
@@ -2506,6 +2530,7 @@ void cProtocol_1_8_0::HandlePacketPlayerPosLook(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  Yaw);
 	HANDLE_READ(a_ByteBuffer, ReadBEFloat,  float,  Pitch);
 	HANDLE_READ(a_ByteBuffer, ReadBool,     bool,   IsOnGround);
+
 	m_Client->HandlePlayerMoveLook(PosX, PosY, PosZ, Yaw, Pitch, IsOnGround);
 }
 
@@ -2557,6 +2582,7 @@ void cProtocol_1_8_0::HandlePacketResourcePackStatus(cByteBuffer & a_ByteBuffer)
 void cProtocol_1_8_0::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
+
 	m_Client->HandleSlotSelected(SlotNum);
 }
 
@@ -2633,6 +2659,7 @@ void cProtocol_1_8_0::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 	for (int i = 0; i < 4; i++)
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Line);
+
 		if (JsonUtils::ParseString(Line, root) && root.isString())
 		{
 			Lines[i] = root.asString();
@@ -2703,6 +2730,7 @@ void cProtocol_1_8_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  Button);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt16, UInt16, TransactionID);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,  UInt8,  Mode);
+
 	cItem Item;
 	ReadItem(a_ByteBuffer, Item);
 
@@ -2757,6 +2785,7 @@ void cProtocol_1_8_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 void cProtocol_1_8_0::HandlePacketWindowClose(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, WindowID);
+
 	m_Client->HandleWindowClose(WindowID);
 }
 
@@ -2769,6 +2798,7 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 	if (a_Channel == "MC|AdvCdm")
 	{
 		HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Mode);
+
 		switch (Mode)
 		{
 			case 0x00:
@@ -2777,6 +2807,7 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 				HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, BlockY);
 				HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, BlockZ);
 				HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Command);
+
 				m_Client->HandleCommandBlockBlockChange(BlockX, BlockY, BlockZ, Command);
 				break;
 			}
@@ -2793,6 +2824,7 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 	else if (a_Channel == "MC|Brand")
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Brand);
+
 		m_Client->SetClientBrand(Brand);
 		// Send back our brand, including the length:
 		m_Client->SendPluginMessage("MC|Brand", "\x08""Cuberite");
@@ -2802,18 +2834,21 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 	{
 		HANDLE_READ(a_ByteBuffer, ReadBEUInt32, UInt32, Effect1);
 		HANDLE_READ(a_ByteBuffer, ReadBEUInt32, UInt32, Effect2);
+
 		m_Client->HandleBeaconSelection(Effect1, Effect2);
 		return;
 	}
 	else if (a_Channel == "MC|ItemName")
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, ItemName);
+
 		m_Client->HandleAnvilItemName(ItemName);
 		return;
 	}
 	else if (a_Channel == "MC|TrSel")
 	{
 		HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, SlotNum);
+
 		m_Client->HandleNPCTrade(SlotNum);
 		return;
 	}
@@ -2829,67 +2864,7 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 
 
 
-void cProtocol_1_8_0::SendData(ContiguousByteBufferView a_Data)
-{
-	if (m_IsEncrypted)
-	{
-		std::byte Encrypted[8 KiB];  // Larger buffer, we may be sending lots of data (chunks)
-
-		while (a_Data.size() > 0)
-		{
-			const auto NumBytes = (a_Data.size() > sizeof(Encrypted)) ? sizeof(Encrypted) : a_Data.size();
-			m_Encryptor.ProcessData(Encrypted, a_Data.data(), NumBytes);
-			m_Client->SendData({ Encrypted, NumBytes });
-
-			a_Data = a_Data.substr(NumBytes);
-		}
-	}
-	else
-	{
-		m_Client->SendData(a_Data);
-	}
-}
-
-
-
-
-
-bool cProtocol_1_8_0::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes)
-{
-	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt16, Int16, ItemType);
-	if (ItemType == -1)
-	{
-		// The item is empty, no more data follows
-		a_Item.Empty();
-		return true;
-	}
-	a_Item.m_ItemType = ItemType;
-
-	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt8,  Int8,  ItemCount);
-	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt16, Int16, ItemDamage);
-	a_Item.m_ItemCount  = ItemCount;
-	a_Item.m_ItemDamage = ItemDamage;
-	if (ItemCount <= 0)
-	{
-		a_Item.Empty();
-	}
-
-	ContiguousByteBuffer Metadata;
-	if (!a_ByteBuffer.ReadSome(Metadata, a_ByteBuffer.GetReadableSpace() - a_KeepRemainingBytes) || Metadata.empty() || (Metadata[0] == std::byte(0)))
-	{
-		// No metadata
-		return true;
-	}
-
-	ParseItemMetadata(a_Item, Metadata);
-	return true;
-}
-
-
-
-
-
-void cProtocol_1_8_0::ParseItemMetadata(cItem & a_Item, const ContiguousByteBufferView a_Metadata)
+void cProtocol_1_8_0::ParseItemMetadata(cItem & a_Item, const ContiguousByteBufferView a_Metadata) const
 {
 	// Parse into NBT:
 	cParsedNBT NBT(a_Metadata);
@@ -2962,50 +2937,98 @@ void cProtocol_1_8_0::ParseItemMetadata(cItem & a_Item, const ContiguousByteBuff
 
 
 
-void cProtocol_1_8_0::StartEncryption(const Byte * a_Key)
+bool cProtocol_1_8_0::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes) const
 {
-	m_Encryptor.Init(a_Key, a_Key);
-	m_Decryptor.Init(a_Key, a_Key);
-	m_IsEncrypted = true;
+	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt16, Int16, ItemType);
 
-	// Prepare the m_AuthServerID:
-	cSha1Checksum Checksum;
-	cServer * Server = cRoot::Get()->GetServer();
-	const AString & ServerID = Server->GetServerID();
-	Checksum.Update(reinterpret_cast<const Byte *>(ServerID.c_str()), ServerID.length());
-	Checksum.Update(a_Key, 16);
-	Checksum.Update(reinterpret_cast<const Byte *>(Server->GetPublicKeyDER().data()), Server->GetPublicKeyDER().size());
-	Byte Digest[20];
-	Checksum.Finalize(Digest);
-	cSha1Checksum::DigestToJava(Digest, m_AuthServerID);
+	if (ItemType == -1)
+	{
+		// The item is empty, no more data follows
+		a_Item.Empty();
+		return true;
+	}
+	a_Item.m_ItemType = ItemType;
+
+	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt8,  Int8,  ItemCount);
+	HANDLE_PACKET_READ(a_ByteBuffer, ReadBEInt16, Int16, ItemDamage);
+
+	a_Item.m_ItemCount  = ItemCount;
+	a_Item.m_ItemDamage = ItemDamage;
+	if (ItemCount <= 0)
+	{
+		a_Item.Empty();
+	}
+
+	ContiguousByteBuffer Metadata;
+	if (!a_ByteBuffer.ReadSome(Metadata, a_ByteBuffer.GetReadableSpace() - a_KeepRemainingBytes) || Metadata.empty() || (Metadata[0] == std::byte(0)))
+	{
+		// No metadata
+		return true;
+	}
+
+	ParseItemMetadata(a_Item, Metadata);
+	return true;
 }
 
 
 
 
 
-eBlockFace cProtocol_1_8_0::FaceIntToBlockFace(const Int32 a_BlockFace)
+void cProtocol_1_8_0::SendEntitySpawn(const cEntity & a_Entity, const UInt8 a_ObjectType, const Int32 a_ObjectData)
 {
-	// Normalize the blockface values returned from the protocol
-	// Anything known gets mapped 1:1, everything else returns BLOCK_FACE_NONE
-	switch (a_BlockFace)
+	ASSERT(m_State == 3);  // In game mode?
+
 	{
-		case BLOCK_FACE_XM: return BLOCK_FACE_XM;
-		case BLOCK_FACE_XP: return BLOCK_FACE_XP;
-		case BLOCK_FACE_YM: return BLOCK_FACE_YM;
-		case BLOCK_FACE_YP: return BLOCK_FACE_YP;
-		case BLOCK_FACE_ZM: return BLOCK_FACE_ZM;
-		case BLOCK_FACE_ZP: return BLOCK_FACE_ZP;
-		default: return BLOCK_FACE_NONE;
+		cPacketizer Pkt(*this, pktSpawnObject);
+		Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+		Pkt.WriteBEUInt8(a_ObjectType);
+		Pkt.WriteFPInt(a_Entity.GetPosX());  // Position appears to be ignored...
+		Pkt.WriteFPInt(a_Entity.GetPosY());
+		Pkt.WriteFPInt(a_Entity.GetPosY());
+		Pkt.WriteByteAngle(a_Entity.GetPitch());
+		Pkt.WriteByteAngle(a_Entity.GetYaw());
+		Pkt.WriteBEInt32(a_ObjectData);
+
+		if (a_ObjectData != 0)
+		{
+			Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
+			Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedY() * 400));
+			Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedZ() * 400));
+		}
+	}
+
+	// Otherwise 1.8 clients don't show the entity
+	SendEntityTeleport(a_Entity);
+}
+
+
+
+
+
+void cProtocol_1_8_0::SendData(ContiguousByteBufferView a_Data)
+{
+	if (m_IsEncrypted)
+	{
+		std::byte Encrypted[8 KiB];  // Larger buffer, we may be sending lots of data (chunks)
+
+		while (a_Data.size() > 0)
+		{
+			const auto NumBytes = (a_Data.size() > sizeof(Encrypted)) ? sizeof(Encrypted) : a_Data.size();
+			m_Encryptor.ProcessData(Encrypted, a_Data.data(), NumBytes);
+			m_Client->SendData({ Encrypted, NumBytes });
+
+			a_Data = a_Data.substr(NumBytes);
+		}
+	}
+	else
+	{
+		m_Client->SendData(a_Data);
 	}
 }
 
 
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-// cProtocol_1_8_0::cPacketizer:
 
 void cProtocol_1_8_0::SendPacket(cPacketizer & a_Pkt)
 {
@@ -3067,38 +3090,7 @@ void cProtocol_1_8_0::SendPacket(cPacketizer & a_Pkt)
 
 
 
-void cProtocol_1_8_0::SendEntitySpawn(const cEntity & a_Entity, const UInt8 a_ObjectType, const Int32 a_ObjectData)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	{
-		cPacketizer Pkt(*this, pktSpawnObject);
-		Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-		Pkt.WriteBEUInt8(a_ObjectType);
-		Pkt.WriteFPInt(a_Entity.GetPosX());  // Position appears to be ignored...
-		Pkt.WriteFPInt(a_Entity.GetPosY());
-		Pkt.WriteFPInt(a_Entity.GetPosY());
-		Pkt.WriteByteAngle(a_Entity.GetPitch());
-		Pkt.WriteByteAngle(a_Entity.GetYaw());
-		Pkt.WriteBEInt32(a_ObjectData);
-
-		if (a_ObjectData != 0)
-		{
-			Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedX() * 400));
-			Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedY() * 400));
-			Pkt.WriteBEInt16(static_cast<Int16>(a_Entity.GetSpeedZ() * 400));
-		}
-	}
-
-	// Otherwise 1.8 clients don't show the entity
-	SendEntityTeleport(a_Entity);
-}
-
-
-
-
-
-void cProtocol_1_8_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity)
+void cProtocol_1_8_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) const
 {
 	a_Writer.AddInt("x", a_BlockEntity.GetPosX());
 	a_Writer.AddInt("y", a_BlockEntity.GetPosY());
@@ -3205,89 +3197,7 @@ void cProtocol_1_8_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEn
 
 
 
-void cProtocol_1_8_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
-{
-	short ItemType = a_Item.m_ItemType;
-	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime
-	if (ItemType <= 0)
-	{
-		// Fix, to make sure no invalid values are sent.
-		ItemType = -1;
-	}
-
-	if (a_Item.IsEmpty())
-	{
-		a_Pkt.WriteBEInt16(-1);
-		return;
-	}
-
-	a_Pkt.WriteBEInt16(ItemType);
-	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
-	a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
-
-	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) && (a_Item.m_ItemType != E_ITEM_FIREWORK_STAR) && !a_Item.m_ItemColor.IsValid())
-	{
-		a_Pkt.WriteBEInt8(0);
-		return;
-	}
-
-
-	// Send the enchantments and custom names:
-	cFastNBTWriter Writer;
-	if (a_Item.m_RepairCost != 0)
-	{
-		Writer.AddInt("RepairCost", a_Item.m_RepairCost);
-	}
-	if (!a_Item.m_Enchantments.IsEmpty())
-	{
-		const char * TagName = (a_Item.m_ItemType == E_ITEM_BOOK) ? "StoredEnchantments" : "ench";
-		EnchantmentSerializer::WriteToNBTCompound(a_Item.m_Enchantments, Writer, TagName);
-	}
-	if (!a_Item.IsBothNameAndLoreEmpty() || a_Item.m_ItemColor.IsValid())
-	{
-		Writer.BeginCompound("display");
-		if (a_Item.m_ItemColor.IsValid())
-		{
-			Writer.AddInt("color", static_cast<Int32>(a_Item.m_ItemColor.m_Color));
-		}
-
-		if (!a_Item.IsCustomNameEmpty())
-		{
-			Writer.AddString("Name", a_Item.m_CustomName);
-		}
-		if (!a_Item.IsLoreEmpty())
-		{
-			Writer.BeginList("Lore", TAG_String);
-
-			for (const auto & Line : a_Item.m_LoreTable)
-			{
-				Writer.AddString("", Line);
-			}
-
-			Writer.EndList();
-		}
-		Writer.EndCompound();
-	}
-	if ((a_Item.m_ItemType == E_ITEM_FIREWORK_ROCKET) || (a_Item.m_ItemType == E_ITEM_FIREWORK_STAR))
-	{
-		cFireworkItem::WriteToNBTCompound(a_Item.m_FireworkItem, Writer, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
-	}
-	Writer.Finish();
-
-	const auto Result = Writer.GetResult();
-	if (Result.empty())
-	{
-		a_Pkt.WriteBEInt8(0);
-		return;
-	}
-	a_Pkt.WriteBuf(Result);
-}
-
-
-
-
-
-void cProtocol_1_8_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
+void cProtocol_1_8_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const
 {
 	// Common metadata:
 	Byte Flags = 0;
@@ -3438,7 +3348,129 @@ void cProtocol_1_8_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a
 
 
 
-void cProtocol_1_8_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_8_0::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity) const
+{
+	if (a_Entity.IsPlayer())
+	{
+		const auto & Player = static_cast<const cPlayer &>(a_Entity);
+
+		a_Pkt.WriteBEInt32(1);  // Count.
+		a_Pkt.WriteString("generic.movementSpeed");
+		a_Pkt.WriteBEDouble(0.1 * Player.GetNormalMaxSpeed());  // The default game speed is 0.1, multiply that value by the relative speed.
+
+		// It seems the modifiers aren't conditionally activated; their effects are applied immediately!
+		// We have to keep on re-sending this packet when the client notifies us of sprint start and end, and so on. Strange.
+
+		if (Player.IsSprinting())
+		{
+			a_Pkt.WriteVarInt32(1);  // Modifier count.
+			a_Pkt.WriteBEUInt64(0x662a6b8dda3e4c1c);
+			a_Pkt.WriteBEUInt64(0x881396ea6097278d);  // UUID of the modifier (sprinting speed boost).
+			a_Pkt.WriteBEDouble(Player.GetSprintingMaxSpeed() - Player.GetNormalMaxSpeed());
+			a_Pkt.WriteBEUInt8(2);
+		}
+		else
+		{
+			a_Pkt.WriteVarInt32(0);
+		}
+	}
+	else
+	{
+		// const cMonster & Mob = (const cMonster &)a_Entity;
+
+		// TODO: Send properties and modifiers based on the mob type
+
+		a_Pkt.WriteBEInt32(0);
+	}
+}
+
+
+
+
+
+void cProtocol_1_8_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const
+{
+	short ItemType = a_Item.m_ItemType;
+	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime
+	if (ItemType <= 0)
+	{
+		// Fix, to make sure no invalid values are sent.
+		ItemType = -1;
+	}
+
+	if (a_Item.IsEmpty())
+	{
+		a_Pkt.WriteBEInt16(-1);
+		return;
+	}
+
+	a_Pkt.WriteBEInt16(ItemType);
+	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
+	a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
+
+	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) && (a_Item.m_ItemType != E_ITEM_FIREWORK_STAR) && !a_Item.m_ItemColor.IsValid())
+	{
+		a_Pkt.WriteBEInt8(0);
+		return;
+	}
+
+
+	// Send the enchantments and custom names:
+	cFastNBTWriter Writer;
+	if (a_Item.m_RepairCost != 0)
+	{
+		Writer.AddInt("RepairCost", a_Item.m_RepairCost);
+	}
+	if (!a_Item.m_Enchantments.IsEmpty())
+	{
+		const char * TagName = (a_Item.m_ItemType == E_ITEM_BOOK) ? "StoredEnchantments" : "ench";
+		EnchantmentSerializer::WriteToNBTCompound(a_Item.m_Enchantments, Writer, TagName);
+	}
+	if (!a_Item.IsBothNameAndLoreEmpty() || a_Item.m_ItemColor.IsValid())
+	{
+		Writer.BeginCompound("display");
+		if (a_Item.m_ItemColor.IsValid())
+		{
+			Writer.AddInt("color", static_cast<Int32>(a_Item.m_ItemColor.m_Color));
+		}
+
+		if (!a_Item.IsCustomNameEmpty())
+		{
+			Writer.AddString("Name", a_Item.m_CustomName);
+		}
+		if (!a_Item.IsLoreEmpty())
+		{
+			Writer.BeginList("Lore", TAG_String);
+
+			for (const auto & Line : a_Item.m_LoreTable)
+			{
+				Writer.AddString("", Line);
+			}
+
+			Writer.EndList();
+		}
+		Writer.EndCompound();
+	}
+	if ((a_Item.m_ItemType == E_ITEM_FIREWORK_ROCKET) || (a_Item.m_ItemType == E_ITEM_FIREWORK_STAR))
+	{
+		cFireworkItem::WriteToNBTCompound(a_Item.m_FireworkItem, Writer, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
+	}
+	Writer.Finish();
+
+	const auto Result = Writer.GetResult();
+	if (Result.empty())
+	{
+		a_Pkt.WriteBEInt8(0);
+		return;
+	}
+	a_Pkt.WriteBuf(Result);
+}
+
+
+
+
+
+void cProtocol_1_8_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const
 {
 	// Living Enitiy Metadata
 	if (a_Mob.HasCustomName())
@@ -3764,46 +3796,6 @@ void cProtocol_1_8_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_M
 
 
 
-void cProtocol_1_8_0::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity)
-{
-	if (a_Entity.IsPlayer())
-	{
-		const auto & Player = static_cast<const cPlayer &>(a_Entity);
-
-		a_Pkt.WriteBEInt32(1);  // Count.
-		a_Pkt.WriteString("generic.movementSpeed");
-		a_Pkt.WriteBEDouble(0.1 * Player.GetNormalMaxSpeed());  // The default game speed is 0.1, multiply that value by the relative speed.
-
-		// It seems the modifiers aren't conditionally activated; their effects are applied immediately!
-		// We have to keep on re-sending this packet when the client notifies us of sprint start and end, and so on. Strange.
-
-		if (Player.IsSprinting())
-		{
-			a_Pkt.WriteVarInt32(1);  // Modifier count.
-			a_Pkt.WriteBEUInt64(0x662a6b8dda3e4c1c);
-			a_Pkt.WriteBEUInt64(0x881396ea6097278d);  // UUID of the modifier (sprinting speed boost).
-			a_Pkt.WriteBEDouble(Player.GetSprintingMaxSpeed() - Player.GetNormalMaxSpeed());
-			a_Pkt.WriteBEUInt8(2);
-		}
-		else
-		{
-			a_Pkt.WriteVarInt32(0);
-		}
-	}
-	else
-	{
-		// const cMonster & Mob = (const cMonster &)a_Entity;
-
-		// TODO: Send properties and modifiers based on the mob type
-
-		a_Pkt.WriteBEInt32(0);
-	}
-}
-
-
-
-
-
 void cProtocol_1_8_0::AddReceivedData(cByteBuffer & a_Buffer, const ContiguousByteBufferView a_Data)
 {
 	// Write the incoming data into the comm log file:
@@ -3915,98 +3907,6 @@ void cProtocol_1_8_0::AddReceivedData(cByteBuffer & a_Buffer, const ContiguousBy
 		);
 		m_CommLogFile.Flush();
 	}
-}
-
-
-
-
-
-void cProtocol_1_8_0::HandlePacket(cByteBuffer & a_Buffer)
-{
-	UInt32 PacketType;
-	if (!a_Buffer.ReadVarInt(PacketType))
-	{
-		// Not enough data
-		return;
-	}
-
-	// Log the packet info into the comm log file:
-	if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
-	{
-		ContiguousByteBuffer PacketData;
-		a_Buffer.ReadAll(PacketData);
-		a_Buffer.ResetRead();
-		a_Buffer.ReadVarInt(PacketType);  // We have already read the packet type once, it will be there again
-		ASSERT(PacketData.size() > 0);  // We have written an extra NUL, so there had to be at least one byte read
-		PacketData.resize(PacketData.size() - 1);
-		AString PacketDataHex;
-		CreateHexDump(PacketDataHex, PacketData.data(), PacketData.size(), 16);
-		m_CommLogFile.Printf("Next incoming packet is type %u (0x%x), length %u (0x%x) at state %d. Payload:\n%s\n",
-			PacketType, PacketType, a_Buffer.GetUsedSpace(), a_Buffer.GetUsedSpace(), m_State, PacketDataHex.c_str()
-		);
-	}
-
-	if (!HandlePacket(a_Buffer, PacketType))
-	{
-		// Unknown packet, already been reported, but without the length. Log the length here:
-		LOGWARNING("Unhandled packet: type 0x%x, state %d, length %u", PacketType, m_State, a_Buffer.GetUsedSpace());
-
-#ifndef NDEBUG
-		// Dump the packet contents into the log:
-		a_Buffer.ResetRead();
-		ContiguousByteBuffer Packet;
-		a_Buffer.ReadAll(Packet);
-		Packet.resize(Packet.size() - 1);  // Drop the final NUL pushed there for over-read detection
-		AString Out;
-		CreateHexDump(Out, Packet.data(), Packet.size(), 24);
-		LOGD("Packet contents:\n%s", Out.c_str());
-#endif  // !NDEBUG
-
-		// Put a message in the comm log:
-		if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
-		{
-			m_CommLogFile.Printf("^^^^^^ Unhandled packet ^^^^^^\n\n\n");
-		}
-
-		return;
-	}
-
-	// The packet should have nothing left in the buffer:
-	if (a_Buffer.GetReadableSpace() != 0)
-	{
-		// Read more or less than packet length, report as error
-		LOGWARNING("Protocol 1.8: Wrong number of bytes read for packet 0x%x, state %d. Read %zu bytes, packet contained %u bytes",
-			PacketType, m_State, a_Buffer.GetUsedSpace() - a_Buffer.GetReadableSpace(), a_Buffer.GetUsedSpace()
-		);
-
-		// Put a message in the comm log:
-		if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
-		{
-			m_CommLogFile.Printf("^^^^^^ Wrong number of bytes read for this packet (exp %d left, got %zu left) ^^^^^^\n\n\n",
-				1, a_Buffer.GetReadableSpace()
-			);
-			m_CommLogFile.Flush();
-		}
-
-		ASSERT(!"Read wrong number of bytes!");
-		m_Client->PacketError(PacketType);
-	}
-}
-
-
-
-
-
-void cProtocol_1_8_0::SendEntityTeleport(const cEntity & a_Entity)
-{
-	cPacketizer Pkt(*this, pktTeleportEntity);
-	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
-	Pkt.WriteFPInt(a_Entity.GetPosX());
-	Pkt.WriteFPInt(a_Entity.GetPosY());
-	Pkt.WriteFPInt(a_Entity.GetPosZ());
-	Pkt.WriteByteAngle(a_Entity.GetYaw());
-	Pkt.WriteByteAngle(a_Entity.GetPitch());
-	Pkt.WriteBool(a_Entity.IsOnGround());
 }
 
 
@@ -4229,4 +4129,118 @@ const char * cProtocol_1_8_0::GetProtocolStatisticName(Statistic a_Statistic)
 		case Statistic::SneakTime:                 return "stat.sneakTime";
 		default:                                   return "";
 	}
+}
+
+
+
+
+
+void cProtocol_1_8_0::HandlePacket(cByteBuffer & a_Buffer)
+{
+	UInt32 PacketType;
+	if (!a_Buffer.ReadVarInt(PacketType))
+	{
+		// Not enough data
+		return;
+	}
+
+	// Log the packet info into the comm log file:
+	if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
+	{
+		ContiguousByteBuffer PacketData;
+		a_Buffer.ReadAll(PacketData);
+		a_Buffer.ResetRead();
+		a_Buffer.ReadVarInt(PacketType);  // We have already read the packet type once, it will be there again
+		ASSERT(PacketData.size() > 0);  // We have written an extra NUL, so there had to be at least one byte read
+		PacketData.resize(PacketData.size() - 1);
+		AString PacketDataHex;
+		CreateHexDump(PacketDataHex, PacketData.data(), PacketData.size(), 16);
+		m_CommLogFile.Printf("Next incoming packet is type %u (0x%x), length %u (0x%x) at state %d. Payload:\n%s\n",
+			PacketType, PacketType, a_Buffer.GetUsedSpace(), a_Buffer.GetUsedSpace(), m_State, PacketDataHex.c_str()
+		);
+	}
+
+	if (!HandlePacket(a_Buffer, PacketType))
+	{
+		// Unknown packet, already been reported, but without the length. Log the length here:
+		LOGWARNING("Unhandled packet: type 0x%x, state %d, length %u", PacketType, m_State, a_Buffer.GetUsedSpace());
+
+#ifndef NDEBUG
+		// Dump the packet contents into the log:
+		a_Buffer.ResetRead();
+		ContiguousByteBuffer Packet;
+		a_Buffer.ReadAll(Packet);
+		Packet.resize(Packet.size() - 1);  // Drop the final NUL pushed there for over-read detection
+		AString Out;
+		CreateHexDump(Out, Packet.data(), Packet.size(), 24);
+		LOGD("Packet contents:\n%s", Out.c_str());
+#endif  // !NDEBUG
+
+		// Put a message in the comm log:
+		if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
+		{
+			m_CommLogFile.Printf("^^^^^^ Unhandled packet ^^^^^^\n\n\n");
+		}
+
+		return;
+	}
+
+	// The packet should have nothing left in the buffer:
+	if (a_Buffer.GetReadableSpace() != 0)
+	{
+		// Read more or less than packet length, report as error
+		LOGWARNING("Protocol 1.8: Wrong number of bytes read for packet 0x%x, state %d. Read %zu bytes, packet contained %u bytes",
+			PacketType, m_State, a_Buffer.GetUsedSpace() - a_Buffer.GetReadableSpace(), a_Buffer.GetUsedSpace()
+		);
+
+		// Put a message in the comm log:
+		if (g_ShouldLogCommIn && m_CommLogFile.IsOpen())
+		{
+			m_CommLogFile.Printf("^^^^^^ Wrong number of bytes read for this packet (exp %d left, got %zu left) ^^^^^^\n\n\n",
+				1, a_Buffer.GetReadableSpace()
+			);
+			m_CommLogFile.Flush();
+		}
+
+		ASSERT(!"Read wrong number of bytes!");
+		m_Client->PacketError(PacketType);
+	}
+}
+
+
+
+
+
+void cProtocol_1_8_0::SendEntityTeleport(const cEntity & a_Entity)
+{
+	cPacketizer Pkt(*this, pktTeleportEntity);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteFPInt(a_Entity.GetPosX());
+	Pkt.WriteFPInt(a_Entity.GetPosY());
+	Pkt.WriteFPInt(a_Entity.GetPosZ());
+	Pkt.WriteByteAngle(a_Entity.GetYaw());
+	Pkt.WriteByteAngle(a_Entity.GetPitch());
+	Pkt.WriteBool(a_Entity.IsOnGround());
+}
+
+
+
+
+
+void cProtocol_1_8_0::StartEncryption(const Byte * a_Key)
+{
+	m_Encryptor.Init(a_Key, a_Key);
+	m_Decryptor.Init(a_Key, a_Key);
+	m_IsEncrypted = true;
+
+	// Prepare the m_AuthServerID:
+	cSha1Checksum Checksum;
+	cServer * Server = cRoot::Get()->GetServer();
+	const AString & ServerID = Server->GetServerID();
+	Checksum.Update(reinterpret_cast<const Byte *>(ServerID.c_str()), ServerID.length());
+	Checksum.Update(a_Key, 16);
+	Checksum.Update(reinterpret_cast<const Byte *>(Server->GetPublicKeyDER().data()), Server->GetPublicKeyDER().size());
+	Byte Digest[20];
+	Checksum.Finalize(Digest);
+	cSha1Checksum::DigestToJava(Digest, m_AuthServerID);
 }

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1566,20 +1566,23 @@ void cProtocol_1_8_0::SendTitleTimes(int a_FadeInTicks, int a_DisplayTicks, int 
 
 
 
-void cProtocol_1_8_0::SendTimeUpdate(Int64 a_WorldAge, Int64 a_WorldDate, bool a_DoDaylightCycle)
+void cProtocol_1_8_0::SendTimeUpdate(const cTickTimeLong a_WorldAge, const cTickTimeLong a_WorldDate, const bool a_DoDaylightCycle)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
-	if (!a_DoDaylightCycle)
+	cPacketizer Pkt(*this, pktTimeUpdate);
+	Pkt.WriteBEInt64(a_WorldAge.count());
+
+	if (a_DoDaylightCycle)
+	{
+		Pkt.WriteBEInt64(a_WorldDate.count());
+	}
+	else
 	{
 		// Negating the date stops time from advancing on the client
 		// (the std::min construction is to handle the case where the date is exactly zero):
-		a_WorldDate = std::min(-a_WorldDate, -1LL);
+		Pkt.WriteBEInt64(std::min(-a_WorldDate.count(), -1LL));
 	}
-
-	cPacketizer Pkt(*this, pktTimeUpdate);
-	Pkt.WriteBEInt64(a_WorldAge);
-	Pkt.WriteBEInt64(a_WorldDate);
 }
 
 

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -119,7 +119,7 @@ public:
 	virtual void SendTabCompletionResults       (const AStringVector & a_Results) override;
 	virtual void SendThunderbolt                (int a_BlockX, int a_BlockY, int a_BlockZ) override;
 	virtual void SendTitleTimes                 (int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks) override;
-	virtual void SendTimeUpdate                 (Int64 a_WorldAge, Int64 a_WorldDate, bool a_DoDaylightCycle) override;
+	virtual void SendTimeUpdate                 (cTickTimeLong a_WorldAge, cTickTimeLong a_WorldDate, bool a_DoDaylightCycle) override;
 	virtual void SendUnleashEntity              (const cEntity & a_Entity) override;
 	virtual void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ) override;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) override;

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -95,7 +95,6 @@ public:
 	virtual void SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName) override;
 	virtual void SendPlayerListUpdateGameMode   (const cPlayer & a_Player) override;
 	virtual void SendPlayerListUpdatePing       () override;
-	virtual void SendPlayerMaxSpeed             (void) override;
 	virtual void SendPlayerMoveLook             (void) override;
 	virtual void SendPlayerPosition             (void) override;
 	virtual void SendPlayerSpawn                (const cPlayer & a_Player) override;

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -141,11 +141,12 @@ protected:
 	/** State of the protocol. */
 	State m_State;
 
-	/** Get the packet ID for a given packet. */
-	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
+	/** Converts the BlockFace received by the protocol into eBlockFace constants.
+	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
+	static eBlockFace FaceIntToBlockFace(Int32 a_FaceInt);
 
-	/** Returns 1.8. */
-	virtual Version GetProtocolVersion() override;
+	/** Get the packet ID for a given packet. */
+	virtual UInt32 GetPacketID(ePacketType a_Packet) const override;
 
 	/** Converts an animation into an ID suitable for use with the Entity Animation packet.
 	Returns (uchar)-1 if the protocol version doesn't support this animation. */
@@ -156,7 +157,10 @@ protected:
 	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const;
 
 	/** Converts eMonsterType to protocol-specific mob types */
-	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType);
+	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) const;
+
+	/** Returns the protocol version. */
+	virtual Version GetProtocolVersion() const override;
 
 	/** Reads and handles the packet. The packet length and type have already been read.
 	Returns true if the packet was understood, false if it was an unknown packet. */
@@ -201,43 +205,37 @@ protected:
 	The message payload is still in the bytebuffer, the handler reads it specifically for each handled channel */
 	virtual void HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel);
 
+	/** Parses item metadata as read by ReadItem(), into the item enchantments. */
+	virtual void ParseItemMetadata(cItem & a_Item, ContiguousByteBufferView a_Metadata) const;
+
+	/** Reads an item out of the received data, sets a_Item to the values read.
+	Returns false if not enough received data.
+	a_KeepRemainingBytes tells the function to keep that many bytes at the end of the buffer. */
+	virtual bool ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes = 0) const;
+
+	/** Sends the entity type and entity-dependent data required for the entity to initially spawn. */
+	virtual void SendEntitySpawn(const cEntity & a_Entity, const UInt8 a_ObjectType, const Int32 a_ObjectData);
+
 	/** Sends the data to the client, encrypting them if needed. */
 	virtual void SendData(ContiguousByteBufferView a_Size) override;
 
 	/** Sends the packet to the client. Called by the cPacketizer's destructor. */
 	virtual void SendPacket(cPacketizer & a_Packet) override;
 
-	/** Reads an item out of the received data, sets a_Item to the values read.
-	Returns false if not enough received data.
-	a_KeepRemainingBytes tells the function to keep that many bytes at the end of the buffer. */
-	virtual bool ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t a_KeepRemainingBytes = 0);
-
-	/** Parses item metadata as read by ReadItem(), into the item enchantments. */
-	virtual void ParseItemMetadata(cItem & a_Item, ContiguousByteBufferView a_Metadata);
-
-	virtual void StartEncryption(const Byte * a_Key);
-
-	/** Converts the BlockFace received by the protocol into eBlockFace constants.
-	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
-	static eBlockFace FaceIntToBlockFace(Int32 a_FaceInt);
-
-	/** Sends the entity type and entity-dependent data required for the entity to initially spawn. */
-	virtual void SendEntitySpawn(const cEntity & a_Entity, const UInt8 a_ObjectType, const Int32 a_ObjectData);
-
 	/** Writes the block entity data for the specified block entity into the packet. */
-	virtual void WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity);
-
-	/** Writes the item data into a packet. */
-	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item);
+	virtual void WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) const;
 
 	/** Writes the metadata for the specified entity, not including the terminating 0x7f. */
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity);
-
-	/** Writes the mob-specific metadata for the specified mob */
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob);
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const;
 
 	/** Writes the entity properties for the specified entity, including the Count field. */
-	virtual void WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity);
+	virtual void WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity) const;
+
+	/** Writes the item data into a packet. */
+	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const;
+
+	/** Writes the mob-specific metadata for the specified mob */
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const;
 
 private:
 
@@ -259,14 +257,6 @@ private:
 	/** Adds the received (unencrypted) data to m_ReceivedData, parses complete packets */
 	void AddReceivedData(cByteBuffer & a_Buffer, ContiguousByteBufferView a_Data);
 
-	/** Handle a complete packet stored in the given buffer. */
-	void HandlePacket(cByteBuffer & a_Buffer);
-
-	/** Sends an entity teleport packet.
-	Mitigates a 1.8 bug where the position in the entity spawn packet is ignored,
-	and so entities don't show up until a teleport is sent. */
-	void SendEntityTeleport(const cEntity & a_Entity);
-
 	/** Converts an entity to a protocol-specific entity type.
 	Only entities that the Send Spawn Entity packet supports are valid inputs to this method */
 	static UInt8 GetProtocolEntityType(const cEntity & a_Entity);
@@ -278,4 +268,14 @@ private:
 	Protocols <= 1.12 use strings, hence this is a static as the string-mapping was append-only for the versions that used it.
 	Returns an empty string, handled correctly by the client, for newer, unsupported statistics. */
 	static const char * GetProtocolStatisticName(Statistic a_Statistic);
+
+	/** Handle a complete packet stored in the given buffer. */
+	void HandlePacket(cByteBuffer & a_Buffer);
+
+	/** Sends an entity teleport packet.
+	Mitigates a 1.8 bug where the position in the entity spawn packet is ignored,
+	and so entities don't show up until a teleport is sent. */
+	void SendEntityTeleport(const cEntity & a_Entity);
+
+	void StartEncryption(const Byte * a_Key);
 } ;

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -62,7 +62,7 @@ public:
 	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
 	virtual void SendDisconnect                 (const AString & a_Reason) override;
 	virtual void SendEditSign                   (int a_BlockX, int a_BlockY, int a_BlockZ) override;  ///< Request the client to open up the sign editor for the sign (1.6+)
-	virtual void SendEntityAnimation            (const cEntity & a_Entity, char a_Animation) override;
+	virtual void SendEntityAnimation            (const cEntity & a_Entity, EntityAnimation a_Animation) override;
 	virtual void SendEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, int a_Duration) override;
 	virtual void SendEntityEquipment            (const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item) override;
 	virtual void SendEntityHeadLook             (const cEntity & a_Entity) override;
@@ -70,7 +70,6 @@ public:
 	virtual void SendEntityMetadata             (const cEntity & a_Entity) override;
 	virtual void SendEntityPosition             (const cEntity & a_Entity) override;
 	virtual void SendEntityProperties           (const cEntity & a_Entity) override;
-	virtual void SendEntityStatus               (const cEntity & a_Entity, char a_Status) override;
 	virtual void SendEntityVelocity             (const cEntity & a_Entity) override;
 	virtual void SendExperience                 (void) override;
 	virtual void SendExperienceOrb              (const cExpOrb & a_ExpOrb) override;
@@ -123,7 +122,6 @@ public:
 	virtual void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ) override;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) override;
 	virtual void SendUpdateSign                 (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) override;
-	virtual void SendUseBed                     (const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ) override;
 	virtual void SendUnlockRecipe               (UInt32 a_RecipeID) override;
 	virtual void SendInitRecipes                (UInt32 a_RecipeID) override;
 	virtual void SendWeather                    (eWeather a_Weather) override;
@@ -138,26 +136,30 @@ public:
 	a_Compressed will be set to the compressed packet includes packet length and data length. */
 	static void CompressPacket(CircularBufferCompressor & a_Packet, ContiguousByteBuffer & a_Compressed);
 
-	/** The 1.8 protocol use a particle id instead of a string. This function converts the name to the id. If the name is incorrect, it returns 0. */
-	static int GetParticleID(const AString & a_ParticleName);
-
 protected:
 
 	/** State of the protocol. */
 	State m_State;
 
-	/** Nobody inherits 1.8, so it doesn't use this method */
+	/** Get the packet ID for a given packet. */
 	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
 
 	/** Returns 1.8. */
 	virtual Version GetProtocolVersion() override;
 
+	/** Converts an animation into an ID suitable for use with the Entity Animation packet.
+	Returns (uchar)-1 if the protocol version doesn't support this animation. */
+	virtual unsigned char GetProtocolEntityAnimation(EntityAnimation a_Animation) const;
+
+	/** Converts an animation into an ID suitable for use with the Entity Status packet.
+	Returns -1 if the protocol version doesn't support this animation. */
+	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const;
+
 	/** Converts eMonsterType to protocol-specific mob types */
 	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType);
 
 	/** Reads and handles the packet. The packet length and type have already been read.
-	Returns true if the packet was understood, false if it was an unknown packet
-	*/
+	Returns true if the packet was understood, false if it was an unknown packet. */
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType);
 
 	// Packet handlers while in the Status state (m_State == 1):
@@ -268,6 +270,9 @@ private:
 	/** Converts an entity to a protocol-specific entity type.
 	Only entities that the Send Spawn Entity packet supports are valid inputs to this method */
 	static UInt8 GetProtocolEntityType(const cEntity & a_Entity);
+
+	/** The 1.8 protocol use a particle id instead of a string. This function converts the name to the id. If the name is incorrect, it returns 0. */
+	static int GetProtocolParticleID(const AString & a_ParticleName);
 
 	/** Converts a statistic to a protocol-specific string.
 	Protocols <= 1.12 use strings, hence this is a static as the string-mapping was append-only for the versions that used it.

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -367,19 +367,6 @@ void cProtocol_1_9_0::SendEntityPosition(const cEntity & a_Entity)
 
 
 
-void cProtocol_1_9_0::SendEntityStatus(const cEntity & a_Entity, char a_Status)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, pktEntityStatus);
-	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteBEInt8(a_Status);
-}
-
-
-
-
-
 void cProtocol_1_9_0::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 {
 	ASSERT(m_State == 3);  // In game mode?
@@ -702,6 +689,37 @@ UInt32 cProtocol_1_9_0::GetPacketID(cProtocol::ePacketType a_Packet)
 		}
 	}
 	UNREACHABLE("Unsupported outgoing packet type");
+}
+
+
+
+
+
+unsigned char cProtocol_1_9_0::GetProtocolEntityAnimation(const EntityAnimation a_Animation) const
+{
+	if (a_Animation == EntityAnimation::PlayerOffHandSwings)
+	{
+		return 3;
+	}
+
+	return Super::GetProtocolEntityAnimation(a_Animation);
+}
+
+
+
+
+
+signed char cProtocol_1_9_0::GetProtocolEntityStatus(const EntityAnimation a_Animation) const
+{
+	switch (a_Animation)
+	{
+		case EntityAnimation::ArmorStandGetsHit: return 32;
+		case EntityAnimation::ArrowTipSparkles: return 0;
+		case EntityAnimation::PawnShieldBlocks: return 29;
+		case EntityAnimation::PawnShieldBreaks: return 30;
+		case EntityAnimation::PawnThornsPricks: return 33;
+		default: return Super::GetProtocolEntityStatus(a_Animation);
+	}
 }
 
 

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -490,35 +490,6 @@ void cProtocol_1_9_0::SendMapData(const cMap & a_Map, int a_DataStartX, int a_Da
 
 
 
-void cProtocol_1_9_0::SendPlayerMaxSpeed(void)
-{
-	ASSERT(m_State == 3);  // In game mode?
-
-	cPacketizer Pkt(*this, pktPlayerMaxSpeed);
-	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteVarInt32(Player->GetUniqueID());
-	Pkt.WriteBEInt32(1);  // Count
-	Pkt.WriteString("generic.movementSpeed");
-	// The default game speed is 0.1, multiply that value by the relative speed:
-	Pkt.WriteBEDouble(0.1 * Player->GetNormalMaxSpeed());
-	if (Player->IsSprinting())
-	{
-		Pkt.WriteVarInt32(1);  // Modifier count
-		Pkt.WriteBEUInt64(0x662a6b8dda3e4c1c);
-		Pkt.WriteBEUInt64(0x881396ea6097278d);  // UUID of the modifier
-		Pkt.WriteBEDouble(Player->GetSprintingMaxSpeed() - Player->GetNormalMaxSpeed());
-		Pkt.WriteBEUInt8(2);
-	}
-	else
-	{
-		Pkt.WriteVarInt32(0);  // Modifier count
-	}
-}
-
-
-
-
-
 void cProtocol_1_9_0::SendPlayerMoveLook(void)
 {
 	ASSERT(m_State == 3);  // In game mode?
@@ -690,7 +661,6 @@ UInt32 cProtocol_1_9_0::GetPacketID(cProtocol::ePacketType a_Packet)
 		case pktPlayerAbilities:        return 0x2b;
 		case pktPlayerList:             return 0x2d;
 		case pktPlayerListHeaderFooter: return 0x48;
-		case pktPlayerMaxSpeed:         return 0x4b;
 		case pktPlayerMoveLook:         return 0x2e;
 		case pktPluginMessage:          return 0x18;
 		case pktRemoveEntityEffect:     return 0x31;
@@ -2271,26 +2241,6 @@ void cProtocol_1_9_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_M
 
 
 
-void cProtocol_1_9_0::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity)
-{
-	if (!a_Entity.IsMob())
-	{
-		// No properties for anything else than mobs
-		a_Pkt.WriteBEInt32(0);
-		return;
-	}
-
-	// const cMonster & Mob = (const cMonster &)a_Entity;
-
-	// TODO: Send properties and modifiers based on the mob type
-
-	a_Pkt.WriteBEInt32(0);  // NumProperties
-}
-
-
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_9_1:
 
@@ -2320,9 +2270,6 @@ void cProtocol_1_9_1::SendLogin(const cPlayer & a_Player, const cWorld & a_World
 		cPacketizer Pkt(*this, pktDifficulty);
 		Pkt.WriteBEInt8(1);
 	}
-
-	// Send player abilities:
-	SendPlayerAbilities();
 }
 
 
@@ -2405,7 +2352,6 @@ UInt32 cProtocol_1_9_4::GetPacketID(cProtocol::ePacketType a_Packet)
 		case pktCollectEntity:          return 0x48;
 		case pktEntityEffect:           return 0x4b;
 		case pktEntityProperties:       return 0x4a;
-		case pktPlayerMaxSpeed:         return 0x4a;
 		case pktPlayerListHeaderFooter: return 0x47;
 		case pktTeleportEntity:         return 0x49;
 

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -51,9 +51,11 @@ Implements the 1.9 protocol classes:
 
 
 
-/** Value for main hand in Hand parameter for Protocol 1.9. */
-static const UInt32 MAIN_HAND = 0;
-static const UInt32 OFF_HAND = 1;
+// Value for main hand in Hand parameter for Protocol 1.9.
+#define MAIN_HAND 0
+
+// Value for left hand in MainHand parameter for Protocol 1.9.
+#define LEFT_HAND 0
 
 
 
@@ -602,7 +604,7 @@ void cProtocol_1_9_0::SendUnloadChunk(int a_ChunkX, int a_ChunkZ)
 
 
 
-UInt32 cProtocol_1_9_0::GetPacketID(cProtocol::ePacketType a_Packet)
+UInt32 cProtocol_1_9_0::GetPacketID(cProtocol::ePacketType a_Packet) const
 {
 	switch (a_Packet)
 	{
@@ -726,22 +728,22 @@ signed char cProtocol_1_9_0::GetProtocolEntityStatus(const EntityAnimation a_Ani
 
 
 
-cProtocol::Version cProtocol_1_9_0::GetProtocolVersion()
-{
-	return Version::v1_9_0;
-}
-
-
-
-
-
-UInt32 cProtocol_1_9_0::GetProtocolMobType(const eMonsterType a_MobType)
+UInt32 cProtocol_1_9_0::GetProtocolMobType(const eMonsterType a_MobType) const
 {
 	switch (a_MobType)
 	{
 		case mtShulker: return 69;
 		default:        return Super::GetProtocolMobType(a_MobType);
 	}
+}
+
+
+
+
+
+cProtocol::Version cProtocol_1_9_0::GetProtocolVersion() const
+{
+	return Version::v1_9_0;
 }
 
 
@@ -824,7 +826,7 @@ void cProtocol_1_9_0::HandlePacketAnimation(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Hand);
 
-	m_Client->HandleAnimation(0);  // Packet exists solely for arm-swing notification
+	m_Client->HandleAnimation(Hand == MAIN_HAND);  // Packet exists solely for arm-swing notification (main and off-hand).
 }
 
 
@@ -862,7 +864,8 @@ void cProtocol_1_9_0::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorX);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorY);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, CursorZ);
-	m_Client->HandleRightClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), CursorX, CursorY, CursorZ, HandIntToEnum(Hand));
+
+	m_Client->HandleRightClick(BlockX, BlockY, BlockZ, FaceIntToBlockFace(Face), CursorX, CursorY, CursorZ, Hand == MAIN_HAND);
 }
 
 
@@ -899,12 +902,12 @@ void cProtocol_1_9_0::HandlePacketClientSettings(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   ChatFlags);
 	HANDLE_READ(a_ByteBuffer, ReadBool,          bool,    ChatColors);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8,       UInt8,   SkinParts);
-	HANDLE_READ(a_ByteBuffer, ReadVarInt,        UInt32,   MainHand);
+	HANDLE_READ(a_ByteBuffer, ReadVarInt,        UInt32,  MainHand);
 
 	m_Client->SetLocale(Locale);
 	m_Client->SetViewDistance(ViewDistance);
 	m_Client->GetPlayer()->SetSkinParts(SkinParts);
-	m_Client->GetPlayer()->SetMainHand(static_cast<eMainHand>(MainHand));
+	m_Client->GetPlayer()->SetLeftHanded(MainHand == LEFT_HAND);
 	// TODO: Handle chat flags and chat colors
 }
 
@@ -964,7 +967,7 @@ void cProtocol_1_9_0::HandlePacketPlayerPos(cByteBuffer & a_ByteBuffer)
 
 	if (m_IsTeleportIdConfirmed)
 	{
-		m_Client->HandlePlayerPos(PosX, PosY, PosZ, IsOnGround);
+		m_Client->HandlePlayerMove(PosX, PosY, PosZ, IsOnGround);
 	}
 }
 
@@ -1065,6 +1068,7 @@ void cProtocol_1_9_0::HandlePacketUseEntity(cByteBuffer & a_ByteBuffer)
 		case 0:
 		{
 			HANDLE_READ(a_ByteBuffer, ReadVarInt, UInt32, Hand);
+
 			if (Hand == MAIN_HAND)  // TODO: implement handling of off-hand actions; ignore them for now to avoid processing actions twice
 			{
 				m_Client->HandleUseEntity(EntityID, false);
@@ -1102,7 +1106,7 @@ void cProtocol_1_9_0::HandlePacketUseItem(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarInt, Int32, Hand);
 
-	m_Client->HandleUseItem(HandIntToEnum(Hand));
+	m_Client->HandleUseItem(Hand == MAIN_HAND);
 }
 
 
@@ -1193,7 +1197,7 @@ void cProtocol_1_9_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 
 
 
-void cProtocol_1_9_0::ParseItemMetadata(cItem & a_Item, const ContiguousByteBufferView a_Metadata)
+void cProtocol_1_9_0::ParseItemMetadata(cItem & a_Item, const ContiguousByteBufferView a_Metadata) const
 {
 	// Parse into NBT:
 	cParsedNBT NBT(a_Metadata);
@@ -1397,25 +1401,6 @@ void cProtocol_1_9_0::ParseItemMetadata(cItem & a_Item, const ContiguousByteBuff
 
 
 
-eHand cProtocol_1_9_0::HandIntToEnum(Int32 a_Hand)
-{
-	// Convert hand parameter into eHand enum
-	switch (a_Hand)
-	{
-		case MAIN_HAND: return eHand::hMain;
-		case OFF_HAND: return eHand::hOff;
-		default:
-		{
-			ASSERT(!"Unknown hand value");
-			return eHand::hMain;
-		}
-	}
-}
-
-
-
-
-
 void cProtocol_1_9_0::SendEntitySpawn(const cEntity & a_Entity, const UInt8 a_ObjectType, const Int32 a_ObjectData)
 {
 	ASSERT(m_State == 3);  // In game mode?
@@ -1443,7 +1428,7 @@ void cProtocol_1_9_0::SendEntitySpawn(const cEntity & a_Entity, const UInt8 a_Ob
 
 
 
-void cProtocol_1_9_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity)
+void cProtocol_1_9_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) const
 {
 	a_Writer.AddInt("x", a_BlockEntity.GetPosX());
 	a_Writer.AddInt("y", a_BlockEntity.GetPosY());
@@ -1467,7 +1452,229 @@ void cProtocol_1_9_0::WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEn
 
 
 
-void cProtocol_1_9_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
+void cProtocol_1_9_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const
+{
+	// Common metadata:
+	Int8 Flags = 0;
+	if (a_Entity.IsOnFire())
+	{
+		Flags |= 0x01;
+	}
+	if (a_Entity.IsCrouched())
+	{
+		Flags |= 0x02;
+	}
+	if (a_Entity.IsSprinting())
+	{
+		Flags |= 0x08;
+	}
+	if (a_Entity.IsRclking())
+	{
+		Flags |= 0x10;
+	}
+	if (a_Entity.IsInvisible())
+	{
+		Flags |= 0x20;
+	}
+	if (a_Entity.IsElytraFlying())
+	{
+		Flags |= 0x80;
+	}
+	a_Pkt.WriteBEUInt8(0);  // Index 0
+	a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);  // Type
+	a_Pkt.WriteBEInt8(Flags);
+
+	switch (a_Entity.GetEntityType())
+	{
+		case cEntity::etPlayer:
+		{
+			auto & Player = static_cast<const cPlayer &>(a_Entity);
+
+			// TODO Set player custom name to their name.
+			// Then it's possible to move the custom name of mobs to the entities
+			// and to remove the "special" player custom name.
+			a_Pkt.WriteBEUInt8(2);  // Index 2: Custom name
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_STRING);
+			a_Pkt.WriteString(Player.GetName());
+
+			a_Pkt.WriteBEUInt8(6);  // Index 6: Health
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
+			a_Pkt.WriteBEFloat(static_cast<float>(Player.GetHealth()));
+
+			a_Pkt.WriteBEUInt8(12);
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetSkinParts()));
+
+			a_Pkt.WriteBEUInt8(13);
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+			a_Pkt.WriteBEUInt8(Player.IsLeftHanded() ? 0 : 1);
+			break;
+		}
+		case cEntity::etPickup:
+		{
+			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+			WriteItem(a_Pkt, static_cast<const cPickup &>(a_Entity).GetItem());
+			break;
+		}
+		case cEntity::etMinecart:
+		{
+			a_Pkt.WriteBEUInt8(5);  // Index 5: Shaking power
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+
+			// The following expression makes Minecarts shake more with less health or higher damage taken
+			auto & Minecart = static_cast<const cMinecart &>(a_Entity);
+			auto maxHealth = a_Entity.GetMaxHealth();
+			auto curHealth = a_Entity.GetHealth();
+			a_Pkt.WriteVarInt32(static_cast<UInt32>((maxHealth - curHealth) * Minecart.LastDamage() * 4));
+
+			a_Pkt.WriteBEUInt8(6);  // Index 6: Shaking direction (doesn't seem to effect anything)
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(1);
+
+			a_Pkt.WriteBEUInt8(7);  // Index 7: Shake multiplier / damage taken
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
+			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));
+
+			if (Minecart.GetPayload() == cMinecart::mpNone)
+			{
+				auto & RideableMinecart = static_cast<const cRideableMinecart &>(Minecart);
+				const cItem & MinecartContent = RideableMinecart.GetContent();
+				if (!MinecartContent.IsEmpty())
+				{
+					a_Pkt.WriteBEUInt8(8);  // Index 8: Block ID and damage
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+					int Content = MinecartContent.m_ItemType;
+					Content |= MinecartContent.m_ItemDamage << 8;
+					a_Pkt.WriteVarInt32(static_cast<UInt32>(Content));
+
+					a_Pkt.WriteBEUInt8(9);  // Index 9: Block ID and damage
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+					a_Pkt.WriteVarInt32(static_cast<UInt32>(RideableMinecart.GetBlockHeight()));
+
+					a_Pkt.WriteBEUInt8(10);  // Index 10: Show block
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+					a_Pkt.WriteBool(true);
+				}
+			}
+			else if (Minecart.GetPayload() == cMinecart::mpFurnace)
+			{
+				a_Pkt.WriteBEUInt8(11);  // Index 11: Is powered
+				a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+				a_Pkt.WriteBool(static_cast<const cMinecartWithFurnace &>(Minecart).IsFueled());
+			}
+			break;
+		}  // case etMinecart
+
+		case cEntity::etProjectile:
+		{
+			auto & Projectile = static_cast<const cProjectileEntity &>(a_Entity);
+			switch (Projectile.GetProjectileKind())
+			{
+				case cProjectileEntity::pkArrow:
+				{
+					a_Pkt.WriteBEUInt8(5);  // Index 5: Is critical
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
+					a_Pkt.WriteBEInt8(static_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
+					break;
+				}
+				case cProjectileEntity::pkFirework:
+				{
+					a_Pkt.WriteBEUInt8(5);  // Index 5: Firework item used for this firework
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+					WriteItem(a_Pkt, static_cast<const cFireworkEntity &>(Projectile).GetItem());
+					break;
+				}
+				case cProjectileEntity::pkSplashPotion:
+				{
+					a_Pkt.WriteBEUInt8(5);  // Index 5: Potion item which was thrown
+					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+					WriteItem(a_Pkt, static_cast<const cSplashPotionEntity &>(Projectile).GetItem());
+				}
+				default:
+				{
+					break;
+				}
+			}
+			break;
+		}  // case etProjectile
+
+		case cEntity::etMonster:
+		{
+			WriteMobMetadata(a_Pkt, static_cast<const cMonster &>(a_Entity));
+			break;
+		}
+
+		case cEntity::etBoat:
+		{
+			auto & Boat = static_cast<const cBoat &>(a_Entity);
+
+			a_Pkt.WriteBEInt8(5);  // Index 6: Time since last hit
+			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetLastDamage()));
+
+			a_Pkt.WriteBEInt8(6);  // Index 7: Forward direction
+			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetForwardDirection()));
+
+			a_Pkt.WriteBEInt8(7);  // Index 8: Damage taken
+			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
+			a_Pkt.WriteBEFloat(Boat.GetDamageTaken());
+
+			a_Pkt.WriteBEInt8(8);  // Index 9: Type
+			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetMaterial()));
+
+			a_Pkt.WriteBEInt8(9);  // Index 10: Right paddle turning
+			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Boat.IsRightPaddleUsed());
+
+			a_Pkt.WriteBEInt8(10);  // Index 11: Left paddle turning
+			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(Boat.IsLeftPaddleUsed());
+
+			break;
+		}  // case etBoat
+
+		case cEntity::etItemFrame:
+		{
+			auto & Frame = static_cast<const cItemFrame &>(a_Entity);
+			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
+			WriteItem(a_Pkt, Frame.GetItem());
+			a_Pkt.WriteBEUInt8(6);  // Index 6: Rotation
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
+			a_Pkt.WriteVarInt32(Frame.GetItemRotation());
+			break;
+		}  // case etItemFrame
+
+		case cEntity::etEnderCrystal:
+		{
+			const auto & EnderCrystal = static_cast<const cEnderCrystal &>(a_Entity);
+			a_Pkt.WriteBEUInt8(5);
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_OPTIONAL_POSITION);
+			a_Pkt.WriteBool(EnderCrystal.DisplaysBeam());
+			if (EnderCrystal.DisplaysBeam())
+			{
+				a_Pkt.WriteXYZPosition64(EnderCrystal.GetBeamTarget());
+			}
+			a_Pkt.WriteBEUInt8(6);
+			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
+			a_Pkt.WriteBool(EnderCrystal.ShowsBottom());
+			break;
+		}  // case etEnderCrystal
+		default:
+		{
+			break;
+		}
+	}
+}
+
+
+
+
+
+void cProtocol_1_9_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const
 {
 	short ItemType = a_Item.m_ItemType;
 	ASSERT(ItemType >= -1);  // Check validity of packets in debug runtime
@@ -1637,229 +1844,7 @@ void cProtocol_1_9_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 
 
 
-void cProtocol_1_9_0::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity)
-{
-	// Common metadata:
-	Int8 Flags = 0;
-	if (a_Entity.IsOnFire())
-	{
-		Flags |= 0x01;
-	}
-	if (a_Entity.IsCrouched())
-	{
-		Flags |= 0x02;
-	}
-	if (a_Entity.IsSprinting())
-	{
-		Flags |= 0x08;
-	}
-	if (a_Entity.IsRclking())
-	{
-		Flags |= 0x10;
-	}
-	if (a_Entity.IsInvisible())
-	{
-		Flags |= 0x20;
-	}
-	if (a_Entity.IsElytraFlying())
-	{
-		Flags |= 0x80;
-	}
-	a_Pkt.WriteBEUInt8(0);  // Index 0
-	a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);  // Type
-	a_Pkt.WriteBEInt8(Flags);
-
-	switch (a_Entity.GetEntityType())
-	{
-		case cEntity::etPlayer:
-		{
-			auto & Player = static_cast<const cPlayer &>(a_Entity);
-
-			// TODO Set player custom name to their name.
-			// Then it's possible to move the custom name of mobs to the entities
-			// and to remove the "special" player custom name.
-			a_Pkt.WriteBEUInt8(2);  // Index 2: Custom name
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_STRING);
-			a_Pkt.WriteString(Player.GetName());
-
-			a_Pkt.WriteBEUInt8(6);  // Index 6: Health
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
-			a_Pkt.WriteBEFloat(static_cast<float>(Player.GetHealth()));
-
-			a_Pkt.WriteBEUInt8(12);
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetSkinParts()));
-
-			a_Pkt.WriteBEUInt8(13);
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-			a_Pkt.WriteBEUInt8(static_cast<UInt8>(Player.GetMainHand()));
-			break;
-		}
-		case cEntity::etPickup:
-		{
-			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
-			WriteItem(a_Pkt, static_cast<const cPickup &>(a_Entity).GetItem());
-			break;
-		}
-		case cEntity::etMinecart:
-		{
-			a_Pkt.WriteBEUInt8(5);  // Index 5: Shaking power
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-
-			// The following expression makes Minecarts shake more with less health or higher damage taken
-			auto & Minecart = static_cast<const cMinecart &>(a_Entity);
-			auto maxHealth = a_Entity.GetMaxHealth();
-			auto curHealth = a_Entity.GetHealth();
-			a_Pkt.WriteVarInt32(static_cast<UInt32>((maxHealth - curHealth) * Minecart.LastDamage() * 4));
-
-			a_Pkt.WriteBEUInt8(6);  // Index 6: Shaking direction (doesn't seem to effect anything)
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(1);
-
-			a_Pkt.WriteBEUInt8(7);  // Index 7: Shake multiplier / damage taken
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_FLOAT);
-			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));
-
-			if (Minecart.GetPayload() == cMinecart::mpNone)
-			{
-				auto & RideableMinecart = static_cast<const cRideableMinecart &>(Minecart);
-				const cItem & MinecartContent = RideableMinecart.GetContent();
-				if (!MinecartContent.IsEmpty())
-				{
-					a_Pkt.WriteBEUInt8(8);  // Index 8: Block ID and damage
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-					int Content = MinecartContent.m_ItemType;
-					Content |= MinecartContent.m_ItemDamage << 8;
-					a_Pkt.WriteVarInt32(static_cast<UInt32>(Content));
-
-					a_Pkt.WriteBEUInt8(9);  // Index 9: Block ID and damage
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-					a_Pkt.WriteVarInt32(static_cast<UInt32>(RideableMinecart.GetBlockHeight()));
-
-					a_Pkt.WriteBEUInt8(10);  // Index 10: Show block
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-					a_Pkt.WriteBool(true);
-				}
-			}
-			else if (Minecart.GetPayload() == cMinecart::mpFurnace)
-			{
-				a_Pkt.WriteBEUInt8(11);  // Index 11: Is powered
-				a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-				a_Pkt.WriteBool(static_cast<const cMinecartWithFurnace &>(Minecart).IsFueled());
-			}
-			break;
-		}  // case etMinecart
-
-		case cEntity::etProjectile:
-		{
-			auto & Projectile = static_cast<const cProjectileEntity &>(a_Entity);
-			switch (Projectile.GetProjectileKind())
-			{
-				case cProjectileEntity::pkArrow:
-				{
-					a_Pkt.WriteBEUInt8(5);  // Index 5: Is critical
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_BYTE);
-					a_Pkt.WriteBEInt8(static_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
-					break;
-				}
-				case cProjectileEntity::pkFirework:
-				{
-					a_Pkt.WriteBEUInt8(5);  // Index 5: Firework item used for this firework
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
-					WriteItem(a_Pkt, static_cast<const cFireworkEntity &>(Projectile).GetItem());
-					break;
-				}
-				case cProjectileEntity::pkSplashPotion:
-				{
-					a_Pkt.WriteBEUInt8(5);  // Index 5: Potion item which was thrown
-					a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
-					WriteItem(a_Pkt, static_cast<const cSplashPotionEntity &>(Projectile).GetItem());
-				}
-				default:
-				{
-					break;
-				}
-			}
-			break;
-		}  // case etProjectile
-
-		case cEntity::etMonster:
-		{
-			WriteMobMetadata(a_Pkt, static_cast<const cMonster &>(a_Entity));
-			break;
-		}
-
-		case cEntity::etBoat:
-		{
-			auto & Boat = static_cast<const cBoat &>(a_Entity);
-
-			a_Pkt.WriteBEInt8(5);  // Index 6: Time since last hit
-			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetLastDamage()));
-
-			a_Pkt.WriteBEInt8(6);  // Index 7: Forward direction
-			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetForwardDirection()));
-
-			a_Pkt.WriteBEInt8(7);  // Index 8: Damage taken
-			a_Pkt.WriteBEInt8(METADATA_TYPE_FLOAT);
-			a_Pkt.WriteBEFloat(Boat.GetDamageTaken());
-
-			a_Pkt.WriteBEInt8(8);  // Index 9: Type
-			a_Pkt.WriteBEInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(static_cast<UInt32>(Boat.GetMaterial()));
-
-			a_Pkt.WriteBEInt8(9);  // Index 10: Right paddle turning
-			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Boat.IsRightPaddleUsed());
-
-			a_Pkt.WriteBEInt8(10);  // Index 11: Left paddle turning
-			a_Pkt.WriteBEInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(Boat.IsLeftPaddleUsed());
-
-			break;
-		}  // case etBoat
-
-		case cEntity::etItemFrame:
-		{
-			auto & Frame = static_cast<const cItemFrame &>(a_Entity);
-			a_Pkt.WriteBEUInt8(5);  // Index 5: Item
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_ITEM);
-			WriteItem(a_Pkt, Frame.GetItem());
-			a_Pkt.WriteBEUInt8(6);  // Index 6: Rotation
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_VARINT);
-			a_Pkt.WriteVarInt32(Frame.GetItemRotation());
-			break;
-		}  // case etItemFrame
-
-		case cEntity::etEnderCrystal:
-		{
-			const auto & EnderCrystal = static_cast<const cEnderCrystal &>(a_Entity);
-			a_Pkt.WriteBEUInt8(5);
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_OPTIONAL_POSITION);
-			a_Pkt.WriteBool(EnderCrystal.DisplaysBeam());
-			if (EnderCrystal.DisplaysBeam())
-			{
-				a_Pkt.WriteXYZPosition64(EnderCrystal.GetBeamTarget());
-			}
-			a_Pkt.WriteBEUInt8(6);
-			a_Pkt.WriteBEUInt8(METADATA_TYPE_BOOL);
-			a_Pkt.WriteBool(EnderCrystal.ShowsBottom());
-			break;
-		}  // case etEnderCrystal
-		default:
-		{
-			break;
-		}
-	}
-}
-
-
-
-
-
-void cProtocol_1_9_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
+void cProtocol_1_9_0::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const
 {
 	// Living entity metadata
 	if (a_Mob.HasCustomName())
@@ -2294,7 +2279,7 @@ void cProtocol_1_9_1::SendLogin(const cPlayer & a_Player, const cWorld & a_World
 
 
 
-cProtocol::Version cProtocol_1_9_1::GetProtocolVersion()
+cProtocol::Version cProtocol_1_9_1::GetProtocolVersion() const
 {
 	return Version::v1_9_1;
 }
@@ -2306,7 +2291,7 @@ cProtocol::Version cProtocol_1_9_1::GetProtocolVersion()
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_9_2:
 
-cProtocol::Version cProtocol_1_9_2::GetProtocolVersion()
+cProtocol::Version cProtocol_1_9_2::GetProtocolVersion() const
 {
 	return Version::v1_9_2;
 }
@@ -2354,16 +2339,7 @@ void cProtocol_1_9_4::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 
 
-cProtocol::Version cProtocol_1_9_4::GetProtocolVersion()
-{
-	return Version::v1_9_4;
-}
-
-
-
-
-
-UInt32 cProtocol_1_9_4::GetPacketID(cProtocol::ePacketType a_Packet)
+UInt32 cProtocol_1_9_4::GetPacketID(cProtocol::ePacketType a_Packet) const
 {
 	switch (a_Packet)
 	{
@@ -2375,4 +2351,13 @@ UInt32 cProtocol_1_9_4::GetPacketID(cProtocol::ePacketType a_Packet)
 
 		default: return Super::GetPacketID(a_Packet);
 	}
+}
+
+
+
+
+
+cProtocol::Version cProtocol_1_9_4::GetProtocolVersion() const
+{
+	return Version::v1_9_4;
 }

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -57,7 +57,6 @@ public:
 	virtual void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) override;
 	virtual void SendMapData                    (const cMap & a_Map, int a_DataStartX, int a_DataStartY) override;
 	virtual void SendPaintingSpawn              (const cPainting & a_Painting) override;
-	virtual void SendPlayerMaxSpeed             (void) override;
 	virtual void SendPlayerMoveLook             (void) override;
 	virtual void SendPlayerSpawn                (const cPlayer & a_Player) override;
 	virtual void SendSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch) override;
@@ -124,9 +123,6 @@ protected:
 
 	/** Writes the mob-specific metadata for the specified mob */
 	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override;
-
-	/** Writes the entity properties for the specified entity, including the Count field. */
-	virtual void WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity) override;
 
 	/** Types used within metadata */
 	enum eMetadataType

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -51,7 +51,6 @@ public:
 	virtual void SendEntityEquipment            (const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item) override;
 	virtual void SendEntityMetadata             (const cEntity & a_Entity) override;
 	virtual void SendEntityPosition             (const cEntity & a_Entity) override;
-	virtual void SendEntityStatus               (const cEntity & a_Entity, char a_Status) override;
 	virtual void SendExperienceOrb              (const cExpOrb & a_ExpOrb) override;
 	virtual void SendKeepAlive                  (UInt32 a_PingID) override;
 	virtual void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) override;
@@ -73,6 +72,9 @@ protected:
 
 	/** Get the packet ID for a given packet. */
 	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
+
+	virtual unsigned char GetProtocolEntityAnimation(EntityAnimation a_Animation) const override;
+	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
 
 	/** Returns 1.9. */
 	virtual Version GetProtocolVersion() override;

--- a/src/Protocol/Protocol_1_9.h
+++ b/src/Protocol/Protocol_1_9.h
@@ -21,10 +21,6 @@ Declares the 1.9 protocol classes:
 
 #include "Protocol.h"
 #include "Protocol_1_8.h"
-#include "../ByteBuffer.h"
-
-#include "../mbedTLS++/AesCfb128Decryptor.h"
-#include "../mbedTLS++/AesCfb128Encryptor.h"
 
 
 
@@ -39,54 +35,45 @@ public:
 
 	cProtocol_1_9_0(cClientHandle * a_Client, const AString & a_ServerAddress, State a_State);
 
-	/** Sending stuff to clients (alphabetically sorted): */
-	virtual void SendAttachEntity               (const cEntity & a_Entity, const cEntity & a_Vehicle) override;
-	virtual void SendBossBarAdd                 (UInt32 a_UniqueID, const cCompositeChat & a_Title, float a_FractionFilled, BossBarColor a_Color, BossBarDivisionType a_DivisionType, bool a_DarkenSky, bool a_PlayEndMusic, bool a_CreateFog) override;
-	virtual void SendBossBarRemove              (UInt32 a_UniqueID) override;
-	virtual void SendBossBarUpdateFlags         (UInt32 a_UniqueID, bool a_DarkenSky, bool a_PlayEndMusic, bool a_CreateFog) override;
-	virtual void SendBossBarUpdateHealth        (UInt32 a_UniqueID, float a_FractionFilled) override;
-	virtual void SendBossBarUpdateStyle         (UInt32 a_UniqueID, BossBarColor a_Color, BossBarDivisionType a_DivisionType) override;
-	virtual void SendBossBarUpdateTitle         (UInt32 a_UniqueID, const cCompositeChat & a_Title) override;
-	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
-	virtual void SendEntityEquipment            (const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item) override;
-	virtual void SendEntityMetadata             (const cEntity & a_Entity) override;
-	virtual void SendEntityPosition             (const cEntity & a_Entity) override;
-	virtual void SendExperienceOrb              (const cExpOrb & a_ExpOrb) override;
-	virtual void SendKeepAlive                  (UInt32 a_PingID) override;
-	virtual void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) override;
-	virtual void SendMapData                    (const cMap & a_Map, int a_DataStartX, int a_DataStartY) override;
-	virtual void SendPaintingSpawn              (const cPainting & a_Painting) override;
-	virtual void SendPlayerMoveLook             (void) override;
-	virtual void SendPlayerSpawn                (const cPlayer & a_Player) override;
-	virtual void SendSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch) override;
-	virtual void SendSpawnMob                   (const cMonster & a_Mob) override;
-	virtual void SendThunderbolt                (int a_BlockX, int a_BlockY, int a_BlockZ) override;
-	virtual void SendUnleashEntity              (const cEntity & a_Entity) override;
-	virtual void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ) override;
+	virtual void SendAttachEntity       (const cEntity & a_Entity, const cEntity & a_Vehicle) override;
+	virtual void SendBossBarAdd         (UInt32 a_UniqueID, const cCompositeChat & a_Title, float a_FractionFilled, BossBarColor a_Color, BossBarDivisionType a_DivisionType, bool a_DarkenSky, bool a_PlayEndMusic, bool a_CreateFog) override;
+	virtual void SendBossBarRemove      (UInt32 a_UniqueID) override;
+	virtual void SendBossBarUpdateFlags (UInt32 a_UniqueID, bool a_DarkenSky, bool a_PlayEndMusic, bool a_CreateFog) override;
+	virtual void SendBossBarUpdateHealth(UInt32 a_UniqueID, float a_FractionFilled) override;
+	virtual void SendBossBarUpdateStyle (UInt32 a_UniqueID, BossBarColor a_Color, BossBarDivisionType a_DivisionType) override;
+	virtual void SendBossBarUpdateTitle (UInt32 a_UniqueID, const cCompositeChat & a_Title) override;
+	virtual void SendDetachEntity       (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
+	virtual void SendEntityEquipment    (const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item) override;
+	virtual void SendEntityMetadata     (const cEntity & a_Entity) override;
+	virtual void SendEntityPosition     (const cEntity & a_Entity) override;
+	virtual void SendExperienceOrb      (const cExpOrb & a_ExpOrb) override;
+	virtual void SendKeepAlive          (UInt32 a_PingID) override;
+	virtual void SendLeashEntity        (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) override;
+	virtual void SendMapData            (const cMap & a_Map, int a_DataStartX, int a_DataStartY) override;
+	virtual void SendPaintingSpawn      (const cPainting & a_Painting) override;
+	virtual void SendPlayerMoveLook     (void) override;
+	virtual void SendPlayerSpawn        (const cPlayer & a_Player) override;
+	virtual void SendSoundEffect        (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch) override;
+	virtual void SendSpawnMob           (const cMonster & a_Mob) override;
+	virtual void SendThunderbolt        (int a_BlockX, int a_BlockY, int a_BlockZ) override;
+	virtual void SendUnleashEntity      (const cEntity & a_Entity) override;
+	virtual void SendUnloadChunk        (int a_ChunkX, int a_ChunkZ) override;
 
 protected:
 
-	/** The current teleport ID, and whether it has been confirmed by the client */
+	/** The current teleport ID. */
 	bool m_IsTeleportIdConfirmed;
+
+	/** Whether the current teleport ID has been confirmed by the client. */
 	UInt32 m_OutstandingTeleportId;
 
-	/** Get the packet ID for a given packet. */
-	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
-
+	virtual UInt32 GetPacketID(ePacketType a_Packet) const override;
 	virtual unsigned char GetProtocolEntityAnimation(EntityAnimation a_Animation) const override;
 	virtual signed char GetProtocolEntityStatus(EntityAnimation a_Animation) const override;
+	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) const override;
+	virtual Version GetProtocolVersion() const override;
 
-	/** Returns 1.9. */
-	virtual Version GetProtocolVersion() override;
-
-	/** Converts eMonsterType to protocol-specific mob types */
-	virtual UInt32 GetProtocolMobType(eMonsterType a_MobType) override;
-
-	/** Reads and handles the packet. The packet length and type have already been read.
-	Returns true if the packet was understood, false if it was an unknown packet. */
-	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
-
-	// Packet handlers while in the Game state (m_State == 3):
+	virtual bool HandlePacket                       (cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
 	virtual void HandlePacketAnimation              (cByteBuffer & a_ByteBuffer) override;
 	virtual void HandlePacketBlockDig               (cByteBuffer & a_ByteBuffer) override;
 	virtual void HandlePacketBlockPlace             (cByteBuffer & a_ByteBuffer) override;
@@ -104,27 +91,12 @@ protected:
 	virtual void HandlePacketVehicleMove            (cByteBuffer & a_ByteBuffer);
 	virtual void HandlePacketWindowClick            (cByteBuffer & a_ByteBuffer) override;
 
-	/** Parses item metadata as read by ReadItem(), into the item enchantments. */
-	virtual void ParseItemMetadata(cItem & a_Item, ContiguousByteBufferView a_Metadata) override;
-
-	/** Converts the hand parameter received by the protocol into eHand constants.
-	If the received value doesn't match any of the know value, raise an assertion fail or return hMain. */
-	static eHand HandIntToEnum(Int32 a_Hand);
-
-	/** Sends the entity type and entity-dependent data required for the entity to initially spawn. */
+	virtual void ParseItemMetadata(cItem & a_Item, ContiguousByteBufferView a_Metadata) const override;
 	virtual void SendEntitySpawn(const cEntity & a_Entity, const UInt8 a_ObjectType, const Int32 a_ObjectData) override;
-
-	/** Writes the block entity data for the specified block entity into the packet. */
-	virtual void WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) override;
-
-	/** Writes the item data into a packet. */
-	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) override;
-
-	/** Writes the metadata for the specified entity, not including the terminating 0xff. */
-	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) override;
-
-	/** Writes the mob-specific metadata for the specified mob */
-	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) override;
+	virtual void WriteBlockEntity(cFastNBTWriter & a_Writer, const cBlockEntity & a_BlockEntity) const override;
+	virtual void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity) const override;
+	virtual void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const override;
+	virtual void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob) const override;
 
 	/** Types used within metadata */
 	enum eMetadataType
@@ -163,8 +135,7 @@ protected:
 
 	virtual void SendLogin(const cPlayer & a_Player, const cWorld & a_World) override;
 
-	/** Returns 1.9.1. */
-	virtual Version GetProtocolVersion() override;
+	virtual Version GetProtocolVersion() const override;
 } ;
 
 
@@ -183,8 +154,7 @@ public:
 
 protected:
 
-	/** Returns 1.9.2. */
-	virtual Version GetProtocolVersion() override;
+	virtual Version GetProtocolVersion() const override;
 } ;
 
 
@@ -205,7 +175,6 @@ protected:
 
 	virtual void SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4) override;
 
-	/** Returns 1.9.4. */
-	virtual Version GetProtocolVersion() override;
-	virtual UInt32 GetPacketID(ePacketType a_Packet) override;
+	virtual UInt32 GetPacketID(ePacketType a_Packet) const override;
+	virtual Version GetProtocolVersion() const override;
 } ;

--- a/src/Simulator/IncrementalRedstoneSimulator/DaylightSensorHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/DaylightSensorHandler.h
@@ -18,7 +18,7 @@ namespace DaylightSensorHandler
 		}
 
 		// The [0, 1) proportion of the current day that has elapsed.
-		const auto ProportionOfDay = a_Chunk.GetWorld()->GetTimeOfDay() * (static_cast<float>(M_PI) / 12000.f);
+		const auto ProportionOfDay = a_Chunk.GetWorld()->GetTimeOfDay().count() * (static_cast<float>(M_PI) / 12000.f);
 
 		// The curved value of darkened skylight, with outputs somewhat similar to Vanilla.
 		const auto RawOutput = a_Chunk.GetSkyLightAltered(a_Position) * (0.6f * std::sin(ProportionOfDay) + 0.5f);

--- a/src/Simulator/IncrementalRedstoneSimulator/HopperHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/HopperHandler.h
@@ -24,20 +24,31 @@ namespace HopperHandler
 	{
 		// LOGD("Evaluating holey the hopper (%d %d %d)", a_Position.x, a_Position.y, a_Position.z);
 
-		const auto Previous = DataForChunk(a_Chunk).ExchangeUpdateOncePowerData(a_Position, Power);
-		if (Previous == Power)
+		const bool ShouldBeLocked = Power != 0;
+		const bool PreviouslyLocked = (a_Meta & 0x8) == 0x8;
+
+		if (ShouldBeLocked == PreviouslyLocked)
 		{
 			return;
 		}
 
-		a_Chunk.DoWithBlockEntityAt(a_Position, [Power](cBlockEntity & a_BlockEntity)
+		if (ShouldBeLocked)
+		{
+			a_Chunk.SetMeta(a_Position, a_Meta | 0x8);
+		}
+		else
+		{
+			a_Chunk.SetMeta(a_Position, a_Meta & ~0x8);
+		}
+
+		a_Chunk.DoWithBlockEntityAt(a_Position, [ShouldBeLocked](cBlockEntity & a_BlockEntity)
 		{
 			if (a_BlockEntity.GetBlockType() != E_BLOCK_HOPPER)
 			{
 				return false;
 			}
 
-			static_cast<cHopperEntity &>(a_BlockEntity).SetLocked(Power != 0);
+			static_cast<cHopperEntity &>(a_BlockEntity).SetLocked(ShouldBeLocked);
 			return false;
 		});
 	}

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -108,7 +108,7 @@ cWorld::cTickThread::cTickThread(cWorld & a_World) :
 void cWorld::cTickThread::Execute(void)
 {
 	auto LastTime = std::chrono::steady_clock::now();
-	auto TickTime = std::chrono::duration_cast<std::chrono::milliseconds>(cTickTime(1));
+	auto TickTime = std::chrono::duration_cast<std::chrono::milliseconds>(1_tick);
 
 	while (!m_ShouldTerminate)
 	{
@@ -117,10 +117,10 @@ void cWorld::cTickThread::Execute(void)
 		m_World.Tick(WaitTime, TickTime);
 		TickTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - NowTime);
 
-		if (TickTime < cTickTime(1))
+		if (TickTime < 1_tick)
 		{
-			// Stretch tick time until it's at least 1 tick
-			std::this_thread::sleep_for(cTickTime(1) - TickTime);
+			// Stretch tick time until it's at least 1 tick:
+			std::this_thread::sleep_for(1_tick - TickTime);
 		}
 
 		LastTime = NowTime;
@@ -404,7 +404,7 @@ cWorld::cWorld(
 	cComposableGenerator::InitializeGeneratorDefaults(IniFile, m_Dimension);
 
 	InitializeAndLoadMobSpawningValues(IniFile);
-	SetTimeOfDay(IniFile.GetValueSetI("General", "TimeInTicks", GetTimeOfDay()));
+	m_WorldDate = cTickTime(IniFile.GetValueSetI("General", "TimeInTicks", GetWorldDate().count()));
 
 	// preallocate some memory for ticking blocks so we don't need to allocate that often
 	m_BlockTickQueue.reserve(1000);
@@ -434,10 +434,10 @@ cWorld::cWorld(
 	}
 
 	// Init of the spawn monster time (as they are supposed to have different spawn rate)
-	m_LastSpawnMonster.emplace(cMonster::mfHostile, cTickTimeLong(0));
-	m_LastSpawnMonster.emplace(cMonster::mfPassive, cTickTimeLong(0));
-	m_LastSpawnMonster.emplace(cMonster::mfAmbient, cTickTimeLong(0));
-	m_LastSpawnMonster.emplace(cMonster::mfWater,   cTickTimeLong(0));
+	m_LastSpawnMonster.emplace(cMonster::mfHostile, 0_tick);
+	m_LastSpawnMonster.emplace(cMonster::mfPassive, 0_tick);
+	m_LastSpawnMonster.emplace(cMonster::mfAmbient, 0_tick);
+	m_LastSpawnMonster.emplace(cMonster::mfWater,   0_tick);
 }
 
 
@@ -475,31 +475,49 @@ void cWorld::CastThunderbolt(Vector3i a_Block)
 
 
 
-int cWorld::GetTimeOfDay(void) const
+cTickTime cWorld::GetTimeOfDay(void) const
 {
 	using namespace std::chrono_literals;
 
-	return std::chrono::duration_cast<cTickTime>(m_WorldDate % 20min).count();
+	return std::chrono::duration_cast<cTickTime>(m_WorldDate % 20min);
 }
 
 
 
 
 
-Int64 cWorld::GetWorldAge(void) const
+cTickTimeLong cWorld::GetWorldAge(void) const
 {
-	return std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count();
+	return std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
 }
 
 
 
 
 
-void cWorld::SetTimeOfDay(int a_TimeOfDay)
+cTickTimeLong cWorld::GetWorldDate() const
+{
+	return std::chrono::duration_cast<cTickTimeLong>(m_WorldDate);
+}
+
+
+
+
+
+cTickTimeLong cWorld::GetWorldTickAge() const
+{
+	return m_WorldTickAge;
+}
+
+
+
+
+
+void cWorld::SetTimeOfDay(const cTickTime a_TimeOfDay)
 {
 	using namespace std::chrono_literals;
 
-	m_WorldDate = (m_WorldDate / 20min) * 20min + cTickTime(a_TimeOfDay);
+	m_WorldDate = (m_WorldDate / 20min) * 20min + a_TimeOfDay;
 	UpdateSkyDarkness();
 	BroadcastTimeUpdate();
 }
@@ -955,7 +973,7 @@ void cWorld::Stop(cDeadlockDetect & a_DeadlockDetect)
 		IniFile.SetValueB("Mechanics", "UseChatPrefixes", m_bUseChatPrefixes);
 		IniFile.SetValueB("General", "IsDaylightCycleEnabled", m_IsDaylightCycleEnabled);
 		IniFile.SetValueI("General", "Weather", static_cast<int>(m_Weather));
-		IniFile.SetValueI("General", "TimeInTicks", GetTimeOfDay());
+		IniFile.SetValueI("General", "TimeInTicks", GetWorldDate().count());
 		IniFile.SetValueI("General", "WorldAgeMS", static_cast<Int64>(m_WorldAge.count()));
 	IniFile.WriteFile(m_IniFileName);
 
@@ -988,7 +1006,7 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 	cPluginManager::Get()->CallHookWorldTick(*this, a_Dt, a_LastTickDurationMSec);
 
 	m_WorldAge += a_Dt;
-	m_WorldTickAge += 1;
+	m_WorldTickAge++;
 
 	if (m_IsDaylightCycleEnabled)
 	{
@@ -998,14 +1016,14 @@ void cWorld::Tick(std::chrono::milliseconds a_Dt, std::chrono::milliseconds a_La
 		UpdateSkyDarkness();
 
 		// Broadcast time update every 64 ticks (3.2 seconds):
-		if ((m_WorldTickAge % 64) == 0)
+		if ((m_WorldTickAge % 64_tick) == 0_tick)
 		{
 			BroadcastTimeUpdate();
 		}
 	}
 
 	// Broadcast player list pings every 256 ticks (12.8 seconds):
-	if ((m_WorldTickAge % 256) == 0)
+	if ((m_WorldTickAge % 256_tick) == 0_tick)
 	{
 		BroadcastPlayerListUpdatePing();
 	}
@@ -1098,15 +1116,14 @@ void cWorld::TickMobs(std::chrono::milliseconds a_Dt)
 		for (size_t i = 0; i < ARRAYCOUNT(AllFamilies); i++)
 		{
 			cMonster::eFamily Family = AllFamilies[i];
-			cTickTime SpawnDelay = cTickTime(cMonster::GetSpawnDelay(Family));
 			if (
-				(m_LastSpawnMonster[Family] > m_WorldAge - SpawnDelay) ||  // Not reached the needed ticks before the next round
+				(m_LastSpawnMonster[Family] > (m_WorldTickAge - cMonster::GetSpawnDelay(Family))) ||  // Not reached the needed ticks before the next round
 				MobCensus.IsCapped(Family)
 			)
 			{
 				continue;
 			}
-			m_LastSpawnMonster[Family] = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
+			m_LastSpawnMonster[Family] = m_WorldTickAge;
 			cMobSpawner Spawner(Family, m_AllowedMobs);
 			if (Spawner.CanSpawnAnything())
 			{
@@ -1258,11 +1275,9 @@ void cWorld::TickQueuedTasks(void)
 
 		// Partition everything to be executed by returning false to move to end of list if time reached
 		auto MoveBeginIterator = std::partition(m_Tasks.begin(), m_Tasks.end(), [this](const decltype(m_Tasks)::value_type & a_Task)
-			{
-				const auto WorldAgeTicks = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count();
-				return (a_Task.first >= WorldAgeTicks);
-			}
-		);
+		{
+			return a_Task.first >= m_WorldAge;
+		});
 
 		// Cut all the due tasks from m_Tasks into Tasks:
 		Tasks.insert(
@@ -1286,11 +1301,11 @@ void cWorld::TickQueuedTasks(void)
 
 void cWorld::UpdateSkyDarkness(void)
 {
-	const int TIME_SUNSET = 12000;
-	const int TIME_NIGHT_START = 13187;
-	const int TIME_NIGHT_END = 22812;
-	const int TIME_SUNRISE = 23999;
-	const int TIME_SPAWN_DIVISOR = 148;
+	const auto TIME_SUNSET = 12000_tick;
+	const auto TIME_NIGHT_START = 13187_tick;
+	const auto TIME_NIGHT_END = 22812_tick;
+	const auto TIME_SUNRISE = 23999_tick;
+	const auto TIME_SPAWN_DIVISOR = 148_tick;
 
 	const auto TempTime = GetTimeOfDay();
 	if (TempTime <= TIME_SUNSET)
@@ -1448,7 +1463,7 @@ bool cWorld::GrowTreeFromSapling(Vector3i a_BlockPos)
 {
 	cNoise Noise(m_Generator.GetSeed());
 	sSetBlockVector Logs, Other;
-	auto WorldAge = static_cast<int>(std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count() & 0xffffffff);
+	auto WorldAge = static_cast<int>(m_WorldTickAge.count() & 0xffffffff);
 	auto SaplingMeta = GetBlockMeta(a_BlockPos);
 	switch (SaplingMeta & 0x07)
 	{
@@ -1577,7 +1592,7 @@ bool cWorld::GrowTreeByBiome(const Vector3i a_BlockPos)
 {
 	cNoise Noise(m_Generator.GetSeed());
 	sSetBlockVector Logs, Other;
-	auto seq = static_cast<int>(std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count() & 0xffffffff);
+	auto seq = static_cast<int>(m_WorldTickAge.count() & 0xffffffff);
 	GetTreeImageByBiome(a_BlockPos, Noise, seq, GetBiomeAt(a_BlockPos.x, a_BlockPos.z), Logs, Other);
 	Other.insert(Other.begin(), Logs.begin(), Logs.end());
 	Logs.clear();
@@ -2192,7 +2207,7 @@ bool cWorld::HasChunkAnyClients(int a_ChunkX, int a_ChunkZ) const
 
 void cWorld::UnloadUnusedChunks(void)
 {
-	m_LastChunkCheck = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
+	m_LastChunkCheck = m_WorldAge;
 	m_ChunkMap.UnloadUnusedChunks();
 }
 
@@ -2668,7 +2683,7 @@ void cWorld::SaveAllChunks(void)
 {
 	if (IsSavingEnabled())
 	{
-		m_LastSave = std::chrono::duration_cast<cTickTimeLong>(m_WorldAge);
+		m_LastSave = m_WorldAge;
 		m_ChunkMap.SaveAllChunks();
 	}
 }
@@ -2696,9 +2711,9 @@ void cWorld::QueueTask(std::function<void(cWorld &)> a_Task)
 
 
 
-void cWorld::ScheduleTask(int a_DelayTicks, std::function<void (cWorld &)> a_Task)
+void cWorld::ScheduleTask(const cTickTime a_DelayTicks, std::function<void (cWorld &)> a_Task)
 {
-	Int64 TargetTick = a_DelayTicks + std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count();
+	const auto TargetTick = a_DelayTicks + m_WorldAge;
 
 	// Insert the task into the list of scheduled tasks
 	{

--- a/src/World.h
+++ b/src/World.h
@@ -56,8 +56,6 @@ class cWorld  // tolua_export
 public:
 	// tolua_end
 
-
-
 	/** A simple RAII locker for the chunkmap - locks the chunkmap in its constructor, unlocks it in the destructor */
 	class cLock:
 		public cCSLock
@@ -66,13 +64,6 @@ public:
 	public:
 		cLock(const cWorld & a_World);
 	};
-
-
-
-	static const char * GetClassStatic(void)  // Needed for ManualBindings's ForEach templates
-	{
-		return "cWorld";
-	}
 
 	/** Construct the world and read settings from its ini file.
 	@param a_DeadlockDetect is used for tracking this world's age, detecting a possible deadlock.

--- a/src/World.h
+++ b/src/World.h
@@ -184,6 +184,7 @@ public:
 	virtual void BroadcastEntityLook                 (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastEntityMetadata             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastEntityPosition             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
+	void         BroadcastEntityProperties           (const cEntity & a_Entity);
 	virtual void BroadcastEntityStatus               (const cEntity & a_Entity, Int8 a_Status, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastEntityVelocity             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastEntityAnimation            (const cEntity & a_Entity, Int8 a_Animation, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export

--- a/src/World.h
+++ b/src/World.h
@@ -176,9 +176,8 @@ public:
 	virtual void BroadcastEntityMetadata             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastEntityPosition             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
 	void         BroadcastEntityProperties           (const cEntity & a_Entity);
-	virtual void BroadcastEntityStatus               (const cEntity & a_Entity, Int8 a_Status, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastEntityVelocity             (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
-	virtual void BroadcastEntityAnimation            (const cEntity & a_Entity, Int8 a_Animation, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export
+	virtual void BroadcastEntityAnimation            (const cEntity & a_Entity, EntityAnimation a_Animation, const cClientHandle * a_Exclude = nullptr) override;  // tolua_export
 	virtual void BroadcastLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) override;
 	virtual void BroadcastParticleEffect             (const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, const cClientHandle * a_Exclude = nullptr) override;  // Exported in ManualBindings_World.cpp
 	virtual void BroadcastParticleEffect             (const AString & a_ParticleName, Vector3f a_Src, Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, std::array<int, 2> a_Data, const cClientHandle * a_Exclude = nullptr) override;  // Exported in ManualBindings_World.cpp
@@ -198,7 +197,6 @@ public:
 	virtual void BroadcastThunderbolt                (Vector3i a_BlockPos, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastTimeUpdate                 (const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastUnleashEntity              (const cEntity & a_Entity) override;
-	virtual void BroadcastUseBed                     (const cEntity & a_Entity, Vector3i a_BlockPos) override;
 	virtual void BroadcastWeather                    (eWeather a_Weather, const cClientHandle * a_Exclude = nullptr) override;
 
 	virtual cBroadcastInterface & GetBroadcastManager(void) override

--- a/src/World.h
+++ b/src/World.h
@@ -106,15 +106,10 @@ public:
 		BroadcastTimeUpdate();
 	}
 
-	virtual int GetTimeOfDay(void) const override;
-	virtual Int64 GetWorldAge(void) const override;
-
 	void SetTicksUntilWeatherChange(int a_WeatherInterval)
 	{
 		m_WeatherInterval = a_WeatherInterval;
 	}
-
-	virtual void SetTimeOfDay(int a_TimeOfDay) override;
 
 	/** Returns the default weather interval for the specific weather type.
 	Returns -1 for any unknown weather. */
@@ -149,6 +144,13 @@ public:
 	virtual int GetHeight(int a_BlockX, int a_BlockZ) override;
 
 	// tolua_end
+
+	virtual cTickTime GetTimeOfDay(void) const override;
+	virtual cTickTimeLong GetWorldAge(void) const override;
+	cTickTimeLong GetWorldDate() const;
+	cTickTimeLong GetWorldTickAge() const;
+
+	virtual void SetTimeOfDay(cTickTime a_TimeOfDay) override;
 
 	/** Retrieves the world height at the specified coords; returns false if chunk not loaded / generated */
 	bool TryGetHeight(int a_BlockX, int a_BlockZ, int & a_Height);  // Exported in ManualBindings.cpp
@@ -754,7 +756,7 @@ public:
 	void QueueTask(std::function<void(cWorld &)> a_Task);  // Exported in ManualBindings.cpp
 
 	/** Queues a lambda task onto the tick thread, with the specified delay. */
-	void ScheduleTask(int a_DelayTicks, std::function<void(cWorld &)> a_Task);
+	void ScheduleTask(cTickTime a_DelayTicks, std::function<void(cWorld &)> a_Task);
 
 	/** Returns the number of chunks loaded	 */
 	size_t GetNumChunks() const;  // tolua_export
@@ -993,10 +995,10 @@ private:
 	/** The time since this world began, in ticks.
 	Monotonic, but does not persist across restarts.
 	Used for less important but heavy tasks that run periodically. These tasks don't need to follow wallclock time, and slowing their rate down if TPS drops is desirable. */
-	unsigned long long m_WorldTickAge;
+	cTickTimeLong m_WorldTickAge;
 
-	cTickTimeLong  m_LastChunkCheck;        // The last WorldAge (in ticks) in which unloading and possibly saving was triggered
-	cTickTimeLong  m_LastSave;          // The last WorldAge (in ticks) in which save-all was triggerred
+	std::chrono::milliseconds m_LastChunkCheck;  // The last WorldAge in which unloading and possibly saving was triggered.
+	std::chrono::milliseconds m_LastSave;  // The last WorldAge in which save-all was triggerred.
 	std::map<cMonster::eFamily, cTickTimeLong> m_LastSpawnMonster;  // The last WorldAge (in ticks) in which a monster was spawned (for each megatype of monster)  // MG TODO : find a way to optimize without creating unmaintenability (if mob IDs are becoming unrowed)
 
 	NIBBLETYPE m_SkyDarkness;
@@ -1093,7 +1095,7 @@ private:
 	cCriticalSection m_CSTasks;
 
 	/** Tasks that have been queued onto the tick thread, possibly to be executed at target tick in the future; guarded by m_CSTasks */
-	std::vector<std::pair<Int64, std::function<void(cWorld &)>>> m_Tasks;
+	std::vector<std::pair<std::chrono::milliseconds, std::function<void(cWorld &)>>> m_Tasks;
 
 	/** Guards m_EntitiesToAdd */
 	cCriticalSection m_CSEntitiesToAdd;

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -1252,7 +1252,7 @@ void NBTChunkSerializer::Serialize(const cWorld & aWorld, cChunkCoords aCoords, 
 	}
 
 	// Save the world age to the chunk data. Required by vanilla and mcedit.
-	aWriter.AddLong("LastUpdate", aWorld.GetWorldAge());
+	aWriter.AddLong("LastUpdate", aWorld.GetWorldAge().count());
 
 	// Store the flag that the chunk has all the ores, trees, dungeons etc. Cuberite chunks are always complete.
 	aWriter.AddByte("TerrainPopulated", 1);

--- a/src/WorldStorage/NamespaceSerializer.cpp
+++ b/src/WorldStorage/NamespaceSerializer.cpp
@@ -501,11 +501,12 @@ eMonsterType NamespaceSerializer::ToMonsterType(const std::string_view a_ID)
 		{ "zoglin",           mtZoglin },
 		{ "zombie",           mtZombie },
 		{ "zombie_horse",     mtZombieHorse },
-		{ "zombie_pigman",    mtZombiePigman },
+		{ "zombified_piglin", mtZombiePigman },
 		{ "zombie_villager",  mtZombieVillager },
 
-		{ "villager_golem",   mtIronGolem },
 		{ "snowman",          mtSnowGolem },
+		{ "villager_golem",   mtIronGolem },
+		{ "zombie_pigman",    mtZombiePigman },
 
 		// Old names:
 		{ "Bat",            mtBat },

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -109,8 +109,8 @@ cWSSAnvil::cWSSAnvil(cWorld * a_World, int a_CompressionFactor) :
 		Writer.AddInt("SpawnY", FloorC(a_World->GetSpawnY()));
 		Writer.AddInt("SpawnZ", FloorC(a_World->GetSpawnZ()));
 		Writer.AddInt("version", 19133);
-		Writer.AddLong("DayTime", a_World->GetTimeOfDay());
-		Writer.AddLong("Time", a_World->GetWorldAge());
+		Writer.AddLong("DayTime", a_World->GetWorldDate().count());
+		Writer.AddLong("Time", a_World->GetWorldAge().count());
 		Writer.AddLong("SizeOnDisk", 0);
 		Writer.AddString("generatorName", "default");
 		Writer.AddString("generatorOptions", "");

--- a/tests/Generating/Stubs.cpp
+++ b/tests/Generating/Stubs.cpp
@@ -446,7 +446,7 @@ void cEnderCrystal::KilledBy(struct TakeDamageInfo & a_TakeDamageInfo)
 
 
 
-cEntity::cEntity(enum cEntity::eEntityType a_EntityType, class Vector3<double> a_Pos, double a_Height, double a_Width)
+cEntity::cEntity(enum cEntity::eEntityType a_EntityType, class Vector3<double> a_Pos, float a_Height, float a_Width)
 {
 }
 
@@ -790,7 +790,7 @@ void cEntity::ResetPosition(class Vector3<double> a_Pos)
 
 
 
-cPawn::cPawn(enum cEntity::eEntityType,double a_Width, double a_Height) :
+cPawn::cPawn(enum cEntity::eEntityType, float a_Width, float a_Height) :
 	cEntity(etMonster, Vector3d(), a_Height, a_Width)
 {
 }
@@ -862,7 +862,7 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 
 
-cMonster::cMonster(const AString & a_StringA, enum eMonsterType a_MonsterType, const AString & a_StringB, const AString & a_StringC, const AString & a_StringD, double a_Width, double a_Height) :
+cMonster::cMonster(const AString & a_StringA, enum eMonsterType a_MonsterType, const AString & a_StringB, const AString & a_StringC, const AString & a_StringD, float a_Width, float a_Height) :
 	cPawn(etMonster, a_Width, a_Height),
 	m_PathFinder(a_Width, a_Height)
 {
@@ -870,7 +870,7 @@ cMonster::cMonster(const AString & a_StringA, enum eMonsterType a_MonsterType, c
 
 
 
-cPathFinder::cPathFinder(double a_Width, double a_Height)
+cPathFinder::cPathFinder(float a_Width, float a_Height)
 {
 
 }
@@ -1002,7 +1002,7 @@ void cMonster::InStateEscaping(std::chrono::milliseconds a_Dt ,class cChunk & a_
 
 
 
-cAggressiveMonster::cAggressiveMonster(const AString & a_StringA, enum eMonsterType a_MonsterType, const AString & a_StringB, const AString & a_StringC, const AString & a_StringD, double a_Width, double a_Height) :
+cAggressiveMonster::cAggressiveMonster(const AString & a_StringA, enum eMonsterType a_MonsterType, const AString & a_StringB, const AString & a_StringC, const AString & a_StringD, float a_Width, float a_Height) :
 	cMonster(a_StringA, a_MonsterType, a_StringB, a_StringC, a_StringD, a_Width, a_Height)
 {
 }


### PR DESCRIPTION
* Fix sending incorrect date values on world change
* Fall particles: check for valid Y
* Fix block break particles
* Streamline player abilities handling
* Update entity sizes
* Fix incorrect name in deserialiser for zombie pigmen
* Remove unused GetClassStatic in cWorld
* Unify multiprotocol entity animations
* Improve bed handling robustness
* Fix thrown snowball/egg hit animations
* Add magical critical effect
* Add animations for shield/item block & break
* More cProtocol cleanup
* cPlayer: move some constants out of header
* Thrown potions/enderpearls: cleanup
* Hoppers: use 'locked' bit in meta
* Implement random ticks more faithfully