### PR TITLE
a fix that work for bedrock and redstone issue

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,6 +85,7 @@ TheHyper45
 theophriene
 tigerw (Tiger Wang)
 tonibm19
+tonitch (Debucquoy Anthony)
 TooAngel
 tympaniplayer (Nate Palmer)
 UltraCoderRU

--- a/src/Bindings/ManualBindings_BlockArea.cpp
+++ b/src/Bindings/ManualBindings_BlockArea.cpp
@@ -590,40 +590,13 @@ static int tolua_cBlockArea_Read(lua_State * a_LuaState)
 		return L.ApiParamError("Invalid baDataTypes combination (%d)", dataTypes);
 	}
 
-	// Check the coords, shift if needed:
+	// Check the coords:
+	if (!cChunkDef::IsValidHeight(bounds.p1) || !cChunkDef::IsValidHeight(bounds.p2))
+	{
+		return L.FApiParamError("Coordinates {0} - {1} exceed world bounds", bounds.p1, bounds.p2);
+	}
+
 	bounds.Sort();
-	if (bounds.p1.y < 0)
-	{
-		FLOGWARNING("cBlockArea:Read(): MinBlockY less than zero, adjusting to zero. Coords: {0} - {1}",
-			bounds.p1, bounds.p2
-		);
-		L.LogStackTrace();
-		bounds.p1.y = 0;
-	}
-	else if (bounds.p1.y >= cChunkDef::Height)
-	{
-		FLOGWARNING("cBlockArea:Read(): MinBlockY more than chunk height, adjusting to chunk height. Coords: {0} - {1}",
-			bounds.p1, bounds.p2
-		);
-		L.LogStackTrace();
-		bounds.p1.y = cChunkDef::Height - 1;
-	}
-	if (bounds.p2.y < 0)
-	{
-		FLOGWARNING("cBlockArea:Read(): MaxBlockY less than zero, adjusting to zero. Coords: {0} - {1}",
-			bounds.p1, bounds.p2
-		);
-		L.LogStackTrace();
-		bounds.p2.y = 0;
-	}
-	else if (bounds.p2.y > cChunkDef::Height)
-	{
-		FLOGWARNING("cBlockArea:Read(): MaxBlockY more than chunk height, adjusting to chunk height. Coords: {0} - {1}",
-			bounds.p1, bounds.p2
-		);
-		L.LogStackTrace();
-		bounds.p2.y = cChunkDef::Height;
-	}
 
 	// Do the actual read:
 	L.Push(self->Read(*world, bounds, dataTypes));

--- a/src/Simulator/DelayedFluidSimulator.cpp
+++ b/src/Simulator/DelayedFluidSimulator.cpp
@@ -138,18 +138,3 @@ void cDelayedFluidSimulator::AddBlock(cChunk & a_Chunk, Vector3i a_Position, BLO
 
 	++m_TotalBlocks;
 }
-
-
-
-
-
-void cDelayedFluidSimulator::WakeUp(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block)
-{
-	if (!cChunkDef::IsValidHeight(a_Position))
-	{
-		// Not inside the world (may happen when rclk with a full bucket - the client sends Y = -1)
-		return;
-	}
-
-	AddBlock(a_Chunk, a_Position, a_Block);
-}

--- a/src/Simulator/DelayedFluidSimulator.h
+++ b/src/Simulator/DelayedFluidSimulator.h
@@ -59,7 +59,6 @@ protected:
 	virtual void Simulate(float a_Dt) override;
 	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk) override;
 	virtual void AddBlock(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block) override;
-	virtual void WakeUp(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block) override;
 	virtual cFluidSimulatorData * CreateChunkData(void) override { return new cDelayedFluidSimulatorChunkData(m_TickDelay); }
 
 	int m_TickDelay;   // Count of the m_Slots array in each ChunkData

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -363,14 +363,21 @@ void cFireSimulator::RemoveFuelNeighbors(cChunk * a_Chunk, Vector3i a_RelPos)
 {
 	for (auto & coord : gNeighborCoords)
 	{
-		BLOCKTYPE  BlockType;
 		auto relPos = a_RelPos + coord;
-		auto neighbor = a_Chunk->GetRelNeighborChunkAdjustCoords(relPos);
-		if (neighbor == nullptr)
+
+		if (!cChunkDef::IsValidHeight(relPos))
 		{
 			continue;
 		}
-		BlockType = neighbor->GetBlock(relPos);
+
+		const auto neighbor = a_Chunk->GetRelNeighborChunkAdjustCoords(relPos);
+
+		if ((neighbor == nullptr) || !neighbor->IsValid())
+		{
+			continue;
+		}
+
+		BLOCKTYPE BlockType = neighbor->GetBlock(relPos);
 
 		if (!IsFuel(BlockType))
 		{

--- a/src/Simulator/FireSimulator.h
+++ b/src/Simulator/FireSimulator.h
@@ -27,7 +27,6 @@ public:
 
 private:
 
-	virtual void Simulate(float a_Dt) override { UNUSED(a_Dt);}  // not used
 	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk) override;
 
 	static bool IsAllowedBlock(BLOCKTYPE a_BlockType);
@@ -68,7 +67,3 @@ private:
 
 /** Stores individual fire blocks in the chunk; the int data is used as the time [msec] the fire takes to step to another stage (blockmeta++) */
 typedef cCoordWithIntList cFireSimulatorChunkData;
-
-
-
-

--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
@@ -223,7 +223,8 @@ void cIncrementalRedstoneSimulator::WakeUp(cChunk & a_Chunk, Vector3i a_Position
 			continue;
 		}
 
-		auto Chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(Relative);
+		const auto Chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(Relative);
+
 		if ((Chunk == nullptr) || !Chunk->IsValid())
 		{
 			continue;

--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.cpp
@@ -217,6 +217,7 @@ void cIncrementalRedstoneSimulator::WakeUp(cChunk & a_Chunk, Vector3i a_Position
 	for (const auto & Offset : cSimulator::GetLinkedOffsets(a_Offset))
 	{
 		auto Relative = a_Position - a_Offset + Offset;
+
 		if (!cChunkDef::IsValidHeight(Relative))
 		{
 			continue;

--- a/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/IncrementalRedstoneSimulator.h
@@ -26,7 +26,6 @@ private:
 
 	void ProcessWorkItem(cChunk & Chunk, cChunk & TickingSource, const Vector3i Position);
 
-	virtual void Simulate(float Dt) override {}
 	virtual void SimulateChunk(std::chrono::milliseconds Dt, int ChunkX, int ChunkZ, cChunk * Chunk) override;
 	virtual void AddBlock(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block) override;
 	virtual cRedstoneSimulatorChunkData * CreateChunkData() override;

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneDataHelper.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneDataHelper.h
@@ -7,23 +7,39 @@ inline auto & DataForChunk(const cChunk & a_Chunk)
 	return *static_cast<cIncrementalRedstoneSimulatorChunkData *>(a_Chunk.GetRedstoneSimulatorData());
 }
 
-template <typename... ArrayTypes>
-inline void UpdateAdjustedRelative(const cChunk & From, const cChunk & To, const Vector3i Position, const Vector3i Offset)
+inline void UpdateAdjustedRelative(const cChunk & a_Chunk, const cChunk & a_TickingChunk, const Vector3i a_Position, const Vector3i a_Offset)
 {
-	DataForChunk(To).WakeUp(cIncrementalRedstoneSimulatorChunkData::RebaseRelativePosition(From, To, Position + Offset));
+	const auto PositionToWake = a_Position + a_Offset;
 
-	for (const auto & LinkedOffset : cSimulator::GetLinkedOffsets(Offset))
+	if (!cChunkDef::IsValidHeight(PositionToWake))
 	{
-		DataForChunk(To).WakeUp(cIncrementalRedstoneSimulatorChunkData::RebaseRelativePosition(From, To, Position + LinkedOffset));
+		// If an offset position is not a valid height, its linked offset positions won't be either.
+		return;
+	}
+
+	auto & ChunkData = DataForChunk(a_TickingChunk);
+
+	// Schedule the block in the requested direction to update:
+	ChunkData.WakeUp(cIncrementalRedstoneSimulatorChunkData::RebaseRelativePosition(a_Chunk, a_TickingChunk, PositionToWake));
+
+	// To follow Vanilla behaviour, update all linked positions:
+	for (const auto & LinkedOffset : cSimulator::GetLinkedOffsets(a_Offset))
+	{
+		const auto LinkedPositionToWake = a_Position + LinkedOffset;
+
+		if (cChunkDef::IsValidHeight(LinkedPositionToWake))
+		{
+			ChunkData.WakeUp(cIncrementalRedstoneSimulatorChunkData::RebaseRelativePosition(a_Chunk, a_TickingChunk, LinkedPositionToWake));
+		}
 	}
 }
 
 template <typename ArrayType>
-inline void UpdateAdjustedRelatives(const cChunk & From, const cChunk & To, const Vector3i Position, const ArrayType & Relative)
+inline void UpdateAdjustedRelatives(const cChunk & a_Chunk, const cChunk & a_TickingChunk, const Vector3i a_Position, const ArrayType & a_Relative)
 {
-	for (const auto & Offset : Relative)
+	for (const auto & Offset : a_Relative)
 	{
-		UpdateAdjustedRelative(From, To, Position, Offset);
+		UpdateAdjustedRelative(a_Chunk, a_TickingChunk, a_Position, Offset);
 	}
 }
 

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneDataHelper.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneDataHelper.h
@@ -25,9 +25,7 @@ inline void UpdateAdjustedRelative(const cChunk & a_Chunk, const cChunk & a_Tick
 	// To follow Vanilla behaviour, update all linked positions:
 	for (const auto & LinkedOffset : cSimulator::GetLinkedOffsets(a_Offset))
 	{
-		const auto LinkedPositionToWake = a_Position + LinkedOffset;
-
-		if (cChunkDef::IsValidHeight(LinkedPositionToWake))
+		if (const auto LinkedPositionToWake = a_Position + LinkedOffset; cChunkDef::IsValidHeight(LinkedPositionToWake))
 		{
 			ChunkData.WakeUp(cIncrementalRedstoneSimulatorChunkData::RebaseRelativePosition(a_Chunk, a_TickingChunk, LinkedPositionToWake));
 		}

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -269,7 +269,7 @@ namespace RedstoneWireHandler
 		a_Chunk.SetMeta(a_Position, Power);
 
 		// Notify all positions, sans YP, to update:
-		for (const auto & Offset : RelativeLaterals) 
+		for (const auto & Offset : RelativeLaterals)
 		{
 			if (Offset == OffsetYP)
 			{

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -100,19 +100,32 @@ namespace RedstoneWireHandler
 		}
 	}
 
+	static bool IsYPTerracingBlocked(const cChunk & a_Chunk, const Vector3i a_Position)
+	{
+		const auto Position = a_Position + OffsetYP;
+
+		if (!cChunkDef::IsValidHeight(Position))
+		{
+			// Certainly cannot terrace at the top of the world:
+			return true;
+		}
+
+		const auto YPTerraceBlock = a_Chunk.GetBlock(Position);
+		return cBlockInfo::IsSolid(YPTerraceBlock) && !cBlockInfo::IsTransparent(YPTerraceBlock);
+	}
+
 	/** Temporary. Discovers a wire's connection state, including terracing, storing the block inside redstone chunk data.
 	TODO: once the server supports block states this should go in the block handler, with data saved in the world. */
-	static void SetWireState(const cChunk & Chunk, const Vector3i Position)
+	static void SetWireState(const cChunk & a_Chunk, const Vector3i a_Position)
 	{
 		auto Block = Block::RedstoneWire::RedstoneWire();
-		const auto YPTerraceBlock = Chunk.GetBlock(Position + OffsetYP);
-		const bool IsYPTerracingBlocked = cBlockInfo::IsSolid(YPTerraceBlock) && !cBlockInfo::IsTransparent(YPTerraceBlock);
+		const bool IsYPTerracingBlocked = RedstoneWireHandler::IsYPTerracingBlocked(a_Chunk, a_Position);
 
 		// Loop through laterals, discovering terracing connections:
 		for (const auto & Offset : RelativeLaterals)
 		{
-			auto Adjacent = Position + Offset;
-			auto NeighbourChunk = Chunk.GetRelNeighborChunkAdjustCoords(Adjacent);
+			auto Adjacent = a_Position + Offset;
+			auto NeighbourChunk = a_Chunk.GetRelNeighborChunkAdjustCoords(Adjacent);
 
 			if ((NeighbourChunk == nullptr) || !NeighbourChunk->IsValid())
 			{
@@ -131,7 +144,7 @@ namespace RedstoneWireHandler
 				// Temporary: this case will eventually be handled when wires are placed, with the state saved as blocks
 				// When a neighbour wire was loaded into its chunk, its neighbour chunks may not have loaded yet
 				// This function is called during chunk load (through AddBlock). Attempt to tell it its new state:
-				if ((NeighbourChunk != &Chunk) && (LateralBlock == E_BLOCK_REDSTONE_WIRE))
+				if ((NeighbourChunk != &a_Chunk) && (LateralBlock == E_BLOCK_REDSTONE_WIRE))
 				{
 					auto & NeighbourBlock = DataForChunk(*NeighbourChunk).WireStates.find(Adjacent)->second;
 					SetDirectionState(-Offset, NeighbourBlock, TemporaryDirection::Side);
@@ -148,7 +161,7 @@ namespace RedstoneWireHandler
 			{
 				SetDirectionState(Offset, Block, cBlockInfo::IsTransparent(LateralBlock) ? TemporaryDirection::Side : TemporaryDirection::Up);
 
-				if (NeighbourChunk != &Chunk)
+				if (NeighbourChunk != &a_Chunk)
 				{
 					auto & NeighbourBlock = DataForChunk(*NeighbourChunk).WireStates.find(Adjacent + OffsetYP)->second;
 					SetDirectionState(-Offset, NeighbourBlock, TemporaryDirection::Side);
@@ -166,7 +179,7 @@ namespace RedstoneWireHandler
 			{
 				SetDirectionState(Offset, Block, TemporaryDirection::Side);
 
-				if (NeighbourChunk != &Chunk)
+				if (NeighbourChunk != &a_Chunk)
 				{
 					auto & NeighbourBlock = DataForChunk(*NeighbourChunk).WireStates.find(Adjacent + OffsetYM)->second;
 					SetDirectionState(-Offset, NeighbourBlock, TemporaryDirection::Up);
@@ -174,8 +187,8 @@ namespace RedstoneWireHandler
 			}
 		}
 
-		auto & States = DataForChunk(Chunk).WireStates;
-		const auto FindResult = States.find(Position);
+		auto & States = DataForChunk(a_Chunk).WireStates;
+		const auto FindResult = States.find(a_Position);
 		if (FindResult != States.end())
 		{
 			if (Block != FindResult->second)
@@ -184,13 +197,13 @@ namespace RedstoneWireHandler
 
 				// TODO: when state is stored as the block, the block handler updating via SetBlock will do this automatically
 				// When a wire changes connection state, it needs to update its neighbours:
-				Chunk.GetWorld()->WakeUpSimulators(cChunkDef::RelativeToAbsolute(Position, Chunk.GetPos()));
+				a_Chunk.GetWorld()->WakeUpSimulators(cChunkDef::RelativeToAbsolute(a_Position, a_Chunk.GetPos()));
 			}
 
 			return;
 		}
 
-		DataForChunk(Chunk).WireStates.emplace(Position, Block);
+		DataForChunk(a_Chunk).WireStates.emplace(a_Position, Block);
 	}
 
 	static PowerLevel GetPowerDeliveredToPosition(const cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_BlockType, Vector3i a_QueryPosition, BLOCKTYPE a_QueryBlockType, bool IsLinked)

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -269,7 +269,7 @@ namespace RedstoneWireHandler
 		a_Chunk.SetMeta(a_Position, Power);
 
 		// Notify all positions, sans YP, to update:
-		for (const auto & Offset : RelativeAdjacents)
+		for (const auto & Offset : RelativeLaterals) 
 		{
 			if (Offset == OffsetYP)
 			{

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneWireHandler.h
@@ -269,15 +269,8 @@ namespace RedstoneWireHandler
 		a_Chunk.SetMeta(a_Position, Power);
 
 		// Notify all positions, sans YP, to update:
-		for (const auto & Offset : RelativeLaterals)
-		{
-			if (Offset == OffsetYP)
-			{
-				continue;
-			}
-
-			UpdateAdjustedRelative(a_Chunk, CurrentlyTicking, a_Position, Offset);
-		}
+		UpdateAdjustedRelative(a_Chunk, CurrentlyTicking, a_Position, OffsetYM);
+		UpdateAdjustedRelatives(a_Chunk, CurrentlyTicking, a_Position, RelativeLaterals);
 	}
 
 	static void ForValidSourcePositions(const cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_BlockType, NIBBLETYPE a_Meta, ForEachSourceCallback & Callback)

--- a/src/Simulator/NoopFluidSimulator.h
+++ b/src/Simulator/NoopFluidSimulator.h
@@ -15,7 +15,7 @@
 
 
 
-class cNoopFluidSimulator:
+class cNoopFluidSimulator final :
 	public cFluidSimulator
 {
 	using Super = cFluidSimulator;
@@ -26,15 +26,19 @@ public:
 
 private:
 
-	virtual void Simulate(float a_Dt) override { UNUSED(a_Dt);}
+	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk)
+	{
+		UNUSED(a_Dt);
+		UNUSED(a_ChunkX);
+		UNUSED(a_ChunkZ);
+		UNUSED(a_Chunk);
+	}
+
 	virtual void AddBlock(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block) override
 	{
 		UNUSED(a_Block);
 		UNUSED(a_Chunk);
 	}
+
 	virtual cFluidSimulatorData * CreateChunkData(void) override { return nullptr; }
 } ;
-
-
-
-

--- a/src/Simulator/NoopFluidSimulator.h
+++ b/src/Simulator/NoopFluidSimulator.h
@@ -26,7 +26,7 @@ public:
 
 private:
 
-	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk)
+	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk) override
 	{
 		UNUSED(a_Dt);
 		UNUSED(a_ChunkX);

--- a/src/Simulator/NoopRedstoneSimulator.h
+++ b/src/Simulator/NoopRedstoneSimulator.h
@@ -19,7 +19,14 @@ public:
 	{
 	}
 
-	virtual void Simulate(float a_Dt) override { UNUSED(a_Dt);}  // not used
+	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk) override
+	{
+		UNUSED(a_Dt);
+		UNUSED(a_ChunkX);
+		UNUSED(a_ChunkZ);
+		UNUSED(a_Chunk);
+	}
+
 	virtual void AddBlock(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block) override
 	{
 		UNUSED(a_Block);
@@ -30,5 +37,4 @@ public:
 	{
 		return nullptr;
 	}
-
 } ;

--- a/src/Simulator/SandSimulator.h
+++ b/src/Simulator/SandSimulator.h
@@ -55,7 +55,6 @@ public:
 
 private:
 
-	virtual void Simulate(float a_Dt) override { UNUSED(a_Dt);}  // not used
 	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk) override;
 
 	bool m_IsInstantFall;  // If set to true, blocks don't fall using cFallingBlock entity, but instantly instead
@@ -67,12 +66,3 @@ private:
 	/** Performs the instant fall of the block - removes it from top, Finishes it at the bottom */
 	void DoInstantFall(cChunk * a_Chunk, int a_RelX, int a_RelY, int a_RelZ);
 };
-
-
-
-
-
-
-
-
-

--- a/src/Simulator/Simulator.cpp
+++ b/src/Simulator/Simulator.cpp
@@ -3,7 +3,6 @@
 
 #include "Simulator.h"
 #include "../Chunk.h"
-#include "../Cuboid.h"
 #include "../World.h"
 
 
@@ -94,6 +93,15 @@ std::array<Vector3i, 5> cSimulator::GetLinkedOffsets(const Vector3i Offset)
 
 
 
+void cSimulator::Simulate(float a_Dt)
+{
+	UNUSED(a_Dt);
+}
+
+
+
+
+
 void cSimulator::WakeUp(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block)
 {
 	ASSERT(a_Chunk.IsValid());
@@ -110,46 +118,4 @@ void cSimulator::WakeUp(cChunk & a_Chunk, Vector3i a_Position, Vector3i a_Offset
 	ASSERT(a_Chunk.IsValid());
 
 	WakeUp(a_Chunk, a_Position, a_Block);
-}
-
-
-
-
-
-void cSimulator::WakeUp(const cCuboid & a_Area)
-{
-	cCuboid area(a_Area);
-	area.Sort();
-	area.Expand(1, 1, 1, 1, 1, 1);  // Expand the area to contain the neighbors, too.
-	area.ClampY(0, cChunkDef::Height - 1);
-
-	// Add all blocks, in a per-chunk manner:
-	cChunkCoords ChunkStart = cChunkDef::BlockToChunk(area.p1);
-	cChunkCoords ChunkEnd = cChunkDef::BlockToChunk(area.p2);
-	for (int cz = ChunkStart.m_ChunkZ; cz <= ChunkEnd.m_ChunkZ; ++cz)
-	{
-		for (int cx = ChunkStart.m_ChunkX; cx <= ChunkEnd.m_ChunkX; ++cx)
-		{
-			m_World.DoWithChunk(cx, cz, [this, &area](cChunk & a_CBChunk) -> bool
-				{
-					int startX = std::max(area.p1.x, a_CBChunk.GetPosX() * cChunkDef::Width);
-					int startZ = std::max(area.p1.z, a_CBChunk.GetPosZ() * cChunkDef::Width);
-					int endX = std::min(area.p2.x, a_CBChunk.GetPosX() * cChunkDef::Width + cChunkDef::Width - 1);
-					int endZ = std::min(area.p2.z, a_CBChunk.GetPosZ() * cChunkDef::Width + cChunkDef::Width - 1);
-					for (int y = area.p1.y; y <= area.p2.y; ++y)
-					{
-						for (int z = startZ; z <= endZ; ++z)
-						{
-							for (int x = startX; x <= endX; ++x)
-							{
-								const auto Position = cChunkDef::AbsoluteToRelative({ x, y, z });
-								AddBlock(a_CBChunk, Position, a_CBChunk.GetBlock(Position));
-							}  // for x
-						}  // for z
-					}  // for y
-					return true;
-				}  // lambda
-			);  // DoWithChunk
-		}  // for cx
-	}  // for cz
 }

--- a/src/Simulator/Simulator.h
+++ b/src/Simulator/Simulator.h
@@ -50,14 +50,8 @@ protected:
 	friend class cChunk;  // Calls AddBlock() in its WakeUpSimulators() function, to speed things up
 	friend class cSimulatorManager;  // Class reponsible for dispatching calls to the various slave Simulators
 
-	virtual void Simulate(float a_Dt) = 0;
-	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk)
-	{
-		UNUSED(a_Dt);
-		UNUSED(a_ChunkX);
-		UNUSED(a_ChunkZ);
-		UNUSED(a_Chunk);
-	}
+	virtual void Simulate(float a_Dt);
+	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk) = 0;
 
 	/** Called to simulate a new block. Unlike WakeUp this function will perform minimal checking.
 	It queues the block to be simulated as fast as possible, suitable for area wakeups. */
@@ -73,9 +67,6 @@ protected:
 	Simulators may use this information to update additional blocks that were affected by the change, or queue
 	farther, extra-adjacents blocks to be updated. The simulator manager calls this overload after the 3-argument WakeUp. */
 	virtual void WakeUp(cChunk & a_Chunk, Vector3i a_Position, Vector3i a_Offset, BLOCKTYPE a_Block);
-
-	/** Called to simulate an area by the manager, delegated to cSimulator to avoid virtual calls in tight loops. */
-	void WakeUp(const cCuboid & a_Area);
 
 	cWorld & m_World;
 } ;

--- a/src/Simulator/SimulatorManager.cpp
+++ b/src/Simulator/SimulatorManager.cpp
@@ -3,6 +3,7 @@
 
 #include "SimulatorManager.h"
 #include "../Chunk.h"
+#include "../Cuboid.h"
 #include "../World.h"
 
 
@@ -30,6 +31,7 @@ cSimulatorManager::~cSimulatorManager()
 void cSimulatorManager::Simulate(float a_Dt)
 {
 	m_Ticks++;
+
 	for (cSimulators::iterator itr = m_Simulators.begin(); itr != m_Simulators.end(); ++itr)
 	{
 		if ((m_Ticks % itr->second) == 0)
@@ -46,6 +48,7 @@ void cSimulatorManager::Simulate(float a_Dt)
 void cSimulatorManager::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk)
 {
 	// m_Ticks has already been increased in Simulate()
+
 	for (cSimulators::iterator itr = m_Simulators.begin(); itr != m_Simulators.end(); ++itr)
 	{
 		if ((m_Ticks % itr->second) == 0)
@@ -71,6 +74,7 @@ void cSimulatorManager::WakeUp(cChunk & a_Chunk, Vector3i a_Position)
 	for (const auto & Offset : cSimulator::AdjacentOffsets)
 	{
 		auto Relative = a_Position + Offset;
+
 		if (!cChunkDef::IsValidHeight(Relative))
 		{
 			continue;
@@ -99,10 +103,46 @@ void cSimulatorManager::WakeUp(cChunk & a_Chunk, Vector3i a_Position)
 
 void cSimulatorManager::WakeUp(const cCuboid & a_Area)
 {
-	for (const auto & Item : m_Simulators)
+	cCuboid area(a_Area);
+	area.Sort();
+	area.Expand(1, 1, 1, 1, 1, 1);  // Expand the area to contain the neighbors, too.
+	area.ClampY(0, cChunkDef::Height - 1);
+
+	cChunkCoords ChunkStart = cChunkDef::BlockToChunk(area.p1);
+	cChunkCoords ChunkEnd = cChunkDef::BlockToChunk(area.p2);
+
+	// Add all blocks, in a per-chunk manner:
+	for (int cz = ChunkStart.m_ChunkZ; cz <= ChunkEnd.m_ChunkZ; ++cz)
 	{
-		Item.first->WakeUp(a_Area);
-	}
+		for (int cx = ChunkStart.m_ChunkX; cx <= ChunkEnd.m_ChunkX; ++cx)
+		{
+			m_World.DoWithChunk(cx, cz, [this, &area](cChunk & a_CBChunk)
+			{
+				int startX = std::max(area.p1.x, a_CBChunk.GetPosX() * cChunkDef::Width);
+				int startZ = std::max(area.p1.z, a_CBChunk.GetPosZ() * cChunkDef::Width);
+				int endX = std::min(area.p2.x, a_CBChunk.GetPosX() * cChunkDef::Width + cChunkDef::Width - 1);
+				int endZ = std::min(area.p2.z, a_CBChunk.GetPosZ() * cChunkDef::Width + cChunkDef::Width - 1);
+
+				for (const auto & Item : m_Simulators)
+				{
+					const auto Simulator = Item.first;
+
+					for (int y = area.p1.y; y <= area.p2.y; ++y)
+					{
+						for (int z = startZ; z <= endZ; ++z)
+						{
+							for (int x = startX; x <= endX; ++x)
+							{
+								const auto Position = cChunkDef::AbsoluteToRelative({ x, y, z });
+								Simulator->WakeUp(a_CBChunk, Position, a_CBChunk.GetBlock(Position));
+							}  // for x
+						}  // for z
+					}  // for y
+				}
+				return true;
+			});
+		}  // for cx
+	}  // for cz
 }
 
 

--- a/src/Simulator/SimulatorManager.cpp
+++ b/src/Simulator/SimulatorManager.cpp
@@ -80,7 +80,8 @@ void cSimulatorManager::WakeUp(cChunk & a_Chunk, Vector3i a_Position)
 			continue;
 		}
 
-		auto Chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(Relative);
+		const auto Chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(Relative);
+
 		if ((Chunk == nullptr) || !Chunk->IsValid())
 		{
 			continue;

--- a/src/Simulator/VaporizeFluidSimulator.cpp
+++ b/src/Simulator/VaporizeFluidSimulator.cpp
@@ -14,6 +14,20 @@
 
 
 
+void cVaporizeFluidSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk)
+{
+	// Nothing needed
+
+	UNUSED(a_Dt);
+	UNUSED(a_ChunkX);
+	UNUSED(a_ChunkZ);
+	UNUSED(a_Chunk);
+}
+
+
+
+
+
 void cVaporizeFluidSimulator::AddBlock(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block)
 {
 	if ((a_Block == m_FluidBlock) || (a_Block == m_StationaryFluidBlock))
@@ -27,16 +41,3 @@ void cVaporizeFluidSimulator::AddBlock(cChunk & a_Chunk, Vector3i a_Position, BL
 		);
 	}
 }
-
-
-
-
-
-void cVaporizeFluidSimulator::Simulate(float a_Dt)
-{
-	// Nothing needed
-}
-
-
-
-

--- a/src/Simulator/VaporizeFluidSimulator.h
+++ b/src/Simulator/VaporizeFluidSimulator.h
@@ -27,11 +27,7 @@ public:
 
 private:
 
-	virtual void Simulate(float a_Dt) override;
+	virtual void SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX, int a_ChunkZ, cChunk * a_Chunk) override;
 	virtual void AddBlock(cChunk & a_Chunk, Vector3i a_Position, BLOCKTYPE a_Block) override;
 	virtual cFluidSimulatorData * CreateChunkData(void) override { return nullptr; }
 } ;
-
-
-
-


### PR DESCRIPTION
A fix for #5404 that seems to work.

I don't know if there is any side effect.

Basically redstone update was using [RelativeAdjacents](https://github.com/cuberite/cuberite/blob/5ae924ec74bab199284c451552040bcc6f39bb3a/src/Simulator/IncrementalRedstoneSimulator/RedstoneDataHelper.h#L43) witch check for every adjacent block for the redstone dust

Changing it to use [RelativeLaterals](https://github.com/cuberite/cuberite/blob/5ae924ec74bab199284c451552040bcc6f39bb3a/src/Simulator/IncrementalRedstoneSimulator/RedstoneDataHelper.h#L55) doesn't bug anymore but it means that redstone doesn't check under and hover it!

the question is, is it a problem? I don't know the in depth behavior of redstone