### PR TITLE
Fixed diagonal redstone powering

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@ feyokorenhof
 Gareth Nelson
 GefaketHD
 HaoTNN
+havel06 (Michal Havlíček)
 Howaner
 ion232 (Arran Ireland)
 jan64

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -306,31 +306,29 @@ namespace RedstoneWireHandler
 					return;
 				}
 
-				if (Front == FrontState::Up)
-				{
-					Callback(Relative + OffsetYP);
-				}
-
 				BLOCKTYPE LateralBlock;
 				a_Chunk.UnboundedRelGetBlockType(Relative, LateralBlock);
 
-				// Don't check YM side diagonal when blocked by a non-transparent block
-				if (!cBlockInfo::IsTransparent(LateralBlock))
+				if (!cBlockInfo::IsTransparent(LateralBlock))  // Only check YP diagonal when on an opaque block
 				{
-					return;
+					if (Front == FrontState::Up)
+					{
+						Callback(Relative + OffsetYP);
+					}
 				}
-
-				// Have to do a manual check to only accept power from YM diagonal if there's a wire there
-
-				const auto YMDiagonalPosition = Relative + OffsetYM;
-				if (
-					BLOCKTYPE QueryBlock;
-					cChunkDef::IsValidHeight(YMDiagonalPosition.y) &&
-					a_Chunk.UnboundedRelGetBlockType(YMDiagonalPosition, QueryBlock) &&
-					(QueryBlock == E_BLOCK_REDSTONE_WIRE)
-				)
+				else
 				{
-					Callback(YMDiagonalPosition);
+					// Have to do a manual check to only accept power from YM diagonal if there's a wire there
+					const auto YMDiagonalPosition = Relative + OffsetYM;
+					if (
+						BLOCKTYPE QueryBlock;
+						cChunkDef::IsValidHeight(YMDiagonalPosition.y) &&
+						a_Chunk.UnboundedRelGetBlockType(YMDiagonalPosition, QueryBlock) &&
+						(QueryBlock == E_BLOCK_REDSTONE_WIRE)
+					)
+					{
+						Callback(YMDiagonalPosition);
+					}
 				}
 			});
 		}

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -146,7 +146,7 @@ namespace RedstoneWireHandler
 				(NeighbourChunk->GetBlock(Adjacent + OffsetYP) == E_BLOCK_REDSTONE_WIRE)  // Only terrace YP with another wire
 			)
 			{
-				SetDirectionState(Offset, Block, TemporaryDirection::Up);
+				SetDirectionState(Offset, Block, cBlockInfo::IsTransparent(LateralBlock) ? TemporaryDirection::Side : TemporaryDirection::Up);
 
 				if (NeighbourChunk != &Chunk)
 				{

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -301,25 +301,36 @@ namespace RedstoneWireHandler
 			{
 				using FrontState = std::remove_reference_t<decltype(Front)>;
 
+				if (Front == FrontState::None)
+				{
+					return;
+				}
+
 				if (Front == FrontState::Up)
 				{
 					Callback(Relative + OffsetYP);
 				}
-				else if (Front == FrontState::Side)
-				{
-					// Alas, no way to distinguish side lateral and side diagonal
-					// Have to do a manual check to only accept power from YM diagonal if there's a wire there
 
-					const auto YMDiagonalPosition = Relative + OffsetYM;
-					if (
-						BLOCKTYPE QueryBlock;
-						cChunkDef::IsValidHeight(YMDiagonalPosition.y) &&
-						a_Chunk.UnboundedRelGetBlockType(YMDiagonalPosition, QueryBlock) &&
-						(QueryBlock == E_BLOCK_REDSTONE_WIRE)
-					)
-					{
-						Callback(YMDiagonalPosition);
-					}
+				BLOCKTYPE LateralBlock;
+				a_Chunk.UnboundedRelGetBlockType(Relative, LateralBlock);
+
+				// Don't check YM side diagonal when blocked by a non-transparent block
+				if (!cBlockInfo::IsTransparent(LateralBlock))
+				{
+					return;
+				}
+
+				// Have to do a manual check to only accept power from YM diagonal if there's a wire there
+
+				const auto YMDiagonalPosition = Relative + OffsetYM;
+				if (
+					BLOCKTYPE QueryBlock;
+					cChunkDef::IsValidHeight(YMDiagonalPosition.y) &&
+					a_Chunk.UnboundedRelGetBlockType(YMDiagonalPosition, QueryBlock) &&
+					(QueryBlock == E_BLOCK_REDSTONE_WIRE)
+				)
+				{
+					Callback(YMDiagonalPosition);
 				}
 			});
 		}

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -301,24 +301,15 @@ namespace RedstoneWireHandler
 			{
 				using FrontState = std::remove_reference_t<decltype(Front)>;
 
-				if (Front == FrontState::None)
+				if (Front == FrontState::Up)
 				{
-					return;
+					Callback(Relative + OffsetYP);
 				}
-
-				BLOCKTYPE LateralBlock;
-				a_Chunk.UnboundedRelGetBlockType(Relative, LateralBlock);
-
-				if (!cBlockInfo::IsTransparent(LateralBlock))  // Only check YP diagonal when on an opaque block
+				else if (Front == FrontState::Side)
 				{
-					if (Front == FrontState::Up)
-					{
-						Callback(Relative + OffsetYP);
-					}
-				}
-				else
-				{
+					// Alas, no way to distinguish side lateral and side diagonal
 					// Have to do a manual check to only accept power from YM diagonal if there's a wire there
+
 					const auto YMDiagonalPosition = Relative + OffsetYM;
 					if (
 						BLOCKTYPE QueryBlock;


### PR DESCRIPTION
Redstone wire accepts power from lower diagonal through transparent blocks. Fixes #5335. Fixes #2219.