### PR TITLE
Protocol 1.8: fix plugin message payload read size

### DIFF
--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -2880,7 +2880,7 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 
 	// Read the payload and send it through to the clienthandle:
 	ContiguousByteBuffer Message;
-	VERIFY(a_ByteBuffer.ReadSome(Message, a_ByteBuffer.GetReadableSpace() - 1));
+	VERIFY(a_ByteBuffer.ReadSome(Message, a_ByteBuffer.GetReadableSpace()));
 	m_Client->HandlePluginMessage(a_Channel, Message);
 }
 


### PR DESCRIPTION
* Read the entire payload of an unhandled vanilla plugin message, remove -1 offset. This was forgotten by #5085
* Fixes #5322