### PR TITLE
Implement farmland trampling

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ birkett (Anthony Birkett)
 Bond_009
 changyongGuo
 Cocosushi6
+DarkoGNU
 derouinw
 dImrich (Damian Imrich)
 Diusrex

--- a/Server/Plugins/APIDump/Classes/World.lua
+++ b/Server/Plugins/APIDump/Classes/World.lua
@@ -2245,6 +2245,16 @@ function OnAllChunksAvailable()</pre> All return values from the callbacks are i
 				},
 				Notes = "Returns whether the configuration has DeepSnow enabled.",
 			},
+			IsFarmlandTramplingEnabled =
+			{
+				Returns =
+				{
+					{
+						Type = "boolean",
+					},
+				},
+				Notes = "Returns true if farmland trampling is enabled.",
+			},
 			IsGameModeAdventure =
 			{
 				Returns =

--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -1164,6 +1164,7 @@ float cBlockInfo::GetBlockHeight(const BLOCKTYPE Block)
 		case E_BLOCK_DARK_OAK_FENCE:      return 1.5;
 		case E_BLOCK_DARK_OAK_FENCE_GATE: return 1.5;
 		case E_BLOCK_ENCHANTMENT_TABLE:   return 0.75;    // 12 pixels
+		case E_BLOCK_FARMLAND:            return 0.9375;  // 15 / 16
 		case E_BLOCK_FENCE:               return 1.5;
 		case E_BLOCK_JUNGLE_FENCE:        return 1.5;
 		case E_BLOCK_JUNGLE_FENCE_GATE:   return 1.5;

--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -1164,7 +1164,7 @@ float cBlockInfo::GetBlockHeight(const BLOCKTYPE Block)
 		case E_BLOCK_DARK_OAK_FENCE:      return 1.5;
 		case E_BLOCK_DARK_OAK_FENCE_GATE: return 1.5;
 		case E_BLOCK_ENCHANTMENT_TABLE:   return 0.75;    // 12 pixels
-		case E_BLOCK_FARMLAND:            return 0.9375;  // 15 / 16
+		case E_BLOCK_FARMLAND:            return 0.9375;  // 15 pixels
 		case E_BLOCK_FENCE:               return 1.5;
 		case E_BLOCK_JUNGLE_FENCE:        return 1.5;
 		case E_BLOCK_JUNGLE_FENCE_GATE:   return 1.5;

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -161,7 +161,7 @@ private:
 		auto upperBlock = a_ChunkInterface.GetBlock(a_BlockPos.addedY(1));
 		if (cBlockInfo::FullyOccupiesVoxel(upperBlock))
 		{
-			// Until the fix above is done, this line *should* also suffice:
+			// Until the fix above is done, this line should also suffice:
 			// a_ChunkInterface.SetBlock(a_BlockPos, E_BLOCK_DIRT, 0);
 			a_ChunkInterface.DoWithChunkAt(a_BlockPos, [&](cChunk & Chunk)
 			{

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -25,19 +25,10 @@ public:
 
 	using Super::Super;
 
-	void TurnToDirt(cChunk & a_Chunk, Vector3i a_RelPos) const
-	{
-		TurnToDirt(a_Chunk, a_RelPos, a_Chunk.RelativeToAbsolute(a_RelPos));
-	}
-
-
-
-
-
 	/** Turns farmland into dirt.
 	Will first check for any colliding entities and teleport them to a higher position.
 	*/
-	void TurnToDirt(cChunk & a_Chunk, Vector3i a_RelPos, Vector3i a_AbsPos) const
+	static void TurnToDirt(cChunk & a_Chunk, Vector3i a_RelPos, Vector3i a_AbsPos)
 	{
 		static const auto FarmlandHeight = cBlockInfo::GetBlockHeight(E_BLOCK_FARMLAND);
 		static const auto FullHeightDelta = 1 - FarmlandHeight;
@@ -108,7 +99,8 @@ private:
 			}
 			default:
 			{
-				TurnToDirt(a_Chunk, a_RelPos);
+				auto AbsPos = a_Chunk.RelativeToAbsolute(a_RelPos);
+				TurnToDirt(a_Chunk, a_RelPos, AbsPos);
 				break;
 			}
 		}

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -25,6 +25,11 @@ public:
 
 	using Super::Super;
 
+	void TurnToDirt(cChunkInterface & a_ChunkInterface, Vector3i a_BlockPos) const
+	{
+		a_ChunkInterface.SetBlock(a_BlockPos, E_BLOCK_DIRT, 0);
+	}
+
 private:
 
 	virtual cItems ConvertToPickups(const NIBBLETYPE a_BlockMeta, const cItem * const a_Tool) const override
@@ -76,7 +81,7 @@ private:
 			}
 			default:
 			{
-				a_Chunk.SetBlock(a_RelPos, E_BLOCK_DIRT, 0);
+				TurnToDirt(a_ChunkInterface, a_RelPos);
 				break;
 			}
 		}
@@ -104,7 +109,7 @@ private:
 		auto upperBlock = a_ChunkInterface.GetBlock(a_BlockPos.addedY(1));
 		if (cBlockInfo::FullyOccupiesVoxel(upperBlock))
 		{
-			a_ChunkInterface.SetBlock(a_BlockPos, E_BLOCK_DIRT, 0);
+			TurnToDirt(a_ChunkInterface, a_BlockPos);
 		}
 	}
 

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -34,7 +34,7 @@ public:
 
 
 
-	/** Turns farmland into dirt. 
+	/** Turns farmland into dirt.
 	Will first check for any colliding entities and teleport them to a higher position.
 	*/
 	void TurnToDirt(cChunk & a_Chunk, Vector3i a_RelPos, Vector3i a_AbsPos) const

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -12,6 +12,7 @@
 #include "BlockHandler.h"
 #include "ChunkInterface.h"
 #include "../BlockArea.h"
+#include "../Chunk.h"
 
 
 

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "BlockHandler.h"
+#include "ChunkInterface.h"
 #include "../BlockArea.h"
 
 
@@ -28,12 +29,12 @@ public:
 	/** Turns farmland into dirt.
 	Will first check for any colliding entities and teleport them to a higher position.
 	*/
-	static void TurnToDirt(cChunk & a_Chunk, Vector3i a_RelPos, Vector3i a_AbsPos)
+	static void TurnToDirt(cWorld & a_World, Vector3i a_AbsPos)
 	{
 		static const auto FarmlandHeight = cBlockInfo::GetBlockHeight(E_BLOCK_FARMLAND);
 		static const auto FullHeightDelta = 1 - FarmlandHeight;
 
-		a_Chunk.ForEachEntityInBox(
+		a_World.ForEachEntityInBox(
 			cBoundingBox(Vector3d(0.5, FarmlandHeight, 0.5) + a_AbsPos, 0.5, FullHeightDelta),
 			[&](cEntity & Entity)
 			{
@@ -41,7 +42,7 @@ public:
 				return false;
 			});
 
-		a_Chunk.SetBlock(a_RelPos, E_BLOCK_DIRT, 0);
+		a_World.SetBlock(a_AbsPos, E_BLOCK_DIRT, 0);
 	}
 
 
@@ -99,8 +100,9 @@ private:
 			}
 			default:
 			{
+				auto World = a_Chunk.GetWorld();
 				auto AbsPos = a_Chunk.RelativeToAbsolute(a_RelPos);
-				TurnToDirt(a_Chunk, a_RelPos, AbsPos);
+				TurnToDirt(*World, AbsPos);
 				break;
 			}
 		}

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -28,6 +28,9 @@ public:
 
 	using Super::Super;
 
+	/** Turns farmland into dirt.
+	Will first check for any colliding entities and teleport them to a higher position.
+	*/
 	static void TurnToDirt(cChunk & a_Chunk, Vector3i a_AbsPos)
 	{
 		auto RelPos = cChunkDef::AbsoluteToRelative(a_AbsPos);
@@ -61,8 +64,8 @@ public:
 				// The sketchy solution. It will almost always completely stop the player:
 				// Entity.TeleportToCoords(Entity.GetPosX(), Entity.GetPosY() + FullHeightDelta, Entity.GetPosZ());
 
-				// Another sketchy solution. It will rarely completely stop the player.
-				// It often causes weird pitch / yaw changes
+				// Another sketchy solution. It sometimes stops the player completely.
+				// It sometimes causes weird stutter
 				Entity.AddPosY(FullHeightDelta);
 				if (Entity.IsPlayer())
 				{

--- a/src/Blocks/BlockFarmland.h
+++ b/src/Blocks/BlockFarmland.h
@@ -57,19 +57,16 @@ public:
 				{
 					return false;
 				}
-
-				// The solution which will make the player fall through the ground:
-				// Entity.SetPosition(Entity.GetPosition().addedY(FullHeightDelta));
-
-				// The sketchy solution. It will almost always completely stop the player:
-				// Entity.TeleportToCoords(Entity.GetPosX(), Entity.GetPosY() + FullHeightDelta, Entity.GetPosZ());
-
-				// Another sketchy solution. It sometimes stops the player completely.
-				// It sometimes causes weird stutter
 				Entity.AddPosY(FullHeightDelta);
+
+				// Players need a packet that will update their position
 				if (Entity.IsPlayer())
 				{
 					auto Player = static_cast<cPlayer *>(&Entity);
+					// This works, but it's much worse than Vanilla.
+					// This can be easily improved by implementing relative
+					// "Player Position And Look" packets! See
+					// https://wiki.vg/Protocol#Player_Position_And_Look_.28clientbound.29
 					Player->GetClientHandle()->SendPlayerMoveLook();
 				}
 
@@ -164,9 +161,8 @@ private:
 		auto upperBlock = a_ChunkInterface.GetBlock(a_BlockPos.addedY(1));
 		if (cBlockInfo::FullyOccupiesVoxel(upperBlock))
 		{
-			// At the moment, that single line will also do:
+			// Until the fix above is done, this line *should* also suffice:
 			// a_ChunkInterface.SetBlock(a_BlockPos, E_BLOCK_DIRT, 0);
-			// Testing :)
 			a_ChunkInterface.DoWithChunkAt(a_BlockPos, [&](cChunk & Chunk)
 			{
 				TurnToDirt(Chunk, a_BlockPos);

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -42,7 +42,6 @@
 		} \
 	} while (false)
 
-#define VOLUME GetWidth() * GetHeight()
 
 
 

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -42,6 +42,7 @@
 		} \
 	} while (false)
 
+#define VOLUME GetWidth() * GetHeight()
 
 
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -471,7 +471,7 @@ void cPawn::HandleFalling(void)
 		// We only have width and height, so we have to calculate Width^2
 		if (GetWorld()->IsFarmlandTramplingEnabled() &&
 			(BlockAtFoot == E_BLOCK_FARMLAND) &&
-			(std::pow(GetWidth(), 2) * GetHeight() >= 0.512))
+			(GetWidth() * GetWidth() * GetHeight() >= 0.512))
 		{
 			HandleFarmlandTrampling(FallHeight);
 		}

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -478,6 +478,14 @@ void cPawn::HandleFalling(void)
 
 
 
+void cPawn::HandleFarmlandTrampling(void) {
+
+}
+
+
+
+
+
 void cPawn::OnRemoveFromWorld(cWorld & a_World)
 {
 	StopEveryoneFromTargetingMe();

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -430,7 +430,7 @@ void cPawn::HandleFalling(void)
 
 	if (OnGround)
 	{
-		if (m_World->IsFarmlandTramplingEnabled() && BlockAtFoot == E_BLOCK_FARMLAND)
+		if (m_World->IsFarmlandTramplingEnabled() && (BlockAtFoot == E_BLOCK_FARMLAND))
 		{
 			HandleFarmlandTrampling();
 		}
@@ -492,7 +492,7 @@ void cPawn::HandleFarmlandTrampling(void)
 	}
 	if (FallHeight > 1.5625)
 	{
-		
+		// Trample
 	}
 	auto Chance = GetRandomProvider().RandReal();
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -478,7 +478,8 @@ void cPawn::HandleFalling(void)
 
 
 
-void cPawn::HandleFarmlandTrampling(void) {
+void cPawn::HandleFarmlandTrampling(void)
+{
 
 }
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -430,6 +430,11 @@ void cPawn::HandleFalling(void)
 
 	if (OnGround)
 	{
+		if (m_World->IsFarmlandTramplingEnabled() && BlockAtFoot == E_BLOCK_FARMLAND)
+		{
+			HandleFarmlandTrampling();
+		}
+
 		auto Damage = static_cast<int>(m_LastGroundHeight - GetPosY() - 3.0);
 		if ((Damage > 0) && !FallDamageAbsorbed)
 		{
@@ -480,6 +485,16 @@ void cPawn::HandleFalling(void)
 
 void cPawn::HandleFarmlandTrampling(void)
 {
+	auto FallHeight = m_LastGroundHeight - GetPosY();
+	if (FallHeight <= 0.6875)
+	{
+		return;
+	}
+	if (FallHeight > 1.5625)
+	{
+		
+	}
+	auto Chance = GetRandomProvider().RandReal();
 
 }
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -432,8 +432,15 @@ void cPawn::HandleFalling(void)
 	if (OnGround)
 	{
 		auto FallHeight = m_LastGroundHeight - GetPosY();
-		auto Damage = static_cast<int>(FallHeight - 3.0);
 
+		// Farmland trampling. Mobs smaller than 0.512 cubic blocks won't trample (Java Edition's behavior)
+		if (GetWorld()->IsFarmlandTramplingEnabled() &&
+			(BlockAtFoot == E_BLOCK_FARMLAND) && (VOLUME >= 0.512))
+		{
+			HandleFarmlandTrampling(FallHeight);
+		}
+
+		auto Damage = static_cast<int>(FallHeight - 3.0);
 		if ((Damage > 0) && !FallDamageAbsorbed)
 		{
 			if (IsElytraFlying())
@@ -459,12 +466,6 @@ void cPawn::HandleFalling(void)
 					static_cast<int>((Damage - 1.f) * ((50.f - 20.f) / (15.f - 1.f)) + 20.f),  // Map damage (1 - 15) to particle quantity (20 - 50)
 					{ { BlockBelow, 0 } }
 				);
-
-				// Farmland trampling. Mobs smaller than 0.512 cubic blocks won't trample (Java Edition's behavior)
-				if ((BlockAtFoot == E_BLOCK_FARMLAND) && (VOLUME >= 0.512))
-				{
-					HandleFarmlandTrampling(FallHeight);
-				}
 			}
 
 			TakeDamage(dtFalling, nullptr, Damage, static_cast<float>(Damage), 0);

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -8,6 +8,7 @@
 #include "../Bindings/PluginManager.h"
 #include "../BoundingBox.h"
 #include "../Blocks/BlockHandler.h"
+#include "../Blocks/BlockFarmland.h"
 #include "../EffectID.h"
 #include "../Mobs/Monster.h"
 
@@ -459,8 +460,8 @@ void cPawn::HandleFalling(void)
 					{ { BlockBelow, 0 } }
 				);
 
-				// Farmland trampling
-				if (BlockBelow == E_BLOCK_FARMLAND)
+				// Farmland trampling. Mobs smaller than 0.512 cubic blocks won't trample (Java Edition's behavior)
+				if ((BlockAtFoot == E_BLOCK_FARMLAND) && (VOLUME >= 0.512))
 				{
 					HandleFarmlandTrampling(FallHeight);
 				}
@@ -488,21 +489,23 @@ void cPawn::HandleFalling(void)
 
 void cPawn::HandleFarmlandTrampling(double a_FallHeight)
 {
+	// Return if FallHeight <= 0.6875
 	if (a_FallHeight <= 0.6875)
 	{
 		return;
 	}
-	// For height below <= 1.5625 we must get a random number
-	else if ((a_FallHeight <= 1.0625) && (GetRandomProvider().RandReal() <= 0.25))
+	// For FallHeight <= 1.5625 we get a random number to decide whether we should return
+	else if ((a_FallHeight <= 1.0625) && (GetRandomProvider().RandReal() > 0.25))
 	{
 		return;
 	}
-	else if ((a_FallHeight <= 1.5625) && (GetRandomProvider().RandReal() <= 0.66))
+	else if ((a_FallHeight <= 1.5625) && (GetRandomProvider().RandReal() > 0.66))
 	{
 		return;
 	}
+	// For FallHeight > 1.5625 we always trample
 
-	// Height > 1.5625 or random number high enough - trample
+	cBlockFarmlandHandler::TurnToDirt(*GetWorld(), POS_TOINT);
 }
 
 

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -468,9 +468,10 @@ void cPawn::HandleFalling(void)
 		m_LastGroundHeight = GetPosY();
 
 		// Farmland trampling. Mobs smaller than 0.512 cubic blocks won't trample (Java Edition's behavior)
+		// We only have width and height, so we have to calculate Width^2
 		if (GetWorld()->IsFarmlandTramplingEnabled() &&
 			(BlockAtFoot == E_BLOCK_FARMLAND) &&
-			(GetWidth() * GetHeight() >= 0.512))
+			(std::pow(GetWidth(), 2) * GetHeight() >= 0.512))
 		{
 			HandleFarmlandTrampling(FallHeight);
 		}

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -34,18 +34,16 @@ public:
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 
 	/** Handles farmland trampling when hitting the ground.
-	
 	Mobs smaller than 0.512 blocks will never trample (Java Edition's behavior).
-	Other mobs with custom trampling behavior (always/never trampling) should override this function.
 
 	Default algorithm:
-	fall height <= 0.75 blocks: no trampling
-	fall height > 0.75 and <= 1.125: 25% chance of trampling
-	fall height > 1.125 and <= 1.625: 66% chance of trampling
-	fall height > 1.625: always trample
+	fall height <= 0.625 blocks: no trampling
+	fall height > 0.625 and <= 1.0: 25% chance of trampling
+	fall height > 1.0 and <= 1.5: 66% chance of trampling
+	fall height > 1.5: always trample
 	The values may differ from vanilla, they were determined experimentally.
 	*/
-	virtual void HandleFarmlandTrampling(void);
+	void HandleFarmlandTrampling(void);
 
 	/** Tells all pawns which are targeting us to stop targeting us. */
 	void StopEveryoneFromTargetingMe();

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -34,9 +34,7 @@ public:
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 
 	/** Handles farmland trampling when hitting the ground.
-	Mobs smaller than 0.512 blocks will never trample (Java Edition's behavior).
-
-	Default algorithm:
+	Algorithm:
 	fall height <= 0.6875 blocks: no trampling
 	fall height > 0.6875 and <= 1.0625: 25% chance of trampling
 	fall height > 1.0625 and <= 1.5625: 66% chance of trampling

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -43,7 +43,7 @@ public:
 	fall height > 1.5625: always trample
 	The values may differ from vanilla, they were determined experimentally.
 	*/
-	void HandleFarmlandTrampling(void);
+	void HandleFarmlandTrampling(double a_FallHeight);
 
 	/** Tells all pawns which are targeting us to stop targeting us. */
 	void StopEveryoneFromTargetingMe();

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -37,10 +37,10 @@ public:
 	Mobs smaller than 0.512 blocks will never trample (Java Edition's behavior).
 
 	Default algorithm:
-	fall height <= 0.625 blocks: no trampling
-	fall height > 0.625 and <= 1.0: 25% chance of trampling
-	fall height > 1.0 and <= 1.5: 66% chance of trampling
-	fall height > 1.5: always trample
+	fall height <= 0.6875 blocks: no trampling
+	fall height > 0.6875 and <= 1.0625: 25% chance of trampling
+	fall height > 1.0625 and <= 1.5625: 66% chance of trampling
+	fall height > 1.5625: always trample
 	The values may differ from vanilla, they were determined experimentally.
 	*/
 	void HandleFarmlandTrampling(void);

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -39,10 +39,10 @@ public:
 	Other mobs with custom trampling behavior (always/never trampling) should override this function.
 
 	Default algorithm:
-	fall height <= 0,75 blocks: no trampling
-	fall height > 0,75 and <= 1,125: 25% chance of trampling
-	fall height > 1,125 and <= 1,625: 66% chance of trampling
-	fall height > 1,625: always trample
+	fall height <= 0.75 blocks: no trampling
+	fall height > 0.75 and <= 1.125: 25% chance of trampling
+	fall height > 1.125 and <= 1.625: 66% chance of trampling
+	fall height > 1.625: always trample
 	The values may differ from vanilla, they were determined experimentally.
 	*/
 	virtual void HandleFarmlandTrampling(void);

--- a/src/Entities/Pawn.h
+++ b/src/Entities/Pawn.h
@@ -33,6 +33,20 @@ public:
 	virtual void HandleFalling(void);
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;
 
+	/** Handles farmland trampling when hitting the ground.
+	
+	Mobs smaller than 0.512 blocks will never trample (Java Edition's behavior).
+	Other mobs with custom trampling behavior (always/never trampling) should override this function.
+
+	Default algorithm:
+	fall height <= 0,75 blocks: no trampling
+	fall height > 0,75 and <= 1,125: 25% chance of trampling
+	fall height > 1,125 and <= 1,625: 66% chance of trampling
+	fall height > 1,625: always trample
+	The values may differ from vanilla, they were determined experimentally.
+	*/
+	virtual void HandleFarmlandTrampling(void);
+
 	/** Tells all pawns which are targeting us to stop targeting us. */
 	void StopEveryoneFromTargetingMe();
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -166,6 +166,7 @@ cWorld::cWorld(
 	m_SkyDarkness(0),
 	m_GameMode(gmSurvival),
 	m_bEnabledPVP(false),
+	m_bFarmlandTramplingEnabled(false),
 	m_IsDeepSnowEnabled(false),
 	m_ShouldLavaSpawnFire(true),
 	m_VillagersShouldHarvestCrops(true),
@@ -300,6 +301,7 @@ cWorld::cWorld(
 	int TNTShrapnelLevel          = IniFile.GetValueSetI("Physics",       "TNTShrapnelLevel",            static_cast<int>(slAll));
 	m_bCommandBlocksEnabled       = IniFile.GetValueSetB("Mechanics",     "CommandBlocksEnabled",        false);
 	m_bEnabledPVP                 = IniFile.GetValueSetB("Mechanics",     "PVPEnabled",                  true);
+	m_bFarmlandTramplingEnabled   = IniFile.GetValueSetB("Mechanics",     "FarmlandTramplingEnabled",    true);
 	m_bUseChatPrefixes            = IniFile.GetValueSetB("Mechanics",     "UseChatPrefixes",             true);
 	m_MinNetherPortalWidth        = IniFile.GetValueSetI("Mechanics",     "MinNetherPortalWidth",        2);
 	m_MaxNetherPortalWidth        = IniFile.GetValueSetI("Mechanics",     "MaxNetherPortalWidth",        21);

--- a/src/World.h
+++ b/src/World.h
@@ -122,7 +122,7 @@ public:
 	bool IsPVPEnabled(void) const { return m_bEnabledPVP; }
 
 	/** Returns true if farmland trampling is enabled */
-	// bool IsFarmlandTramplingEnabled(void) const { return m_bFarmlandTramplingEnabled; }
+	bool IsFarmlandTramplingEnabled(void) const { return m_bFarmlandTramplingEnabled; }
 
 	bool IsDeepSnowEnabled(void) const { return m_IsDeepSnowEnabled; }
 

--- a/src/World.h
+++ b/src/World.h
@@ -121,6 +121,7 @@ public:
 
 	bool IsPVPEnabled(void) const { return m_bEnabledPVP; }
 
+	/** Returns true if farmland trampling is enabled */
 	bool IsFarmlandTramplingEnabled(void) const { return m_bFarmlandTramplingEnabled; }
 
 	bool IsDeepSnowEnabled(void) const { return m_IsDeepSnowEnabled; }

--- a/src/World.h
+++ b/src/World.h
@@ -121,6 +121,8 @@ public:
 
 	bool IsPVPEnabled(void) const { return m_bEnabledPVP; }
 
+	bool IsFarmlandTramplingEnabled(void) const { return m_bFarmlandTramplingEnabled; }
+
 	bool IsDeepSnowEnabled(void) const { return m_IsDeepSnowEnabled; }
 
 	bool ShouldLavaSpawnFire(void) const { return m_ShouldLavaSpawnFire; }
@@ -993,6 +995,7 @@ private:
 
 	eGameMode m_GameMode;
 	bool m_bEnabledPVP;
+	bool m_bFarmlandTramplingEnabled;
 	bool m_IsDeepSnowEnabled;
 	bool m_ShouldLavaSpawnFire;
 	bool m_VillagersShouldHarvestCrops;

--- a/src/World.h
+++ b/src/World.h
@@ -122,7 +122,7 @@ public:
 	bool IsPVPEnabled(void) const { return m_bEnabledPVP; }
 
 	/** Returns true if farmland trampling is enabled */
-	bool IsFarmlandTramplingEnabled(void) const { return m_bFarmlandTramplingEnabled; }
+	// bool IsFarmlandTramplingEnabled(void) const { return m_bFarmlandTramplingEnabled; }
 
 	bool IsDeepSnowEnabled(void) const { return m_IsDeepSnowEnabled; }
 


### PR DESCRIPTION
Just a draft right now. I've encountered a tiny issue...

So, I'm implementing farmland trampling. I've determined experimentally chances of trampling (described in #5069).

I've decided to create a function cPawn::HandleFarmlandTrampling() that will be responsible for handling trampling. It will be called in cPawn::HandleFalling(). Its body is empty at the moment (I need to implement it). Let me know if there's something wrong with this approach - I'll be happy to implement trampling in another way.

The issue I'm facing - cPawn::m_LastGroundHeight isn't accurate, it misbehaves with thick snow. I'll try to explain the issue with some screenshots including debug messages. These piles of snow are 0.75 blocks high, so you can't just walk onto them.
![Overview](https://user-images.githubusercontent.com/42816979/161451106-7782275d-5e6d-4001-b0b5-39a1a496548d.png)
Falling from the left pile of snow (without jumping onto it):
![Left](https://user-images.githubusercontent.com/42816979/161451179-b285ed61-0ab0-49ce-ad87-652bfe2f3454.png)
Falling from the right pile of snow (with jumping onto it):
![Right](https://user-images.githubusercontent.com/42816979/161451185-e7cd7d53-3a96-4fe5-a91d-00887cb6534a.png)
So, m_LastGroundHeight depends on whether I jump onto snow or walk into it.

I can try to fix m_LastGroundHeight in this pull request or fix it in the future (another PR) and just implement trampling right now. Trampling should generally work OK without the fix, as the issue doesn't affect slabs - and it's probably pretty rare to have multilayered snow near farms. Trampling will be harder to thoroughly test without the fix (look at #5069) though.

I'd also like to make it possible to turn off trampling in world.ini.

Fixes #5069
Fixes #1179
(I think they're duplicates)
Fixes #5402