### PR TITLE
Don't allow spectators or dead entities to activate pressure plates

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/PressurePlateHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/PressurePlateHandler.h
@@ -17,17 +17,29 @@ namespace PressurePlateHandler
 
 		Chunk.ForEachEntityInBox(cBoundingBox(Vector3d(0.5, 0, 0.5) + Position, 0.5, 0.5), [&](cEntity & Entity)
 		{
-			if (Entity.IsPlayer())
+			if (Entity.GetHealth() <= 0)
 			{
-				FoundPlayer = true;
+				return false;
 			}
 
-			if (Entity.IsPickup())
+			if (Entity.IsPlayer())
+			{
+				const auto & Player = static_cast<cPlayer &>(Entity);
+
+				if (Player.IsGameModeSpectator())
+				{
+					return false;
+				}
+
+				FoundPlayer = true;
+			}
+			else if (Entity.IsPickup())
 			{
 				const auto & Pickup = static_cast<cPickup &>(Entity);
 				NumberOfEntities += static_cast<size_t>(Pickup.GetItem().m_ItemCount);
 				return false;
 			}
+
 			NumberOfEntities++;
 			return false;
 		});


### PR DESCRIPTION
This PR stops dead entities or players from activating redstone pressure plates. Fixes #5264 