### PR TITLE
Fix: GetPhysicalRamUsage on FreeBSD (UNIX) - webadmin display

### DIFF
--- a/CMake/AddDependencies.cmake
+++ b/CMake/AddDependencies.cmake
@@ -85,4 +85,7 @@ function(link_dependencies TARGET)
 
 	# Prettify jsoncpp_static name in VS solution explorer:
 	set_property(TARGET jsoncpp_static PROPERTY PROJECT_LABEL "jsoncpp")
+	if(UNIX)
+		target_link_libraries(${TARGET} PRIVATE kvm)
+	endif()
 endfunction()

--- a/CMake/AddDependencies.cmake
+++ b/CMake/AddDependencies.cmake
@@ -85,7 +85,7 @@ function(link_dependencies TARGET)
 
 	# Prettify jsoncpp_static name in VS solution explorer:
 	set_property(TARGET jsoncpp_static PROPERTY PROJECT_LABEL "jsoncpp")
-	if(UNIX)
+	if(${CMAKE_SYSTEM_NAME} MATCHES FreeBSD)
 		target_link_libraries(${TARGET} PRIVATE kvm)
 	endif()
 endfunction()

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,6 +48,7 @@ mBornand
 MeMuXin
 mgueydan
 MikeHunsinger
+Morritz (TJ)
 morsmordere (Anzhelika Iugai)
 mtilden
 nesco

--- a/src/Generating/EnderDragonFightStructuresGen.cpp
+++ b/src/Generating/EnderDragonFightStructuresGen.cpp
@@ -111,7 +111,7 @@ void cEnderDragonFightStructuresGen::Init(const AString & a_TowerProperties, int
 	// A random angle in radian
 	double Angle = m_Noise.IntNoise1D(m_Noise.GetSeed()) * M_PI + M_PI;
 	// Shuffles the order of the towers
-	std::shuffle(TowerProperties.begin(), TowerProperties.end(), std::default_random_engine(static_cast<size_t>(m_Noise.GetSeed())));
+	std::shuffle(TowerProperties.begin(), TowerProperties.end(), std::default_random_engine(static_cast<std::default_random_engine::result_type>(m_Noise.GetSeed())));
 	// Generate Positions in a circle
 	for (size_t I = 0; I < TowerProperties.size(); I++)
 	{

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -20,14 +20,11 @@
 		#endif
 	#elif defined(__APPLE__)
 		#include <mach/mach.h>
-	#elif defined(__unix__)
-		//#include <sys/resource.h>
-		#include <sys/file.h>
+	#elif defined(__FreeBSD__)
+		#include <kvm.h>
+		#include <fcntl.h>
 		#include <sys/sysctl.h>
 		#include <sys/user.h>
-		#include <kvm.h>
-		#include <sys/types.h>
-		#include <unistd.h>
 	#endif
 #endif
 
@@ -893,31 +890,37 @@ int cRoot::GetPhysicalRAMUsage(void)
 			return static_cast<int>(t_info.resident_size / 1024);
 		}
 		return -1;
-	#elif defined (__unix__)
+	#elif defined (__FreeBSD__)
 		/*
 		struct rusage self_usage;
 		int status = getrusage(RUSAGE_SELF, &self_usage);
-		if(!status) return static_cast<int>(self_usage.ru_maxrss);
+		if (!status)
+		{
+			return static_cast<int>(self_usage.ru_maxrss);
+		}
 		return -1;
 		*/
 		// Good to watch: https://www.youtube.com/watch?v=Os5cK0H8EOA - getrusage.
-		// Unfortunately, it only gives peak memory usage a.k.a max resident set size	
+		// Unfortunately, it only gives peak memory usage a.k.a max resident set size
 		// So it is better to use FreeBSD kvm function to get the size of resident pages.
 
 		static kvm_t* kd = NULL;
-	
-		if ( kd == NULL) {
-			kd = kvm_open( NULL, "/dev/null", NULL, O_RDONLY, "kvm_open" ); //returns a descriptor used to access kernel virtual memory
+
+		if (kd == NULL)
+		{
+			kd = kvm_open(NULL, "/dev/null", NULL, O_RDONLY, "kvm_open");  // returns a descriptor used to access kernel virtual memory
 		}
-		if ( kd != NULL ) {
-			int pc = 0; //number of processes found
+		if (kd != NULL)
+		{
+			int pc = 0;  // number of processes found
 			struct kinfo_proc* kp;
-			kp = kvm_getprocs(kd,KERN_PROC_PID,getpid(),&pc); 
-			if ( (kp != NULL) && (pc >= 1) ) { 
+			kp = kvm_getprocs(kd, KERN_PROC_PID, getpid(), &pc);
+			if ((kp != NULL) && (pc >= 1))
+			{
 				return static_cast<int>(kp->ki_rssize * getpagesize() / 1024);
 			}
 		}
-		return -1;	
+		return -1;
 	#else
 		LOGINFO("%s: Unknown platform, cannot query memory usage", __FUNCTION__);
 		return -1;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12800230/116010316-837a6b80-a61e-11eb-81a2-715de7992e41.png)
This patch fixes incorrectly displayed memory usage  (_-0.00_) in the webadmin panel caused by faulty GetPhysicalRamUsage on Unix based platforms such as FreeBSD.