### PR TITLE
Slow down arrows in water

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -61,6 +61,7 @@ nesco
 NiLSPACE (formerly STR_Warrior)
 npresley0506
 p-mcgowan
+Persson-dev
 pokechu22
 ProjectBM
 pwnOrbitals

--- a/src/Entities/ArrowEntity.cpp
+++ b/src/Entities/ArrowEntity.cpp
@@ -194,6 +194,10 @@ void cArrowEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			m_IsInGround = false;  // Yes, begin simulating physics again
 		}
 	}
+	else if (IsInWater())  // Arrow in water?
+	{
+		ApplyFriction(m_Speed, ARROW_WATER_FRICTION, static_cast<float>(a_Dt.count()));  // Yes, slow down arrow
+	}
 }
 
 

--- a/src/Entities/ArrowEntity.h
+++ b/src/Entities/ArrowEntity.h
@@ -39,6 +39,8 @@ public:
 
 	// tolua_end
 
+	static constexpr float ARROW_WATER_FRICTION = 50.0f;    ///< Value used to calculate arrow speed in water
+
 	CLASS_PROTODEF(cArrowEntity)
 
 	/** Creates a new arrow with psNoPickup state and default damage modifier coeff */


### PR DESCRIPTION
Arrow now slow down in water. Fixes #5036. The value of ARROW_WATER_FRICTION might not be the same as vanilla but it looks good anyway.