### PR TITLE
Player chat message formatting removed

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1475,7 +1475,12 @@ void cClientHandle::HandleChat(const AString & a_Message)
 	Msg.AddTextPart(m_Player->GetName(), Color);
 	Msg.ParseText(m_Player->GetSuffix());
 	Msg.AddTextPart("> ");
-	Msg.AddTextPart(Message);
+	if (m_Player->HasPermission("chat.format"))
+	{
+		Msg.ParseText(Message);
+	} else {
+		Msg.AddTextPart(Message);
+	}
 	Msg.UnderlineUrls();
 	cRoot::Get()->BroadcastChat(Msg);
 }

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1478,7 +1478,9 @@ void cClientHandle::HandleChat(const AString & a_Message)
 	if (m_Player->HasPermission("chat.format"))
 	{
 		Msg.ParseText(Message);
-	} else {
+	}
+	else
+	{
 		Msg.AddTextPart(Message);
 	}
 	Msg.UnderlineUrls();

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1475,7 +1475,7 @@ void cClientHandle::HandleChat(const AString & a_Message)
 	Msg.AddTextPart(m_Player->GetName(), Color);
 	Msg.ParseText(m_Player->GetSuffix());
 	Msg.AddTextPart("> ");
-	Msg.ParseText(Message);
+	Msg.AddTextPart(Message);
 	Msg.UnderlineUrls();
 	cRoot::Get()->BroadcastChat(Msg);
 }


### PR DESCRIPTION
As it doesn't processes at Vanilla server and produces unexpected and uncontrollable behavior at all.
Maybe it should be regulable in settings as extra-feature instead of remove?

fix #5287