### PR TITLE
Authenticator: avoid move assignments to self

### DIFF
--- a/src/Protocol/Authenticator.h
+++ b/src/Protocol/Authenticator.h
@@ -41,7 +41,7 @@ public:
 	void ReadSettings(cSettingsRepositoryInterface & a_Settings);
 
 	/** Queues a request for authenticating a user. If the auth fails, the user will be kicked */
-	void Authenticate(int a_ClientID, AString && a_Username, const AString & a_ServerHash);
+	void Authenticate(int a_ClientID, std::string_view a_Username, std::string_view a_ServerHash);
 
 	/** Starts the authenticator thread. The thread may be started and stopped repeatedly */
 	void Start(cSettingsRepositoryInterface & a_Settings);
@@ -58,7 +58,7 @@ private:
 		AString m_Name;
 		AString m_ServerID;
 
-		cUser(int a_ClientID, const AString & a_Name, const AString & a_ServerID) :
+		cUser(int a_ClientID, const std::string_view a_Name, const std::string_view a_ServerID) :
 			m_ClientID(a_ClientID),
 			m_Name(a_Name),
 			m_ServerID(a_ServerID)


### PR DESCRIPTION
If authentication was off cClientHandle::m_Username ended up moved into itself. Add a copy to avoid this. Thanks @Seadragon91!