### PR TITLE
Paintings tweaks

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -61,6 +61,7 @@ p-mcgowan
 pokechu22
 ProjectBM
 pwnOrbitals
+Rorkh
 rs2k
 SamJBarney
 Schwertspize

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -390,6 +390,18 @@ bool cEntity::DoTakeDamage(TakeDamageInfo & a_TDI)
 		return false;
 	}
 
+	if (IsPainting())
+	{
+		KilledBy(a_TDI);
+
+		if (a_TDI.Attacker != nullptr)
+		{
+			a_TDI.Attacker->Killed(this);
+		}
+
+		return true;
+	}
+
 	if ((a_TDI.Attacker != nullptr) && (a_TDI.Attacker->IsPlayer()))
 	{
 		cPlayer * Player = static_cast<cPlayer *>(a_TDI.Attacker);

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -24,6 +24,8 @@ void cPainting::SpawnOn(cClientHandle & a_Client)
 {
 	Super::SpawnOn(a_Client);
 	a_Client.SendPaintingSpawn(*this);
+	
+	m_World->BroadcastSoundEffect("entity.painting.place", GetPosition(), 1, 1);
 }
 
 
@@ -36,6 +38,8 @@ void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 	{
 		a_Items.emplace_back(E_ITEM_PAINTING);
 	}
+	
+	 m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
 }
 
 

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -38,6 +38,16 @@ void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 	{
 		a_Items.emplace_back(E_ITEM_PAINTING);
 	}
+}
 
-	m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
+
+
+
+
+void cPainting::KilledBy(TakeDamageInfo & a_TDI)
+{
+        Super::KilledBy(a_TDI);
+        Destroy();
+
+        m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
 }

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -24,7 +24,7 @@ void cPainting::SpawnOn(cClientHandle & a_Client)
 {
 	Super::SpawnOn(a_Client);
 	a_Client.SendPaintingSpawn(*this);
-	
+
 	m_World->BroadcastSoundEffect("entity.painting.place", GetPosition(), 1, 1);
 }
 
@@ -38,6 +38,6 @@ void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 	{
 		a_Items.emplace_back(E_ITEM_PAINTING);
 	}
-	
-	 m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
+
+	m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
 }

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -41,7 +41,3 @@ void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 	
 	 m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
 }
-
-
-
-

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -46,8 +46,8 @@ void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 
 void cPainting::KilledBy(TakeDamageInfo & a_TDI)
 {
-        Super::KilledBy(a_TDI);
-        Destroy();
+	Super::KilledBy(a_TDI);
+	Destroy();
 
-        m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
+	m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
 }

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -47,7 +47,6 @@ void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 void cPainting::KilledBy(TakeDamageInfo & a_TDI)
 {
 	Super::KilledBy(a_TDI);
-	Destroy();
-
 	m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
+	Destroy();
 }

--- a/src/Entities/Painting.h
+++ b/src/Entities/Painting.h
@@ -28,11 +28,7 @@ private:
 
 	virtual void SpawnOn(cClientHandle & a_Client) override;
 	virtual void GetDrops(cItems & a_Items, cEntity * a_Killer) override;
-	virtual void KilledBy(TakeDamageInfo & a_TDI) override
-	{
-		Super::KilledBy(a_TDI);
-		Destroy();
-	}
+	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
 
 	AString m_Name;
 


### PR DESCRIPTION
Now they are creates sounds they should at spawn and destroy and they can't be critical hitted (they skip default on damage logic cause amount of damage should not be checked for them as critical hits and damage dealt to them shouldn't be registered in statistics (according to Vanilla server behavior)).
Little checklist:

- [x] Sounds when placed and broke
- [x] No critical damage
- [ ] Check if painting fits the surface