### PR TITLE
Added functionality: mobs now enter boats and minecarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,4 +122,3 @@ build-cuberite
 # clang-tidy
 tidy-build
 run-clang-tidy.py
-/CMakeSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ build-cuberite
 # clang-tidy
 tidy-build
 run-clang-tidy.py
+/CMakeSettings.json

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Howaner
 ion232 (Arran Ireland)
 jan64
 jasperarmstrong
+jclever77 (Jon Clever)
 kevinr (Kevin Riggle)
 keyboard
 KingCol13

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -16,7 +16,7 @@
 
 class cBoatCollisionCallback
 {
-  public:
+public:
 	cBoatCollisionCallback(cBoat * a_Boat, cEntity * a_Attachee) :
 		m_Boat(a_Boat), m_Attachee(a_Attachee)
 	{
@@ -35,7 +35,7 @@ class cBoatCollisionCallback
 		return false;
 	}
 
-  protected:
+protected:
 	cBoat * m_Boat;
 	cEntity * m_Attachee;
 };
@@ -341,17 +341,18 @@ cItem cBoat::MaterialToItem(eMaterial a_Material)
 
 
 
+
 void cBoat::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	/** Special version of cEntity::HandlePhysics(...) function for boats, checks if mobs
 	colliding with the boat can be attached and does if that's the case, then returns to
-	normal physics calcualtions*/
+	normal physics calcualtions */
 
 	// Calculate boat's bounding box, run collision callback on all entities in said box
 	cBoatCollisionCallback BoatCollisionCallback(this, m_Attachee);
 	Vector3d BoatPosition = GetPosition();
 	cBoundingBox bbBoat(
-		Vector3d(BoatPosition.x, floor(BoatPosition.y), BoatPosition.z),GetWidth() / 2, GetHeight());
+		Vector3d(BoatPosition.x, floor(BoatPosition.y), BoatPosition.z), GetWidth() / 2, GetHeight());
 	m_World->ForEachEntityInBox(bbBoat, BoatCollisionCallback);
 
 	// Return to calculating physics normally

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -14,6 +14,36 @@
 
 
 
+class cBoatCollisionCallback
+{
+  public:
+	cBoatCollisionCallback(cBoat * a_Boat, cEntity * a_Attachee) :
+		m_Boat(a_Boat), m_Attachee(a_Attachee)
+	{
+	}
+
+	bool operator()(cEntity & a_Entity)
+	{
+		// Checks if boat is empty and if given entity is a mob
+		if ((m_Attachee == nullptr) && (a_Entity.IsMob()))
+		{
+			// if so attach and return true
+			a_Entity.AttachTo(m_Boat);
+			return true;
+		}
+
+		return false;
+	}
+
+  protected:
+	cBoat * m_Boat;
+	cEntity * m_Attachee;
+};
+
+
+
+
+
 cBoat::cBoat(Vector3d a_Pos, eMaterial a_Material) :
 	Super(etBoat, a_Pos, 1.375f, 0.5625f),
 	m_LastDamage(0), m_ForwardDirection(0),
@@ -311,3 +341,19 @@ cItem cBoat::MaterialToItem(eMaterial a_Material)
 
 
 
+void cBoat::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
+{
+	/** Special version of cEntity::HandlePhysics(...) function for boats, checks if mobs
+	colliding with the boat can be attached and does if that's the case, then returns to
+	normal physics calcualtions*/
+
+	// Calculate boat's bounding box, run collision callback on all entities in said box
+	cBoatCollisionCallback BoatCollisionCallback(this, m_Attachee);
+	Vector3d BoatPosition = GetPosition();
+	cBoundingBox bbBoat(
+		Vector3d(BoatPosition.x, floor(BoatPosition.y), BoatPosition.z),GetWidth() / 2, GetHeight());
+	m_World->ForEachEntityInBox(bbBoat, BoatCollisionCallback);
+
+	// Return to calculating physics normally
+	Super::HandlePhysics(a_Dt, a_Chunk);
+}

--- a/src/Entities/Boat.h
+++ b/src/Entities/Boat.h
@@ -48,6 +48,7 @@ public:
 	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways) override;
+	virtual void HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
 	int GetLastDamage(void) const { return m_LastDamage; }
 	int GetForwardDirection(void) const { return m_ForwardDirection; }

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -21,6 +21,36 @@
 
 
 
+class cMinecartAttachCallback
+{
+public:
+	cMinecartAttachCallback(cMinecart * a_Minecart, cEntity * a_Attachee) :
+		m_Minecart(a_Minecart), m_Attachee(a_Attachee)
+	{
+	}
+
+	bool operator () (cEntity & a_Entity)
+	{
+		// Check if minecart is empty and if given entity is a mob
+		if ((m_Attachee == nullptr) && (a_Entity.IsMob()))
+		{
+			// if so, attach to minecart and return true
+			a_Entity.AttachTo(m_Minecart);
+			return true;
+		}
+		
+		return false;
+	}
+
+protected:
+	cMinecart * m_Minecart;
+	cEntity * m_Attachee;
+};
+
+
+
+
+
 class cMinecartCollisionCallback
 {
 public:
@@ -1053,6 +1083,12 @@ bool cMinecart::TestEntityCollision(NIBBLETYPE a_RailMeta)
 	{
 		return false;
 	}
+
+	// Collision was true, create bounding box for minecart, call attach callback for all entities within that box
+	cMinecartAttachCallback MinecartAttachCallback(this, m_Attachee);
+	Vector3d MinecartPosition = GetPosition();
+	cBoundingBox bbMinecart(Vector3d(MinecartPosition.x, floor(MinecartPosition.y), MinecartPosition.z), GetWidth() / 2, GetHeight());
+	m_World->ForEachEntityInBox(bbMinecart, MinecartAttachCallback);
 
 	switch (a_RailMeta)
 	{

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -38,7 +38,6 @@ public:
 			a_Entity.AttachTo(m_Minecart);
 			return true;
 		}
-		
 		return false;
 	}
 


### PR DESCRIPTION
I added the feature where mobs will enter minecarts and boats after coming into contact with them. However, while testing whether this was working for minecarts, I discovered that the rail blocks don't seem to work correctly. Everything was normal for east/west facing rails, but north/south facing rails don't actually act like rails at all. It's only when you push the minecart off of said north/south rails that they snap to "the rails" and behave somewhat normally. I can make a separate issue report for this issue, and it was the only major thing I discovered while working.

Also, if possible just ignore the change made to .gitignore, that was a file created by my VS that I didn't want merging into master, but I forgot ignoring it would add it to the ignore file.

Fixes #5045 