### PR TITLE
Uncrash the server when a 1.13 client is connected and a guardian is sent

### DIFF
--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -1266,6 +1266,9 @@ void cProtocol_1_13::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mo
 		case mtSnowGolem:
 		case mtSpider:
 		case mtZombieVillager:
+
+		case mtElderGuardian:
+		case mtGuardian:
 		{
 			// TODO: Mobs with extra fields that aren't implemented
 			break;
@@ -1280,9 +1283,6 @@ void cProtocol_1_13::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mo
 		case mtDonkey:
 
 		case mtDrowned:
-
-		case mtElderGuardian:
-		case mtGuardian:
 
 		case mtEndermite:
 


### PR DESCRIPTION
I did a little f*ckup while adding the new mobs and a spawned guardian crashed the server when a 1.13 client was connected