### PR TITLE
Don't allow players in adventure mode to break blocks

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1143,6 +1143,12 @@ void cClientHandle::HandleLeftClick(int a_BlockX, int a_BlockY, int a_BlockZ, eB
 
 void cClientHandle::HandleBlockDigStarted(int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace)
 {
+	if (m_Player->IsGameModeAdventure())
+	{
+		// Players in adventure mode can't destroy blocks
+		return;
+	}
+
 	if (
 		m_HasStartedDigging &&
 		(a_BlockX == m_LastDigBlockX) &&


### PR DESCRIPTION
This PR fixes an issue mentioned in #5290 where players can break blocks in adventure mode