### PR TITLE
Haybale damage reduction implementation

### DIFF
--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -423,19 +423,16 @@ void cPawn::HandleFalling(void)
 				Damage = static_cast<int>(static_cast<float>(Damage) * 0.33);
 			}
 
-			const auto Below = POS_TOINT.addedY(-1);
-			const auto BlockBelow = GetWorld()->GetBlock(Below);
-
-			if (BlockBelow == E_BLOCK_HAY_BALE)
-			{
-				Damage = std::clamp(static_cast<int>(static_cast<float>(Damage) * 0.2), 1, 20);
-			}
-
-			TakeDamage(dtFalling, nullptr, Damage, static_cast<float>(Damage), 0);
-
 			// Fall particles:
-			if (Below.y >= 0)
+			if (const auto Below = POS_TOINT.addedY(-1); Below.y >= 0)
 			{
+				const auto BlockBelow = GetWorld()->GetBlock(Below);
+
+				if (BlockBelow == E_BLOCK_HAY_BALE)
+				{
+					Damage = std::clamp(static_cast<int>(static_cast<float>(Damage) * 0.2), 1, 20);
+				}
+
 				GetWorld()->BroadcastParticleEffect(
 					"blockdust",
 					GetPosition(),
@@ -445,6 +442,8 @@ void cPawn::HandleFalling(void)
 					{ { BlockBelow, 0 } }
 				);
 			}
+
+			TakeDamage(dtFalling, nullptr, Damage, static_cast<float>(Damage), 0);
 		}
 
 		m_bTouchGround = true;

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -423,10 +423,18 @@ void cPawn::HandleFalling(void)
 				Damage = static_cast<int>(static_cast<float>(Damage) * 0.33);
 			}
 
+			const auto Below = POS_TOINT.addedY(-1);
+			const auto BlockBelow = GetWorld()->GetBlock(Below);
+
+			if (BlockBelow == E_BLOCK_HAY_BALE)
+			{
+				Damage = std::clamp(static_cast<int>(static_cast<float>(Damage) * 0.2), 1, 20);
+			}
+
 			TakeDamage(dtFalling, nullptr, Damage, static_cast<float>(Damage), 0);
 
 			// Fall particles:
-			if (const auto Below = POS_TOINT.addedY(-1); Below.y >= 0)
+			if (Below.y >= 0)
 			{
 				GetWorld()->BroadcastParticleEffect(
 					"blockdust",
@@ -434,7 +442,7 @@ void cPawn::HandleFalling(void)
 					{ 0, 0, 0 },
 					(Damage - 1.f) * ((0.3f - 0.1f) / (15.f - 1.f)) + 0.1f,  // Map damage (1 - 15) to particle speed (0.1 - 0.3)
 					static_cast<int>((Damage - 1.f) * ((50.f - 20.f) / (15.f - 1.f)) + 20.f),  // Map damage (1 - 15) to particle quantity (20 - 50)
-					{ { GetWorld()->GetBlock(Below), 0 } }
+					{ { BlockBelow, 0 } }
 				);
 			}
 		}


### PR DESCRIPTION
I have used data from official Minecraft wiki (https://minecraft.fandom.com/wiki/Hay_Bale) but still it takes 9 block to give 1 heart damage in Vanilla while in my implementation all 13. 
Is it critical and should I take it personally? It seems like a problem of general fall damage calculation, not a haybale modifier ones