### PR TITLE
Spectator fixes

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1499,8 +1499,8 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 		const auto & ItemHandler = HeldItem.GetHandler();
 		const auto & BlockHandler = cBlockHandler::For(BlockType);
 		const bool BlockUsable = BlockHandler.IsUseable() && (m_Player->IsGameModeSpectator() ? cBlockInfo::IsUseableBySpectator(BlockType) : !(m_Player->IsCrouched() && !HeldItem.IsEmpty()));
-		const bool Placeable = ItemHandler.IsPlaceable() && !m_Player->IsGameModeAdventure() && !m_Player->IsGameModeSpectator();
-		const bool Useable = !m_Player->IsGameModeSpectator();
+		const bool ItemPlaceable = ItemHandler.IsPlaceable() && !m_Player->IsGameModeAdventure() && !m_Player->IsGameModeSpectator();
+		const bool ItemUseable = !m_Player->IsGameModeSpectator();
 
 		if (BlockUsable)
 		{
@@ -1514,8 +1514,8 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 					return;  // Block use was successful, we're done.
 				}
 
-				// Check if the item is place able, for example a torch on a fence:
-				if (Placeable)
+				// If block use failed, fall back to placement:
+				if (ItemPlaceable)
 				{
 					// Place a block:
 					ItemHandler.OnPlayerPlace(*m_Player, HeldItem, ClickedPosition, BlockType, BlockMeta, a_BlockFace, CursorPosition);
@@ -1524,7 +1524,7 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 				return;
 			}
 		}
-		else if (Placeable)
+		else if (ItemPlaceable)
 		{
 			// TODO: Double check that we don't need this for using item and for packet out of range
 			m_NumBlockChangeInteractionsThisTick++;
@@ -1538,7 +1538,7 @@ void cClientHandle::HandleRightClick(int a_BlockX, int a_BlockY, int a_BlockZ, e
 			ItemHandler.OnPlayerPlace(*m_Player, HeldItem, ClickedPosition, BlockType, BlockMeta, a_BlockFace, CursorPosition);
 			return;
 		}
-		else if (Useable)
+		else if (ItemUseable)
 		{
 			if (!PlgMgr->CallHookPlayerUsingItem(*m_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, a_CursorX, a_CursorY, a_CursorZ))
 			{

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -135,10 +135,16 @@ public:
 	Adds the entity to the world. */
 	bool Initialize(OwnedEntity a_Self, cWorld & a_EntityWorld);
 
+	/** Called when a player begins spectating this entity. */
+	void OnAcquireSpectator(cPlayer & a_Player);
+
 	/** Called when the entity is added to a world.
 	e.g after first spawning or after successfuly moving between worlds.
 	\param a_World The world being added to. */
 	virtual void OnAddToWorld(cWorld & a_World);
+
+	/** Called when a player stops spectating this entity. */
+	void OnLoseSpectator(cPlayer & a_Player);
 
 	/** Called when the entity is removed from a world.
 	e.g. When the entity is destroyed or moved to a different world.
@@ -723,4 +729,7 @@ private:
 
 	/** List of leashed mobs to this entity */
 	cMonsterList m_LeashedMobs;
+
+	/** List of players who are spectating this entity. */
+	std::vector<cPlayer *> m_Spectators;
 } ;  // tolua_export

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -93,6 +93,9 @@ public:
 	cPlayer(const std::shared_ptr<cClientHandle> & a_Client);
 	virtual ~cPlayer() override;
 
+	/** Called when spectation stops, because the player crouched or when the entity we're spectating gets removed from the world. */
+	void OnLoseSpectated();
+
 	// tolua_begin
 
 	/** Sets the experience total
@@ -184,7 +187,7 @@ public:
 	void SendRotation(double a_YawDegrees, double a_PitchDegrees);
 
 	/** Spectates the target entity. If a_Target is nullptr or a pointer to self, end spectation. */
-	void SpectateEntity(const cEntity * a_Target);
+	void SpectateEntity(cEntity * a_Target);
 
 	/** Returns the position where projectiles thrown by this player should start, player eye position + adjustment */
 	Vector3d GetThrowStartPos(void) const;
@@ -731,7 +734,7 @@ private:
 	cTeam * m_Team;
 
 	/** The entity that this player is spectating, nullptr if none. */
-	const cEntity * m_Spectating;
+	cEntity * m_Spectating;
 
 	StatisticsManager m_Stats;
 


### PR DESCRIPTION
+ Keep a list of spectators so that pointer clean-up can happen when the spectated is killed.
* Fix invalid game state when riding/spectating and then entering or leaving spectator mode.
* Prevent spectators from using items.