### PR TITLE
Mitigate against CVE-2021-44228

### DIFF
--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -366,7 +366,7 @@ void cProtocol_1_8_0::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type
 	ASSERT(m_State == 3);  // In game mode?
 
 	// Prevent chat messages that might trigger CVE-2021-44228
-	if (a_MessageRaw.find("${jndi") != std::string::npos)
+	if (a_MessageRaw.find("${") != std::string::npos)
 	{
 		return;
 	}

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -365,6 +365,12 @@ void cProtocol_1_8_0::SendChatRaw(const AString & a_MessageRaw, eChatType a_Type
 {
 	ASSERT(m_State == 3);  // In game mode?
 
+	// Prevent chat messages that might trigger CVE-2021-44228
+	if (a_MessageRaw.find("${jndi") != std::string::npos)
+	{
+		return;
+	}
+
 	// Send the json string to the client:
 	cPacketizer Pkt(*this, pktChatRaw);
 	Pkt.WriteString(a_MessageRaw);


### PR DESCRIPTION
Cuberite is not directly affected, but could relay attack payloads to users. This adds some sanitisation to chat messages (which are logged insecurely in Vanilla).