### PR TITLE
Transparent blocks don't conduct restone power

### DIFF
--- a/src/Simulator/IncrementalRedstoneSimulator/ForEachSourceCallback.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/ForEachSourceCallback.cpp
@@ -90,6 +90,11 @@ void ForEachSourceCallback::CheckIndirectPower()
 
 bool ForEachSourceCallback::ShouldQueryLinkedPosition(const BLOCKTYPE Block)
 {
+	// transparent blocks should not conduct restone power
+	if (cBlockInfo::IsTransparent(Block))
+	{
+		return false;
+	}
 	switch (Block)
 	{
 		// Normally we don't ask solid blocks for power because they don't have any (stone, dirt, etc.)

--- a/src/Simulator/IncrementalRedstoneSimulator/ForEachSourceCallback.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/ForEachSourceCallback.cpp
@@ -40,7 +40,7 @@ void ForEachSourceCallback::operator()(Vector3i Location)
 	const auto PotentialSourceBlock = NeighbourChunk->GetBlock(Location);
 	const auto NeighbourRelativeQueryPosition = cIncrementalRedstoneSimulatorChunkData::RebaseRelativePosition(m_Chunk, *NeighbourChunk, m_Position);
 
-	if (ShouldQueryLinkedPosition(PotentialSourceBlock))
+	if (!cBlockInfo::IsTransparent(PotentialSourceBlock))
 	{
 		Power = std::max(Power, QueryLinkedPower(*NeighbourChunk, NeighbourRelativeQueryPosition, m_CurrentBlock, Location));
 	}
@@ -82,37 +82,6 @@ void ForEachSourceCallback::CheckIndirectPower()
 
 	// Get the results:
 	Power = std::max(Power, QuasiQueryCallback.Power);
-}
-
-
-
-
-
-bool ForEachSourceCallback::ShouldQueryLinkedPosition(const BLOCKTYPE Block)
-{
-	// transparent blocks should not conduct restone power
-	if (cBlockInfo::IsTransparent(Block))
-	{
-		return false;
-	}
-	switch (Block)
-	{
-		// Normally we don't ask solid blocks for power because they don't have any (stone, dirt, etc.)
-		// However, these are mechanisms that are IsSolid, but still give power. Don't ignore them:
-		case E_BLOCK_BLOCK_OF_REDSTONE:
-		case E_BLOCK_DAYLIGHT_SENSOR:
-		case E_BLOCK_INVERTED_DAYLIGHT_SENSOR:
-		case E_BLOCK_OBSERVER:
-		case E_BLOCK_TRAPPED_CHEST: return false;
-
-		// Pistons are solid but don't participate in link powering:
-		case E_BLOCK_PISTON:
-		case E_BLOCK_PISTON_EXTENSION:
-		case E_BLOCK_STICKY_PISTON: return false;
-
-		// If a mechanism asks for power from a block, redirect the query to linked positions if:
-		default: return cBlockInfo::IsSolid(Block);
-	}
 }
 
 

--- a/src/Simulator/IncrementalRedstoneSimulator/ForEachSourceCallback.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/ForEachSourceCallback.h
@@ -24,9 +24,6 @@ public:
 
 private:
 
-	/** Returns whether a potential source position that's occupied by Block should be treated as linked. */
-	static bool ShouldQueryLinkedPosition(BLOCKTYPE Block);
-
 	/** Asks redstone handlers adjacent to a solid block how much power they will deliver to the querying position, via the solid block.
 	Both QueryPosition and SolidBlockPosition are relative to Chunk. */
 	static PowerLevel QueryLinkedPower(const cChunk & Chunk, Vector3i QueryPosition, BLOCKTYPE QueryBlock, Vector3i SolidBlockPosition);


### PR DESCRIPTION
Fixed a bug where restone components could be powered through transparent blocks, as shown in #5336 