### PR TITLE
Fix compilation with Clang 13.0.0

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -158,7 +158,7 @@ function(set_exe_flags TARGET)
 			# TODO: actually fix the warnings instead of disabling them
 			# or at least disable on a file-level basis:
 			-Wno-missing-noreturn -Wno-padded -Wno-implicit-fallthrough
-			-Wno-double-promotion -Wno-reserved-identifier
+			-Wno-double-promotion
 
 			# This is a pretty useless warning, we've already got -Wswitch which is what we need:
 			-Wno-switch-enum
@@ -184,6 +184,15 @@ function(set_exe_flags TARGET)
 
 				# int to float conversions happen a lot, not worth fixing all warnings:
 				-Wno-implicit-int-float-conversion
+			)
+		endif()
+
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+			target_compile_options(
+				${TARGET} PRIVATE
+
+				# TODO: fix
+				-Wno-reserved-identifier
 			)
 		endif()
 	endif()

--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -158,7 +158,7 @@ function(set_exe_flags TARGET)
 			# TODO: actually fix the warnings instead of disabling them
 			# or at least disable on a file-level basis:
 			-Wno-missing-noreturn -Wno-padded -Wno-implicit-fallthrough
-			-Wno-double-promotion
+			-Wno-double-promotion -Wno-reserved-identifier
 
 			# This is a pretty useless warning, we've already got -Wswitch which is what we need:
 			-Wno-switch-enum
@@ -169,7 +169,7 @@ function(set_exe_flags TARGET)
 			-Wno-documentation-unknown-command -Wno-reserved-id-macro -Wno-error=unused-command-line-argument
 		)
 
-		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7)
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
 			target_compile_options(
 				${TARGET} PRIVATE
 

--- a/src/ByteBuffer.cpp
+++ b/src/ByteBuffer.cpp
@@ -117,8 +117,8 @@ bool cByteBuffer::Write(const void * a_Bytes, size_t a_Count)
 	size_t CurFreeSpace = GetFreeSpace();
 	#ifndef NDEBUG
 		size_t CurReadableSpace = GetReadableSpace();
+		size_t WrittenBytes = 0;
 	#endif
-	size_t WrittenBytes = 0;
 
 	if (CurFreeSpace < a_Count)
 	{
@@ -135,7 +135,9 @@ bool cByteBuffer::Write(const void * a_Bytes, size_t a_Count)
 			memcpy(m_Buffer + m_WritePos, Bytes, TillEnd);
 			Bytes += TillEnd;
 			a_Count -= TillEnd;
-			WrittenBytes = TillEnd;
+			#ifndef NDEBUG
+				WrittenBytes = TillEnd;
+			#endif
 		}
 		m_WritePos = 0;
 	}
@@ -145,7 +147,9 @@ bool cByteBuffer::Write(const void * a_Bytes, size_t a_Count)
 	{
 		memcpy(m_Buffer + m_WritePos, Bytes, a_Count);
 		m_WritePos += a_Count;
-		WrittenBytes += a_Count;
+		#ifndef NDEBUG
+			WrittenBytes += a_Count;
+		#endif
 	}
 
 	ASSERT(GetFreeSpace() == CurFreeSpace - WrittenBytes);

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -324,7 +324,6 @@ void cPawn::HandleFalling(void)
 
 	/* We initialize these with what the foot is really IN, because for sampling we will move down with the epsilon above */
 	bool IsFootInWater = IsBlockWater(BlockAtFoot);
-	bool IsFootInLiquid = IsFootInWater || IsBlockLava(BlockAtFoot) || (BlockAtFoot == E_BLOCK_COBWEB);  // okay so cobweb is not _technically_ a liquid...
 	bool IsFootOnSlimeBlock = false;
 
 	/* The "cross" we sample around to account for the player width/girth */
@@ -377,7 +376,6 @@ void cPawn::HandleFalling(void)
 			if (j == 0)
 			{
 				IsFootInWater |= IsBlockWater(BlockType);
-				IsFootInLiquid |= IsFootInWater || IsBlockLava(BlockType) || (BlockType == E_BLOCK_COBWEB);  // okay so cobweb is not _technically_ a liquid...
 				IsFootOnSlimeBlock |= (BlockType == E_BLOCK_SLIME_BLOCK);
 			}
 


### PR DESCRIPTION
Clang 13 changes:
* `-Wreserved-identifier` and `-Wunused-but-set-variable` got added
* the `-Wreturn-std-move-in-c++11` option was removed

Builds still fail when native optimizations are enabled