### PR TITLE
Double tall grass drops seeds when broken in creative mode fix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -66,6 +66,7 @@ Persson-dev
 pokechu22
 ProjectBM
 pwnOrbitals
+Rodarg
 Rorkh
 rs2k
 SamJBarney
@@ -92,4 +93,3 @@ worktycho
 Xenoxis
 xoft (Mattes Dolak/madmaxoft on GH)
 Yeeeeezus (Donated AlchemistVillage prefabs)
-Rodarg

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -92,3 +92,4 @@ worktycho
 Xenoxis
 xoft (Mattes Dolak/madmaxoft on GH)
 Yeeeeezus (Donated AlchemistVillage prefabs)
+Rodarg

--- a/src/Blocks/BlockBigFlower.h
+++ b/src/Blocks/BlockBigFlower.h
@@ -125,9 +125,12 @@ private:
 			auto lowerPartPos = a_BlockPos - Vector3i(0, 1, 0);
 			if (a_ChunkInterface.GetBlock(lowerPartPos) == a_OldBlockType)
 			{
-				if (a_Digger->IsPlayer() && (static_cast<const cPlayer *>(a_Digger))->IsGameModeCreative()) {
+				if (a_Digger->IsPlayer() && (static_cast<const cPlayer *>(a_Digger))->IsGameModeCreative())
+				{
 					a_ChunkInterface.SetBlock(lowerPartPos, E_BLOCK_AIR, 0);
-				} else {
+				}
+				else
+				{
 					a_ChunkInterface.DropBlockAsPickups(lowerPartPos);
 				}
 			}

--- a/src/Blocks/BlockBigFlower.h
+++ b/src/Blocks/BlockBigFlower.h
@@ -49,10 +49,6 @@ private:
 
 	virtual cItems ConvertToPickups(const NIBBLETYPE a_BlockMeta, const cItem * const a_Tool) const override
 	{
-		if (IsMetaTopPart(a_BlockMeta))
-		{
-			return {};  // No drops from the top part
-		}
 
 		// With shears, drop self (even tall grass and fern):
 		if ((a_Tool != nullptr) && (a_Tool->m_ItemType == E_ITEM_SHEARS))
@@ -125,7 +121,7 @@ private:
 			auto lowerPartPos = a_BlockPos - Vector3i(0, 1, 0);
 			if (a_ChunkInterface.GetBlock(lowerPartPos) == a_OldBlockType)
 			{
-				a_ChunkInterface.DropBlockAsPickups(lowerPartPos);
+				a_ChunkInterface.SetBlock(lowerPartPos, E_BLOCK_AIR, 0);
 			}
 		}
 		else
@@ -134,7 +130,7 @@ private:
 			auto upperPartPos = a_BlockPos + Vector3i(0, 1, 0);
 			if (a_ChunkInterface.GetBlock(upperPartPos) == a_OldBlockType)
 			{
-				a_ChunkInterface.DropBlockAsPickups(upperPartPos);
+				a_ChunkInterface.SetBlock(upperPartPos, E_BLOCK_AIR, 0);
 			}
 		}
 	}

--- a/src/Blocks/BlockBigFlower.h
+++ b/src/Blocks/BlockBigFlower.h
@@ -49,6 +49,10 @@ private:
 
 	virtual cItems ConvertToPickups(const NIBBLETYPE a_BlockMeta, const cItem * const a_Tool) const override
 	{
+		if (IsMetaTopPart(a_BlockMeta))
+		{
+			return {};
+		}
 
 		// With shears, drop self (even tall grass and fern):
 		if ((a_Tool != nullptr) && (a_Tool->m_ItemType == E_ITEM_SHEARS))
@@ -121,7 +125,11 @@ private:
 			auto lowerPartPos = a_BlockPos - Vector3i(0, 1, 0);
 			if (a_ChunkInterface.GetBlock(lowerPartPos) == a_OldBlockType)
 			{
-				a_ChunkInterface.SetBlock(lowerPartPos, E_BLOCK_AIR, 0);
+				if (a_Digger->IsPlayer() && (static_cast<const cPlayer *>(a_Digger))->IsGameModeCreative()) {
+					a_ChunkInterface.SetBlock(lowerPartPos, E_BLOCK_AIR, 0);
+				} else {
+					a_ChunkInterface.DropBlockAsPickups(lowerPartPos);
+				}
 			}
 		}
 		else


### PR DESCRIPTION
Issue: #5333 

Removed if statement checking if the top part of the block was broken this would prevent seed dropping if the top was broken, this is why the dropBlockAsPickups was added but that isn't very consistent with other models. So I replaced the dropBlockAsPickups to SetBlock(Air) and now no seeds drop in creative and in survival seeds drop for both the top part of the grass and bottom part. 

Ive been testing it and i think the problem has been resolved