### PR TITLE
Implemented cServer::ScheduleTask() and cServer::TickQueuedTasks()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ Diusrex
 Duralex
 Earboxer (Zach DeCook)
 FakeTruth (founder)
+feyokorenhof
 Gareth Nelson
 GefaketHD
 HaoTNN

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -12307,6 +12307,21 @@ end
 					},
 					Notes = "Add a Forge mod name/version to the server ping list.",
 				},
+				ScheduleTask =
+				{
+					Params =
+					{
+						{
+							Name = "DelayTicks",
+							Type = "number",
+						},
+						{
+							Name = "TaskFunction",
+							Type = "function",
+						},
+					},
+					Notes = "Queues the specified function to be executed in the server's tick thread after a the specified number of ticks. This enables operations to be queued for execution in the future. The function signature is <pre class=\"pretty-print lang-lua\">function({{cServer|Server}})</pre>All return values from the function are ignored. Note that it is unsafe to store references to Cuberite objects, such as entities, across from the caller to the task handler function; store the EntityID instead.",
+				},
 				SetMaxPlayers =
 				{
 					Params =

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -3581,6 +3581,10 @@ static int tolua_cServer_RegisterForgeMod(lua_State * a_LuaState)
 	return 0;
 }
 
+
+
+
+
 static int tolua_cServer_ScheduleTask(lua_State * a_LuaState)
 {
 	// Function signature:
@@ -3588,8 +3592,11 @@ static int tolua_cServer_ScheduleTask(lua_State * a_LuaState)
 
 	// Retrieve the args:
 	cLuaState L(a_LuaState);
-	if (!L.CheckParamUserType(1, "cServer") || !L.CheckParamNumber(2) ||
-		!L.CheckParamFunction(3))
+	if (
+		!L.CheckParamUserType(1, "cServer") ||
+		!L.CheckParamNumber(2) ||
+		!L.CheckParamFunction(3)
+	)
 	{
 		return 0;
 	}
@@ -3598,24 +3605,19 @@ static int tolua_cServer_ScheduleTask(lua_State * a_LuaState)
 	auto Task = std::make_shared<cLuaState::cCallback>();
 	if (!L.GetStackValues(1, Server, NumTicks, Task))
 	{
-		return cManualBindings::lua_do_error(
-			a_LuaState,
-			"Error in function call '#funcname#': Cannot read parameters");
+		return cManualBindings::lua_do_error(a_LuaState, "Error in function call '#funcname#': Cannot read parameters");
 	}
 	if (Server == nullptr)
 	{
-		return cManualBindings::lua_do_error(
-			a_LuaState, "Error in function call '#funcname#': Not called on an "
-					 "object instance");
+		return cManualBindings::lua_do_error(a_LuaState, "Error in function call '#funcname#': Not called on an object instance");
 	}
 	if (!Task->IsValid())
 	{
-		return cManualBindings::lua_do_error(
-			a_LuaState, "Error in function call '#funcname#': Could not store the "
-					 "callback parameter");
+		return cManualBindings::lua_do_error(a_LuaState, "Error in function call '#funcname#': Could not store the callback parameter");
 	}
 
-	Server->ScheduleTask(cTickTime(NumTicks), [Task](cServer & a_Server) {
+	Server->ScheduleTask(cTickTime(NumTicks), [Task](cServer & a_Server)
+	{
 		Task->Call(&a_Server);
 	});
 	return 0;

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -3581,6 +3581,46 @@ static int tolua_cServer_RegisterForgeMod(lua_State * a_LuaState)
 	return 0;
 }
 
+static int tolua_cServer_ScheduleTask(lua_State * a_LuaState)
+{
+	// Function signature:
+	// Server:ScheduleTask(NumTicks, Callback)
+
+	// Retrieve the args:
+	cLuaState L(a_LuaState);
+	if (!L.CheckParamUserType(1, "cServer") || !L.CheckParamNumber(2) ||
+		!L.CheckParamFunction(3))
+	{
+		return 0;
+	}
+	cServer * Server;
+	int NumTicks;
+	auto Task = std::make_shared<cLuaState::cCallback>();
+	if (!L.GetStackValues(1, Server, NumTicks, Task))
+	{
+		return cManualBindings::lua_do_error(
+			a_LuaState,
+			"Error in function call '#funcname#': Cannot read parameters");
+	}
+	if (Server == nullptr)
+	{
+		return cManualBindings::lua_do_error(
+			a_LuaState, "Error in function call '#funcname#': Not called on an "
+					 "object instance");
+	}
+	if (!Task->IsValid())
+	{
+		return cManualBindings::lua_do_error(
+			a_LuaState, "Error in function call '#funcname#': Could not store the "
+					 "callback parameter");
+	}
+
+	Server->ScheduleTask(cTickTime(NumTicks), [Task](cServer & a_Server) {
+		Task->Call(&a_Server);
+	});
+	return 0;
+}
+
 
 
 
@@ -4625,6 +4665,7 @@ void cManualBindings::Bind(lua_State * tolua_S)
 
 		tolua_beginmodule(tolua_S, "cServer");
 			tolua_function(tolua_S, "RegisterForgeMod",            tolua_cServer_RegisterForgeMod);
+			tolua_function(tolua_S, "ScheduleTask", tolua_cServer_ScheduleTask);
 		tolua_endmodule(tolua_S);
 
 		tolua_beginmodule(tolua_S, "cStringCompression");

--- a/src/Bindings/ManualBindings.h
+++ b/src/Bindings/ManualBindings.h
@@ -298,7 +298,3 @@ public:
 		return 1;
 	}
 };
-
-
-
-

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -435,12 +435,19 @@ bool cServer::Command(cClientHandle & a_Client, AString & a_Cmd)
 }
 
 
+
+
+
 void cServer::QueueExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallback & a_Output)
 {
 	// Put the command into a queue (Alleviates FS #363):
 	cCSLock Lock(m_CSPendingCommands);
 	m_PendingCommands.emplace_back(a_Cmd, &a_Output);
 }
+
+
+
+
 
 void cServer::ScheduleTask(cTickTime a_DelayTicks, std::function<void(cServer &)> a_Task)
 {
@@ -451,6 +458,10 @@ void cServer::ScheduleTask(cTickTime a_DelayTicks, std::function<void(cServer &)
 		m_Tasks.emplace_back(TargetTick, std::move(a_Task));
 	}
 }
+
+
+
+
 
 void cServer::ExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallback & a_Output)
 {
@@ -736,6 +747,10 @@ void cServer::TickCommands(void)
 	}
 }
 
+
+
+
+
 void cServer::TickQueuedTasks(void)
 {
 	// Move the tasks to be executed to a seperate vector to avoid deadlocks on
@@ -752,7 +767,8 @@ void cServer::TickQueuedTasks(void)
 		// of list if time reached
 		auto MoveBeginIterator = std::partition(
 			m_Tasks.begin(), m_Tasks.end(),
-			[this](const decltype(m_Tasks)::value_type & a_Task) {
+			[this](const decltype(m_Tasks)::value_type & a_Task)
+			{
 				return a_Task.first >= m_UpTime;
 			});
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -117,7 +117,8 @@ cServer::cServer(void) :
 	m_MaxPlayers(0),
 	m_bIsHardcore(false),
 	m_TickThread(*this),
-	m_ShouldAuthenticate(false)
+	m_ShouldAuthenticate(false),
+	m_UpTime(0)
 {
 	// Initialize the LuaStateTracker singleton before the app goes multithreaded:
 	cLuaStateTracker::GetStats();
@@ -326,6 +327,9 @@ cTCPLink::cCallbacksPtr cServer::OnConnectionAccepted(const AString & a_RemoteIP
 
 void cServer::Tick(float a_Dt)
 {
+	// Update server uptime
+	m_UpTime++;
+
 	// Send the tick to the plugins, as well as let the plugin manager reload, if asked to (issue #102):
 	cPluginManager::Get()->Tick(a_Dt);
 
@@ -334,6 +338,9 @@ void cServer::Tick(float a_Dt)
 
 	// Tick all clients not yet assigned to a world:
 	TickClients(a_Dt);
+
+	// Process all queued tasks
+	TickQueuedTasks();
 }
 
 
@@ -428,9 +435,6 @@ bool cServer::Command(cClientHandle & a_Client, AString & a_Cmd)
 }
 
 
-
-
-
 void cServer::QueueExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallback & a_Output)
 {
 	// Put the command into a queue (Alleviates FS #363):
@@ -438,9 +442,15 @@ void cServer::QueueExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCa
 	m_PendingCommands.emplace_back(a_Cmd, &a_Output);
 }
 
-
-
-
+void cServer::ScheduleTask(cTickTime a_DelayTicks, std::function<void(cServer &)> a_Task)
+{
+	const auto TargetTick = a_DelayTicks + m_UpTime;
+	// Insert the task into the list of scheduled tasks
+	{
+		cCSLock Lock(m_CSTasks);
+		m_Tasks.emplace_back(TargetTick, std::move(a_Task));
+	}
+}
 
 void cServer::ExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallback & a_Output)
 {
@@ -724,4 +734,38 @@ void cServer::TickCommands(void)
 	{
 		ExecuteConsoleCommand(Command.first, *Command.second);
 	}
+}
+
+void cServer::TickQueuedTasks(void)
+{
+	// Move the tasks to be executed to a seperate vector to avoid deadlocks on
+	// accessing m_Tasks
+	decltype(m_Tasks) Tasks;
+	{
+		cCSLock Lock(m_CSTasks);
+		if (m_Tasks.empty())
+		{
+			return;
+		}
+
+		// Partition everything to be executed by returning false to move to end
+		// of list if time reached
+		auto MoveBeginIterator = std::partition(
+			m_Tasks.begin(), m_Tasks.end(),
+			[this](const decltype(m_Tasks)::value_type & a_Task) {
+				return a_Task.first >= m_UpTime;
+			});
+
+		// Cut all the due tasks from m_Tasks into Tasks:
+		Tasks.insert(
+			Tasks.end(), std::make_move_iterator(MoveBeginIterator),
+			std::make_move_iterator(m_Tasks.end()));
+		m_Tasks.erase(MoveBeginIterator, m_Tasks.end());
+	}
+
+	// Execute each task:
+	for (const auto & Task : Tasks)
+	{
+		Task.second(*this);
+	}  // for itr - m_Tasks[]
 }

--- a/src/Server.h
+++ b/src/Server.h
@@ -105,6 +105,10 @@ public:
 	The command's output will be written to the a_Output callback. */
 	void QueueExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallback & a_Output);
 
+	/** Queues a lambda task onto the server tick thread, with the specified
+	 * delay in ticks. */
+	void ScheduleTask(cTickTime a_DelayTicks, std::function<void(class cServer &)> a_Task);
+
 	/** Lists all available console commands and their helpstrings */
 	void PrintHelp(const AStringVector & a_Split, cCommandOutputCallback & a_Output);
 
@@ -245,6 +249,18 @@ private:
 	AStringVector m_Ports;
 
 
+	/** Time, in ticks, since the server started
+		Not persistent across server restarts */
+	cTickTimeLong m_UpTime;
+
+	/** Guards the m_Tasks */
+	cCriticalSection m_CSTasks;
+
+	/** Tasks that have been queued onto the tick thread, possibly to be
+	 * executed at target tick in the future; guarded by m_CSTasks */
+	std::vector<std::pair<std::chrono::milliseconds, std::function<void(class cServer &)>>> m_Tasks;
+
+
 	cServer(void);
 
 	/** Executes the console command, sends output through the specified callback. */
@@ -267,6 +283,11 @@ private:
 
 	/** Executes commands queued in the command queue. */
 	void TickCommands(void);
+
+
+	/** Executes all tasks queued onto the tick thread */
+	void TickQueuedTasks(void);
+
 
 };  // tolua_export
 

--- a/src/Server.h
+++ b/src/Server.h
@@ -105,8 +105,7 @@ public:
 	The command's output will be written to the a_Output callback. */
 	void QueueExecuteConsoleCommand(const AString & a_Cmd, cCommandOutputCallback & a_Output);
 
-	/** Queues a lambda task onto the server tick thread, with the specified
-	 * delay in ticks. */
+	/** Queues a lambda task onto the server tick thread, with the specified delay in ticks. */
 	void ScheduleTask(cTickTime a_DelayTicks, std::function<void(class cServer &)> a_Task);
 
 	/** Lists all available console commands and their helpstrings */
@@ -257,7 +256,7 @@ private:
 	cCriticalSection m_CSTasks;
 
 	/** Tasks that have been queued onto the tick thread, possibly to be
-	 * executed at target tick in the future; guarded by m_CSTasks */
+	executed at target tick in the future; guarded by m_CSTasks */
 	std::vector<std::pair<std::chrono::milliseconds, std::function<void(class cServer &)>>> m_Tasks;
 
 


### PR DESCRIPTION
Followed implementation of cWorld::ScheduleTask() and cWorld::TickQueuedTasks() and added them to cServer.
Added cTickTimeLong m_UpTime to cServer to check if tasks are due for execution.

Tested behaviour myself by writing a small lua plugin and scheduling a task on the server. When I scheduled a task and set the delay to 100 ticks the command was executed 5 seconds after the server was started. 

First contribution and pull request so let me know if there is something missing/wrong and I will be happy to change it :)

Fixes issue #1754