### PR TITLE
Added AArch64 to easyinstall.sh

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -47,6 +47,7 @@ maxluchterhand1
 MaxwellScroggs
 mborland
 mBornand
+mcfadyeni
 MeMuXin
 mgueydan
 MikeHunsinger

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -21,6 +21,8 @@ if [ "$KERNEL" = "Linux" ]; then
 		"x86_64") DOWNLOADURL="https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz" ;;
 		# Assume that all arm devices are a raspi for now.
 		arm*) DOWNLOADURL="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz"
+		# Allow install on Raspberry Pi 4 Ubuntu x64 (AArch64) using the ARM builds.
+		"aarch64") DOWNLOADURL="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz"
 	esac
 elif [ "$KERNEL" = "Darwin" ]; then
 	# All Darwins we care about are x86_64


### PR DESCRIPTION
Added case statement in easyinstall.sh to allow install on Raspberry Pi 4 Ubuntu x64 (AArch64), fixing #5221.