### PR TITLE
Performance improvements when spawning many entities

### DIFF
--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -97,6 +97,22 @@ public:
 
 
 
+/** Used to hash ChunkCoors in cChunkMap */
+class cChunkChoordHasher
+{
+  public:
+	// Use sum of lengths of first and last names
+	// as hash function.
+	size_t operator()(const cChunkCoords & a_Coords) const
+	{
+		// https://stackoverflow.com/questions/22826326/good-hashcode-function-for-2d-coordinates
+		size_t Temp = (a_Coords.m_ChunkZ + ((a_Coords.m_ChunkX + 1) / 2));
+		return a_Coords.m_ChunkX + (Temp * Temp);
+	}
+};
+
+
+
 
 /** Constants used throughout the code, useful typedefs and utility functions */
 class cChunkDef

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -97,23 +97,6 @@ public:
 
 
 
-/** Used to hash ChunkCoors in cChunkMap */
-class cChunkChoordHasher
-{
-  public:
-	// Use sum of lengths of first and last names
-	// as hash function.
-	size_t operator()(const cChunkCoords & a_Coords) const
-	{
-		// https://stackoverflow.com/questions/22826326/good-hashcode-function-for-2d-coordinates
-		size_t Temp = (a_Coords.m_ChunkZ + ((a_Coords.m_ChunkX + 1) / 2));
-		return a_Coords.m_ChunkX + (Temp * Temp);
-	}
-};
-
-
-
-
 /** Constants used throughout the code, useful typedefs and utility functions */
 class cChunkDef
 {

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -299,7 +299,7 @@ private:
 
 	/** A map of chunk coordinates to chunks.
 	Uses a map (as opposed to unordered_map) because sorted maps are apparently faster. */
-	std::map<cChunkCoords, cChunk> m_Chunks;
+	std::unordered_map<cChunkCoords, cChunk, cChunkChoordHasher> m_Chunks;
 
 	cEvent m_evtChunkValid;  // Set whenever any chunk becomes valid, via ChunkValidated()
 

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -299,7 +299,7 @@ private:
 
 	/** A map of chunk coordinates to chunks.
 	Uses a map (as opposed to unordered_map) because sorted maps are apparently faster. */
-	std::unordered_map<cChunkCoords, cChunk, cChunkChoordHasher> m_Chunks;
+	std::map<cChunkCoords, cChunk> m_Chunks;
 
 	cEvent m_evtChunkValid;  // Set whenever any chunk becomes valid, via ChunkValidated()
 

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -189,7 +189,8 @@ void cArrowEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 	if (m_IsInGround)
 	{
-		if (m_World->GetBlock(m_HitBlockPos) == E_BLOCK_AIR)  // Block attached to was destroyed?
+		BLOCKTYPE BlockType;
+		if (a_Chunk.UnboundedRelGetBlockType(m_HitBlockPos, BlockType) && (BlockType == E_BLOCK_AIR))  // Block attached to was destroyed?
 		{
 			m_IsInGround = false;  // Yes, begin simulating physics again
 		}

--- a/src/Entities/Boat.cpp
+++ b/src/Entities/Boat.cpp
@@ -182,8 +182,8 @@ void cBoat::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	{
 		return;
 	}
-
-	if (IsBlockWater(m_World->GetBlock(POS_TOINT)))
+	BLOCKTYPE BlockType;
+	if (a_Chunk.UnboundedRelGetBlockType(POS_TOINT, BlockType) && IsBlockWater(BlockType))
 	{
 		if (GetSpeedY() < 2)
 		{

--- a/src/Entities/EnderCrystal.cpp
+++ b/src/Entities/EnderCrystal.cpp
@@ -75,9 +75,10 @@ void cEnderCrystal::SpawnOn(cClientHandle & a_ClientHandle)
 void cEnderCrystal::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	UNUSED(a_Dt);
-	if ((m_World->GetDimension() == dimEnd) && (m_World->GetBlock(POS_TOINT) != E_BLOCK_FIRE))
+	BLOCKTYPE BlockType;
+	if ((m_World->GetDimension() == dimEnd) && a_Chunk.UnboundedRelGetBlockType(POS_TOINT, BlockType) && (BlockType != E_BLOCK_FIRE))
 	{
-		m_World->SetBlock(POS_TOINT, E_BLOCK_FIRE, 0);
+		a_Chunk.UnboundedRelSetBlock(POS_TOINT, E_BLOCK_FIRE, 0);
 	}
 }
 

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -917,7 +917,7 @@ void cEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			(IsPlayer() && !((static_cast<cPlayer *>(this))->IsGameModeCreative() || (static_cast<cPlayer *>(this))->IsGameModeSpectator()))
 		)
 		{
-			DetectCacti();
+			DetectCacti(a_Chunk);
 		}
 
 		// Handle magma block damage
@@ -934,7 +934,7 @@ void cEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			)
 		)
 		{
-			DetectMagma();
+			DetectMagma(a_Chunk);
 		}
 
 		// Handle drowning:
@@ -1317,7 +1317,7 @@ void cEntity::TickInVoid(cChunk & a_Chunk)
 
 
 
-void cEntity::DetectCacti(void)
+void cEntity::DetectCacti(cChunk & a_Chunk)
 {
 	int MinX = FloorC(GetPosX() - m_Width / 2);
 	int MaxX = FloorC(GetPosX() + m_Width / 2);
@@ -1332,7 +1332,12 @@ void cEntity::DetectCacti(void)
 		{
 			for (int y = MinY; y <= MaxY; y++)
 			{
-				if (GetWorld()->GetBlock({ x, y, z }) == E_BLOCK_CACTUS)
+				BLOCKTYPE BlockType;
+				if (!a_Chunk.UnboundedRelGetBlockType({x, y, z}, BlockType))
+				{
+					continue;
+				}
+				if (BlockType == E_BLOCK_CACTUS)
 				{
 					TakeDamage(dtCactusContact, nullptr, 1, 0);
 					return;
@@ -1346,7 +1351,7 @@ void cEntity::DetectCacti(void)
 
 
 
-void cEntity::DetectMagma(void)
+void cEntity::DetectMagma(cChunk & a_Chunk)
 {
 	int MinX = FloorC(GetPosX() - m_Width / 2);
 	int MaxX = FloorC(GetPosX() + m_Width / 2);
@@ -1361,7 +1366,12 @@ void cEntity::DetectMagma(void)
 		{
 			for (int y = MinY; y <= MaxY; y++)
 			{
-				if (GetWorld()->GetBlock({ x, y, z }) == E_BLOCK_MAGMA)
+				BLOCKTYPE BlockType;
+				if (!a_Chunk.UnboundedRelGetBlockType({x, y, z}, BlockType))
+				{
+					continue;
+				}
+				if (BlockType == E_BLOCK_MAGMA)
 				{
 					TakeDamage(dtMagmaContact, nullptr, 1, 0);
 					return;

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -374,10 +374,10 @@ public:
 	virtual void TickBurning(cChunk & a_Chunk);
 
 	/** Detects the time for application of cacti damage */
-	virtual void DetectCacti(void);
+	virtual void DetectCacti(cChunk & a_Chunk);
 
 	/** Detects the time for application of magma block damage */
-	virtual void DetectMagma(void);
+	virtual void DetectMagma(cChunk & a_Chunk);
 
 	/** Detects whether we are in a portal block and begins teleportation procedures if so
 	Returns true if MoveToWorld() was called, false if not

--- a/src/Entities/ExpOrb.cpp
+++ b/src/Entities/ExpOrb.cpp
@@ -33,7 +33,7 @@ void cExpOrb::SpawnOn(cClientHandle & a_Client)
 
 void cExpOrb::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
-	DetectCacti();
+	DetectCacti(a_Chunk);
 	m_TicksAlive++;
 
 	// Find closest player within 6.5 meter (slightly increase detect range to have same effect in client)

--- a/src/Entities/Floater.cpp
+++ b/src/Entities/Floater.cpp
@@ -154,10 +154,11 @@ void cFloater::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		}
 	}
 
+	BLOCKTYPE BlockType;
 	// Check water at the top of floater otherwise it floats into the air above the water
 	if (
 		const auto Above = Rel.addedY(FloorC(GetPosY() + GetHeight()));
-		(Above.y < cChunkDef::Height) && IsBlockWater(m_World->GetBlock(Above))
+		(Above.y < cChunkDef::Height) && a_Chunk.UnboundedRelGetBlockType(Above, BlockType) && IsBlockWater(BlockType)
 	)
 	{
 		SetSpeedY(0.7);

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -234,8 +234,12 @@ void cMinecart::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 	if (m_bIsOnDetectorRail && !Vector3i(POSX_TOINT, POSY_TOINT, POSZ_TOINT).Equals(m_DetectorRailPosition))
 	{
-		m_World->SetBlock(m_DetectorRailPosition, E_BLOCK_DETECTOR_RAIL, m_World->GetBlockMeta(m_DetectorRailPosition) & 0x07);
-		m_bIsOnDetectorRail = false;
+		NIBBLETYPE Meta;
+		if (a_Chunk.UnboundedRelGetBlockMeta(m_DetectorRailPosition, Meta))
+		{
+			a_Chunk.UnboundedRelSetBlock(m_DetectorRailPosition, E_BLOCK_DETECTOR_RAIL, (Meta & 0x07));
+			m_bIsOnDetectorRail = false;
+		}
 	}
 	else if (WasDetectorRail)
 	{

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -304,7 +304,7 @@ void cPawn::HandleFalling(cChunk & a_Chunk)
 	With this in mind, we first check the block at the player's feet, then the one below that (because fences),
 	and decide which behaviour we want to go with.
 	*/
-	BLOCKTYPE BlockAtFoot;
+	BLOCKTYPE BlockAtFoot = E_BLOCK_AIR;
 
 	if (!cChunkDef::IsValidHeight(POS_TOINT.y) || !a_Chunk.UnboundedRelGetBlockType(POS_TOINT, BlockAtFoot))
 	{

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -353,8 +353,10 @@ void cPawn::HandleFalling(void)
 				continue;
 			}
 
-			BLOCKTYPE BlockType = GetWorld()->GetBlock(BlockTestPosition);
-			NIBBLETYPE BlockMeta = GetWorld()->GetBlockMeta(BlockTestPosition);
+			BLOCKTYPE BlockType;
+			NIBBLETYPE BlockMeta;
+
+			GetWorld()->GetBlockTypeMeta(BlockTestPosition, BlockType, BlockMeta);
 
 			/* we do the cross-shaped sampling to check for water / liquids, but only on our level because water blocks are never bigger than unit voxels */
 			if (j == 0)

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -30,7 +30,7 @@ public:
 	virtual bool IsFireproof(void) const override;
 	virtual bool IsInvisible() const override;
 	virtual void HandleAir(void) override;
-	virtual void HandleFalling(void);
+	virtual void HandleFalling(cChunk & a_Chunk);
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 
 	/** Tells all pawns which are targeting us to stop targeting us. */

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -529,10 +529,10 @@ void cMonster::SetPitchAndYawFromDestination(bool a_IsFollowingPath)
 
 
 
-void cMonster::HandleFalling()
+void cMonster::HandleFalling(cChunk & a_Chunk)
 {
 	m_bTouchGround = IsOnGround();
-	Super::HandleFalling();
+	Super::HandleFalling(a_Chunk);
 }
 
 

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -61,7 +61,7 @@ public:
 
 	virtual void OnRightClicked(cPlayer & a_Player) override;
 
-	virtual void HandleFalling(void) override;
+	virtual void HandleFalling(cChunk & a_Chunk) override;
 
 	/** Engage pathfinder and tell it to calculate a path to a given position, and move the mob accordingly. */
 	virtual void MoveToPosition(const Vector3d & a_Position);  // tolua_export

--- a/tests/Generating/Stubs.cpp
+++ b/tests/Generating/Stubs.cpp
@@ -800,7 +800,7 @@ void cPawn::HandleAir(void)
 
 
 
-void cPawn::HandleFalling()
+void cPawn::HandleFalling(cChunk & a_Chunk)
 {
 }
 
@@ -921,7 +921,7 @@ void cMonster::OnRightClicked(class cPlayer & a_Player)
 
 
 
-void cMonster::HandleFalling(void)
+void cMonster::HandleFalling(cChunk & a_Chunk)
 {
 }
 


### PR DESCRIPTION
I put cuberite in the VS performance profiler and spawned a lot of animals and took a look what makes the server slow down.
In the end, it's cause by sampling the world around the entity.

In the end, the bottleneck is that we have to find the chunk to ask for the blocks.

There is a double call to `GetBlock` and `GetMeta` which can be removed so that there is one less search each call. -> 53ce8b7

And I replaced the `std::map` in `cChunkMap` with a `unordered_map`. The map has a time of `O(log(n))` in any case. And the `unordered_map` has an armotised runtime of `O(1)` in good case (good hashing). And `O(n)` in worst case (bad hashing). I took a function for hashing that is a Bijection to decrease the collision to a little amount (or 0) so we get a time close to `O(1)`

The downside of this is that `unordered_map` uses more memory!

https://www.geeksforgeeks.org/map-vs-unordered_map-c/

Subjectively, this improved the performance. I can do some actual measurements.

I also thought about copying the part around the pawn into a `cBlockArea`. But I'll have to check the performance of that.

What are your thoughts?