### PR TITLE
Bound more ClientHandle functions to lua

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ as provided in the LICENSE file.
 12xx12
 9caihezi
 Altenius
+AirOne01
 BasedDoge (Donated AlchemistVillage prefabs)
 bearbin (Alexander Harkness)
 beeduck

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,8 +7,8 @@ as provided in the LICENSE file.
 
 12xx12
 9caihezi
-Altenius
 AirOne01
+Altenius
 BasedDoge (Donated AlchemistVillage prefabs)
 bearbin (Alexander Harkness)
 beeduck

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1542,33 +1542,33 @@ end
 					},
 					Notes = "Kicks the user with the specified reason",
 				},
-        SendBlockBreakAnim =
-        {
-          Params =
-          {
-            {
-              Name = "EntityID",
-              Type = "number",
-            },
-            {
-              Name = "BlockX",
-              Type = "number",
-            },
-            {
-              Name = "BlockY",
-              Type = "number",
-            },
-            {
-              Name = "BlockZ",
-              Type = "number",
-            },
-            {
-              Name = "Stage",
-              Type = "number",
-            },
-          },
-          Notes = "Sends a BlockBreakAnim packet to the client. Only one block can be broken at a time with the same UUID (the other will be reset). You can counter this using random values. The breaking stage ranges between 0 (first stage) and 9 (almost destroyed). Use -1 to reset the destruction.",
-        },
+				SendBlockBreakAnim =
+				{
+					Params =
+					{
+						{
+							Name = "EntityID",
+							Type = "number",
+						},
+						{
+							Name = "BlockX",
+							Type = "number",
+						},
+						{
+							Name = "BlockY",
+							Type = "number",
+						},
+						{
+							Name = "BlockZ",
+							Type = "number",
+						},
+						{
+							Name = "Stage",
+							Type = "number",
+						},
+					},
+					Notes = "Sends a BlockBreakAnim packet to the client. Only one block can be broken at a time with the same UUID (the other will be reset). You can counter this using random values. The breaking stage ranges between 0 (first stage) and 9 (almost destroyed). Use -1 to reset the destruction.",
+				},
 				SendBlockChange =
 				{
 					Params =
@@ -1718,62 +1718,62 @@ end
 					},
 					Notes = "Updates the health displayed by the boss bar with the given ID.",
 				},
-        SendCollectEntity =
-        {
-          Params =
-          {
-            {
-              Name = "Entity",
-              Type = "cEntity",
-            },
-            {
-              Name = "Collector",
-              Type = "cEntity",
-            },
-          },
-          Notes = "Sends the CollectEntity packet to the client. This fakes item collecting.",
-        },
-        SendDestroyEntity =
-        {
-          Params =
-          {
-            {
-              Name = "Entity",
-              Type = "cEntity",
-            },
-          },
-          Notes = "Sends the DestroyEntity packet to the client. This tells the client to remove the entity from the world.",
-        },
-        SendDetachEntity =
-        {
-          Params =
-          {
-            {
-              Name = "Entity",
-              Type = "cEntity",
-            },
-          },
-          Notes = "Sends the DetachEntity packet to the client. This drop entities riding another one (boat, minecarts, pigs, horses...).",
-        },
-        SendEditSign =
-        {
-          Params =
-          {
-            {
-              Name = "BlockX",
-              Type = "number",
-            },
-            {
-              Name = "BlockY",
-              Type = "number",
-            },
-            {
-              Name = "BlockZ",
-              Type = "number",
-            },
-          },
-          Notes = "Sends the EditSign packet to the client. This opens the sign editor GUI.",
-        },
+				SendCollectEntity =
+				{
+					Params =
+					{
+						{
+							Name = "Entity",
+							Type = "cEntity",
+						},
+						{
+							Name = "Collector",
+							Type = "cEntity",
+						},
+					},
+					Notes = "Sends the CollectEntity packet to the client. This fakes item collecting.",
+				},
+				SendDestroyEntity =
+				{
+					Params =
+					{
+						{
+							Name = "Entity",
+							Type = "cEntity",
+						},
+					},
+					Notes = "Sends the DestroyEntity packet to the client. This tells the client to remove the entity from the world.",
+				},
+				SendDetachEntity =
+				{
+					Params =
+					{
+						{
+							Name = "Entity",
+							Type = "cEntity",
+						},
+					},
+					Notes = "Sends the DetachEntity packet to the client. This drop entities riding another one (boat, minecarts, pigs, horses...).",
+				},
+				SendEditSign =
+				{
+					Params =
+					{
+						{
+							Name = "BlockX",
+							Type = "number",
+						},
+						{
+							Name = "BlockY",
+							Type = "number",
+						},
+						{
+							Name = "BlockZ",
+							Type = "number",
+						},
+					},
+					Notes = "Sends the EditSign packet to the client. This opens the sign editor GUI.",
+				},
 				SendEntityAnimation =
 				{
 					Params =
@@ -1808,21 +1808,21 @@ end
 				{
 					Notes = "Hides the title. This makes the title and subtitle disappear, but if you call SendTitleTimes() the same title and subtitle will appear again."
 				},
-        SendLeashEntity =
-        {
-          Params =
-          {
-            {
-              Name = "Entity",
-              Type = "cEntity",
-            },
-            {
-              Name = "EntityLeashedTo",
-              Type = "cEntity",
-            },
-          },
-          Notes = "Sends the LeashEntity packet to the client. Leashes entities together. Leashing to the player, the leash will appear on the player's hand",
-        },
+				SendLeashEntity =
+				{
+					Params =
+					{
+						{
+							Name = "Entity",
+							Type = "cEntity",
+						},
+						{
+							Name = "EntityLeashedTo",
+							Type = "cEntity",
+						},
+					},
+					Notes = "Sends the LeashEntity packet to the client. Leashes entities together. Leashing to the player, the leash will appear on the player's hand",
+				},
 				SendPluginMessage =
 				{
 					Params =
@@ -1842,17 +1842,17 @@ end
 				{
 					Notes = "Resets and hides the title but not the subtitle."
 				},
-        SendResourcePack =
-        {
-          Params =
-          {
-            {
-              Name = "ResourcePackURL",
-              Type = "string",
-            },
-          },
-          Notes = "Sends the ResourcePack packet to the client. The client will request the resource pack from the given URL. If the url is blank, the resource pack will be reset.",
-        },
+				SendResourcePack =
+				{
+					Params =
+					{
+						{
+							Name = "ResourcePackURL",
+							Type = "string",
+						},
+					},
+					Notes = "Sends the ResourcePack packet to the client. The client will request the resource pack from the given URL. If the url is blank, the resource pack will be reset.",
+				},
 				SendSetSubTitle =
 				{
 					Params =
@@ -1951,25 +1951,25 @@ end
 					},
 					Notes = "Sends a sound effect request to the client. The sound is played at the specified coords, with the specified volume (a float, 1.0 is full volume, can be more) and pitch (0-255, 63 is 100%) (DEPRECATED, use vector-parametered version instead)",
 				},
-        SendThunderbolt =
-        {
-          Params =
-          {
-            {
-              Name = "BlockX",
-              Type = "number",
-            },
-            {
-              Name = "BlockY",
-              Type = "number",
-            },
-            {
-              Name = "BlockZ",
-              Type = "number",
-            },
-          },
-          Notes = "Sends the thunderbolt at the specified coords to the client. The client will display the effect without any sound.",
-        },
+				SendThunderbolt =
+				{
+					Params =
+					{
+						{
+							Name = "BlockX",
+							Type = "number",
+						},
+						{
+							Name = "BlockY",
+							Type = "number",
+						},
+						{
+							Name = "BlockZ",
+							Type = "number",
+						},
+					},
+					Notes = "Sends the thunderbolt at the specified coords to the client. The client will display the effect without any sound.",
+				},
 				SendTitleTimes =
 				{
 					Params =
@@ -2008,17 +2008,17 @@ end
 					},
 					Notes = "Sends the specified time update to the client. WorldAge is the total age of the world, in ticks. WorldDate is the current date, in ticks, and is used by the client to calculate the days elapsed (F3 debug overlay's day count) and the time of day (rendered sun position). DoDaylightCycle is a bool that specifies whether the client should automatically move the sun (true) or keep it in the same place (false).",
 				},
-        SendUnleashEntity =
-        {
-          Params =
-          {
-            {
-              Name = "EntityID",
-              Type = "number",
-            },
-          },
-          Notes = "Sends the UnleashEntity packet to the client. The client will remove any leashes related to the entity.",
-        },
+				SendUnleashEntity =
+				{
+					Params =
+					{
+						{
+							Name = "EntityID",
+							Type = "number",
+						},
+					},
+					Notes = "Sends the UnleashEntity packet to the client. The client will remove any leashes related to the entity.",
+				},
 				SetClientBrand =
 				{
 					Params =

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1951,7 +1951,7 @@ end
 					},
 					Notes = "Sends a sound effect request to the client. The sound is played at the specified coords, with the specified volume (a float, 1.0 is full volume, can be more) and pitch (0-255, 63 is 100%) (DEPRECATED, use vector-parametered version instead)",
 				},
-        SenThunderbolt =
+        SendThunderbolt =
         {
           Params =
           {

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -1542,6 +1542,33 @@ end
 					},
 					Notes = "Kicks the user with the specified reason",
 				},
+        SendBlockBreakAnim =
+        {
+          Params =
+          {
+            {
+              Name = "EntityID",
+              Type = "number",
+            },
+            {
+              Name = "BlockX",
+              Type = "number",
+            },
+            {
+              Name = "BlockY",
+              Type = "number",
+            },
+            {
+              Name = "BlockZ",
+              Type = "number",
+            },
+            {
+              Name = "Stage",
+              Type = "number",
+            },
+          },
+          Notes = "Sends a BlockBreakAnim packet to the client. Only one block can be broken at a time with the same UUID (the other will be reset). You can counter this using random values. The breaking stage ranges between 0 (first stage) and 9 (almost destroyed). Use -1 to reset the destruction.",
+        },
 				SendBlockChange =
 				{
 					Params =
@@ -1691,6 +1718,62 @@ end
 					},
 					Notes = "Updates the health displayed by the boss bar with the given ID.",
 				},
+        SendCollectEntity =
+        {
+          Params =
+          {
+            {
+              Name = "Entity",
+              Type = "cEntity",
+            },
+            {
+              Name = "Collector",
+              Type = "cEntity",
+            },
+          },
+          Notes = "Sends the CollectEntity packet to the client. This fakes item collecting.",
+        },
+        SendDestroyEntity =
+        {
+          Params =
+          {
+            {
+              Name = "Entity",
+              Type = "cEntity",
+            },
+          },
+          Notes = "Sends the DestroyEntity packet to the client. This tells the client to remove the entity from the world.",
+        },
+        SendDetachEntity =
+        {
+          Params =
+          {
+            {
+              Name = "Entity",
+              Type = "cEntity",
+            },
+          },
+          Notes = "Sends the DetachEntity packet to the client. This drop entities riding another one (boat, minecarts, pigs, horses...).",
+        },
+        SendEditSign =
+        {
+          Params =
+          {
+            {
+              Name = "BlockX",
+              Type = "number",
+            },
+            {
+              Name = "BlockY",
+              Type = "number",
+            },
+            {
+              Name = "BlockZ",
+              Type = "number",
+            },
+          },
+          Notes = "Sends the EditSign packet to the client. This opens the sign editor GUI.",
+        },
 				SendEntityAnimation =
 				{
 					Params =
@@ -1725,6 +1808,21 @@ end
 				{
 					Notes = "Hides the title. This makes the title and subtitle disappear, but if you call SendTitleTimes() the same title and subtitle will appear again."
 				},
+        SendLeashEntity =
+        {
+          Params =
+          {
+            {
+              Name = "Entity",
+              Type = "cEntity",
+            },
+            {
+              Name = "EntityLeashedTo",
+              Type = "cEntity",
+            },
+          },
+          Notes = "Sends the LeashEntity packet to the client. Leashes entities together. Leashing to the player, the leash will appear on the player's hand",
+        },
 				SendPluginMessage =
 				{
 					Params =
@@ -1744,6 +1842,17 @@ end
 				{
 					Notes = "Resets and hides the title but not the subtitle."
 				},
+        SendResourcePack =
+        {
+          Params =
+          {
+            {
+              Name = "ResourcePackURL",
+              Type = "string",
+            },
+          },
+          Notes = "Sends the ResourcePack packet to the client. The client will request the resource pack from the given URL. If the url is blank, the resource pack will be reset.",
+        },
 				SendSetSubTitle =
 				{
 					Params =
@@ -1842,6 +1951,25 @@ end
 					},
 					Notes = "Sends a sound effect request to the client. The sound is played at the specified coords, with the specified volume (a float, 1.0 is full volume, can be more) and pitch (0-255, 63 is 100%) (DEPRECATED, use vector-parametered version instead)",
 				},
+        SenThunderbolt =
+        {
+          Params =
+          {
+            {
+              Name = "BlockX",
+              Type = "number",
+            },
+            {
+              Name = "BlockY",
+              Type = "number",
+            },
+            {
+              Name = "BlockZ",
+              Type = "number",
+            },
+          },
+          Notes = "Sends the thunderbolt at the specified coords to the client. The client will display the effect without any sound.",
+        },
 				SendTitleTimes =
 				{
 					Params =
@@ -1880,6 +2008,17 @@ end
 					},
 					Notes = "Sends the specified time update to the client. WorldAge is the total age of the world, in ticks. WorldDate is the current date, in ticks, and is used by the client to calculate the days elapsed (F3 debug overlay's day count) and the time of day (rendered sun position). DoDaylightCycle is a bool that specifies whether the client should automatically move the sun (true) or keep it in the same place (false).",
 				},
+        SendUnleashEntity =
+        {
+          Params =
+          {
+            {
+              Name = "EntityID",
+              Type = "number",
+            },
+          },
+          Notes = "Sends the UnleashEntity packet to the client. The client will remove any leashes related to the entity.",
+        },
 				SetClientBrand =
 				{
 					Params =

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -185,7 +185,7 @@ public:  // tolua_export
 	void SendEntityProperties           (const cEntity & a_Entity);
 	void SendEntityVelocity             (const cEntity & a_Entity);
 	void SendExperience                 (void);
-	void SendExperienceOrb              (const cExpOrb & a_ExpOrb);  // tolua_export
+	void SendExperienceOrb              (const cExpOrb & a_ExpOrb);
 	void SendExplosion                  (Vector3f a_Position, float a_Power);
 	void SendGameMode                   (eGameMode a_GameMode);
 	void SendHealth                     (void);

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -151,7 +151,7 @@ public:  // tolua_export
 	// (Please keep these alpha-sorted)
 	void SendAttachEntity               (const cEntity & a_Entity, const cEntity & a_Vehicle);
 	void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType);
-	void SendBlockBreakAnim             (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage);
+	void SendBlockBreakAnim             (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage);  // tolua_export
 	void SendBlockChange                (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);  // tolua_export
 	void SendBlockChanges               (int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes);
 	void SendBossBarAdd                 (UInt32 a_UniqueID, const cCompositeChat & a_Title, float a_FractionFilled, BossBarColor a_Color, BossBarDivisionType a_DivisionType, bool a_DarkenSky, bool a_PlayEndMusic, bool a_CreateFog);  // tolua_export
@@ -169,12 +169,12 @@ public:  // tolua_export
 	void SendChatSystem                 (const AString & a_Message, eMessageType a_ChatPrefix, const AString & a_AdditionalData = "");
 	void SendChatSystem                 (const cCompositeChat & a_Message);
 	void SendChunkData                  (int a_ChunkX, int a_ChunkZ, ContiguousByteBufferView a_ChunkData);
-	void SendCollectEntity              (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count);
-	void SendDestroyEntity              (const cEntity & a_Entity);
-	void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);
+	void SendCollectEntity              (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count);   // tolua_export
+	void SendDestroyEntity              (const cEntity & a_Entity);   // tolua_export
+	void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);   // tolua_export
 	void SendDisconnect                 (const AString & a_Reason);
 	void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display);
-	void SendEditSign                   (int a_BlockX, int a_BlockY, int a_BlockZ);
+	void SendEditSign                   (int a_BlockX, int a_BlockY, int a_BlockZ);  // tolua_export
 	void SendEntityAnimation            (const cEntity & a_Entity, EntityAnimation a_Animation);  // tolua_export
 	void SendEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, int a_Duration);
 	void SendEntityEquipment            (const cEntity & a_Entity, short a_SlotNum, const cItem & a_Item);
@@ -185,21 +185,21 @@ public:  // tolua_export
 	void SendEntityProperties           (const cEntity & a_Entity);
 	void SendEntityVelocity             (const cEntity & a_Entity);
 	void SendExperience                 (void);
-	void SendExperienceOrb              (const cExpOrb & a_ExpOrb);
+	void SendExperienceOrb              (const cExpOrb & a_ExpOrb);  // tolua_export
 	void SendExplosion                  (Vector3f a_Position, float a_Power);
 	void SendGameMode                   (eGameMode a_GameMode);
 	void SendHealth                     (void);
 	void SendHeldItemChange             (int a_ItemIndex);
 	void SendHideTitle                  (void);   // tolua_export
 	void SendInventorySlot              (char a_WindowID, short a_SlotNum, const cItem & a_Item);
-	void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo);
+	void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo);  // tolua_export
 	void SendMapData                    (const cMap & a_Map, int a_DataStartX, int a_DataStartY);
 	void SendPaintingSpawn              (const cPainting & a_Painting);
 	void SendParticleEffect             (const AString & a_ParticleName, float a_SrcX, float a_SrcY, float a_SrcZ, float a_OffsetX, float a_OffsetY, float a_OffsetZ, float a_ParticleData, int a_ParticleAmount);
 	void SendParticleEffect             (const AString & a_ParticleName, const Vector3f a_Src, const Vector3f a_Offset, float a_ParticleData, int a_ParticleAmount, std::array<int, 2> a_Data);
 	void SendPlayerAbilities            (void);
 	void SendPlayerListAddPlayer        (const cPlayer & a_Player);
-	void SendPlayerListHeaderFooter     (const cCompositeChat & a_Header, const cCompositeChat & a_Footer);   // tolua_export
+	void SendPlayerListHeaderFooter     (const cCompositeChat & a_Header, const cCompositeChat & a_Footer);  // tolua_export
 	void SendPlayerListRemovePlayer     (const cPlayer & a_Player);
 	void SendPlayerListUpdateDisplayName(const cPlayer & a_Player, const AString & a_CustomName);
 	void SendPlayerListUpdateGameMode   (const cPlayer & a_Player);
@@ -210,7 +210,7 @@ public:  // tolua_export
 	void SendPluginMessage              (const AString & a_Channel, std::string_view a_Message);  // Exported in ManualBindings.cpp
 	void SendPluginMessage              (const AString & a_Channel, ContiguousByteBufferView a_Message);
 	void SendRemoveEntityEffect         (const cEntity & a_Entity, int a_EffectID);
-	void SendResourcePack               (const AString & a_ResourcePackUrl);
+	void SendResourcePack               (const AString & a_ResourcePackUrl);  // tolua_export
 	void SendResetTitle                 (void);  // tolua_export
 	void SendRespawn                    (eDimension a_Dimension, bool a_IsRespawningFromDeath);
 	void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode);
@@ -226,10 +226,10 @@ public:  // tolua_export
 	void SendSpawnMob                   (const cMonster & a_Mob);
 	void SendStatistics                 (const StatisticsManager & a_Manager);
 	void SendTabCompletionResults       (const AStringVector & a_Results);
-	void SendThunderbolt                (int a_BlockX, int a_BlockY, int a_BlockZ);
+	void SendThunderbolt                (int a_BlockX, int a_BlockY, int a_BlockZ);  // tolua_export
 	void SendTitleTimes                 (int a_FadeInTicks, int a_DisplayTicks, int a_FadeOutTicks);  // tolua_export
 	void SendTimeUpdate                 (cTickTimeLong a_WorldAge, cTickTimeLong a_WorldDate, bool a_DoDaylightCycle);
-	void SendUnleashEntity              (const cEntity & a_Entity);
+	void SendUnleashEntity              (const cEntity & a_Entity);  // tolua_export
 	void SendUnloadChunk                (int a_ChunkX, int a_ChunkZ);
 	void SendUpdateBlockEntity          (cBlockEntity & a_BlockEntity);
 	void SendUpdateSign                 (int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4);


### PR DESCRIPTION
A demo plugin to test these is available [here](https://gist.github.com/AirOne01/3334c2d358f7cb0f460bcdbb1d7cd405)
* Bound the following functions to lua
  + SendBlockBreakAnim
  + SendCollectEntity
  + SendDestroyEntity
  + SendDetachEntity
  + SendEditSign
  + SendExperienceOrb
  + SendLeashEntity
  + SendThunderbolt
  + SendUnleashEntity