### PR TITLE
Implemented multi-threaded chunk generation #2320

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "lib/libdeflate"]
 	path = lib/libdeflate
 	url = https://github.com/cuberite/libdeflate
+[submodule "lib/oneTBB"]
+	path = lib/oneTBB
+	url = https://github.com/oneapi-src/oneTBB.git

--- a/CMake/AddDependencies.cmake
+++ b/CMake/AddDependencies.cmake
@@ -23,6 +23,16 @@ function(build_dependencies)
 	set(JSONCPP_WITH_CMAKE_PACKAGE OFF CACHE BOOL "Generate and install cmake package files")
 	set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build jsoncpp_lib as a shared library.")
 	set(BUILD_OBJECT_LIBS OFF CACHE BOOL "Build jsoncpp_lib as a object library.")
+	
+	set(TBB_TEST OFF CACHE BOOL "TBB: Enable testing")
+	set(TBB_EXAMPLES OFF CACHE BOOL "TBB: Enable examples")
+	set(TBB_STRICT ON CACHE BOOL "TBB: Treat compiler warnings as errors")
+	set(TBB4PY_BUILD OFF CACHE BOOL "TBB: Enable tbb4py build")
+	set(TBB_BUILD ON CACHE BOOL "TBB: Enable tbb build")
+	set(TBBMALLOC_BUILD OFF CACHE BOOL "TBB: Enable tbbmalloc build") # Not used for now maybe in the future?
+	set(TBB_CPF OFF CACHE BOOL "TBB: Enable preview features of the library")
+	set(TBB_FIND_PACKAGE OFF CACHE BOOL "TBB: Enable search for external oneTBB using find_package instead of build from sources")
+	set(TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH OFF CACHE BOOL "TBB: Disable HWLOC automatic search by pkg-config tool")
 
 	# Set options for mbedtls:
 	set(ENABLE_PROGRAMS OFF CACHE BOOL "Build mbed TLS programs.")
@@ -30,7 +40,7 @@ function(build_dependencies)
 
 	# Enumerate all submodule libraries
 	# SQLiteCpp needs to be included before sqlite so the lsqlite target is available:
-	set(DEPENDENCIES expat fmt jsoncpp libdeflate libevent lua luaexpat mbedtls SQLiteCpp sqlite tolua++)
+	set(DEPENDENCIES expat fmt jsoncpp libdeflate libevent lua luaexpat mbedtls SQLiteCpp sqlite tolua++ oneTBB)
 	foreach(DEPENDENCY ${DEPENDENCIES})
 		# Check that the libraries are present:
 		if (NOT EXISTS "${PROJECT_SOURCE_DIR}/lib/${DEPENDENCY}/CMakeLists.txt")
@@ -71,6 +81,7 @@ function(link_dependencies TARGET)
 		mbedtls
 		SQLiteCpp
 		tolualib
+		TBB::tbb
 	)
 
 	# Link process information, multimedia (for sleep resolution) libraries:

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -239,7 +239,7 @@ void cPluginManager::Tick(float a_Dt)
 
 
 template <typename HookFunction>
-bool cPluginManager::GenericCallHook(PluginHook a_HookName, HookFunction a_HookFunction)
+bool cPluginManager::GenericCallHook(PluginHook a_HookName, HookFunction a_HookFunction) const
 {
 	auto Plugins = m_Hooks.find(a_HookName);
 	if (Plugins == m_Hooks.end())
@@ -387,7 +387,7 @@ bool cPluginManager::CallHookChunkAvailable(cWorld & a_World, int a_ChunkX, int 
 
 
 
-bool cPluginManager::CallHookChunkGenerated(cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc)
+bool cPluginManager::CallHookChunkGenerated(cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc) const
 {
 	return GenericCallHook(HOOK_CHUNK_GENERATED, [&](cPlugin * a_Plugin)
 		{
@@ -400,7 +400,7 @@ bool cPluginManager::CallHookChunkGenerated(cWorld & a_World, int a_ChunkX, int 
 
 
 
-bool cPluginManager::CallHookChunkGenerating(cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc)
+bool cPluginManager::CallHookChunkGenerating(cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc) const
 {
 	return GenericCallHook(HOOK_CHUNK_GENERATING, [&](cPlugin * a_Plugin)
 		{

--- a/src/Bindings/PluginManager.h
+++ b/src/Bindings/PluginManager.h
@@ -242,8 +242,8 @@ public:
 	bool CallHookBrewingCompleted         (cWorld & a_World, cBrewingstandEntity & a_Brewingstand);
 	bool CallHookChat                     (cPlayer & a_Player, AString & a_Message);
 	bool CallHookChunkAvailable           (cWorld & a_World, int a_ChunkX, int a_ChunkZ);
-	bool CallHookChunkGenerated           (cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc);
-	bool CallHookChunkGenerating          (cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc);
+	bool CallHookChunkGenerated           (cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc) const;
+	bool CallHookChunkGenerating          (cWorld & a_World, int a_ChunkX, int a_ChunkZ, cChunkDesc * a_ChunkDesc) const;
 	bool CallHookChunkUnloaded            (cWorld & a_World, int a_ChunkX, int a_ChunkZ);
 	bool CallHookChunkUnloading           (cWorld & a_World, int a_ChunkX, int a_ChunkZ);
 	bool CallHookCollectingPickup         (cPlayer & a_Player, cPickup & a_Pickup);
@@ -467,7 +467,7 @@ private:
 	Returns false if the action is to continue or true if the plugin wants to abort.
 	Accessible only from within PluginManager.cpp */
 	template <typename HookFunction>
-	bool GenericCallHook(PluginHook a_HookName, HookFunction a_HookFunction);
+	bool GenericCallHook(PluginHook a_HookName, HookFunction a_HookFunction) const;
 } ;  // tolua_export
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
 
 	Resources/Cuberite.rc
 
+	ThreadPool.cpp
 	BiomeDef.cpp
 	BlockArea.cpp
 	BlockInfo.cpp
@@ -67,6 +68,7 @@ target_sources(
 	World.cpp
 	main.cpp
 
+	ThreadPool.h
 	BiomeDef.h
 	BlockArea.h
 	BlockInServerPluginInterface.h

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -58,6 +58,8 @@ public:
 	int m_ChunkX;
 	int m_ChunkZ;
 
+	cChunkCoords() = default;
+
 	cChunkCoords(int a_ChunkX, int a_ChunkZ) : m_ChunkX(a_ChunkX), m_ChunkZ(a_ChunkZ) {}
 
 

--- a/src/ChunkGeneratorThread.cpp
+++ b/src/ChunkGeneratorThread.cpp
@@ -3,6 +3,15 @@
 #include "Generating/ChunkGenerator.h"
 #include "Generating/ChunkDesc.h"
 
+// The new and free macros break tbb
+#pragma push_macro("new")
+#undef new
+#pragma push_macro("free")
+#undef free
+#include <oneapi/tbb/task_group.h>
+#pragma pop_macro("free")
+#pragma pop_macro("new")
+
 
 
 
@@ -38,7 +47,8 @@ cChunkGeneratorThread::~cChunkGeneratorThread()
 
 
 
-bool cChunkGeneratorThread::Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile)
+bool cChunkGeneratorThread::Initialize(const cPluginInterface & a_PluginInterface,
+                                       cChunkSink & a_ChunkSink, cIniFile & a_IniFile)
 {
 	m_PluginInterface = &a_PluginInterface;
 	m_ChunkSink = &a_ChunkSink;
@@ -60,7 +70,6 @@ void cChunkGeneratorThread::Stop(void)
 {
 	m_ShouldTerminate = true;
 	m_Event.Set();
-	m_evtRemoved.Set();  // Wake up anybody waiting for empty queue
 	Super::Stop();
 	m_Generator.reset();
 }
@@ -78,14 +87,8 @@ void cChunkGeneratorThread::QueueGenerateChunk(
 	ASSERT(m_ChunkSink->IsChunkQueued(a_Coords));
 
 	{
-		cCSLock Lock(m_CS);
-
-		// Add to queue, issue a warning if too many:
-		if (m_Queue.size() >= QUEUE_WARNING_LIMIT)
-		{
-			LOGWARN("WARNING: Adding chunk %s to generation queue; Queue is too big! (%zu)", a_Coords.ToString().c_str(), m_Queue.size());
-		}
-		m_Queue.emplace_back(a_Coords, a_ForceRegeneration, a_Callback);
+		std::shared_lock SharedLock{m_SharedMutex};	 // This operation is thread safe unless someone calls GetQueueLength()
+		m_Queue.emplace(a_Coords, a_ForceRegeneration, a_Callback);
 	}
 
 	m_Event.Set();
@@ -95,7 +98,7 @@ void cChunkGeneratorThread::QueueGenerateChunk(
 
 
 
-void cChunkGeneratorThread::GenerateBiomes(cChunkCoords a_Coords, cChunkDef::BiomeMap & a_BiomeMap)
+void cChunkGeneratorThread::GenerateBiomes(cChunkCoords a_Coords, cChunkDef::BiomeMap & a_BiomeMap) const
 {
 	if (m_Generator != nullptr)
 	{
@@ -107,24 +110,10 @@ void cChunkGeneratorThread::GenerateBiomes(cChunkCoords a_Coords, cChunkDef::Bio
 
 
 
-void cChunkGeneratorThread::WaitForQueueEmpty(void)
-{
-	cCSLock Lock(m_CS);
-	while (!m_ShouldTerminate && !m_Queue.empty())
-	{
-		cCSUnlock Unlock(Lock);
-		m_evtRemoved.Wait();
-	}
-}
-
-
-
-
-
 size_t cChunkGeneratorThread::GetQueueLength(void) const
 {
-	cCSLock Lock(m_CS);
-	return m_Queue.size();
+	std::unique_lock UniqueLock{m_SharedMutex};	 // This operation is not thread safe, meaning we must lock the queue
+	return m_Queue.unsafe_size();
 }
 
 
@@ -140,7 +129,7 @@ int cChunkGeneratorThread::GetSeed() const
 
 
 
-EMCSBiome cChunkGeneratorThread::GetBiomeAt(int a_BlockX, int a_BlockZ)
+EMCSBiome cChunkGeneratorThread::GetBiomeAt(int a_BlockX, int a_BlockZ) const
 {
 	ASSERT(m_Generator != nullptr);
 	return m_Generator->GetBiomeAt(a_BlockX, a_BlockZ);
@@ -154,93 +143,103 @@ void cChunkGeneratorThread::Execute(void)
 {
 	// To be able to display performance information, the generator counts the chunks generated.
 	// When the queue gets empty, the count is reset, so that waiting for the queue is not counted into the total time.
-	int NumChunksGenerated = 0;  // Number of chunks generated since the queue was last empty
-	clock_t GenerationStart = clock();  // Clock tick when the queue started to fill
-	clock_t LastReportTick = clock();  // Clock tick of the last report made (so that performance isn't reported too often)
+	std::atomic_size_t NumChunksGenerated = 0;	// Number of chunks generated since the queue was last empty
+	std::atomic GenerationStart = clock();		// Clock tick when the queue started to fill
+	std::atomic LastReportTick = clock();		// Clock tick of the last report made (so that performance isn't reported too often)
+	tbb::task_group Pool;						// TBB task group for this generation thread
 
 	while (!m_ShouldTerminate)
 	{
-		cCSLock Lock(m_CS);
-		while (m_Queue.empty())
+		while (GetQueueLength() == 0)
 		{
-			if ((NumChunksGenerated > 16) && (clock() - LastReportTick > CLOCKS_PER_SEC))
+			// Wait for tasks to complete
+			if (auto Status = Pool.wait(); Status != tbb::complete)
 			{
-				/* LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
-					static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC/ (clock() - GenerationStart),
-					NumChunksGenerated
-				); */
+				LOGD("Generator task group result status: %d", Status);
 			}
-			cCSUnlock Unlock(Lock);
+
 			m_Event.Wait();
+
 			if (m_ShouldTerminate)
 			{
 				return;
 			}
+
+			// Reset perf counters
 			NumChunksGenerated = 0;
 			GenerationStart = clock();
 			LastReportTick = clock();
 		}
 
-		if (m_Queue.empty())
-		{
-			// Sometimes the queue remains empty
-			// If so, we can't do any front() operations on it!
-			continue;
-		}
+		const auto SkipEnabled = GetQueueLength() > QUEUE_SKIP_LIMIT;
 
-		auto item = m_Queue.front();  // Get next chunk from the queue
-		bool SkipEnabled = (m_Queue.size() > QUEUE_SKIP_LIMIT);
-		m_Queue.erase(m_Queue.begin());  // Remove the item from the queue
-		Lock.Unlock();  // Unlock ASAP
-		m_evtRemoved.Set();
-
-		// Display perf info once in a while:
-		if ((NumChunksGenerated > 512) && (clock() - LastReportTick > 2 * CLOCKS_PER_SEC))
 		{
-			LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
-				static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC / (clock() - GenerationStart),
-				NumChunksGenerated
-			);
-			LastReportTick = clock();
-		}
+			std::shared_lock SharedLock{m_SharedMutex};	 // This operation is concurrent unless someone calls
 
-		// Skip the chunk if it's already generated and regeneration is not forced. Report as success:
-		if (!item.m_ForceRegeneration && m_ChunkSink->IsChunkValid(item.m_Coords))
-		{
-			LOGD("Chunk %s already generated, skipping generation", item.m_Coords.ToString().c_str());
-			if (item.m_Callback != nullptr)
+			QueueItem Item{};
+			while (m_Queue.try_pop(Item))
 			{
-				item.m_Callback->Call(item.m_Coords, true);
-			}
-			continue;
-		}
+				// Take Item and SkipEnabled by copy
+				Pool.run([&, Item, SkipEnabled]() {
+					Generate(Item, SkipEnabled);
 
-		// Skip the chunk if the generator is overloaded:
-		if (SkipEnabled && !m_ChunkSink->HasChunkAnyClients(item.m_Coords))
-		{
-			LOGWARNING("Chunk generator overloaded, skipping chunk %s", item.m_Coords.ToString().c_str());
-			if (item.m_Callback != nullptr)
-			{
-				item.m_Callback->Call(item.m_Coords, false);
-			}
-			continue;
-		}
+					++NumChunksGenerated;
 
-		// Generate the chunk:
-		DoGenerate(item.m_Coords);
-		if (item.m_Callback != nullptr)
-		{
-			item.m_Callback->Call(item.m_Coords, true);
+					// Display perf info once in a while:
+					if ((NumChunksGenerated > 512U) && (clock() - LastReportTick > 2 * CLOCKS_PER_SEC))
+					{
+						LOG("Chunk generator performance: %.2f ch / sec (%d ch total)",
+							static_cast<double>(NumChunksGenerated) * CLOCKS_PER_SEC / (clock() - GenerationStart), NumChunksGenerated);
+						LastReportTick = clock();
+					}
+				});
+			}
 		}
-		NumChunksGenerated++;
-	}  // while (!bStop)
+	}
 }
 
 
 
 
 
-void cChunkGeneratorThread::DoGenerate(cChunkCoords a_Coords)
+void cChunkGeneratorThread::Generate(const QueueItem & a_Item, const bool a_SkipEnable) const
+{
+	// Skip the chunk if it's already generated and regeneration is not forced.
+	// Report as success:
+	if (!a_Item.m_ForceRegeneration && m_ChunkSink->IsChunkValid(a_Item.m_Coords))
+	{
+		LOGD("Chunk %s already generated, skipping generation", a_Item.m_Coords.ToString().c_str());
+		if (a_Item.m_Callback != nullptr)
+		{
+			a_Item.m_Callback->Call(a_Item.m_Coords, true);
+		}
+		return;
+	}
+
+	// Skip the chunk if the generator is overloaded:
+	if (a_SkipEnable && !m_ChunkSink->HasChunkAnyClients(a_Item.m_Coords))
+	{
+		LOGWARNING("Chunk generator overloaded, skipping chunk %s", a_Item.m_Coords.ToString().c_str());
+		if (a_Item.m_Callback != nullptr)
+		{
+			a_Item.m_Callback->Call(a_Item.m_Coords, false);
+		}
+		return;
+	}
+
+	// Generate the chunk:
+	DoGenerate(a_Item.m_Coords);
+	if (a_Item.m_Callback != nullptr)
+	{
+		a_Item.m_Callback->Call(a_Item.m_Coords, true);
+	}
+}
+
+
+
+
+
+void cChunkGeneratorThread::DoGenerate(cChunkCoords a_Coords) const
 {
 	ASSERT(m_PluginInterface != nullptr);
 	ASSERT(m_ChunkSink != nullptr);

--- a/src/ChunkGeneratorThread.h
+++ b/src/ChunkGeneratorThread.h
@@ -3,7 +3,16 @@
 #include "OSSupport/IsThread.h"
 #include "ChunkDef.h"
 
+#include <shared_mutex>
 
+// The new and free macros break tbb
+#pragma push_macro("new")
+#undef new
+#pragma push_macro("free")
+#undef free
+#include <oneapi/tbb/concurrent_queue.h>
+#pragma pop_macro("free")
+#pragma pop_macro("new")
 
 
 // fwd:
@@ -37,11 +46,11 @@ public:
 
 		/** Called when the chunk is about to be generated.
 		The generator may be partly or fully overriden by the implementation. */
-		virtual void CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) = 0;
+		virtual void CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) const = 0;
 
 		/** Called after the chunk is generated, before it is handed to the chunk sink.
 		a_ChunkDesc contains the generated chunk data. Implementation may modify this data. */
-		virtual void CallHookChunkGenerated(cChunkDesc & a_ChunkDesc) = 0;
+		virtual void CallHookChunkGenerated(cChunkDesc & a_ChunkDesc) const = 0;
 	} ;
 
 
@@ -61,15 +70,15 @@ public:
 		/** Called just before the chunk generation is started,
 		to verify that it hasn't been generated in the meantime.
 		If this callback returns true, the chunk is not generated. */
-		virtual bool IsChunkValid(cChunkCoords a_Coords) = 0;
+		virtual bool IsChunkValid(cChunkCoords a_Coords) const = 0;
 
 		/** Called when the generator is overloaded to skip chunks that are no longer needed.
 		If this callback returns false, the chunk is not generated. */
-		virtual bool HasChunkAnyClients(cChunkCoords a_Coords) = 0;
+		virtual bool HasChunkAnyClients(cChunkCoords a_Coords) const = 0;
 
 		/** Called to check whether the specified chunk is in the queued state.
 		Currently used only in Debug-mode asserts. */
-		virtual bool IsChunkQueued(cChunkCoords a_Coords) = 0;
+		virtual bool IsChunkQueued(cChunkCoords a_Coords) const = 0;
 	} ;
 
 
@@ -77,7 +86,7 @@ public:
 	virtual ~cChunkGeneratorThread() override;
 
 	/** Read settings from the ini file and initialize in preperation for being started. */
-	bool Initialize(cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile);
+	bool Initialize(const cPluginInterface & a_PluginInterface, cChunkSink & a_ChunkSink, cIniFile & a_IniFile);
 
 	void Stop(void);
 
@@ -89,16 +98,15 @@ public:
 	void QueueGenerateChunk(cChunkCoords a_Coords, bool a_ForceRegeneration, cChunkCoordCallback * a_Callback = nullptr);
 
 	/** Generates the biomes for the specified chunk (directly, not in a separate thread). Used by the world loader if biomes failed loading. */
-	void GenerateBiomes(cChunkCoords a_Coords, cChunkDef::BiomeMap & a_BiomeMap);
+	void GenerateBiomes(cChunkCoords a_Coords, cChunkDef::BiomeMap & a_BiomeMap) const;
 
-	void WaitForQueueEmpty();
-
+	/** Get number of items in the queue, this call is blocking. */
 	size_t GetQueueLength() const;
 
 	int GetSeed() const;
 
 	/** Returns the biome at the specified coords. Used by ChunkMap if an invalid chunk is queried for biome */
-	EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ);
+	EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ) const;
 
 
 private:
@@ -114,6 +122,8 @@ private:
 		/** Callback to call after generating. */
 		cChunkCoordCallback * m_Callback;
 
+		QueueItem() = default;
+
 		QueueItem(cChunkCoords a_Coords, bool a_ForceRegeneration, cChunkCoordCallback * a_Callback):
 			m_Coords(a_Coords),
 			m_ForceRegeneration(a_ForceRegeneration),
@@ -122,11 +132,11 @@ private:
 		}
 	};
 
-	using Queue = std::list<QueueItem>;
+	using Queue = tbb::concurrent_queue<QueueItem>;
 
 
-	/** CS protecting access to the queue. */
-	mutable cCriticalSection m_CS;
+	/** Shared Mutex protecting access to the queue. */
+	mutable std::shared_mutex m_SharedMutex;
 
 	/** Queue of the chunks to be generated. Protected against multithreaded access by m_CS. */
 	Queue m_Queue;
@@ -134,14 +144,11 @@ private:
 	/** Set when an item is added to the queue or the thread should terminate. */
 	cEvent m_Event;
 
-	/** Set when an item is removed from the queue. */
-	cEvent m_evtRemoved;
-
 	/** The actual chunk generator engine used. */
-	std::unique_ptr<cChunkGenerator> m_Generator;
+	std::unique_ptr<const cChunkGenerator> m_Generator;
 
 	/** The plugin interface that may modify the generated chunks */
-	cPluginInterface * m_PluginInterface;
+	const cPluginInterface * m_PluginInterface;
 
 	/** The destination where the generated chunks are sent */
 	cChunkSink * m_ChunkSink;
@@ -150,8 +157,11 @@ private:
 	// cIsThread override:
 	virtual void Execute(void) override;
 
+	/** Generates the specified chunk. */
+	void Generate(const QueueItem & a_Item, bool a_SkipEnable) const;
+
 	/** Generates the specified chunk and sets it into the chunksink. */
-	void DoGenerate(cChunkCoords a_Coords);
+	void DoGenerate(cChunkCoords a_Coords) const;
 };
 
 

--- a/src/ChunkSender.cpp
+++ b/src/ChunkSender.cpp
@@ -92,29 +92,7 @@ void cChunkSender::Stop(void)
 void cChunkSender::QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Priority, cClientHandle * a_Client)
 {
 	ASSERT(a_Client != nullptr);
-	{
-		cChunkCoords Chunk{a_ChunkX, a_ChunkZ};
-		cCSLock Lock(m_CS);
-		auto iter = m_ChunkInfo.find(Chunk);
-		if (iter != m_ChunkInfo.end())
-		{
-			auto & info = iter->second;
-			if (info.m_Priority < a_Priority)  // Was the chunk's priority boosted?
-			{
-				m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
-				info.m_Priority = a_Priority;
-			}
-			info.m_Clients.insert(a_Client->shared_from_this());
-		}
-		else
-		{
-			m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
-			auto info = sSendChunk{Chunk, a_Priority};
-			info.m_Clients.insert(a_Client->shared_from_this());
-			m_ChunkInfo.emplace(Chunk, info);
-		}
-	}
-	m_evtQueue.Set();
+	QueueSendChunkTo(a_ChunkX, a_ChunkZ, a_Priority, std::vector{a_Client});
 }
 
 
@@ -123,16 +101,21 @@ void cChunkSender::QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Prior
 
 void cChunkSender::QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Priority, const std::vector<cClientHandle *> & a_Clients)
 {
+	cChunkCoords Chunk{a_ChunkX, a_ChunkZ};
+	// cCSLock Lock(m_CS);
+
+	bool found{};
 	{
-		cChunkCoords Chunk{a_ChunkX, a_ChunkZ};
-		cCSLock Lock(m_CS);
+		std::shared_lock Lock{m_ChunkInfoSharedMutex};
 		auto iter = m_ChunkInfo.find(Chunk);
-		if (iter != m_ChunkInfo.end())
+		found = iter != m_ChunkInfo.end();
+
+		if (found)
 		{
 			auto & info = iter->second;
 			if (info.m_Priority < a_Priority)  // Was the chunk's priority boosted?
 			{
-				m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
+				m_SendChunks.emplace(sChunkQueue{a_Priority, Chunk});
 				info.m_Priority = a_Priority;
 			}
 			for (const auto & Client : a_Clients)
@@ -140,16 +123,17 @@ void cChunkSender::QueueSendChunkTo(int a_ChunkX, int a_ChunkZ, Priority a_Prior
 				info.m_Clients.insert(Client->shared_from_this());
 			}
 		}
-		else
+	}
+
+	if (!found)
+	{
+		m_SendChunks.emplace(sChunkQueue{a_Priority, Chunk});
+		auto info = sSendChunk{Chunk, a_Priority};
+		for (const auto & Client : a_Clients)
 		{
-			m_SendChunks.push(sChunkQueue{a_Priority, Chunk});
-			auto info = sSendChunk{Chunk, a_Priority};
-			for (const auto & Client : a_Clients)
-			{
-				info.m_Clients.insert(Client->shared_from_this());
-			}
-			m_ChunkInfo.emplace(Chunk, info);
+			info.m_Clients.insert(Client->shared_from_this());
 		}
+		m_ChunkInfo.emplace(Chunk, info);
 	}
 	m_evtQueue.Set();
 }
@@ -164,25 +148,34 @@ void cChunkSender::Execute(void)
 	{
 		m_evtQueue.Wait();
 
+		if (m_ShouldTerminate)
 		{
-			cCSLock Lock(m_CS);
-			while (!m_SendChunks.empty())
+			return;
+		}
+
+		sChunkQueue ChunkQueue{};
+		while (m_SendChunks.try_pop(ChunkQueue))  // Take one from the queue
+		{
+			const auto & Chunk = ChunkQueue.m_Chunk;
+
+			ChunkInfoMap::iterator itr;
 			{
-				// Take one from the queue:
-				auto Chunk = m_SendChunks.top().m_Chunk;
-				m_SendChunks.pop();
-				auto itr = m_ChunkInfo.find(Chunk);
+				std::shared_lock Lock{m_ChunkInfoSharedMutex};
+				itr = m_ChunkInfo.find(Chunk);
 				if (itr == m_ChunkInfo.end())
 				{
 					continue;
 				}
-
-				auto clients = std::move(itr->second.m_Clients);
-				m_ChunkInfo.erase(itr);
-
-				cCSUnlock Unlock(Lock);
-				SendChunk(Chunk.m_ChunkX, Chunk.m_ChunkZ, clients);
 			}
+
+			cChunkSender::WeakClients clients;
+			{
+				std::unique_lock Lock{m_ChunkInfoSharedMutex};
+				clients = std::move(itr->second.m_Clients);
+				m_ChunkInfo.unsafe_erase(itr);
+			}
+
+			SendChunk(Chunk.m_ChunkX, Chunk.m_ChunkZ, clients);
 		}
 	}  // while (!m_ShouldTerminate)
 }

--- a/src/Generating/BioGen.h
+++ b/src/Generating/BioGen.h
@@ -55,6 +55,9 @@ protected:
 
 	friend class cBioGenMulticache;
 
+	/** Generator cache protection mutex. */
+	mutable cCriticalSection m_CS;
+
 	cBiomeGen & m_BioGenToCache;
 
 	struct sCacheData
@@ -214,7 +217,7 @@ protected:
 	virtual void InitializeBiomeGen(cIniFile & a_IniFile) override;
 
 	/** Distorts the coords using a Perlin-like noise */
-	void Distort(int a_BlockX, int a_BlockZ, int & a_DistortedX, int & a_DistortedZ);
+	void Distort(int a_BlockX, int a_BlockZ, int & a_DistortedX, int & a_DistortedZ) const;
 } ;
 
 
@@ -255,27 +258,27 @@ protected:
 
 	/** Step 1: Decides between ocean, land and mushroom, using a DistVoronoi with special conditions and post-processing for mushroom islands
 	Sets biomes to biOcean, -1 (i.e. land), biMushroomIsland or biMushroomShore. */
-	void DecideOceanLandMushroom(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap);
+	void DecideOceanLandMushroom(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) const;
 
 	/** Step 2: Add rivers to the land
 	Flips some "-1" biomes into biRiver. */
-	void AddRivers(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap);
+	void AddRivers(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) const;
 
 	/** Step 3: Decide land biomes using a temperature / humidity map; freeze ocean / river in low temperatures.
 	Flips all remaining "-1" biomes into land biomes. Also flips some biOcean and biRiver into biFrozenOcean, biFrozenRiver, based on temp map. */
-	void ApplyTemperatureHumidity(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap);
+	void ApplyTemperatureHumidity(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) const;
 
 	/** Distorts the coords using a Perlin-like noise, with a specified cell-size */
-	void Distort(int a_BlockX, int a_BlockZ, int & a_DistortedX, int & a_DistortedZ, int a_CellSize);
+	void Distort(int a_BlockX, int a_BlockZ, int & a_DistortedX, int & a_DistortedZ, int a_CellSize) const;
 
 	/** Builds two Perlin-noise maps, one for temperature, the other for humidity. Trims both into [0..255] range */
-	void BuildTemperatureHumidityMaps(cChunkCoords a_ChunkCoords, IntMap & a_TemperatureMap, IntMap & a_HumidityMap);
+	void BuildTemperatureHumidityMaps(cChunkCoords a_ChunkCoords, IntMap & a_TemperatureMap, IntMap & a_HumidityMap) const;
 
 	/** Flips all remaining "-1" biomes into land biomes using the two maps */
-	void DecideLandBiomes(cChunkDef::BiomeMap & a_BiomeMap, const IntMap & a_TemperatureMap, const IntMap & a_HumidityMap);
+	static void DecideLandBiomes(cChunkDef::BiomeMap & a_BiomeMap, const IntMap & a_TemperatureMap, const IntMap & a_HumidityMap);
 
 	/** Flips biOcean and biRiver into biFrozenOcean and biFrozenRiver if the temperature is too low */
-	void FreezeWaterBiomes(cChunkDef::BiomeMap & a_BiomeMap, const IntMap & a_TemperatureMap);
+	static void FreezeWaterBiomes(cChunkDef::BiomeMap & a_BiomeMap, const IntMap & a_TemperatureMap);
 } ;
 
 
@@ -322,5 +325,5 @@ protected:
 	/** Selects biome from the specified biome group, based on the specified index.
 	Note that both params may overflow
 	a_DistLevel is either 0 or 1; zero when it is at the edge of the small Voronoi cell, 1 near the center */
-	EMCSBiome SelectBiome(int a_BiomeGroup, size_t a_BiomeIdx, int a_DistLevel);
+	static EMCSBiome SelectBiome(int a_BiomeGroup, size_t a_BiomeIdx, int a_DistLevel);
 } ;

--- a/src/Generating/Caves.cpp
+++ b/src/Generating/Caves.cpp
@@ -103,7 +103,7 @@ public:
 		cChunkDef::BlockTypes & a_BlockTypes,
 		cChunkDesc::BlockNibbleBytes & a_BlockMetas,
 		cChunkDef::HeightMap & a_HeightMap
-	);
+	) const;
 
 	#ifndef NDEBUG
 	AString ExportAsSVG(int a_Color, int a_OffsetX, int a_OffsetZ) const;
@@ -147,7 +147,7 @@ protected:
 	int GetRadius(cNoise & a_Noise, int a_OriginX, int a_OriginY, int a_OriginZ);
 
 	// cGridStructGen::cStructure overrides:
-	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) override;
+	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) const override;
 } ;
 
 
@@ -460,7 +460,7 @@ void cCaveTunnel::ProcessChunk(
 	cChunkDef::BlockTypes & a_BlockTypes,
 	cChunkDesc::BlockNibbleBytes & a_BlockMetas,
 	cChunkDef::HeightMap & a_HeightMap
-)
+) const
 {
 	int BaseX = a_ChunkX * cChunkDef::Width;
 	int BaseZ = a_ChunkZ * cChunkDef::Width;
@@ -611,7 +611,7 @@ cStructGenWormNestCaves::cCaveSystem::~cCaveSystem()
 
 
 
-void cStructGenWormNestCaves::cCaveSystem::DrawIntoChunk(cChunkDesc & a_ChunkDesc)
+void cStructGenWormNestCaves::cCaveSystem::DrawIntoChunk(cChunkDesc & a_ChunkDesc) const
 {
 	int ChunkX = a_ChunkDesc.GetChunkX();
 	int ChunkZ = a_ChunkDesc.GetChunkZ();

--- a/src/Generating/ChunkDesc.cpp
+++ b/src/Generating/ChunkDesc.cpp
@@ -649,7 +649,7 @@ void cChunkDesc::CompressBlockMetas(cChunkDef::BlockNibbles & a_DestMetas)
 
 #ifndef NDEBUG
 
-void cChunkDesc::VerifyHeightmap(void)
+void cChunkDesc::VerifyHeightmap(void) const
 {
 	for (int x = 0; x < cChunkDef::Width; x++)
 	{

--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -231,7 +231,7 @@ public:
 
 	#ifndef NDEBUG
 	/** Verifies that the heightmap corresponds to blocktype contents; if not, asserts on that column */
-	void VerifyHeightmap(void);
+	void VerifyHeightmap(void) const;
 	#endif  // !NDEBUG
 
 private:

--- a/src/Generating/ChunkGenerator.cpp
+++ b/src/Generating/ChunkGenerator.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<cChunkGenerator> cChunkGenerator::CreateFromIniFile(cIniFile & a
 
 
 
-EMCSBiome cChunkGenerator::GetBiomeAt(int a_BlockX, int a_BlockZ)
+EMCSBiome cChunkGenerator::GetBiomeAt(int a_BlockX, int a_BlockZ) const
 {
 	cChunkDef::BiomeMap Biomes;
 	int Y = 0;

--- a/src/Generating/ChunkGenerator.h
+++ b/src/Generating/ChunkGenerator.h
@@ -28,16 +28,16 @@ public:
 
 	/** Generates the biomes for the specified chunk.
 	Used by the world loader if biomes failed loading. */
-	virtual void GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) = 0;
+	virtual void GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) const = 0;
 
 	/** Returns the biome at the specified coords.
 	Used by ChunkMap if an invalid chunk is queried for biome.
 	The default implementation uses GenerateBiomes(). */
-	virtual EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ);
+	virtual EMCSBiome GetBiomeAt(int a_BlockX, int a_BlockZ) const;
 
 	/** Does the actual chunk generation.
 	Descendants need to override this and generate into a_ChunkDesc. */
-	virtual void Generate(cChunkDesc & a_ChunkDesc) = 0;
+	virtual void Generate(cChunkDesc & a_ChunkDesc) const = 0;
 
 	/** Returns the seed that was read from the INI file. */
 	int GetSeed(void) const { return m_Seed; }

--- a/src/Generating/CompoGen.cpp
+++ b/src/Generating/CompoGen.cpp
@@ -364,62 +364,72 @@ cCompoGenCache::~cCompoGenCache()
 
 void cCompoGenCache::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc::Shape & a_Shape)
 {
-	#ifndef NDEBUG
-	if (((m_NumHits + m_NumMisses) % 1024) == 10)
+	const int ChunkX = a_ChunkDesc.GetChunkX();
+	const int ChunkZ = a_ChunkDesc.GetChunkZ();
+
 	{
-		// LOGD("CompoGenCache: %d hits, %d misses, saved %.2f %%", m_NumHits, m_NumMisses, 100.0 * m_NumHits / (m_NumHits + m_NumMisses));
-		// LOGD("CompoGenCache: Avg cache chain length: %.2f", static_cast<float>(m_TotalChain) / m_NumHits);
+		cCSLock Lock{ m_CS };
+
+#ifndef NDEBUG
+		if (((m_NumHits + m_NumMisses) % 1024) == 10)
+		{
+			// LOGD("CompoGenCache: %d hits, %d misses, saved %.2f %%", m_NumHits, m_NumMisses, 100.0 * m_NumHits / (m_NumHits + m_NumMisses));
+			// LOGD("CompoGenCache: Avg cache chain length: %.2f", static_cast<float>(m_TotalChain) / m_NumHits);
+		}
+#endif  // !NDEBUG
+
+		for (int i = 0; i < m_CacheSize; i++)
+		{
+			if (
+				(m_CacheData[m_CacheOrder[i]].m_ChunkX != ChunkX) ||
+				(m_CacheData[m_CacheOrder[i]].m_ChunkZ != ChunkZ)
+				)
+			{
+				continue;
+			}
+			// Found it in the cache
+			int Idx = m_CacheOrder[i];
+
+			// Move to front:
+			for (int j = i; j > 0; j--)
+			{
+				m_CacheOrder[j] = m_CacheOrder[j - 1];
+			}
+			m_CacheOrder[0] = Idx;
+
+			// Use the cached data:
+			memcpy(a_ChunkDesc.GetBlockTypes(), m_CacheData[Idx].m_BlockTypes, sizeof(a_ChunkDesc.GetBlockTypes()));
+			memcpy(a_ChunkDesc.GetBlockMetasUncompressed(), m_CacheData[Idx].m_BlockMetas, sizeof(a_ChunkDesc.GetBlockMetasUncompressed()));
+			memcpy(a_ChunkDesc.GetHeightMap(), m_CacheData[Idx].m_HeightMap, sizeof(a_ChunkDesc.GetHeightMap()));
+
+			m_NumHits++;
+			m_TotalChain += i;
+			return;
+		}  // for i - cache
+
+		// Not in the cache:
+		m_NumMisses++;
 	}
-	#endif  // !NDEBUG
 
-	int ChunkX = a_ChunkDesc.GetChunkX();
-	int ChunkZ = a_ChunkDesc.GetChunkZ();
-
-	for (int i = 0; i < m_CacheSize; i++)
-	{
-		if (
-			(m_CacheData[m_CacheOrder[i]].m_ChunkX != ChunkX) ||
-			(m_CacheData[m_CacheOrder[i]].m_ChunkZ != ChunkZ)
-		)
-		{
-			continue;
-		}
-		// Found it in the cache
-		int Idx = m_CacheOrder[i];
-
-		// Move to front:
-		for (int j = i; j > 0; j--)
-		{
-			m_CacheOrder[j] = m_CacheOrder[j - 1];
-		}
-		m_CacheOrder[0] = Idx;
-
-		// Use the cached data:
-		memcpy(a_ChunkDesc.GetBlockTypes(),             m_CacheData[Idx].m_BlockTypes, sizeof(a_ChunkDesc.GetBlockTypes()));
-		memcpy(a_ChunkDesc.GetBlockMetasUncompressed(), m_CacheData[Idx].m_BlockMetas, sizeof(a_ChunkDesc.GetBlockMetasUncompressed()));
-		memcpy(a_ChunkDesc.GetHeightMap(),              m_CacheData[Idx].m_HeightMap,  sizeof(a_ChunkDesc.GetHeightMap()));
-
-		m_NumHits++;
-		m_TotalChain += i;
-		return;
-	}  // for i - cache
-
-	// Not in the cache:
-	m_NumMisses++;
+	// multi-threaded code
 	m_Underlying->ComposeTerrain(a_ChunkDesc, a_Shape);
 
-	// Insert it as the first item in the MRU order:
-	int Idx = m_CacheOrder[m_CacheSize - 1];
-	for (int i = m_CacheSize - 1; i > 0; i--)
 	{
-		m_CacheOrder[i] = m_CacheOrder[i - 1];
-	}  // for i - m_CacheOrder[]
-	m_CacheOrder[0] = Idx;
-	memcpy(m_CacheData[Idx].m_BlockTypes, a_ChunkDesc.GetBlockTypes(),             sizeof(a_ChunkDesc.GetBlockTypes()));
-	memcpy(m_CacheData[Idx].m_BlockMetas, a_ChunkDesc.GetBlockMetasUncompressed(), sizeof(a_ChunkDesc.GetBlockMetasUncompressed()));
-	memcpy(m_CacheData[Idx].m_HeightMap,  a_ChunkDesc.GetHeightMap(),              sizeof(a_ChunkDesc.GetHeightMap()));
-	m_CacheData[Idx].m_ChunkX = ChunkX;
-	m_CacheData[Idx].m_ChunkZ = ChunkZ;
+		cCSLock Lock{ m_CS };
+
+		// Insert it as the first item in the MRU order:
+		int Idx = m_CacheOrder[m_CacheSize - 1];
+		for (int i = m_CacheSize - 1; i > 0; i--)
+		{
+			m_CacheOrder[i] = m_CacheOrder[i - 1];
+		}  // for i - m_CacheOrder[]
+		m_CacheOrder[0] = Idx;
+		memcpy(m_CacheData[Idx].m_BlockTypes, a_ChunkDesc.GetBlockTypes(), sizeof(a_ChunkDesc.GetBlockTypes()));
+		memcpy(m_CacheData[Idx].m_BlockMetas, a_ChunkDesc.GetBlockMetasUncompressed(), sizeof(a_ChunkDesc.GetBlockMetasUncompressed()));
+		memcpy(m_CacheData[Idx].m_HeightMap, a_ChunkDesc.GetHeightMap(), sizeof(a_ChunkDesc.GetHeightMap()));
+		m_CacheData[Idx].m_ChunkX = ChunkX;
+		m_CacheData[Idx].m_ChunkZ = ChunkZ;
+	}
 }
 
 

--- a/src/Generating/CompoGen.h
+++ b/src/Generating/CompoGen.h
@@ -124,6 +124,9 @@ public:
 
 protected:
 
+	/** Generator cache protection mutex. */
+	mutable cCriticalSection m_CS;
+
 	std::unique_ptr<cTerrainCompositionGen> m_Underlying;
 
 	struct sCacheData

--- a/src/Generating/CompoGenBiomal.cpp
+++ b/src/Generating/CompoGenBiomal.cpp
@@ -280,7 +280,7 @@ protected:
 
 
 	/** Composes a single column in a_ChunkDesc. Chooses what to do based on the biome in that column. */
-	void ComposeColumn(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, const Byte * a_ShapeColumn)
+	void ComposeColumn(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, const Byte * a_ShapeColumn) const
 	{
 		// Frequencies for the podzol floor selecting noise:
 		const NOISE_DATATYPE FrequencyX = 8;
@@ -409,7 +409,7 @@ protected:
 
 	/** Fills the specified column with the specified pattern; restarts the pattern when air is reached,
 	switches to ocean floor pattern if ocean is reached. Always adds bedrock at the very bottom. */
-	void FillColumnPattern(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, const cPattern::BlockInfo * a_Pattern, const Byte * a_ShapeColumn)
+	void FillColumnPattern(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, const cPattern::BlockInfo * a_Pattern, const Byte * a_ShapeColumn) const
 	{
 		bool HasHadWater = false;
 		int PatternIdx = 0;
@@ -462,7 +462,7 @@ protected:
 
 
 	/** Fills the specified column with mesa pattern, based on the column height */
-	void FillColumnMesa(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, const Byte * a_ShapeColumn)
+	void FillColumnMesa(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, const Byte * a_ShapeColumn) const
 	{
 		// Frequencies for the clay floor noise:
 		const NOISE_DATATYPE FrequencyX = 50;
@@ -553,7 +553,7 @@ protected:
 
 	/** Returns the pattern to use for an ocean floor in the specified column.
 	The returned pattern is guaranteed to be 256 blocks long. */
-	const cPattern::BlockInfo * ChooseOceanFloorPattern(int a_ChunkX, int a_ChunkZ, int a_RelX, int a_RelZ)
+	const cPattern::BlockInfo * ChooseOceanFloorPattern(int a_ChunkX, int a_ChunkZ, int a_RelX, int a_RelZ) const
 	{
 		// Frequencies for the ocean floor selecting noise:
 		const NOISE_DATATYPE FrequencyX = 3;

--- a/src/Generating/ComposableGenerator.cpp
+++ b/src/Generating/ComposableGenerator.cpp
@@ -143,7 +143,7 @@ void cComposableGenerator::Initialize(cIniFile & a_IniFile)
 
 
 
-void cComposableGenerator::GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap)
+void cComposableGenerator::GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) const
 {
 	if (m_BiomeGen != nullptr)  // Quick fix for generator deinitializing before the world storage finishes loading
 	{
@@ -155,7 +155,7 @@ void cComposableGenerator::GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef:
 
 
 
-void cComposableGenerator::Generate(cChunkDesc & a_ChunkDesc)
+void cComposableGenerator::Generate(cChunkDesc & a_ChunkDesc) const
 {
 	if (a_ChunkDesc.IsUsingDefaultBiomes())
 	{

--- a/src/Generating/ComposableGenerator.h
+++ b/src/Generating/ComposableGenerator.h
@@ -204,8 +204,8 @@ public:
 
 	// cChunkGenerator::cGenerator overrides:
 	virtual void Initialize(cIniFile & a_IniFile) override;
-	virtual void GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) override;
-	virtual void Generate(cChunkDesc & a_ChunkDesc) override;
+	virtual void GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) const override;
+	virtual void Generate(cChunkDesc & a_ChunkDesc) const override;
 
 	/** If there's no particular sub-generator set in the INI file,
 	adds the default one, based on the dimension. */

--- a/src/Generating/DistortedHeightmap.cpp
+++ b/src/Generating/DistortedHeightmap.cpp
@@ -121,7 +121,6 @@ const cDistortedHeightmap::sGenParam cDistortedHeightmap::m_GenParam[256] =
 cDistortedHeightmap::cDistortedHeightmap(int a_Seed, cBiomeGen & a_BiomeGen) :
 	m_NoiseDistortX(a_Seed + 1000),
 	m_NoiseDistortZ(a_Seed + 2000),
-	m_CurChunkCoords(0x7fffffff, 0x7fffffff),  // Set impossible coords for the chunk so that it's always considered stale
 	m_BiomeGen(a_BiomeGen),
 	m_UnderlyingHeiGen(a_Seed, a_BiomeGen),
 	m_HeightGen(m_UnderlyingHeiGen, 64),
@@ -160,36 +159,40 @@ void cDistortedHeightmap::Initialize(cIniFile & a_IniFile)
 
 
 
-void cDistortedHeightmap::PrepareState(cChunkCoords a_ChunkCoords)
+void cDistortedHeightmap::PrepareState(cChunkCoords a_ChunkCoords, NOISE_DATATYPE m_DistortedHeightmap[17 * 257 * 17])
 {
-	if (m_CurChunkCoords == a_ChunkCoords)
-	{
-		return;
-	}
-	m_CurChunkCoords = a_ChunkCoords;
+	//TODO: Removed, not thread safe
+	//if (m_CurChunkCoords == a_ChunkCoords)
+	//{
+	//	return;
+	//}
+	//m_CurChunkCoords = a_ChunkCoords;
 
+	cChunkDef::HeightMap CurChunkHeights;
+	NOISE_DATATYPE DistortAmpX[DIM_X * DIM_Z];
+	NOISE_DATATYPE DistortAmpZ[DIM_X * DIM_Z];
 
-	m_HeightGen.GenHeightMap(a_ChunkCoords, m_CurChunkHeights);
-	UpdateDistortAmps();
-	GenerateHeightArray();
+	m_HeightGen.GenHeightMap(a_ChunkCoords, CurChunkHeights);
+	UpdateDistortAmps(a_ChunkCoords, DistortAmpX, DistortAmpZ);
+	GenerateHeightArray(a_ChunkCoords, DistortAmpX, DistortAmpZ, CurChunkHeights, m_DistortedHeightmap);
 }
 
 
 
 
 
-void cDistortedHeightmap::GenerateHeightArray(void)
+void cDistortedHeightmap::GenerateHeightArray(cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_DistortAmpX[DIM_X * DIM_Z], NOISE_DATATYPE a_DistortAmpZ[DIM_X * DIM_Z], const cChunkDef::HeightMap& a_CurChunkHeights, NOISE_DATATYPE m_DistortedHeightmap[17 * 257 * 17])
 {
 	// Generate distortion noise:
 	NOISE_DATATYPE DistortNoiseX[DIM_X * DIM_Y * DIM_Z];
 	NOISE_DATATYPE DistortNoiseZ[DIM_X * DIM_Y * DIM_Z];
 	NOISE_DATATYPE Workspace[DIM_X * DIM_Y * DIM_Z];
-	NOISE_DATATYPE StartX = static_cast<NOISE_DATATYPE>(m_CurChunkCoords.m_ChunkX * cChunkDef::Width) / m_FrequencyX;
-	NOISE_DATATYPE EndX   = static_cast<NOISE_DATATYPE>((m_CurChunkCoords.m_ChunkX + 1) * cChunkDef::Width - 1) / m_FrequencyX;
+	NOISE_DATATYPE StartX = static_cast<NOISE_DATATYPE>(a_ChunkCoords.m_ChunkX * cChunkDef::Width) / m_FrequencyX;
+	NOISE_DATATYPE EndX   = static_cast<NOISE_DATATYPE>((a_ChunkCoords.m_ChunkX + 1) * cChunkDef::Width - 1) / m_FrequencyX;
 	NOISE_DATATYPE StartY = 0;
 	NOISE_DATATYPE EndY   = static_cast<NOISE_DATATYPE>(257) / m_FrequencyY;
-	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(m_CurChunkCoords.m_ChunkZ * cChunkDef::Width) / m_FrequencyZ;
-	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>((m_CurChunkCoords.m_ChunkZ + 1) * cChunkDef::Width - 1) / m_FrequencyZ;
+	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(a_ChunkCoords.m_ChunkZ * cChunkDef::Width) / m_FrequencyZ;
+	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>((a_ChunkCoords.m_ChunkZ + 1) * cChunkDef::Width - 1) / m_FrequencyZ;
 
 	m_NoiseDistortX.Generate3D(DistortNoiseX, DIM_X, DIM_Y, DIM_Z, StartX, EndX, StartY, EndY, StartZ, EndZ, Workspace);
 	m_NoiseDistortZ.Generate3D(DistortNoiseZ, DIM_X, DIM_Y, DIM_Z, StartX, EndX, StartY, EndY, StartZ, EndZ, Workspace);
@@ -206,12 +209,12 @@ void cDistortedHeightmap::GenerateHeightArray(void)
 			int NoiseArrayIdx = z * DIM_X * DIM_Y + y * DIM_X;
 			for (int x = 0; x < DIM_X; x++)
 			{
-				NOISE_DATATYPE DistX = DistortNoiseX[NoiseArrayIdx + x] * m_DistortAmpX[AmpIdx + x];
-				NOISE_DATATYPE DistZ = DistortNoiseZ[NoiseArrayIdx + x] * m_DistortAmpZ[AmpIdx + x];
-				DistX += static_cast<NOISE_DATATYPE>(m_CurChunkCoords.m_ChunkX * cChunkDef::Width + x * INTERPOL_X);
-				DistZ += static_cast<NOISE_DATATYPE>(m_CurChunkCoords.m_ChunkZ * cChunkDef::Width + z * INTERPOL_Z);
+				NOISE_DATATYPE DistX = DistortNoiseX[NoiseArrayIdx + x] * a_DistortAmpX[AmpIdx + x];
+				NOISE_DATATYPE DistZ = DistortNoiseZ[NoiseArrayIdx + x] * a_DistortAmpZ[AmpIdx + x];
+				DistX += static_cast<NOISE_DATATYPE>(a_ChunkCoords.m_ChunkX * cChunkDef::Width + x * INTERPOL_X);
+				DistZ += static_cast<NOISE_DATATYPE>(a_ChunkCoords.m_ChunkZ * cChunkDef::Width + z * INTERPOL_Z);
 				// Adding 0.5 helps alleviate the interpolation artifacts
-				DistHei[NoiseArrayIdx + x] = static_cast<NOISE_DATATYPE>(GetHeightmapAt(DistX, DistZ)) + static_cast<NOISE_DATATYPE>(0.5);
+				DistHei[NoiseArrayIdx + x] = static_cast<NOISE_DATATYPE>(GetHeightmapAt(a_ChunkCoords, DistX, DistZ, a_CurChunkHeights)) + static_cast<NOISE_DATATYPE>(0.5);
 			}
 		}
 	}
@@ -231,7 +234,8 @@ void cDistortedHeightmap::GenerateHeightArray(void)
 
 void cDistortedHeightmap::GenShape(cChunkCoords a_ChunkCoords, cChunkDesc::Shape & a_Shape)
 {
-	PrepareState(a_ChunkCoords);
+	NOISE_DATATYPE m_DistortedHeightmap[17 * 257 * 17];
+	PrepareState(a_ChunkCoords, m_DistortedHeightmap);
 	for (int z = 0; z < cChunkDef::Width; z++)
 	{
 		for (int x = 0; x < cChunkDef::Width; x++)
@@ -258,7 +262,7 @@ void cDistortedHeightmap::InitializeShapeGen(cIniFile & a_IniFile)
 
 
 
-int cDistortedHeightmap::GetHeightmapAt(NOISE_DATATYPE a_X, NOISE_DATATYPE a_Z)
+int cDistortedHeightmap::GetHeightmapAt(cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_X, NOISE_DATATYPE a_Z, const cChunkDef::HeightMap & a_CurChunkHeights)
 {
 	int RelX = FloorC(a_X);
 	int RelY = 0;
@@ -267,9 +271,9 @@ int cDistortedHeightmap::GetHeightmapAt(NOISE_DATATYPE a_X, NOISE_DATATYPE a_Z)
 	cChunkDef::AbsoluteToRelative(RelX, RelY, RelZ, ChunkX, ChunkZ);
 
 	// If we're within the same chunk, return the pre-cached heightmap:
-	if ((ChunkX == m_CurChunkCoords.m_ChunkX) && (ChunkZ == m_CurChunkCoords.m_ChunkZ))
+	if ((ChunkX == a_ChunkCoords.m_ChunkX) && (ChunkZ == a_ChunkCoords.m_ChunkZ))
 	{
-		return cChunkDef::GetHeight(m_CurChunkHeights, RelX, RelZ);
+		return cChunkDef::GetHeight(a_CurChunkHeights, RelX, RelZ);
 	}
 
 	// Ask the cache:
@@ -290,22 +294,23 @@ int cDistortedHeightmap::GetHeightmapAt(NOISE_DATATYPE a_X, NOISE_DATATYPE a_Z)
 
 
 
-void cDistortedHeightmap::UpdateDistortAmps(void)
+void cDistortedHeightmap::UpdateDistortAmps(
+	cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_DistortAmpX[DIM_X * DIM_Z], NOISE_DATATYPE a_DistortAmpZ[DIM_X * DIM_Z]) const
 {
 	BiomeNeighbors Biomes;
 	for (int z = -1; z <= 1; z++)
 	{
 		for (int x = -1; x <= 1; x++)
 		{
-			m_BiomeGen.GenBiomes({m_CurChunkCoords.m_ChunkX + x, m_CurChunkCoords.m_ChunkZ + z}, Biomes[x + 1][z + 1]);
+			m_BiomeGen.GenBiomes({a_ChunkCoords.m_ChunkX + x, a_ChunkCoords.m_ChunkZ + z}, Biomes[x + 1][z + 1]);
 		}  // for x
-	}  // for z
+	}	   // for z
 
 	for (int z = 0; z < DIM_Z; z++)
 	{
 		for (int x = 0; x < DIM_Z; x++)
 		{
-			GetDistortAmpsAt(Biomes, x * INTERPOL_X, z * INTERPOL_Z, m_DistortAmpX[x + DIM_X * z], m_DistortAmpZ[x + DIM_X * z]);
+			GetDistortAmpsAt(Biomes, x * INTERPOL_X, z * INTERPOL_Z, a_DistortAmpX[x + DIM_X * z], a_DistortAmpZ[x + DIM_X * z]);
 		}
 	}
 }
@@ -314,7 +319,8 @@ void cDistortedHeightmap::UpdateDistortAmps(void)
 
 
 
-void cDistortedHeightmap::GetDistortAmpsAt(BiomeNeighbors & a_Neighbors, int a_RelX, int a_RelZ, NOISE_DATATYPE & a_DistortAmpX, NOISE_DATATYPE & a_DistortAmpZ)
+void cDistortedHeightmap::GetDistortAmpsAt(const BiomeNeighbors & a_Neighbors, int a_RelX, int a_RelZ, NOISE_DATATYPE
+                                           & a_DistortAmpX, NOISE_DATATYPE & a_DistortAmpZ)
 {
 	// Sum up how many biomes of each type there are in the neighborhood:
 	int BiomeCounts[256];

--- a/src/Generating/DistortedHeightmap.h
+++ b/src/Generating/DistortedHeightmap.h
@@ -49,9 +49,6 @@ protected:
 	NOISE_DATATYPE m_FrequencyY;
 	NOISE_DATATYPE m_FrequencyZ;
 
-	cChunkCoords m_CurChunkCoords;
-	NOISE_DATATYPE m_DistortedHeightmap[17 * 257 * 17];
-
 	/** The bime generator to query for biomes. */
 	cBiomeGen & m_BiomeGen;
 
@@ -61,9 +58,6 @@ protected:
 	/** Cache for m_UnderlyingHeiGen. */
 	cHeiGenCache m_HeightGen;
 
-	/** Heightmap for the current chunk, before distortion (from m_HeightGen). Used for optimization. */
-	cChunkDef::HeightMap m_CurChunkHeights;
-
 	// Per-biome terrain generator parameters:
 	struct sGenParam
 	{
@@ -72,28 +66,26 @@ protected:
 	} ;
 	static const sGenParam m_GenParam[256];
 
-	// Distortion amplitudes for each direction, before linear upscaling
-	NOISE_DATATYPE m_DistortAmpX[DIM_X * DIM_Z];
-	NOISE_DATATYPE m_DistortAmpZ[DIM_X * DIM_Z];
-
 	/** True if Initialize() has been called. Used to initialize-once even with multiple init entrypoints (HeiGen / CompoGen). */
 	bool m_IsInitialized;
 
 
 	/** Unless the LastChunk coords are equal to coords given, prepares the internal state (noise arrays, heightmap). */
-	void PrepareState(cChunkCoords a_ChunkCoords);
+	void PrepareState(cChunkCoords a_ChunkCoords, NOISE_DATATYPE m_DistortedHeightmap[17 * 257 * 17]);
 
 	/** Generates the m_DistortedHeightmap array for the current chunk. */
-	void GenerateHeightArray(void);
+	void GenerateHeightArray(cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_DistortAmpX[DIM_X * DIM_Z], NOISE_DATATYPE a_DistortAmpZ[DIM_X * DIM_Z], const cChunkDef::HeightMap& a_CurChunkHeights, NOISE_DATATYPE m_DistortedHeightmap[17 * 257 * 17]);
 
 	/** Calculates the heightmap value (before distortion) at the specified (floating-point) coords. */
-	int GetHeightmapAt(NOISE_DATATYPE a_X, NOISE_DATATYPE a_Z);
+	int GetHeightmapAt(cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_X, NOISE_DATATYPE a_Z, const cChunkDef::HeightMap & a_CurChunkHeights);
 
 	/** Updates m_DistortAmpX/Z[] based on m_CurChunkX and m_CurChunkZ. */
-	void UpdateDistortAmps(void);
+	void UpdateDistortAmps(cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_DistortAmpX[DIM_X * DIM_Z],
+		NOISE_DATATYPE a_DistortAmpZ[DIM_X * DIM_Z]) const;
 
 	/** Calculates the X and Z distortion amplitudes based on the neighbors' biomes. */
-	void GetDistortAmpsAt(BiomeNeighbors & a_Neighbors, int a_RelX, int a_RelZ, NOISE_DATATYPE & a_DistortAmpX, NOISE_DATATYPE & a_DistortAmpZ);
+	static void GetDistortAmpsAt(const BiomeNeighbors & a_Neighbors, int a_RelX, int a_RelZ, NOISE_DATATYPE &
+	                             a_DistortAmpX, NOISE_DATATYPE & a_DistortAmpZ);
 
 	/** Reads the settings from the ini file. Skips reading if already initialized. */
 	void Initialize(cIniFile & a_IniFile);

--- a/src/Generating/DungeonRoomsFinisher.cpp
+++ b/src/Generating/DungeonRoomsFinisher.cpp
@@ -128,7 +128,7 @@ protected:
 
 	/** Fills the specified area of blocks in the chunk with the specified blocktype if they are one of the overwritten block types.
 	The coords are absolute, start coords are inclusive, end coords are exclusive. */
-	void ReplaceCuboid(cChunkDesc & a_ChunkDesc, int a_StartX, int a_StartY, int a_StartZ, int a_EndX, int a_EndY, int a_EndZ, BLOCKTYPE a_DstBlockType)
+	static void ReplaceCuboid(cChunkDesc & a_ChunkDesc, int a_StartX, int a_StartY, int a_StartZ, int a_EndX, int a_EndY, int a_EndZ, BLOCKTYPE a_DstBlockType)
 	{
 		int BlockX = a_ChunkDesc.GetChunkX() * cChunkDef::Width;
 		int BlockZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;
@@ -155,7 +155,7 @@ protected:
 
 	/** Fills the specified area of blocks in the chunk with a random pattern of the specified blocktypes, if they are one of the overwritten block types.
 	The coords are absolute, start coords are inclusive, end coords are exclusive. The first blocktype uses 75% chance, the second 25% chance. */
-	void ReplaceCuboidRandom(cChunkDesc & a_ChunkDesc, int a_StartX, int a_StartY, int a_StartZ, int a_EndX, int a_EndY, int a_EndZ, BLOCKTYPE a_DstBlockType1, BLOCKTYPE a_DstBlockType2)
+	static void ReplaceCuboidRandom(cChunkDesc & a_ChunkDesc, int a_StartX, int a_StartY, int a_StartZ, int a_EndX, int a_EndY, int a_EndZ, BLOCKTYPE a_DstBlockType1, BLOCKTYPE a_DstBlockType2)
 	{
 		int BlockX = a_ChunkDesc.GetChunkX() * cChunkDef::Width;
 		int BlockZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;
@@ -184,7 +184,7 @@ protected:
 
 	/** Tries to place a chest at the specified (absolute) coords.
 	Does nothing if the coords are outside the chunk. */
-	void TryPlaceChest(cChunkDesc & a_ChunkDesc, const Vector3i & a_Chest)
+	void TryPlaceChest(cChunkDesc & a_ChunkDesc, const Vector3i & a_Chest) const
 	{
 		int RelX = a_Chest.x - a_ChunkDesc.GetChunkX() * cChunkDef::Width;
 		int RelZ = a_Chest.z - a_ChunkDesc.GetChunkZ() * cChunkDef::Width;
@@ -236,7 +236,7 @@ protected:
 
 
 	// cGridStructGen::cStructure override:
-	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) override
+	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) const override
 	{
 		if (
 			(m_EndX   <  a_ChunkDesc.GetChunkX() * cChunkDef::Width) ||

--- a/src/Generating/EnderDragonFightStructuresGen.h
+++ b/src/Generating/EnderDragonFightStructuresGen.h
@@ -34,5 +34,5 @@ protected:
 	int m_MinX = -1, m_MaxX = 1, m_MinZ = -1, m_MaxZ = 1;
 
 	void GenFinish(cChunkDesc &a_ChunkDesc) override;
-	void PlaceTower(cChunkDesc & a_ChunkDesc, const sTowerProperties & a_TowerProperties);
+	static void PlaceTower(cChunkDesc & a_ChunkDesc, const sTowerProperties & a_TowerProperties);
 };

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -89,7 +89,7 @@ void cFinishGenNetherClumpFoliage::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-void cFinishGenNetherClumpFoliage::TryPlaceClump(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Block)
+void cFinishGenNetherClumpFoliage::TryPlaceClump(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Block) const
 {
 	bool IsFireBlock = a_Block == E_BLOCK_FIRE;
 
@@ -239,7 +239,7 @@ void cFinishGenClumpTopBlock::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-void cFinishGenClumpTopBlock::TryPlaceFoliageClump(cChunkDesc & a_ChunkDesc, int a_CenterX, int a_CenterZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_IsDoubleTall)
+void cFinishGenClumpTopBlock::TryPlaceFoliageClump(cChunkDesc & a_ChunkDesc, int a_CenterX, int a_CenterZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_IsDoubleTall) const
 {
 	int ChunkX = a_ChunkDesc.GetChunkX();
 	int ChunkZ = a_ChunkDesc.GetChunkZ();
@@ -454,7 +454,7 @@ void cFinishGenGlowStone::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-void cFinishGenGlowStone::TryPlaceGlowstone(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, int a_Size, int a_NumStrings)
+void cFinishGenGlowStone::TryPlaceGlowstone(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, int a_Size, int a_NumStrings) const
 {
 	// The starting point of every glowstone string
 	Vector3i StartPoint = Vector3i(a_RelX, a_RelY, a_RelZ);
@@ -833,7 +833,7 @@ void cFinishGenVines::GenFinish(cChunkDesc & a_ChunkDesc)
 ////////////////////////////////////////////////////////////////////////////////
 // cFinishGenSprinkleFoliage:
 
-bool cFinishGenSprinkleFoliage::TryAddCactus(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ)
+bool cFinishGenSprinkleFoliage::TryAddCactus(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ) const
 {
 	if (!IsDesertVariant(a_ChunkDesc.GetBiome(a_RelX, a_RelZ)))
 	{
@@ -882,7 +882,7 @@ bool cFinishGenSprinkleFoliage::TryAddCactus(cChunkDesc & a_ChunkDesc, int a_Rel
 ////////////////////////////////////////////////////////////////////////////////
 // cFinishGenSprinkleFoliage:
 
-bool cFinishGenSprinkleFoliage::TryAddSugarcane(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ)
+bool cFinishGenSprinkleFoliage::TryAddSugarcane(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ) const
 {
 	int SugarcaneHeight = 1 + (m_Noise.IntNoise2DInt(a_RelX, a_RelZ) % m_MaxSugarcaneHeight);
 
@@ -1155,7 +1155,7 @@ void cFinishGenIce::GenFinish(cChunkDesc & a_ChunkDesc)
 ////////////////////////////////////////////////////////////////////////////////
 // cFinishGenSingleTopBlock:
 
-int cFinishGenSingleTopBlock::GetNumToGen(const cChunkDef::BiomeMap & a_BiomeMap)
+int cFinishGenSingleTopBlock::GetNumToGen(const cChunkDef::BiomeMap & a_BiomeMap) const
 {
 	int res = 0;
 	for (size_t i = 0; i < ARRAYCOUNT(a_BiomeMap); i++)
@@ -1345,7 +1345,7 @@ void cFinishGenPreSimulator::StationarizeFluid(
 	cChunkDef::HeightMap & a_HeightMap,      // Height map to read
 	BLOCKTYPE a_Fluid,
 	BLOCKTYPE a_StationaryFluid
-)
+) const
 {
 	// Turn fluid in the middle to stationary, unless it has air or washable block next to it:
 	for (int z = 1; z < cChunkDef::Width - 1; z++)
@@ -1516,7 +1516,7 @@ void cFinishGenFluidSprings::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int y, int z)
+bool cFinishGenFluidSprings::TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int y, int z) const
 {
 	// In order to place a spring, it needs exactly one of the XZ neighbors or a below neighbor to be air
 	// Also, its neighbor on top of it must be non-air
@@ -1645,7 +1645,7 @@ void cFinishGenPassiveMobs::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, eMonsterType AnimalToSpawn)
+bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, eMonsterType AnimalToSpawn) const
 {
 	if ((a_RelY >= cChunkDef::Height - 1) || (a_RelY <= 0))
 	{
@@ -1699,7 +1699,7 @@ bool cFinishGenPassiveMobs::TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int a_RelX
 
 
 
-eMonsterType cFinishGenPassiveMobs::GetRandomMob(cChunkDesc & a_ChunkDesc)
+eMonsterType cFinishGenPassiveMobs::GetRandomMob(cChunkDesc & a_ChunkDesc) const
 {
 	std::vector<eMonsterType> ListOfSpawnables;
 	int chunkX = a_ChunkDesc.GetChunkX();
@@ -1887,7 +1887,7 @@ void cFinishGenOreNests::GenerateOre(
 	BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta,
 	int a_MaxHeight, int a_NumNests, int a_NestSize,
 	int a_Seq
-)
+) const
 {
 	// This function generates several "nests" of ore, each nest consisting of number of ore blocks relatively adjacent to each other.
 	// It does so by making a random XYZ walk and adding ore along the way in cuboids of different (random) sizes
@@ -2068,7 +2068,7 @@ void cFinishGenOrePockets::GenerateOre(
 	BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta,
 	int a_MaxHeight, int a_NumNests, int a_NestSize,
 	int a_Seq
-)
+) const
 {
 	// This function generates several "pockets" of the specified ore
 	// Each chunk can contain only pockets that are generated for that chunk, or for its XM / ZM neighbors.
@@ -2092,7 +2092,7 @@ void cFinishGenOrePockets::imprintChunkOrePockets(
 	BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta,
 	int a_MaxHeight, int a_NumNests, int a_NestSize,
 	int a_Seq
-)
+) const
 {
 	// Pick a starting coord for each nest:
 	int baseBlockX = a_ChunkX * cChunkDef::Width;
@@ -2124,7 +2124,7 @@ void cFinishGenOrePockets::imprintPocket(
 	int a_MinPocketX, int a_PocketY, int a_MinPocketZ,
 	int a_NestSize, int a_Seq,
 	BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta
-)
+) const
 {
 	// A line segment in a random direction is chosen. Then, several spheres are formed along this line segment,
 	// with their diameters diminishing towards the line ends (one half of a sinusoid)
@@ -2165,7 +2165,7 @@ void cFinishGenOrePockets::imprintSphere(
 	cChunkDesc & a_ChunkDesc,
 	double a_SphereX, double a_SphereY, double a_SphereZ, double a_Radius,
 	BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta
-)
+) const
 {
 	// Get the sphere's bounding box, unioned with the chunk's bounding box (possibly empty):
 	int baseX = a_ChunkDesc.GetChunkX() * cChunkDef::Width;

--- a/src/Generating/FinishGen.h
+++ b/src/Generating/FinishGen.h
@@ -64,7 +64,7 @@ protected:
 	cNoise m_Noise;
 	int    m_Seed;
 
-	void TryPlaceClump(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Block);
+	void TryPlaceClump(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_Block) const;
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 } ;
 
@@ -138,7 +138,7 @@ protected:
 	/** The maximum range a foliage can be placed from the center of the clump */
 	const int RANGE_FROM_CENTER = 5;
 
-	void TryPlaceFoliageClump(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_IsDoubleTall);
+	void TryPlaceFoliageClump(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, bool a_IsDoubleTall) const;
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 };
 
@@ -160,7 +160,7 @@ protected:
 	cNoise m_Noise;
 	int    m_Seed;
 
-	void TryPlaceGlowstone(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, int a_Size, int a_NumStrings);
+	void TryPlaceGlowstone(cChunkDesc & a_ChunkDesc, int a_RelX, int a_RelY, int a_RelZ, int a_Size, int a_NumStrings) const;
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 } ;
 
@@ -201,7 +201,7 @@ public:
 	{
 	}
 
-	bool IsJungleVariant(EMCSBiome a_Biome);
+	static bool IsJungleVariant(EMCSBiome a_Biome);
 
 protected:
 	cNoise m_Noise;
@@ -251,10 +251,10 @@ protected:
 	int    m_MaxSugarcaneHeight;
 
 	/** Tries to place sugarcane at the coords specified, returns true if successful, updates the top variable (hence the & a_RefY) */
-	bool TryAddSugarcane(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ);
+	bool TryAddSugarcane(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ) const;
 
 	/** Tries to place cactus at the coords specified, returns true if successful, updates the top variable (hence the & a_RefY) */
-	bool TryAddCactus(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ);
+	bool TryAddCactus(cChunkDesc & a_ChunkDesc, int a_RelX, HEIGHTTYPE & a_RelY, int a_RelZ) const;
 
 	// Returns true is the specified biome is a desert or its variant
 	static bool IsDesertVariant(EMCSBiome a_biome);
@@ -323,16 +323,16 @@ protected:
 	int m_Amount;
 
 
-	int GetNumToGen(const cChunkDef::BiomeMap & a_BiomeMap);
+	int GetNumToGen(const cChunkDef::BiomeMap & a_BiomeMap) const;
 
 	/** Returns true if the given biome is a biome that is allowed. */
-	inline bool IsAllowedBiome(EMCSBiome a_Biome)
+	inline bool IsAllowedBiome(EMCSBiome a_Biome) const
 	{
 		return m_IsBiomeAllowed[a_Biome];
 	}
 
 	/** Returns true if the given blocktype may be below m_BlockType */
-	inline bool IsAllowedBlockBelow(BLOCKTYPE a_BlockBelow)
+	inline bool IsAllowedBlockBelow(BLOCKTYPE a_BlockBelow) const
 	{
 		return m_IsAllowedBelow[a_BlockBelow];
 	}
@@ -380,7 +380,7 @@ protected:
 	bool m_PreSimulateLava;
 
 	/** Drops hanging sand and gravel down to the ground, recalculates heightmap */
-	void CollapseSandGravel(cChunkDesc & a_ChunkDesc);
+	static void CollapseSandGravel(cChunkDesc & a_ChunkDesc);
 
 	/** For each fluid block:
 	- if all surroundings are of the same fluid, makes it stationary; otherwise makes it flowing (excl. top)
@@ -390,7 +390,7 @@ protected:
 		cChunkDef::HeightMap & a_HeightMap,      // Height map to read
 		BLOCKTYPE a_Fluid,
 		BLOCKTYPE a_StationaryFluid
-	);
+	) const;
 
 	// cFinishGen override:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
@@ -417,7 +417,7 @@ protected:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 
 	/** Tries to place a spring at the specified coords, checks neighbors. Returns true if successful. */
-	bool TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int y, int z);
+	bool TryPlaceSpring(cChunkDesc & a_ChunkDesc, int x, int y, int z) const;
 } ;
 
 
@@ -446,11 +446,11 @@ protected:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 
 	/** Returns false if an animal cannot spawn at given coords, else adds it to the chunk's entity list and returns true */
-	bool TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int x, int y, int z, eMonsterType AnimalToSpawn);
+	bool TrySpawnAnimals(cChunkDesc & a_ChunkDesc, int x, int y, int z, eMonsterType AnimalToSpawn) const;
 
 	/** Picks a random animal from biome-dependant list for a random position in the chunk.
 	Returns the chosen mob type, or mtInvalid if no mob chosen. */
-	eMonsterType GetRandomMob(cChunkDesc & a_ChunkDesc);
+	eMonsterType GetRandomMob(cChunkDesc & a_ChunkDesc) const;
 } ;
 
 
@@ -543,7 +543,7 @@ protected:
 		BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta,
 		int a_MaxHeight, int a_NumNests, int a_NestSize,
 		int a_Seq
-	) = 0;
+	) const = 0;
 
 	// TODO: Helper function to parse a config string into m_OreInfos
 };
@@ -571,7 +571,7 @@ protected:
 		BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta,
 		int a_MaxHeight, int a_NumNests, int a_NestSize,
 		int a_Seq
-	) override;
+	) const override;
 } ;
 
 
@@ -601,7 +601,7 @@ protected:
 		BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta,
 		int a_MaxNestHeight, int a_NumNests, int a_NestSize,
 		int a_Seq
-	) override;
+	) const override;
 
 	/** Calculates the pockets for the specified chunk and imprints them into the specified ChunkDesc (not necessarily the same chunk).
 	a_Seq is the sequence number of the ore, to provide another source of randomness. */
@@ -611,7 +611,7 @@ protected:
 		BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta,
 		int a_MaxHeight, int a_NumNests, int a_NestSize,
 		int a_Seq
-	);
+	) const;
 
 	/** Imprints a single pocket of the specified ore at the specified coords into the chunk.
 	The pocket shape has its minimum X and Z coords specified, Y can be anywhere around the specified Y coord.
@@ -621,14 +621,14 @@ protected:
 		int a_MinPocketX, int a_PocketY, int a_MinPocketZ,
 		int a_NestSize, int a_Seq,
 		BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta
-	);
+	) const;
 
 	/** Imprints a single sphere of the specified ore at the specified coords. */
 	void imprintSphere(
 		cChunkDesc & a_ChunkDesc,
 		double a_SphereX, double a_SphereY, double a_SphereZ, double a_Radius,
 		BLOCKTYPE a_OreType, NIBBLETYPE a_OreMeta
-	);
+	) const;
 };
 
 

--- a/src/Generating/GridStructGen.h
+++ b/src/Generating/GridStructGen.h
@@ -69,7 +69,7 @@ public:
 		virtual ~cStructure() {}
 
 		/** Draws self into the specified chunk */
-		virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) = 0;
+		virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) const = 0;
 
 		/** Returns the cost of keeping this structure in the cache */
 		virtual size_t GetCacheCost(void) const { return 1; }
@@ -98,6 +98,9 @@ public:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 
 protected:
+	/** Generator cache protection mutex. */
+	mutable cCriticalSection m_CS;
+
 	/** Base seed of the world for which the generator generates chunk. */
 	int m_BaseSeed;
 

--- a/src/Generating/HeiGen.h
+++ b/src/Generating/HeiGen.h
@@ -49,6 +49,9 @@ protected:
 		{}
 	} ;
 
+	/** Generator cache protection mutex. */
+	mutable cCriticalSection m_CS;
+
 	/** The terrain height generator that is being cached. */
 	cTerrainHeightGen & m_HeiGenToCache;
 
@@ -133,7 +136,7 @@ protected:
 	float m_HeightFreq2, m_HeightAmp2;
 	float m_HeightFreq3, m_HeightAmp3;
 
-	float GetNoise(float x, float y);
+	float GetNoise(float x, float y) const;
 
 	// cTerrainHeightGen overrides:
 	virtual void GenHeightMap(cChunkCoords a_ChunkCoords, cChunkDef::HeightMap & a_HeightMap) override;
@@ -205,5 +208,5 @@ protected:
 	static const sGenParam m_GenParam[256];
 
 
-	NOISE_DATATYPE GetHeightAt(int a_RelX, int a_RelZ, int a_ChunkX, int a_ChunkZ, const BiomeNeighbors & a_BiomeNeighbors);
+	NOISE_DATATYPE GetHeightAt(int a_RelX, int a_RelZ, int a_ChunkX, int a_ChunkZ, const BiomeNeighbors & a_BiomeNeighbors) const;
 } ;

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -271,7 +271,7 @@ public:
 	bool CanAppend(const cCuboid & a_BoundingBox);
 
 	// cGridStructGen::cStructure overrides:
-	virtual void DrawIntoChunk(cChunkDesc & a_Chunk) override;
+	virtual void DrawIntoChunk(cChunkDesc & a_Chunk) const override;
 } ;
 
 
@@ -331,7 +331,7 @@ cStructGenMineShafts::cMineShaftSystem::~cMineShaftSystem()
 
 
 
-void cStructGenMineShafts::cMineShaftSystem::DrawIntoChunk(cChunkDesc & a_Chunk)
+void cStructGenMineShafts::cMineShaftSystem::DrawIntoChunk(cChunkDesc & a_Chunk) const
 {
 	for (cMineShafts::const_iterator itr = m_MineShafts.begin(), end = m_MineShafts.end(); itr != end; ++itr)
 	{

--- a/src/Generating/Noise3DGenerator.h
+++ b/src/Generating/Noise3DGenerator.h
@@ -31,8 +31,8 @@ public:
 	virtual ~cNoise3DGenerator() override;
 
 	virtual void Initialize(cIniFile & a_IniFile) override;
-	virtual void GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) override;
-	virtual void Generate(cChunkDesc & a_ChunkDesc) override;
+	virtual void GenerateBiomes(cChunkCoords a_ChunkCoords, cChunkDef::BiomeMap & a_BiomeMap) const override;
+	virtual void Generate(cChunkDesc & a_ChunkDesc) const override;
 
 protected:
 	// Linear interpolation step sizes, must be divisors of cChunkDef::Width and cChunkDef::Height, respectively:
@@ -60,10 +60,10 @@ protected:
 	NOISE_DATATYPE m_AirThreshold;
 
 	/** Generates the 3D noise array used for terrain generation into a_Noise; a_Noise is of ChunkData-size */
-	void GenerateNoiseArray(cChunkCoords a_ChunkCoords, NOISE_DATATYPE * a_Noise);
+	void GenerateNoiseArray(cChunkCoords a_ChunkCoords, NOISE_DATATYPE * a_Noise) const;
 
 	/** Composes terrain - adds dirt, grass and sand */
-	void ComposeTerrain(cChunkDesc & a_ChunkDesc);
+	static void ComposeTerrain(cChunkDesc & a_ChunkDesc);
 } ;
 
 
@@ -115,13 +115,14 @@ protected:
 	// Threshold for when the values are considered air:
 	NOISE_DATATYPE m_AirThreshold;
 
+	//TODO: Removed, not thread safe
 	// Cache for the last calculated chunk (reused between heightmap and composition queries):
-	cChunkCoords m_LastChunkCoords;
-	NOISE_DATATYPE m_NoiseArray[17 * 17 * 257];  // x + 17 * z + 17 * 17 * y
+	//cChunkCoords m_LastChunkCoords;
+	//NOISE_DATATYPE m_NoiseArray[17 * 17 * 257];  // x + 17 * z + 17 * 17 * y
 
 
 	/** Generates the 3D noise array used for terrain generation (m_NoiseArray), unless the LastChunk coords are equal to coords given */
-	void GenerateNoiseArrayIfNeeded(cChunkCoords a_ChunkCoords);
+	void GenerateNoiseArrayIfNeeded(cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_NoiseArray[17 * 17 * 257]) const;
 
 	// cTerrainHeightGen overrides:
 	virtual void GenShape(cChunkCoords a_ChunkCoords, cChunkDesc::Shape & a_Shape) override;
@@ -183,9 +184,9 @@ protected:
 	// Threshold for when the values are considered air:
 	NOISE_DATATYPE m_AirThreshold;
 
+	//TODO: Removed, not thread safe
 	// Cache for the last calculated chunk (reused between heightmap and composition queries):
-	cChunkCoords m_LastChunkCoords;
-	NOISE_DATATYPE m_NoiseArray[17 * 17 * 257];  // 257 * x + y + 257 * 17 * z
+	//cChunkCoords m_LastChunkCoords;
 
 	/** Weights for summing up neighboring biomes. */
 	NOISE_DATATYPE m_Weight[AVERAGING_SIZE * 2 + 1][AVERAGING_SIZE * 2 + 1];
@@ -195,7 +196,7 @@ protected:
 
 
 	/** Generates the 3D noise array used for terrain generation (m_NoiseArray), unless the LastChunk coords are equal to coords given */
-	void GenerateNoiseArrayIfNeeded(cChunkCoords a_ChunkCoords);
+	void GenerateNoiseArrayIfNeeded(cChunkCoords a_ChunkCoords, NOISE_DATATYPE a_Noise[17 * 17 * 257]);
 
 	/** Calculates the biome-related parameters for the chunk. */
 	void CalcBiomeParamArrays(cChunkCoords a_ChunkCoords, ChunkParam & a_HeightAmp, ChunkParam & a_MidPoint);

--- a/src/Generating/PieceGeneratorBFSTree.cpp
+++ b/src/Generating/PieceGeneratorBFSTree.cpp
@@ -30,7 +30,7 @@ cPieceGeneratorBFSTree::cPieceGeneratorBFSTree(cPiecePool & a_PiecePool, int a_S
 
 
 
-cPlacedPiecePtr cPieceGeneratorBFSTree::PlaceStartingPiece(int a_BlockX, int a_BlockZ, cFreeConnectors & a_OutConnectors)
+cPlacedPiecePtr cPieceGeneratorBFSTree::PlaceStartingPiece(int a_BlockX, int a_BlockZ, cFreeConnectors & a_OutConnectors) const
 {
 	m_PiecePool.Reset();
 	int rnd = m_Noise.IntNoise2DInt(a_BlockX, a_BlockZ) / 7;
@@ -102,7 +102,7 @@ bool cPieceGeneratorBFSTree::TryPlacePieceAtConnector(
 	const cPiece::cConnector & a_Connector,
 	cPlacedPieces & a_OutPieces,
 	cPieceGeneratorBFSTree::cFreeConnectors & a_OutConnectors
-)
+) const
 {
 	// Get a list of available connections:
 	cConnections Connections;
@@ -225,7 +225,7 @@ bool cPieceGeneratorBFSTree::CheckConnection(
 
 
 
-void cPieceGeneratorBFSTree::PlacePieces(int a_BlockX, int a_BlockZ, int a_MaxDepth, cPlacedPieces & a_OutPieces)
+void cPieceGeneratorBFSTree::PlacePieces(int a_BlockX, int a_BlockZ, int a_MaxDepth, cPlacedPieces & a_OutPieces) const
 {
 	a_OutPieces.clear();
 	cFreeConnectors ConnectorPool;

--- a/src/Generating/PieceGeneratorBFSTree.h
+++ b/src/Generating/PieceGeneratorBFSTree.h
@@ -25,7 +25,7 @@ public:
 
 	/** Generates a placement for pieces at the specified coords.
 	The Y coord is generated automatically based on the starting piece that is chosen. */
-	void PlacePieces(int a_BlockX, int a_BlockZ, int a_MaxDepth, cPlacedPieces & a_OutPieces);
+	void PlacePieces(int a_BlockX, int a_BlockZ, int a_MaxDepth, cPlacedPieces & a_OutPieces) const;
 
 
 protected:
@@ -66,7 +66,7 @@ protected:
 
 	/** Selects a starting piece and places it, including its height and rotation.
 	Also puts the piece's connectors in a_OutConnectors. */
-	cPlacedPiecePtr PlaceStartingPiece(int a_BlockX, int a_BlockZ, cFreeConnectors & a_OutConnectors);
+	cPlacedPiecePtr PlaceStartingPiece(int a_BlockX, int a_BlockZ, cFreeConnectors & a_OutConnectors) const;
 
 	/** Tries to place a new piece at the specified (placed) connector. Returns true if successful. */
 	bool TryPlacePieceAtConnector(
@@ -74,7 +74,7 @@ protected:
 		const cPiece::cConnector & a_Connector,  // The existing connector (world-coords) to which a new piece should be placed
 		cPlacedPieces & a_OutPieces,             // Already placed pieces, to be checked for intersections
 		cFreeConnectors & a_OutConnectors        // List of free connectors to which the new connectors will be placed
-	);
+	) const;
 
 	/** Checks if the specified piece would fit with the already-placed pieces, using the specified connector
 	and number of CCW rotations.
@@ -82,7 +82,7 @@ protected:
 	a_ToPos is the world-coords position on which the new connector should be placed (1 block away from a_ExistingConnector, in its Direction)
 	a_NewConnector is in the original (non-rotated) coords.
 	Returns true if the piece fits, false if not. */
-	bool CheckConnection(
+	static bool CheckConnection(
 		const cPiece::cConnector & a_ExistingConnector,  // The existing connector
 		const Vector3i & a_ToPos,                        // The position on which the new connector should be placed
 		const cPiece & a_Piece,                          // The new piece

--- a/src/Generating/PiecePool.h
+++ b/src/Generating/PiecePool.h
@@ -282,11 +282,11 @@ public:
 
 	/** Returns a list of pieces that contain the specified connector type.
 	The cPiece pointers returned are managed by the pool and the caller doesn't free them. */
-	virtual cPieces GetPiecesWithConnector(int a_ConnectorType) = 0;
+	virtual cPieces GetPiecesWithConnector(int a_ConnectorType) const = 0;
 
 	/** Returns the pieces that should be used as the starting point.
 	Multiple starting points are supported, one of the returned piece will be chosen. */
-	virtual cPieces GetStartingPieces(void) = 0;
+	virtual cPieces GetStartingPieces(void) const = 0;
 
 	/** Returns the relative weight with which the a_NewPiece is to be selected for placing under a_PlacedPiece through a_ExistingConnector.
 	a_ExistingConnector is the original connector, before any movement or rotation is applied to it.
@@ -296,7 +296,7 @@ public:
 		const cPlacedPiece & a_PlacedPiece,
 		const cPiece::cConnector & a_ExistingConnector,
 		const cPiece & a_NewPiece
-	)
+	) const
 	{
 		return 1;
 	}
@@ -305,7 +305,7 @@ public:
 	This allows the pool to tweak the piece's chances.
 	The higher the number returned, the higher the chance the piece will be chosen. 0 means the piece will not be chosen.
 	If all pieces return 0, a random piece is chosen, with all equal chances. */
-	virtual int GetStartingPieceWeight(const cPiece & a_NewPiece)
+	virtual int GetStartingPieceWeight(const cPiece & a_NewPiece) const
 	{
 		return 1;
 	}

--- a/src/Generating/PrefabPiecePool.cpp
+++ b/src/Generating/PrefabPiecePool.cpp
@@ -765,16 +765,16 @@ void cPrefabPiecePool::AssignGens(int a_Seed, cBiomeGen & a_BiomeGen, cTerrainHe
 
 
 
-cPieces cPrefabPiecePool::GetPiecesWithConnector(int a_ConnectorType)
+cPieces cPrefabPiecePool::GetPiecesWithConnector(int a_ConnectorType) const
 {
-	return m_PiecesByConnector[a_ConnectorType];
+	return m_PiecesByConnector.at(a_ConnectorType);
 }
 
 
 
 
 
-cPieces cPrefabPiecePool::GetStartingPieces(void)
+cPieces cPrefabPiecePool::GetStartingPieces(void) const
 {
 	if (m_StartingPieces.empty())
 	{
@@ -790,18 +790,18 @@ cPieces cPrefabPiecePool::GetStartingPieces(void)
 
 
 
-int cPrefabPiecePool::GetPieceWeight(const cPlacedPiece & a_PlacedPiece, const cPiece::cConnector & a_ExistingConnector, const cPiece & a_NewPiece)
+int cPrefabPiecePool::GetPieceWeight(const cPlacedPiece & a_PlacedPiece, const cPiece::cConnector & a_ExistingConnector, const cPiece & a_NewPiece) const
 {
-	return (static_cast<const cPrefab &>(a_NewPiece)).GetPieceWeight(a_PlacedPiece, a_ExistingConnector);
+	return static_cast<const cPrefab &>(a_NewPiece).GetPieceWeight(a_PlacedPiece, a_ExistingConnector);
 }
 
 
 
 
 
-int cPrefabPiecePool::GetStartingPieceWeight(const cPiece & a_NewPiece)
+int cPrefabPiecePool::GetStartingPieceWeight(const cPiece & a_NewPiece) const
 {
-	return (static_cast<const cPrefab &>(a_NewPiece)).GetDefaultWeight();
+	return static_cast<const cPrefab &>(a_NewPiece).GetDefaultWeight();
 }
 
 

--- a/src/Generating/PrefabPiecePool.h
+++ b/src/Generating/PrefabPiecePool.h
@@ -111,10 +111,10 @@ public:
 	void AssignGens(int a_Seed, cBiomeGen & a_BiomeGen, cTerrainHeightGen & a_HeightGen, int a_SeaLevel);
 
 	// cPiecePool overrides:
-	virtual cPieces GetPiecesWithConnector(int a_ConnectorType) override;
-	virtual cPieces GetStartingPieces(void) override;
-	virtual int GetPieceWeight(const cPlacedPiece & a_PlacedPiece, const cPiece::cConnector & a_ExistingConnector, const cPiece & a_NewPiece) override;
-	virtual int GetStartingPieceWeight(const cPiece & a_NewPiece) override;
+	virtual cPieces GetPiecesWithConnector(int a_ConnectorType) const override;
+	virtual cPieces GetStartingPieces(void) const override;
+	virtual int GetPieceWeight(const cPlacedPiece & a_PlacedPiece, const cPiece::cConnector & a_ExistingConnector, const cPiece & a_NewPiece) const override;
+	virtual int GetStartingPieceWeight(const cPiece & a_NewPiece) const override;
 	virtual void PiecePlaced(const cPiece & a_Piece) override;
 	virtual void Reset(void) override;
 

--- a/src/Generating/PrefabStructure.cpp
+++ b/src/Generating/PrefabStructure.cpp
@@ -27,11 +27,11 @@ cPrefabStructure::cPrefabStructure(
 
 
 
-void cPrefabStructure::DrawIntoChunk(cChunkDesc & a_Chunk)
+void cPrefabStructure::DrawIntoChunk(cChunkDesc & a_Chunk) const
 {
 	// Iterate over all items
 	// Each intersecting prefab is placed on ground, if requested, then drawn
-	for (cPlacedPieces::iterator itr = m_Pieces.begin(), end = m_Pieces.end(); itr != end; ++itr)
+	for (cPlacedPieces::const_iterator itr = m_Pieces.begin(), end = m_Pieces.end(); itr != end; ++itr)
 	{
 		const cPrefab & Prefab = static_cast<const cPrefab &>((*itr)->GetPiece());
 		if (Prefab.ShouldMoveToGround() && !(*itr)->HasBeenMovedToGround())
@@ -46,7 +46,7 @@ void cPrefabStructure::DrawIntoChunk(cChunkDesc & a_Chunk)
 
 
 
-void cPrefabStructure::PlacePieceOnGround(cPlacedPiece & a_Piece)
+void cPrefabStructure::PlacePieceOnGround(cPlacedPiece & a_Piece) const
 {
 	cPiece::cConnector FirstConnector = a_Piece.GetRotatedConnector(0);
 	int ChunkX, ChunkZ;

--- a/src/Generating/PrefabStructure.h
+++ b/src/Generating/PrefabStructure.h
@@ -39,9 +39,9 @@ protected:
 
 
 	// cGridStructGen::cStructure overrides:
-	virtual void DrawIntoChunk(cChunkDesc & a_Chunk) override;
+	virtual void DrawIntoChunk(cChunkDesc & a_Chunk) const override;
 
 	/**  Adjusts the Y coord of the given piece so that the piece is on the ground.
 	Ground level is assumed to be represented by the first connector in the piece. */
-	void PlacePieceOnGround(cPlacedPiece & a_Piece);
+	void PlacePieceOnGround(cPlacedPiece & a_Piece) const;
 };

--- a/src/Generating/ProtIntGen.h
+++ b/src/Generating/ProtIntGen.h
@@ -59,7 +59,7 @@ public:
 	virtual ~cProtIntGen() {}
 
 	/** Generates the array of specified size into a_Values, based on given min coords. */
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) = 0;
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const = 0;
 };
 
 
@@ -83,14 +83,14 @@ protected:
 	cNoise m_Noise;
 
 	/** Chooses one of a_Val1 or a_Val2, based on m_Noise and the coordinates for querying the noise. */
-	int chooseRandomOne(int a_RndX, int a_RndZ, int a_Val1, int a_Val2)
+	int chooseRandomOne(int a_RndX, int a_RndZ, int a_Val1, int a_Val2) const
 	{
 		int rnd = m_Noise.IntNoise2DInt(a_RndX, a_RndZ) / 7;
 		return ((rnd & 1) == 0) ? a_Val1 : a_Val2;
 	}
 
 	/** Chooses one of a_ValN, based on m_Noise and the coordinates for querying the noise. */
-	int chooseRandomOne(int a_RndX, int a_RndZ, int a_Val1, int a_Val2, int a_Val3, int a_Val4)
+	int chooseRandomOne(int a_RndX, int a_RndZ, int a_Val1, int a_Val2, int a_Val3, int a_Val4) const
 	{
 		int rnd = m_Noise.IntNoise2DInt(a_RndX, a_RndZ) / 7;
 		switch (rnd % 4)
@@ -122,7 +122,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		for (size_t z = 0; z < a_SizeZ; z++)
 		{
@@ -159,7 +159,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		for (size_t z = 0; z < a_SizeZ; z++)
 		{
@@ -203,7 +203,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Get the coords for the lower generator:
 		int lowerMinX = a_MinX >> 1;
@@ -274,7 +274,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		size_t lowerSizeX = a_SizeX + 2;
@@ -347,7 +347,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		size_t lowerSizeX = a_SizeX + 1;
@@ -392,7 +392,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		size_t lowerSizeX = a_SizeX + 4;
@@ -443,7 +443,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		size_t lowerSizeX = a_SizeX + 3;
@@ -495,7 +495,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		m_Underlying->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);
@@ -542,7 +542,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		m_Underlying->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);
@@ -585,7 +585,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		size_t lowerSizeX = a_SizeX + 2;
@@ -643,7 +643,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		size_t lowerSizeX = a_SizeX + 2;
@@ -698,7 +698,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Map for biome -> its beach:
 		static const int ToBeach[] =
@@ -803,7 +803,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		m_Underlying->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);
 		for (size_t z = 0; z < a_SizeZ; z++)
@@ -847,7 +847,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int * a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int * a_Values) const override
 	{
 		// Generate the underlying biome groups:
 		size_t lowerSizeX = a_SizeX + 2;
@@ -907,7 +907,7 @@ protected:
 	Underlying m_Underlying;
 
 
-	inline bool isDesertCompatible(int a_BiomeGroup)
+	static inline bool isDesertCompatible(int a_BiomeGroup)
 	{
 		switch (a_BiomeGroup)
 		{
@@ -946,7 +946,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Define the per-biome-group biomes:
 		static const int oceanBiomes[] =
@@ -1077,7 +1077,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying values:
 		m_Underlying->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);
@@ -1137,7 +1137,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying data:
 		ASSERT(a_SizeX * a_SizeZ <= m_BufferSize);
@@ -1202,7 +1202,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying data:
 		size_t lowerSizeX = a_SizeX + 2;
@@ -1261,7 +1261,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying data:
 		size_t lowerSizeX = a_SizeX + 2;
@@ -1352,7 +1352,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying data:
 		m_Underlying->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);
@@ -1401,7 +1401,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying data:
 		m_Underlying->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);
@@ -1450,7 +1450,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the base biomes and the alterations:
 		m_BaseBiomes->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);
@@ -1515,7 +1515,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying biomes:
 		size_t lowerSizeX = a_SizeX + 2;
@@ -1611,7 +1611,7 @@ protected:
 	Underlying m_Underlying;
 
 
-	bool isMesaCompatible(int a_Biome)
+	static bool isMesaCompatible(int a_Biome)
 	{
 		switch (a_Biome)
 		{
@@ -1635,7 +1635,7 @@ protected:
 	}
 
 
-	bool isJungleCompatible(int a_Biome)
+	static bool isJungleCompatible(int a_Biome)
 	{
 		switch (a_Biome)
 		{
@@ -1676,7 +1676,7 @@ public:
 	}
 
 
-	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) override
+	virtual void GetInts(int a_MinX, int a_MinZ, size_t a_SizeX, size_t a_SizeZ, int *a_Values) const override
 	{
 		// Generate the underlying biomes and the alterations:
 		m_Underlying->GetInts(a_MinX, a_MinZ, a_SizeX, a_SizeZ, a_Values);

--- a/src/Generating/Ravines.cpp
+++ b/src/Generating/Ravines.cpp
@@ -70,7 +70,7 @@ public:
 
 protected:
 	// cGridStructGen::cStructure overrides:
-	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) override;
+	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) const override;
 } ;
 
 
@@ -324,7 +324,7 @@ AString cStructGenRavines::cRavine::ExportAsSVG(int a_Color, int a_OffsetX, int 
 
 
 
-void cStructGenRavines::cRavine::DrawIntoChunk(cChunkDesc & a_ChunkDesc)
+void cStructGenRavines::cRavine::DrawIntoChunk(cChunkDesc & a_ChunkDesc) const
 {
 	int BlockStartX = a_ChunkDesc.GetChunkX() * cChunkDef::Width;
 	int BlockStartZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;

--- a/src/Generating/RoughRavines.cpp
+++ b/src/Generating/RoughRavines.cpp
@@ -154,7 +154,7 @@ protected:
 	}
 
 
-	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) override
+	virtual void DrawIntoChunk(cChunkDesc & a_ChunkDesc) const override
 	{
 		int BlockStartX = a_ChunkDesc.GetChunkX() * cChunkDef::Width;
 		int BlockStartZ = a_ChunkDesc.GetChunkZ() * cChunkDef::Width;

--- a/src/Generating/StructGen.cpp
+++ b/src/Generating/StructGen.cpp
@@ -99,7 +99,7 @@ void cStructGenTrees::GenerateSingleTree(
 	cChunkDesc & a_ChunkDesc,
 	sSetBlockVector & a_OutsideLogs,
 	sSetBlockVector & a_OutsideOther
-)
+) const
 {
 	if ((a_Pos.y <= 0) || (a_Pos.y >= 230))
 	{
@@ -338,7 +338,7 @@ void cStructGenLakes::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-void cStructGenLakes::CreateLakeImage(int a_ChunkX, int a_ChunkZ, int a_MaxLakeHeight, cBlockArea & a_Lake)
+void cStructGenLakes::CreateLakeImage(int a_ChunkX, int a_ChunkZ, int a_MaxLakeHeight, cBlockArea & a_Lake) const
 {
 	a_Lake.Create(16, 8, 16);
 	a_Lake.Fill(cBlockArea::baTypes, E_BLOCK_SPONGE);  // Sponge is the NOP blocktype for lake merging strategy
@@ -508,7 +508,7 @@ void cStructGenDirectOverhangs::GenFinish(cChunkDesc & a_ChunkDesc)
 
 
 
-bool cStructGenDirectOverhangs::HasWantedBiome(cChunkDesc & a_ChunkDesc) const
+bool cStructGenDirectOverhangs::HasWantedBiome(cChunkDesc & a_ChunkDesc)
 {
 	cChunkDef::BiomeMap & Biomes = a_ChunkDesc.GetBiomeMap();
 	for (size_t i = 0; i < ARRAYCOUNT(Biomes); i++)

--- a/src/Generating/StructGen.h
+++ b/src/Generating/StructGen.h
@@ -48,10 +48,10 @@ protected:
 		cChunkDesc & a_ChunkDesc,
 		sSetBlockVector & a_OutsideLogs,
 		sSetBlockVector & a_OutsideOther
-	) ;
+	) const;
 
 	/** Applies an image into chunk blockdata; all blocks outside the chunk will be appended to a_Overflow. */
-	void ApplyTreeImage(
+	static void ApplyTreeImage(
 		int a_ChunkX, int a_ChunkZ,
 		cChunkDesc & a_ChunkDesc,
 		const sSetBlockVector & a_Image,
@@ -61,7 +61,7 @@ protected:
 	/** Get the the number of trees to generate in a_Chunk
 	If the value is between 0 and 1, it should be interpreted as the probability that a tree should be generated.
 	*/
-	double GetNumTrees(
+	static double GetNumTrees(
 		int a_ChunkX, int a_ChunkZ,
 		const cChunkDef::BiomeMap & a_Biomes
 	);
@@ -101,7 +101,7 @@ protected:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 
 	/** Creates a lake image for the specified chunk into a_Lake. */
-	void CreateLakeImage(int a_ChunkX, int a_ChunkZ, int a_MaxLakeHeight, cBlockArea & a_Lake);
+	void CreateLakeImage(int a_ChunkX, int a_ChunkZ, int a_MaxLakeHeight, cBlockArea & a_Lake) const;
 } ;
 
 
@@ -121,7 +121,7 @@ protected:
 	// cFinishGen override:
 	virtual void GenFinish(cChunkDesc & a_ChunkDesc) override;
 
-	bool HasWantedBiome(cChunkDesc & a_ChunkDesc) const;
+	static bool HasWantedBiome(cChunkDesc & a_ChunkDesc);
 } ;
 
 

--- a/src/Generating/Trees.cpp
+++ b/src/Generating/Trees.cpp
@@ -270,7 +270,7 @@ inline void PushCoordBlocks(int a_BlockX, int a_Height, int a_BlockZ, sSetBlockV
 
 
 
-inline void PushCornerBlocks(int a_BlockX, int a_Height, int a_BlockZ, int a_Seq, cNoise & a_Noise, int a_Chance, sSetBlockVector & a_Blocks, int a_CornersDist, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta)
+inline void PushCornerBlocks(int a_BlockX, int a_Height, int a_BlockZ, int a_Seq, const cNoise & a_Noise, int a_Chance, sSetBlockVector & a_Blocks, int a_CornersDist, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta)
 {
 	for (size_t i = 0; i < ARRAYCOUNT(Corners); i++)
 	{
@@ -287,7 +287,7 @@ inline void PushCornerBlocks(int a_BlockX, int a_Height, int a_BlockZ, int a_Seq
 
 
 
-inline void PushSomeColumns(int a_BlockX, int a_Height, int a_BlockZ, int a_ColumnHeight, int a_Seq, cNoise & a_Noise, int a_Chance, sSetBlockVector & a_Blocks, const sMetaCoords * a_Coords, size_t a_NumCoords, BLOCKTYPE a_BlockType)
+inline void PushSomeColumns(int a_BlockX, int a_Height, int a_BlockZ, int a_ColumnHeight, int a_Seq, const cNoise & a_Noise, int a_Chance, sSetBlockVector & a_Blocks, const sMetaCoords * a_Coords, size_t a_NumCoords, BLOCKTYPE a_BlockType)
 {
 	for (size_t i = 0; i < a_NumCoords; i++)
 	{
@@ -307,7 +307,7 @@ inline void PushSomeColumns(int a_BlockX, int a_Height, int a_BlockZ, int a_Colu
 
 
 
-void GetTreeImageByBiome(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, EMCSBiome a_Biome, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetTreeImageByBiome(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, EMCSBiome a_Biome, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	switch (a_Biome)
 	{
@@ -519,7 +519,7 @@ void GetTreeImageByBiome(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, EMCSB
 
 
 
-void GetAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetAppleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	if (a_Noise.IntNoise3DInt(a_BlockPos.addedX(32 * a_Seq).addedY(32 * a_Seq)) < 0x60000000)
 	{
@@ -535,7 +535,7 @@ void GetAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlo
 
 
 
-void GetSmallAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetSmallAppleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	/* Small apple tree has:
 	- a top plus (no log)
@@ -587,7 +587,7 @@ void GetSmallAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sS
 
 
 
-void GetLargeAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetLargeAppleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	int Height = 7 + a_Noise.IntNoise3DInt(a_BlockPos) % 4;
 
@@ -670,7 +670,7 @@ NIBBLETYPE GetLogMetaFromDirection(NIBBLETYPE a_BlockMeta, Vector3d a_Direction)
 
 
 
-void GetBirchTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetBirchTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	HEIGHTTYPE Height = 5 + static_cast<HEIGHTTYPE>(a_Noise.IntNoise3DInt(a_BlockPos.addedX(64 * a_Seq)) % 3);
 
@@ -708,7 +708,7 @@ void GetBirchTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlo
 
 
 
-void GetAcaciaTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetAcaciaTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	// Calculate a base height
 	int Height = 2 + (a_Noise.IntNoise3DInt(a_BlockPos) / 11 % 3);
@@ -766,7 +766,7 @@ void GetAcaciaTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBl
 
 
 
-void GetDarkoakTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetDarkoakTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	// Pick a height
 	int Height = 5 + (a_Noise.IntNoise3DInt(a_BlockPos.addedX(32 * a_Seq).addedZ(32 * a_Seq)) / 11) % 4;
@@ -837,7 +837,7 @@ void GetDarkoakTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetB
 
 
 
-void GetTallBirchTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetTallBirchTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	HEIGHTTYPE Height = 9 + static_cast<HEIGHTTYPE>(a_Noise.IntNoise3DInt(a_BlockPos.addedX(64 * a_Seq)) % 3);
 
@@ -875,7 +875,7 @@ void GetTallBirchTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSe
 
 
 
-void GetConiferTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
+void GetConiferTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
 {
 	// Half chance for a spruce, half for a pine and for the large ones 3 chances for a pine and one for spruce:
 	if (a_Noise.IntNoise3DInt(a_BlockPos.addedX(64 * a_Seq).addedZ(32 * a_Seq)) < (a_Large ? 0x20000000 : 0x40000000))
@@ -892,7 +892,7 @@ void GetConiferTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetB
 
 
 
-void GetSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
+void GetSpruceTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
 {
 	if (a_Large)
 	{
@@ -909,7 +909,7 @@ void GetSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBl
 
 
 
-void GetPineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
+void GetPineTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
 {
 	if (a_Large)
 	{
@@ -926,7 +926,7 @@ void GetPineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBloc
 
 
 
-void GetSmallSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetSmallSpruceTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	// Spruces have a top section with layer sizes of (0, 1, 0) or only (1, 0),
 	// then 1 - 3 sections of ascending sizes (1, 2) [most often], (1, 3) or (1, 2, 3)
@@ -1037,7 +1037,7 @@ static void LargeSpruceAddRing(Vector3i a_BlockPos, int & a_Height, const sCoord
 
 const int MIN_LARGE_SPRUCE_TREE_RINGS = 3;
 const int MAX_LARGE_SPRUCE_TREE_RINGS = 11;
-void GetLargeSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetLargeSpruceTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	int Height = 20 + (a_Noise.IntNoise3DInt(a_BlockPos.addedXZ(32 * a_Seq, 32 * a_Seq)) / 11) % 12;
 	int LeavesRingCount =
@@ -1128,7 +1128,7 @@ void GetLargeSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, s
 
 
 
-void GetSmallPineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetSmallPineTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	// Tall, little leaves on top. The top leaves are arranged in a shape of two cones joined by their bases.
 	// There can be one or two layers representing the cone bases (SameSizeMax)
@@ -1181,7 +1181,7 @@ void GetSmallPineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSe
 
 
 
-void GetLargePineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetLargePineTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	int Height = 20 + (a_Noise.IntNoise3DInt(a_BlockPos.addedXZ(32 * a_Seq, 32 * a_Seq)) / 11) % 12;
 
@@ -1217,7 +1217,7 @@ void GetLargePineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSe
 
 
 
-void GetSwampTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetSwampTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	// Vines are around the BigO3, but not in the corners; need proper meta for direction
 	static const sMetaCoords Vines[] =
@@ -1264,7 +1264,7 @@ void GetSwampTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlo
 
 
 
-void GetAppleBushImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetAppleBushImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	a_OtherBlocks.reserve(3 + ARRAYCOUNT(BigO2) + ARRAYCOUNT(BigO1));
 
@@ -1284,7 +1284,7 @@ void GetAppleBushImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlo
 
 
 
-void GetJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
+void GetJungleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large)
 {
 	if (!a_Large)
 	{
@@ -1300,7 +1300,7 @@ void GetJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBl
 
 
 
-void GetLargeJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetLargeJungleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	static const sMetaCoords VinesTrunk[] =
 	{
@@ -1385,7 +1385,7 @@ void GetLargeJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, s
 
 
 
-void GetSmallJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetSmallJungleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	// Vines are around the BigO3, but not in the corners; need proper meta for direction
 	static const sMetaCoords Vines[] =
@@ -1442,7 +1442,7 @@ void GetSmallJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, s
 
 
 
-void GetRedMushroomTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetRedMushroomTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	static constexpr int Height = 4;
 
@@ -1489,7 +1489,7 @@ void GetRedMushroomTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, s
 
 
 
-void GetBrownMushroomTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
+void GetBrownMushroomTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks)
 {
 	static constexpr int Height = 4;
 	static constexpr int Radius = 2;

--- a/src/Generating/Trees.h
+++ b/src/Generating/Trees.h
@@ -50,16 +50,16 @@ logs can overwrite others(leaves), but others shouldn't overwrite logs. This is 
 
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a tree at the specified coords (lowest trunk block) in the specified biome */
-void GetTreeImageByBiome(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, EMCSBiome a_Biome, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetTreeImageByBiome(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, EMCSBiome a_Biome, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random apple tree */
-void GetAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetAppleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a small (nonbranching) apple tree */
-void GetSmallAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetSmallAppleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a large (branching) apple tree */
-void GetLargeAppleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetLargeAppleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks with the logs of a tree branch of the provided log type.
 The length of the branch can be changed with the a_BranchLength.
@@ -71,55 +71,55 @@ Vector3d GetTreeBranch(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a
 NIBBLETYPE GetLogMetaFromDirection(NIBBLETYPE a_BlockMeta, Vector3d a_Direction);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random birch tree */
-void GetBirchTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetBirchTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random acacia tree */
-void GetAcaciaTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetAcaciaTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random darkoak tree */
-void GetDarkoakTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetDarkoakTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random large birch tree */
-void GetTallBirchTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetTallBirchTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random conifer tree. The probability to get a large pine is higher than a spruce tree */
-void GetConiferTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large = false);
+void GetConiferTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large = false);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random spruce */
-void GetSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large = false);
+void GetSpruceTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large = false);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random pine */
-void GetPineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large = false);
+void GetPineTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large = false);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random small spruce (short conifer, two layers of leaves) */
-void GetSmallSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetSmallSpruceTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random small pine (tall conifer, little leaves at top) */
-void GetSmallPineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetSmallPineTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random large spruce (short conifer, multiple layers of leaves) */
-void GetLargeSpruceTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetLargeSpruceTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random large pine (tall conifer, little leaves at top) */
-void GetLargePineTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetLargePineTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random swampland tree */
-void GetSwampTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetSwampTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random apple bush (for jungles) */
-void GetAppleBushImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetAppleBushImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a random jungle tree */
-void GetJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large);
+void GetJungleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks, bool a_Large);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a large jungle tree (2x2 trunk) */
-void GetLargeJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetLargeJungleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks (dirt & leaves) with the blocks required to form a small jungle tree (1x1 trunk) */
-void GetSmallJungleTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetSmallJungleTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks with the blocks required to form the red mushroom */
-void GetRedMushroomTreeImage(Vector3i vector3, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetRedMushroomTreeImage(Vector3i vector3, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
 
 /** Fills a_LogBlocks and a_OtherBlocks with the blocks required to form the brown mushroom */
-void GetBrownMushroomTreeImage(Vector3i a_BlockPos, cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);
+void GetBrownMushroomTreeImage(Vector3i a_BlockPos, const cNoise & a_Noise, int a_Seq, sSetBlockVector & a_LogBlocks, sSetBlockVector & a_OtherBlocks);

--- a/src/Generating/VillageGen.cpp
+++ b/src/Generating/VillageGen.cpp
@@ -93,7 +93,7 @@ public:
 
 
 	// cPrefabPiecePool overrides:
-	virtual int GetPieceWeight(const cPlacedPiece & a_PlacedPiece, const cPiece::cConnector & a_ExistingConnector, const cPiece & a_NewPiece) override
+	virtual int GetPieceWeight(const cPlacedPiece & a_PlacedPiece, const cPiece::cConnector & a_ExistingConnector, const cPiece & a_NewPiece) const override
 	{
 		// Roads cannot branch T-wise (appending -2 connector to a +2 connector on a 1-high piece):
 		if ((a_ExistingConnector.m_Type == 2) && (a_PlacedPiece.GetDepth() > 0) && (a_PlacedPiece.GetPiece().GetSize().y == 1))
@@ -176,14 +176,14 @@ protected:
 
 
 	// cGridStructGen::cStructure overrides:
-	virtual void DrawIntoChunk(cChunkDesc & a_Chunk) override
+	virtual void DrawIntoChunk(cChunkDesc & a_Chunk) const override
 	{
 		// Iterate over all items
 		// Each intersecting prefab is placed on ground, then drawn
 		// Each intersecting road is drawn by replacing top soil blocks with gravel / sandstone blocks
 		cChunkDef::HeightMap HeightMap;  // Heightmap for this chunk, used by roads
 		m_HeightGen.GenHeightMap(a_Chunk.GetChunkCoords(), HeightMap);
-		for (cPlacedPieces::iterator itr = m_Pieces.begin(), end = m_Pieces.end(); itr != end; ++itr)
+		for (cPlacedPieces::const_iterator itr = m_Pieces.begin(), end = m_Pieces.end(); itr != end; ++itr)
 		{
 			const cPrefab & Prefab = static_cast<const cPrefab &>((*itr)->GetPiece());
 			if ((*itr)->GetPiece().GetSize().y == 1)
@@ -203,7 +203,7 @@ protected:
 
 	/**  Adjusts the Y coord of the given piece so that the piece is on the ground.
 	Ground level is assumed to be represented by the first connector in the piece. */
-	void PlacePieceOnGround(cPlacedPiece & a_Piece)
+	void PlacePieceOnGround(cPlacedPiece & a_Piece) const
 	{
 		cPiece::cConnector FirstConnector = a_Piece.GetRotatedConnector(0);
 		int ChunkX, ChunkZ;
@@ -221,7 +221,7 @@ protected:
 	/** Draws the road into the chunk.
 	The heightmap is not queried from the heightgen, but is given via parameter, so that it may be queried just
 	once for all roads in a chunk. */
-	void DrawRoad(cChunkDesc & a_Chunk, cPlacedPiece & a_Road, cChunkDef::HeightMap & a_HeightMap)
+	void DrawRoad(cChunkDesc & a_Chunk, cPlacedPiece & a_Road, cChunkDef::HeightMap & a_HeightMap) const
 	{
 		cCuboid RoadCoords = a_Road.GetHitBox();
 		RoadCoords.Sort();
@@ -252,13 +252,13 @@ protected:
 
 
 	// cPiecePool overrides:
-	virtual cPieces GetPiecesWithConnector(int a_ConnectorType) override
+	virtual cPieces GetPiecesWithConnector(int a_ConnectorType) const override
 	{
 		return m_Prefabs.GetPiecesWithConnector(a_ConnectorType);
 	}
 
 
-	virtual cPieces GetStartingPieces(void) override
+	virtual cPieces GetStartingPieces(void) const override
 	{
 		return m_Prefabs.GetStartingPieces();
 	}
@@ -268,7 +268,7 @@ protected:
 		const cPlacedPiece & a_PlacedPiece,
 		const cPiece::cConnector & a_ExistingConnector,
 		const cPiece & a_NewPiece
-	) override
+	) const override
 	{
 		// Check against the density:
 		if (a_ExistingConnector.m_Type == 1)
@@ -286,7 +286,7 @@ protected:
 	}
 
 
-	virtual int GetStartingPieceWeight(const cPiece & a_NewPiece) override
+	virtual int GetStartingPieceWeight(const cPiece & a_NewPiece) const override
 	{
 		return m_Prefabs.GetStartingPieceWeight(a_NewPiece);
 	}

--- a/src/SpawnPrepare.h
+++ b/src/SpawnPrepare.h
@@ -24,7 +24,7 @@ protected:
 	int m_PrepareDistance;
 
 	/** The index of the next chunk to be queued in the lighting thread. */
-	int m_NextIdx;
+	std::atomic<int> m_NextIdx;
 
 	/** The maximum index of the prepared chunks. Queueing stops when m_NextIdx reaches this number. */
 	int m_MaxIdx;

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -1,0 +1,28 @@
+#include "Globals.h"
+
+#include "ThreadPool.h"
+
+
+
+
+
+std::size_t cThreadPool::GenThreadCount()
+{
+	const auto TotalThreadsCount = std::thread::hardware_concurrency();
+	return TotalThreadsCount > m_MinHwThreads
+			   ? static_cast<std::size_t>(static_cast<float>(TotalThreadsCount) * m_ThreadCountFactor)
+			   : m_MinPoolThreads;	// If the hardware we are running on does not have more then m_MinHwThreads hardware logical threads then only
+									// make the thread pool be the size of m_MinPoolThreads to optimize performance of threads running outside the pool
+}
+
+
+
+
+
+cThreadPool::cThreadPool() : m_ThreadsCount{GenThreadCount()}, m_Control{tbb::global_control::max_allowed_parallelism, m_ThreadsCount } {}
+
+
+
+
+
+std::size_t cThreadPool::GetThreadsCount() const { return m_ThreadsCount; }

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// The new and free macros break tbb
+#pragma push_macro("new")
+#undef new
+#pragma push_macro("free")
+#undef free
+#include <oneapi/tbb/global_control.h>
+#pragma pop_macro("free")
+#pragma pop_macro("new")
+
+
+
+
+
+class cThreadPool
+{
+	/** Factor of the amount of hardware threads compared to the pool size. */
+	constexpr static float m_ThreadCountFactor{0.8F};
+
+	/** Minimum amount of thread to start using m_ThreadCountFactor for pool size. */
+	constexpr static std::size_t m_MinHwThreads{4};
+
+	/** Pool size when hardware does not have enough threads. */
+	constexpr static std::size_t m_MinPoolThreads{1};
+
+	/** Thread pool size. */
+	std::size_t m_ThreadsCount;
+
+	/** OneAPI TBB global control. */
+	tbb::global_control m_Control;
+
+	/** Calculate the thread pool size.*/
+	static std::size_t GenThreadCount();
+
+  public:
+	/** Constructor.*/
+	cThreadPool();
+
+	/** Calculate the thread pool size.*/
+	[[nodiscard]] std::size_t GetThreadsCount() const;
+};

--- a/src/VoronoiMap.cpp
+++ b/src/VoronoiMap.cpp
@@ -85,6 +85,8 @@ int cVoronoiMap::GetValueAt(
 	int & a_MinDist2  // Distance to the second closest cell
 )
 {
+	cCSLock Lock{ m_CS };
+
 	int CellX = a_X / m_CellSize;
 	int CellY = a_Y / m_CellSize;
 

--- a/src/VoronoiMap.h
+++ b/src/VoronoiMap.h
@@ -54,6 +54,9 @@ public:
 	);
 
 protected:
+	/** Generator state lock. */
+	mutable cCriticalSection m_CS;
+
 	/** The noise used for generating Voronoi seeds */
 	cNoise m_Noise1;
 	cNoise m_Noise2;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1234,7 +1234,7 @@ void cWorld::TickQueuedEntityAdditions(void)
 	decltype(m_EntitiesToAdd) EntitiesToAdd;
 	{
 		cCSLock Lock(m_CSEntitiesToAdd);
-		EntitiesToAdd = std::move(m_EntitiesToAdd);
+		std::swap(EntitiesToAdd, m_EntitiesToAdd);
 	}
 
 	// Ensures m_Players manipulation happens under the chunkmap lock.
@@ -3166,7 +3166,7 @@ void cWorld::cChunkGeneratorCallbacks::OnChunkGenerated(cChunkDesc & a_ChunkDesc
 
 
 
-bool cWorld::cChunkGeneratorCallbacks::IsChunkValid(cChunkCoords a_Coords)
+bool cWorld::cChunkGeneratorCallbacks::IsChunkValid(cChunkCoords a_Coords) const
 {
 	return m_World->IsChunkValid(a_Coords.m_ChunkX, a_Coords.m_ChunkZ);
 }
@@ -3175,7 +3175,7 @@ bool cWorld::cChunkGeneratorCallbacks::IsChunkValid(cChunkCoords a_Coords)
 
 
 
-bool cWorld::cChunkGeneratorCallbacks::IsChunkQueued(cChunkCoords a_Coords)
+bool cWorld::cChunkGeneratorCallbacks::IsChunkQueued(cChunkCoords a_Coords) const
 {
 	return m_World->IsChunkQueued(a_Coords.m_ChunkX, a_Coords.m_ChunkZ);
 }
@@ -3184,7 +3184,7 @@ bool cWorld::cChunkGeneratorCallbacks::IsChunkQueued(cChunkCoords a_Coords)
 
 
 
-bool cWorld::cChunkGeneratorCallbacks::HasChunkAnyClients(cChunkCoords a_Coords)
+bool cWorld::cChunkGeneratorCallbacks::HasChunkAnyClients(cChunkCoords a_Coords) const
 {
 	return m_World->HasChunkAnyClients(a_Coords.m_ChunkX, a_Coords.m_ChunkZ);
 }
@@ -3193,7 +3193,7 @@ bool cWorld::cChunkGeneratorCallbacks::HasChunkAnyClients(cChunkCoords a_Coords)
 
 
 
-void cWorld::cChunkGeneratorCallbacks::CallHookChunkGenerating(cChunkDesc & a_ChunkDesc)
+void cWorld::cChunkGeneratorCallbacks::CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) const
 {
 	cPluginManager::Get()->CallHookChunkGenerating(
 		*m_World, a_ChunkDesc.GetChunkX(), a_ChunkDesc.GetChunkZ(), &a_ChunkDesc
@@ -3204,7 +3204,7 @@ void cWorld::cChunkGeneratorCallbacks::CallHookChunkGenerating(cChunkDesc & a_Ch
 
 
 
-void cWorld::cChunkGeneratorCallbacks::CallHookChunkGenerated (cChunkDesc & a_ChunkDesc)
+void cWorld::cChunkGeneratorCallbacks::CallHookChunkGenerated (cChunkDesc & a_ChunkDesc) const
 {
 	cPluginManager::Get()->CallHookChunkGenerated(
 		*m_World, a_ChunkDesc.GetChunkX(), a_ChunkDesc.GetChunkZ(), &a_ChunkDesc

--- a/src/World.h
+++ b/src/World.h
@@ -914,13 +914,13 @@ private:
 
 		// cChunkSink overrides:
 		virtual void OnChunkGenerated  (cChunkDesc & a_ChunkDesc) override;
-		virtual bool IsChunkValid      (cChunkCoords a_Coords) override;
-		virtual bool HasChunkAnyClients(cChunkCoords a_Coords) override;
-		virtual bool IsChunkQueued     (cChunkCoords a_Coords) override;
+		virtual bool IsChunkValid      (cChunkCoords a_Coords) const override;
+		virtual bool HasChunkAnyClients(cChunkCoords a_Coords) const override;
+		virtual bool IsChunkQueued     (cChunkCoords a_Coords) const override;
 
 		// cPluginInterface overrides:
-		virtual void CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) override;
-		virtual void CallHookChunkGenerated (cChunkDesc & a_ChunkDesc) override;
+		virtual void CallHookChunkGenerating(cChunkDesc & a_ChunkDesc) const override;
+		virtual void CallHookChunkGenerated (cChunkDesc & a_ChunkDesc) const override;
 
 	public:
 		cChunkGeneratorCallbacks(cWorld & a_World);
@@ -1089,7 +1089,7 @@ private:
 	cCriticalSection m_CSEntitiesToAdd;
 
 	/** List of entities that are scheduled for adding, waiting for the Tick thread to add them. */
-	std::vector<std::pair<OwnedEntity, cWorld *>> m_EntitiesToAdd;
+	std::vector<std::pair<OwnedEntity, cWorld*>> m_EntitiesToAdd;
 
 	/** CS protecting m_SetChunkDataQueue. */
 	cCriticalSection m_CSSetChunkDataQueue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "Logger.h"
 #include "MemorySettingsRepository.h"
 #include "Root.h"
+#include "ThreadPool.h"
 #include "tclap/CmdLine.h"
 
 #include "OSSupport/ConsoleSignalHandler.h"
@@ -136,6 +137,9 @@ static int UniversalMain(int argc, char * argv[], const bool a_RunningAsService)
 			SleepResolutionBooster::Unregister();
 		}
 	} SleepResolutionBooster;
+
+	// Initialize thread pool
+	[[maybe_unused]] cThreadPool ThreadPool;
 
 	// Register signal handlers, enabling graceful shutdown from the terminal:
 	ConsoleSignalHandler::Register();


### PR DESCRIPTION
This Pull Request tries to solve issue #2320 , the solution is not perfect as there are still bottlenecks, mostly caused by the locks in World, ChunkMap, LightingThread and the ones around the caches and some generators; even with these bottlenecks the performance difference is still very noticeable especially on systems with 6 or more cores, performance on low end systems with 4 or less cores may have decreased and should be verified, some performance tuning can be achieved by modifying the constants in ThreadPool.h.

Side notes:
Even with the changes in this Pull Request chunk **loading** on the client side still looks slow (especially on Windows where the timers are low resolution and thread wake up is slow), meaning that there must still be some bottlenecks, my guesses are chunk loading and saving, networking and lighting code, also I noticed that it _may_ be beneficial to have a dedicated thread for chunk saving (instead of the current implementation where it's shared with loading) but the biggest show stopper to any changes for added parallelism seems to be the way the  ChunkMap lock is implemented, there is no easy way to make a lot of the read only operations concurrent (thus allowing more then one thread at a time to use the chunk map and each chunk).

Changes:
* Added oneTBB library;
* Added ThreadPool class, used only to initialize TBB with
  the required parameters;
* Changed ChunkGeneratorThread to spawn a tbb task for each chunk,
  made the chunk generation request queue concurrent;
* Added "const" and "static" to many functions and parameters that where missing it
  to make it easier to spot already thread safe code;
* Added some mutexes around caches used in the chunk generation process;
* Made m_NextIdx in SpawnPrepare  atomic;
* Fixed undefined behaviour in cWorld::TickQueuedEntityAdditions;
* Changed ChunkSender to use concurrent data structures.

