### PR TITLE
Prevent placing of hangables on illegal blocks/Break when support block broken

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -5206,6 +5206,23 @@ cFile:DeleteFile("/usr/bin/virus.exe");
 					},
 					Notes = "Set the direction in which the entity is facing.",
 				},
+				ValidSupportBlock =
+				{
+					Params =
+					{
+						{
+							Name = "BlockType",
+							Type = "number",
+						},
+					},
+					Returns =
+					{
+						{
+							Type = "boolean",
+						}
+					},
+					Notes = "Returns true if the specified block is a valid support block.",
+				},
 			},
 			Inherits = "cEntity",
 		},

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -5195,19 +5195,9 @@ cFile:DeleteFile("/usr/bin/virus.exe");
 					},
 					Notes = "Returns the direction in which the entity is facing.",
 				},
-				SetFacing =
+				IsValidSupportBlock =
 				{
-					Params =
-					{
-						{
-							Name = "BlockFace",
-							Type = "eBlockFace",
-						},
-					},
-					Notes = "Set the direction in which the entity is facing.",
-				},
-				ValidSupportBlock =
-				{
+					IsStatic = true,
 					Params =
 					{
 						{
@@ -5221,7 +5211,18 @@ cFile:DeleteFile("/usr/bin/virus.exe");
 							Type = "boolean",
 						}
 					},
-					Notes = "Returns true if the specified block is a valid support block.",
+					Notes = "Returns true if the specified block type can support a hanging entity. This means that paintings and item frames can be placed on such a block.",
+				},
+				SetFacing =
+				{
+					Params =
+					{
+						{
+							Name = "BlockFace",
+							Type = "eBlockFace",
+						},
+					},
+					Notes = "Set the direction in which the entity is facing.",
 				},
 			},
 			Inherits = "cEntity",

--- a/src/Entities/HangingEntity.cpp
+++ b/src/Entities/HangingEntity.cpp
@@ -56,7 +56,7 @@ void cHangingEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 {
 	UNUSED(a_Dt);
 
-	// Check for supports once every 64 ticks (3.2 seconds):
+	// Check for a valid support block once every 64 ticks (3.2 seconds):
 	if ((m_World->GetWorldTickAge() % 64_tick) != 0_tick)
 	{
 		return;
@@ -69,5 +69,6 @@ void cHangingEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		return;
 	}
 
-	TakeDamage(dtEnvironment, nullptr, GetMaxHealth(), 0);
+	// Take environmental damage, intending to self-destruct, with "take damage" handling done by child classes:
+	TakeDamage(dtEnvironment, nullptr, static_cast<int>(GetMaxHealth()), 0);
 }

--- a/src/Entities/HangingEntity.cpp
+++ b/src/Entities/HangingEntity.cpp
@@ -3,6 +3,7 @@
 
 #include "HangingEntity.h"
 #include "Player.h"
+#include "Chunk.h"
 #include "../ClientHandle.h"
 
 
@@ -29,3 +30,38 @@ void cHangingEntity::SpawnOn(cClientHandle & a_ClientHandle)
 
 
 
+
+void cHangingEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
+{
+	if (m_TickCounter++ >= 100)
+	{
+		m_TickCounter = 0;
+
+		const auto & Pos = GetPosition();
+		const auto SupportBlockPos =
+			AddFaceDirection(Pos, ProtocolFaceToBlockFace(m_Facing), true);
+
+		BLOCKTYPE Block;
+
+		const auto ChunkPos = a_Chunk.PositionToWorldPosition(Vector3i());
+		const auto RelPos = SupportBlockPos - ChunkPos;
+
+		if (!a_Chunk.UnboundedRelGetBlockType(RelPos, Block))
+		{
+			return;
+		}
+
+		if (!ValidSupportBlock(Block))
+		{
+			cItems Item;
+			GetDrops(Item);
+
+			GetWorld()->SpawnItemPickups(Item, GetPosition(), 5);
+
+			Destroy();
+			return;
+		}
+	}
+
+	UNUSED(a_Dt);
+}

--- a/src/Entities/HangingEntity.h
+++ b/src/Entities/HangingEntity.h
@@ -32,6 +32,48 @@ public:  // tolua_export
 		m_Facing = cHangingEntity::BlockFaceToProtocolFace(a_Facing);
 	}
 
+	inline static bool ValidSupportBlock(BLOCKTYPE BlockType)
+	{
+		switch (BlockType)
+		{
+			case E_BLOCK_AIR:
+			case E_BLOCK_RAIL:
+			case E_BLOCK_ACTIVATOR_RAIL:
+			case E_BLOCK_DETECTOR_RAIL:
+			case E_BLOCK_POWERED_RAIL:
+			case E_BLOCK_LEVER:
+			case E_BLOCK_STONE_BUTTON:
+			case E_BLOCK_WOODEN_BUTTON:
+			case E_BLOCK_TRIPWIRE:
+			case E_BLOCK_TRIPWIRE_HOOK:
+			case E_BLOCK_REDSTONE_WIRE:
+			case E_BLOCK_REDSTONE_TORCH_ON:
+			case E_BLOCK_REDSTONE_TORCH_OFF:
+			case E_BLOCK_TORCH:
+			case E_BLOCK_SAPLING:
+			case E_BLOCK_DEAD_BUSH:
+			case E_BLOCK_TALL_GRASS:
+			case E_BLOCK_BROWN_MUSHROOM:
+			case E_BLOCK_RED_MUSHROOM:
+			case E_BLOCK_CARPET:
+			case E_BLOCK_HEAD:
+			case E_BLOCK_FLOWER_POT:
+			case E_BLOCK_FLOWER:
+			case E_BLOCK_BIG_FLOWER:
+			case E_BLOCK_YELLOW_FLOWER:
+			case E_BLOCK_BREWING_STAND:
+			case E_BLOCK_END_ROD:
+			case E_BLOCK_LADDER:
+			case E_BLOCK_END_PORTAL:
+			case E_BLOCK_NETHER_PORTAL:
+				return false;
+			default:
+			{
+				return true;
+			}
+		}
+	}
+
 	// tolua_end
 
 	/** Returns the direction in which the entity is facing. */
@@ -48,13 +90,10 @@ protected:
 
 	Byte m_Facing;
 
+	Byte m_TickCounter = 0;
 
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
-	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override
-	{
-		UNUSED(a_Dt);
-		UNUSED(a_Chunk);
-	}
+	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 
 
 	/** Converts protocol hanging item facing to eBlockFace values */

--- a/src/Entities/HangingEntity.h
+++ b/src/Entities/HangingEntity.h
@@ -21,63 +21,20 @@ public:  // tolua_export
 
 	cHangingEntity(eEntityType a_EntityType, eBlockFace a_BlockFace, Vector3d a_Pos);
 
-	// tolua_begin
+	/** Returns the direction in which the entity is facing. */
+	eBlockFace GetFacing() const { return cHangingEntity::ProtocolFaceToBlockFace(m_Facing); }  // tolua_export
 
 	/** Returns the direction in which the entity is facing. */
-	eBlockFace GetFacing() const { return cHangingEntity::ProtocolFaceToBlockFace(m_Facing); }
+	Byte GetProtocolFacing() const { return m_Facing; }
+
+	/** Returns if the given block can support hanging entity placements. */
+	static bool IsValidSupportBlock(BLOCKTYPE a_BlockType);  // tolua_export
 
 	/** Set the direction in which the entity is facing. */
 	void SetFacing(eBlockFace a_Facing)
 	{
 		m_Facing = cHangingEntity::BlockFaceToProtocolFace(a_Facing);
 	}
-
-	inline static bool ValidSupportBlock(BLOCKTYPE BlockType)
-	{
-		switch (BlockType)
-		{
-			case E_BLOCK_AIR:
-			case E_BLOCK_RAIL:
-			case E_BLOCK_ACTIVATOR_RAIL:
-			case E_BLOCK_DETECTOR_RAIL:
-			case E_BLOCK_POWERED_RAIL:
-			case E_BLOCK_LEVER:
-			case E_BLOCK_STONE_BUTTON:
-			case E_BLOCK_WOODEN_BUTTON:
-			case E_BLOCK_TRIPWIRE:
-			case E_BLOCK_TRIPWIRE_HOOK:
-			case E_BLOCK_REDSTONE_WIRE:
-			case E_BLOCK_REDSTONE_TORCH_ON:
-			case E_BLOCK_REDSTONE_TORCH_OFF:
-			case E_BLOCK_TORCH:
-			case E_BLOCK_SAPLING:
-			case E_BLOCK_DEAD_BUSH:
-			case E_BLOCK_TALL_GRASS:
-			case E_BLOCK_BROWN_MUSHROOM:
-			case E_BLOCK_RED_MUSHROOM:
-			case E_BLOCK_CARPET:
-			case E_BLOCK_HEAD:
-			case E_BLOCK_FLOWER_POT:
-			case E_BLOCK_FLOWER:
-			case E_BLOCK_BIG_FLOWER:
-			case E_BLOCK_YELLOW_FLOWER:
-			case E_BLOCK_BREWING_STAND:
-			case E_BLOCK_END_ROD:
-			case E_BLOCK_LADDER:
-			case E_BLOCK_END_PORTAL:
-			case E_BLOCK_NETHER_PORTAL:
-				return false;
-			default:
-			{
-				return true;
-			}
-		}
-	}
-
-	// tolua_end
-
-	/** Returns the direction in which the entity is facing. */
-	Byte GetProtocolFacing() const { return m_Facing; }
 
 	/** Set the direction in which the entity is facing. */
 	void SetProtocolFacing(Byte a_Facing)
@@ -90,11 +47,9 @@ protected:
 
 	Byte m_Facing;
 
-	Byte m_TickCounter = 0;
-
+	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
-
 
 	/** Converts protocol hanging item facing to eBlockFace values */
 	inline static eBlockFace ProtocolFaceToBlockFace(Byte a_ProtocolFace)
@@ -141,7 +96,3 @@ protected:
 		UNREACHABLE("Unsupported block face");
 	}
 };  // tolua_export
-
-
-
-

--- a/src/Entities/ItemFrame.cpp
+++ b/src/Entities/ItemFrame.cpp
@@ -23,16 +23,26 @@ cItemFrame::cItemFrame(eBlockFace a_BlockFace, Vector3d a_Pos):
 
 bool cItemFrame::DoTakeDamage(TakeDamageInfo & a_TDI)
 {
+	// Take environmental or non-player damage normally:
 	if (m_Item.IsEmpty() || (a_TDI.Attacker == nullptr) || !a_TDI.Attacker->IsPlayer())
 	{
 		return Super::DoTakeDamage(a_TDI);
 	}
 
+	// Only pop out a pickup if attacked by a non-creative player:
 	if (!static_cast<cPlayer *>(a_TDI.Attacker)->IsGameModeCreative())
 	{
-		GetWorld()->SpawnItemPickup(GetPosition().addedY(-0.125), m_Item, AddFaceDirection(Vector3i(), ProtocolFaceToBlockFace(m_Facing)) * 2);
+		// Where the pickup spawns, offset by half cPickup height to centre in the block.
+		const auto SpawnPosition = GetPosition().addedY(-0.125);
+
+		// The direction the pickup travels to simulate a pop-out effect.
+		const auto FlyOutSpeed = AddFaceDirection(Vector3i(), ProtocolFaceToBlockFace(m_Facing)) * 2;
+
+		// Spawn the frame's held item:
+		GetWorld()->SpawnItemPickup(SpawnPosition, m_Item, FlyOutSpeed);
 	}
 
+	// In any case we have a held item and were hit by a player, so clear it:
 	m_Item.Empty();
 	m_ItemRotation = 0;
 	a_TDI.FinalDamage = 0;

--- a/src/Entities/ItemFrame.cpp
+++ b/src/Entities/ItemFrame.cpp
@@ -21,6 +21,44 @@ cItemFrame::cItemFrame(eBlockFace a_BlockFace, Vector3d a_Pos):
 
 
 
+bool cItemFrame::DoTakeDamage(TakeDamageInfo & a_TDI)
+{
+	if (m_Item.IsEmpty() || (a_TDI.Attacker == nullptr) || !a_TDI.Attacker->IsPlayer())
+	{
+		return Super::DoTakeDamage(a_TDI);
+	}
+
+	if (!static_cast<cPlayer *>(a_TDI.Attacker)->IsGameModeCreative())
+	{
+		GetWorld()->SpawnItemPickup(GetPosition().addedY(-0.125), m_Item, AddFaceDirection(Vector3i(), ProtocolFaceToBlockFace(m_Facing)) * 2);
+	}
+
+	m_Item.Empty();
+	m_ItemRotation = 0;
+	a_TDI.FinalDamage = 0;
+	SetInvulnerableTicks(0);
+	GetWorld()->BroadcastEntityMetadata(*this);
+	return false;
+}
+
+
+
+
+
+void cItemFrame::GetDrops(cItems & a_Items, cEntity * a_Killer)
+{
+	if (!m_Item.IsEmpty())
+	{
+		a_Items.push_back(m_Item);
+	}
+
+	a_Items.emplace_back(E_ITEM_ITEM_FRAME);
+}
+
+
+
+
+
 void cItemFrame::OnRightClicked(cPlayer & a_Player)
 {
 	Super::OnRightClicked(a_Player);
@@ -48,43 +86,6 @@ void cItemFrame::OnRightClicked(cPlayer & a_Player)
 
 	GetWorld()->BroadcastEntityMetadata(*this);  // Update clients
 	GetParentChunk()->MarkDirty();               // Mark chunk dirty to save rotation or item
-}
-
-
-
-
-
-void cItemFrame::KilledBy(TakeDamageInfo & a_TDI)
-{
-	if (m_Item.IsEmpty())
-	{
-		Super::KilledBy(a_TDI);
-		Destroy();
-		return;
-	}
-
-	if ((a_TDI.Attacker != nullptr) && a_TDI.Attacker->IsPlayer() && !static_cast<cPlayer *>(a_TDI.Attacker)->IsGameModeCreative())
-	{
-		cItems Item;
-		Item.push_back(m_Item);
-
-		GetWorld()->SpawnItemPickups(Item, GetPosX(), GetPosY(), GetPosZ());
-	}
-
-	SetHealth(GetMaxHealth());
-	m_Item.Empty();
-	m_ItemRotation = 0;
-	SetInvulnerableTicks(0);
-	GetWorld()->BroadcastEntityMetadata(*this);
-}
-
-
-
-
-
-void cItemFrame::GetDrops(cItems & a_Items, cEntity * a_Killer)
-{
-	a_Items.emplace_back(E_ITEM_ITEM_FRAME);
 }
 
 

--- a/src/Entities/ItemFrame.cpp
+++ b/src/Entities/ItemFrame.cpp
@@ -84,10 +84,7 @@ void cItemFrame::KilledBy(TakeDamageInfo & a_TDI)
 
 void cItemFrame::GetDrops(cItems & a_Items, cEntity * a_Killer)
 {
-	if ((a_Killer != nullptr) && a_Killer->IsPlayer() && !static_cast<cPlayer *>(a_Killer)->IsGameModeCreative())
-	{
-		a_Items.emplace_back(E_ITEM_ITEM_FRAME);
-	}
+	a_Items.emplace_back(E_ITEM_ITEM_FRAME);
 }
 
 

--- a/src/Entities/ItemFrame.h
+++ b/src/Entities/ItemFrame.h
@@ -39,16 +39,12 @@ public:  // tolua_export
 
 private:
 
-	virtual void OnRightClicked(cPlayer & a_Player) override;
-	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
+	virtual bool DoTakeDamage(TakeDamageInfo & a_TDI) override;
 	virtual void GetDrops(cItems & a_Items, cEntity * a_Killer) override;
+	virtual void OnRightClicked(cPlayer & a_Player) override;
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 
 	cItem m_Item;
 	Byte m_ItemRotation;
 
 };  // tolua_export
-
-
-
-

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -44,6 +44,6 @@ void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 void cPainting::KilledBy(TakeDamageInfo & a_TDI)
 {
 	Super::KilledBy(a_TDI);
+
 	m_World->BroadcastSoundEffect("entity.painting.break", GetPosition(), 1, 1);
-	Destroy();
 }

--- a/src/Entities/Painting.cpp
+++ b/src/Entities/Painting.cpp
@@ -34,10 +34,7 @@ void cPainting::SpawnOn(cClientHandle & a_Client)
 
 void cPainting::GetDrops(cItems & a_Items, cEntity * a_Killer)
 {
-	if ((a_Killer != nullptr) && a_Killer->IsPlayer() && !static_cast<cPlayer *>(a_Killer)->IsGameModeCreative())
-	{
-		a_Items.emplace_back(E_ITEM_PAINTING);
-	}
+	a_Items.emplace_back(E_ITEM_PAINTING);
 }
 
 

--- a/src/Items/ItemItemFrame.h
+++ b/src/Items/ItemItemFrame.h
@@ -54,7 +54,7 @@ public:
 			return false;
 		}
 
-		// Place the item frame:
+		// An item frame, centred so pickups spawn nicely.
 		auto ItemFrame = std::make_unique<cItemFrame>(a_ClickedBlockFace, Vector3d(0.5, 0.5, 0.5) + PlacePos);
 		auto ItemFramePtr = ItemFrame.get();
 		if (!ItemFramePtr->Initialize(std::move(ItemFrame), *a_World))

--- a/src/Items/ItemItemFrame.h
+++ b/src/Items/ItemItemFrame.h
@@ -40,6 +40,13 @@ public:
 			return false;
 		}
 
+		// Make sure the support block is a valid block to place an item frame on
+		BLOCKTYPE SupportBlockType = a_World->GetBlock(a_ClickedBlockPos);
+		if (!cHangingEntity::ValidSupportBlock(SupportBlockType))
+		{
+			return false;
+		}
+
 		// Make sure block that will be occupied by the item frame is free now:
 		const auto PlacePos = AddFaceDirection(a_ClickedBlockPos, a_ClickedBlockFace);
 		BLOCKTYPE Block = a_World->GetBlock(PlacePos);

--- a/src/Items/ItemItemFrame.h
+++ b/src/Items/ItemItemFrame.h
@@ -40,9 +40,8 @@ public:
 			return false;
 		}
 
-		// Make sure the support block is a valid block to place an item frame on
-		BLOCKTYPE SupportBlockType = a_World->GetBlock(a_ClickedBlockPos);
-		if (!cHangingEntity::ValidSupportBlock(SupportBlockType))
+		// Make sure the support block is a valid block to place an item frame on:
+		if (!cHangingEntity::IsValidSupportBlock(a_World->GetBlock(a_ClickedBlockPos)))
 		{
 			return false;
 		}
@@ -56,7 +55,7 @@ public:
 		}
 
 		// Place the item frame:
-		auto ItemFrame = std::make_unique<cItemFrame>(a_ClickedBlockFace, PlacePos);
+		auto ItemFrame = std::make_unique<cItemFrame>(a_ClickedBlockFace, Vector3d(0.5, 0.5, 0.5) + PlacePos);
 		auto ItemFramePtr = ItemFrame.get();
 		if (!ItemFramePtr->Initialize(std::move(ItemFrame), *a_World))
 		{

--- a/src/Items/ItemPainting.h
+++ b/src/Items/ItemPainting.h
@@ -45,9 +45,8 @@ public:
 			return false;
 		}
 
-		// Make sure the support block is a valid block to place a painting on
-		BLOCKTYPE SupportBlockType = a_World->GetBlock(a_ClickedBlockPos);
-		if (!cHangingEntity::ValidSupportBlock(SupportBlockType))
+		// Make sure the support block is a valid block to place a painting on:
+		if (!cHangingEntity::IsValidSupportBlock(a_World->GetBlock(a_ClickedBlockPos)))
 		{
 			return false;
 		}
@@ -92,7 +91,7 @@ public:
 		};
 
 		auto PaintingTitle = gPaintingTitlesList[a_World->GetTickRandomNumber(ARRAYCOUNT(gPaintingTitlesList) - 1)];
-		auto Painting = std::make_unique<cPainting>(PaintingTitle, a_ClickedBlockFace, PlacePos);
+		auto Painting = std::make_unique<cPainting>(PaintingTitle, a_ClickedBlockFace, Vector3d(0.5, 0.5, 0.5) + PlacePos);
 		auto PaintingPtr = Painting.get();
 		if (!PaintingPtr->Initialize(std::move(Painting), *a_World))
 		{

--- a/src/Items/ItemPainting.h
+++ b/src/Items/ItemPainting.h
@@ -91,6 +91,8 @@ public:
 		};
 
 		auto PaintingTitle = gPaintingTitlesList[a_World->GetTickRandomNumber(ARRAYCOUNT(gPaintingTitlesList) - 1)];
+
+		// A painting, centred so pickups spawn nicely.
 		auto Painting = std::make_unique<cPainting>(PaintingTitle, a_ClickedBlockFace, Vector3d(0.5, 0.5, 0.5) + PlacePos);
 		auto PaintingPtr = Painting.get();
 		if (!PaintingPtr->Initialize(std::move(Painting), *a_World))

--- a/src/Items/ItemPainting.h
+++ b/src/Items/ItemPainting.h
@@ -45,6 +45,13 @@ public:
 			return false;
 		}
 
+		// Make sure the support block is a valid block to place a painting on
+		BLOCKTYPE SupportBlockType = a_World->GetBlock(a_ClickedBlockPos);
+		if (!cHangingEntity::ValidSupportBlock(SupportBlockType))
+		{
+			return false;
+		}
+
 		// Make sure block that will be occupied is free:
 		auto PlacePos = AddFaceDirection(a_ClickedBlockPos, a_ClickedBlockFace);
 		BLOCKTYPE PlaceBlockType = a_World->GetBlock(PlacePos);


### PR DESCRIPTION
This PR fixes #5299 
It also implements the weird second-or-so before the item frame/painting actually breaks. I just use a std::chrono clock to track that.

- [x] Destroy Paintings/Item Frames when there's no or 'illegal' block behind them
- [x] Don't allow hangables to be placed on illegal blocks 
- [x] Vanilla Behaviour