### PR TITLE
Fixing anvil crash issue

### DIFF
--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -638,6 +638,7 @@ bool cProtocol_1_13::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketTyp
 		case 0x19: HandlePacketEntityAction(a_ByteBuffer); return true;
 		case 0x1a: HandlePacketSteerVehicle(a_ByteBuffer); return true;
 		case 0x1b: HandlePacketCraftingBookData(a_ByteBuffer); return true;
+		case 0x1c: HandlePacketNameItem(a_ByteBuffer); return true;
 		case 0x1d: break;  // Resource pack status - not yet implemented
 		case 0x1e: HandlePacketAdvancementTab(a_ByteBuffer); return true;
 		case 0x20: HandlePacketSetBeaconEffect(a_ByteBuffer); return true;
@@ -651,6 +652,17 @@ bool cProtocol_1_13::HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketTyp
 	}
 
 	return Super::HandlePacket(a_ByteBuffer, a_PacketType);
+}
+
+
+
+
+
+void cProtocol_1_13::HandlePacketNameItem(cByteBuffer & a_ByteBuffer)
+{
+	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, NewItemName);
+
+	LOGD("New item name : %s", NewItemName);
 }
 
 

--- a/src/Protocol/Protocol_1_13.h
+++ b/src/Protocol/Protocol_1_13.h
@@ -57,6 +57,7 @@ protected:
 	virtual Version GetProtocolVersion() const override;
 
 	virtual bool HandlePacket(cByteBuffer & a_ByteBuffer, UInt32 a_PacketType) override;
+	virtual void HandlePacketNameItem(cByteBuffer & a_ByteBuffer);
 	virtual void HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer) override;
 	virtual void HandlePacketSetBeaconEffect(cByteBuffer & a_ByteBuffer);
 	virtual void HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, std::string_view a_Channel) override;


### PR DESCRIPTION
Prevents the server from crashing when an item is put in an anvil with 1.13.2 version (#5354). Should i fully implement it or leave it like it is ?