### PR TITLE
Disables the weather packet for 1.13

### DIFF
--- a/src/Protocol/Protocol_1_13.h
+++ b/src/Protocol/Protocol_1_13.h
@@ -46,6 +46,8 @@ protected:
 	virtual void SendTabCompletionResults       (const AStringVector & a_Results) override;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) override;
 
+	virtual void SendWeather                    (eWeather a_Weather) override {}; // This packet was removed. This keeps players from joining the server with 1.13 while there is downfall
+
 	virtual UInt8 GetEntityMetadataID(EntityMetadata a_Metadata) const;
 	virtual UInt8 GetEntityMetadataID(EntityMetadataType a_FieldType) const;
 	virtual std::pair<short, short> GetItemFromProtocolID(UInt32 a_ProtocolID) const;

--- a/src/Protocol/Protocol_1_13.h
+++ b/src/Protocol/Protocol_1_13.h
@@ -46,7 +46,7 @@ protected:
 	virtual void SendTabCompletionResults       (const AStringVector & a_Results) override;
 	virtual void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity) override;
 
-	virtual void SendWeather                    (eWeather a_Weather) override {}; // This packet was removed. This keeps players from joining the server with 1.13 while there is downfall
+	virtual void SendWeather                    (eWeather a_Weather) override {}  // This packet was removed. This keeps players from joining the server with 1.13 while there is downfall
 
 	virtual UInt8 GetEntityMetadataID(EntityMetadata a_Metadata) const;
 	virtual UInt8 GetEntityMetadataID(EntityMetadataType a_FieldType) const;


### PR DESCRIPTION
I didn't find any documentation of any explicit weather packet. When there is downfall in the world and a 1.13 client wants to join i will get disconnected because the client can't interpret the packet.