### PR TITLE
rework of the color code with & and standard codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build*/
 nbproject/
 ipch/
 Win32/
@@ -122,3 +123,6 @@ build-cuberite
 # clang-tidy
 tidy-build
 run-clang-tidy.py
+
+# ctags output
+tags

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -2249,18 +2249,20 @@ end
 				Chaining example below for details.</p>
 				<p>
 				Each part of the composite chat message takes a "Style" parameter, this is a string that describes
-				the formatting. It uses the following strings, concatenated together:
+				the formatting. It uses the "standard" minecraft format code without the '&' symbole, concatenated
+				together:
 				<table>
 				<tr><th>String</th><th>Style</th></tr>
-				<tr><td>b</td><td>Bold text</td></tr>
-				<tr><td>i</td><td>Italic text</td></tr>
-				<tr><td>u</td><td>Underlined text</td></tr>
-				<tr><td>s</td><td>Strikethrough text</td></tr>
-				<tr><td>o</td><td>Obfuscated text</td></tr>
-				<tr><td>@X</td><td>color [0–9a–f], same as dye meta</td></tr>
+				<tr><td>l</td><td>Bold text</td></tr>
+				<tr><td>o</td><td>Italic text</td></tr>
+				<tr><td>n</td><td>Underlined text</td></tr>
+				<tr><td>m</td><td>Strikethrough text</td></tr>
+				<tr><td>k</td><td>Obfuscated text</td></tr>
+				<tr><td>r</td><td>Reset Style</td></tr>
+				<tr><td>[0-9a-f]</td><td>colors</td></tr>
 				</table>
 				The following picture, taken from the Minecraft Wiki, illustrates the color codes:</p>
-				<img src="http://images.wikia.com/minecraft_gamepedia/images/archive/4/4c/20200824112326!Colors.png" />
+				<img src="https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7e/Minecraft_Formatting.gif/revision/latest/scale-to-width-down/292?cb=20200828001454" />
 			]],
 			Functions =
 			{

--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -2261,6 +2261,7 @@ end
 				<tr><td>r</td><td>Reset Style</td></tr>
 				<tr><td>[0-9a-f]</td><td>colors</td></tr>
 				</table>
+				You can escape the '&' character with an antislash in front of it. as follow: `I love Choco\&chips`
 				The following picture, taken from the Minecraft Wiki, illustrates the color codes:</p>
 				<img src="https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7e/Minecraft_Formatting.gif/revision/latest/scale-to-width-down/292?cb=20200828001454" />
 			]],

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -3911,7 +3911,7 @@ static int tolua_cCompositeChat_AddRunCommandPart(lua_State * tolua_S)
 	}
 
 	// Add the part:
-	AString Text, Command, Style = "u@a";
+	AString Text, Command, Style = "na";
 	L.GetStackValue(2, Text);
 	L.GetStackValue(3, Command);
 	L.GetStackValue(4, Style);

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -387,8 +387,14 @@ void cCompositeChat::AddChatPartStyle(Json::Value & a_Value, const AString & a_P
 		{
 			case 'k': a_Value["obfuscated"] = Json::Value(true); break;
 			case 'l': a_Value["bold"] = Json::Value(true); break;
+			case 's':  // Deprecated
+				LOG("Value s in AddChatPartStyle() is deprecated");
 			case 'm': a_Value["strikethrough"] = Json::Value(true); break;
+			case 'u':  // Deprecated
+				LOG("Value u in AddChatPartStyle() is deprecated");
 			case 'n': a_Value["underlined"] = Json::Value(true); break;
+			case 'i':  // Deprecated
+				LOG("Value i in AddChatPartStyle() is deprecated");
 			case 'o': a_Value["italic"] = Json::Value(true); break;
 			case '0': a_Value["color"] = Json::Value("black"); break;
 			case '1': a_Value["color"] = Json::Value("dark_blue"); break;

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -95,7 +95,6 @@ void cCompositeChat::AddShowAchievementPart(const AString & a_PlayerName, const 
 
 
 
-//TODO tonitch
 
 /**
  * Parse the input message to add colors or link then add it to the object.
@@ -118,7 +117,7 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 		{
 			case '&': //< Color code
 			{
-				if(a_ParseText[i-1] == '\\')
+				if(i != 0 && a_ParseText[i-1] == '\\')
 				{
 					CurrentText.append(a_ParseText, cursor, i-1-cursor).append("&");
 					AddTextPart(CurrentText, CurrentStyle);

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -119,7 +119,7 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 			{
 				if ((i != 0) && (a_ParseText[i-1] == '\\'))
 				{
-					CurrentText.append(a_ParseText, cursor, i-1-cursor).append("&");
+					CurrentText.append(a_ParseText, cursor, i - cursor - 1).append("&");
 					AddTextPart(CurrentText, CurrentStyle);
 					CurrentText.clear();
 					cursor = ++i;
@@ -128,7 +128,7 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 
 				if (cursor < i)
 				{
-					CurrentText.append(a_ParseText, cursor, i-cursor);
+					CurrentText.append(a_ParseText, cursor, i - cursor);
 					AddTextPart(CurrentText, CurrentStyle);
 					CurrentText.clear();
 				}

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -391,7 +391,7 @@ void cCompositeChat::AddChatPartStyle(Json::Value & a_Value, const AString & a_P
 				LOGERROR("Value s in AddChatPartStyle() is deprecated");
 			case 'm': a_Value["strikethrough"] = Json::Value(true); break;
 			case 'u':  // Deprecated
-				LOG("Value u in AddChatPartStyle() is deprecated");
+				LOGERROR("Value u in AddChatPartStyle() is deprecated");
 			case 'n': a_Value["underlined"] = Json::Value(true); break;
 			case 'i':  // Deprecated
 				LOG("Value i in AddChatPartStyle() is deprecated");

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -388,7 +388,7 @@ void cCompositeChat::AddChatPartStyle(Json::Value & a_Value, const AString & a_P
 			case 'k': a_Value["obfuscated"] = Json::Value(true); break;
 			case 'l': a_Value["bold"] = Json::Value(true); break;
 			case 's':  // Deprecated
-				LOG("Value s in AddChatPartStyle() is deprecated");
+				LOGERROR("Value s in AddChatPartStyle() is deprecated");
 			case 'm': a_Value["strikethrough"] = Json::Value(true); break;
 			case 'u':  // Deprecated
 				LOG("Value u in AddChatPartStyle() is deprecated");

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -97,13 +97,13 @@ void cCompositeChat::AddShowAchievementPart(const AString & a_PlayerName, const 
 
 
 /**
- * Parse the input message to add colors or link then add it to the object.
- *
- * It detect every & of the message and the next character for it to colorize.
- * It detect : in the text to detect link structures.
- *
- * @param a_ParseText The input text to parse
- */
+* Parse the input message to add colors or link then add it to the object.
+*
+* It detect every & of the message and the next character for it to colorize.
+* It detect : in the text to detect link structures.
+*
+* @param a_ParseText The input text to parse
+*/
 void cCompositeChat::ParseText(const AString & a_ParseText)
 {
 	size_t len = a_ParseText.length();
@@ -115,9 +115,9 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 	{
 		switch (a_ParseText[i])
 		{
-			case '&': //< Color code
+			case '&':  //< Color code
 			{
-				if(i != 0 && a_ParseText[i-1] == '\\')
+				if ((i != 0) && (a_ParseText[i-1] == '\\'))
 				{
 					CurrentText.append(a_ParseText, cursor, i-1-cursor).append("&");
 					AddTextPart(CurrentText, CurrentStyle);
@@ -132,7 +132,7 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 				i++;
 				cursor = i + 1;
 
-				if(a_ParseText[i] == 'r')
+				if (a_ParseText[i] == 'r')
 				{
 					CurrentStyle = "";
 				}
@@ -382,27 +382,27 @@ void cCompositeChat::AddChatPartStyle(Json::Value & a_Value, const AString & a_P
 	{
 		switch (a_PartStyle[i])
 		{
-			case 'k': a_Value["obfuscated"] = Json::Value(true);		break;
-			case 'l': a_Value["bold"] = Json::Value(true);			break;
-			case 'm': a_Value["strikethrough"] = Json::Value(true); 	break;
-			case 'n': a_Value["underlined"] = Json::Value(true);		break;
-			case 'o': a_Value["italic"] = Json::Value(true);		break;
-			case '0': a_Value["color"] = Json::Value("black");		break;
-			case '1': a_Value["color"] = Json::Value("dark_blue");		break;
-			case '2': a_Value["color"] = Json::Value("dark_green");		break;
-			case '3': a_Value["color"] = Json::Value("dark_aqua");		break;
-			case '4': a_Value["color"] = Json::Value("dark_red");		break;
-			case '5': a_Value["color"] = Json::Value("dark_purple");	break;
-			case '6': a_Value["color"] = Json::Value("gold");		break;
-			case '7': a_Value["color"] = Json::Value("gray");		break;
-			case '8': a_Value["color"] = Json::Value("dark_gray");		break;
-			case '9': a_Value["color"] = Json::Value("blue");		break;
-			case 'a': a_Value["color"] = Json::Value("green");		break;
-			case 'b': a_Value["color"] = Json::Value("aqua");		break;
-			case 'c': a_Value["color"] = Json::Value("red");		break;
-			case 'd': a_Value["color"] = Json::Value("light_purple");	break;
-			case 'e': a_Value["color"] = Json::Value("yellow");		break;
-			case 'f': a_Value["color"] = Json::Value("white");		break;
+			case 'k': a_Value["obfuscated"] = Json::Value(true); break;
+			case 'l': a_Value["bold"] = Json::Value(true); break;
+			case 'm': a_Value["strikethrough"] = Json::Value(true); break;
+			case 'n': a_Value["underlined"] = Json::Value(true); break;
+			case 'o': a_Value["italic"] = Json::Value(true); break;
+			case '0': a_Value["color"] = Json::Value("black"); break;
+			case '1': a_Value["color"] = Json::Value("dark_blue"); break;
+			case '2': a_Value["color"] = Json::Value("dark_green"); break;
+			case '3': a_Value["color"] = Json::Value("dark_aqua"); break;
+			case '4': a_Value["color"] = Json::Value("dark_red"); break;
+			case '5': a_Value["color"] = Json::Value("dark_purple"); break;
+			case '6': a_Value["color"] = Json::Value("gold"); break;
+			case '7': a_Value["color"] = Json::Value("gray"); break;
+			case '8': a_Value["color"] = Json::Value("dark_gray"); break;
+			case '9': a_Value["color"] = Json::Value("blue"); break;
+			case 'a': a_Value["color"] = Json::Value("green"); break;
+			case 'b': a_Value["color"] = Json::Value("aqua"); break;
+			case 'c': a_Value["color"] = Json::Value("red"); break;
+			case 'd': a_Value["color"] = Json::Value("light_purple"); break;
+			case 'e': a_Value["color"] = Json::Value("yellow"); break;
+			case 'f': a_Value["color"] = Json::Value("white"); break;
 
 		}  // switch (Style[i])
 	}  // for i - a_PartStyle[]

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -95,6 +95,7 @@ void cCompositeChat::AddShowAchievementPart(const AString & a_PlayerName, const 
 
 
 
+//TODO tonitch
 
 /**
  * Parse the input message to add colors or link then add it to the object.
@@ -139,15 +140,15 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 				{
 					size_t PrefixLen = Prefix.size();
 					if (
-						(i >= first + PrefixLen) &&  // There is enough space in front of the colon for the prefix
+						(i >= cursor + PrefixLen) &&  // There is enough space in front of the colon for the prefix
 						(std::string_view(a_ParseText).substr(i - PrefixLen, PrefixLen) == Prefix)  // the prefix matches
 					)
 					{
 						// Add everything before this as a text part:
-						if (i > first + PrefixLen)
+						if (i > cursor+ PrefixLen)
 						{
-							CurrentText.append(a_ParseText.c_str() + first, i - first - PrefixLen);
-							first = i - PrefixLen;
+							CurrentText.append(a_ParseText.c_str() + cursor, i - cursor - PrefixLen);
+							cursor= i - PrefixLen;
 						}
 						if (!CurrentText.empty())
 						{
@@ -163,8 +164,8 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 								break;
 							}
 						}
-						AddUrlPart(a_ParseText.substr(first, i - first), a_ParseText.substr(first, i - first), CurrentStyle);
-						first = i;
+						AddUrlPart(a_ParseText.substr(cursor, i - cursor), a_ParseText.substr(cursor, i - cursor), CurrentStyle);
+						cursor = i;
 						break;
 					}
 				}  // for Prefix - LinkPrefix[]
@@ -200,7 +201,7 @@ void cCompositeChat::UnderlineUrls(void)
 		{
 			[](TextPart &             a_Part) {  },
 			[](ClientTranslatedPart & a_Part) {  },
-			[](UrlPart &              a_Part) { a_Part.Style += 'u'; },
+			[](UrlPart &              a_Part) { a_Part.Style += 'n'; },
 			[](RunCommandPart &       a_Part) {  },
 			[](SuggestCommandPart &   a_Part) {  },
 			[](ShowAchievementPart &  a_Part) {  },
@@ -257,6 +258,8 @@ eLogLevel cCompositeChat::MessageTypeToLogLevel(eMessageType a_MessageType)
 
 
 
+
+// TODO tonitch
 
 void cCompositeChat::AddStyle(AString & a_Style, const AString & a_AddStyle)
 {
@@ -386,70 +389,28 @@ void cCompositeChat::AddChatPartStyle(Json::Value & a_Value, const AString & a_P
 	{
 		switch (a_PartStyle[i])
 		{
-			case 'b':
-			{
-				// bold
-				a_Value["bold"] = Json::Value(true);
-				break;
-			}
+			case 'k': a_Value["obfuscated"] = Json::Value(true);		break;
+			case 'l': a_Value["bold"] = Json::Value(true);			break;
+			case 'm': a_Value["strikethrough"] = Json::Value(true); 	break;
+			case 'n': a_Value["underlined"] = Json::Value(true);		break;
+			case 'o': a_Value["italic"] = Json::Value(true);		break;
+			case '0': a_Value["color"] = Json::Value("black");		break;
+			case '1': a_Value["color"] = Json::Value("dark_blue");		break;
+			case '2': a_Value["color"] = Json::Value("dark_green");		break;
+			case '3': a_Value["color"] = Json::Value("dark_aqua");		break;
+			case '4': a_Value["color"] = Json::Value("dark_red");		break;
+			case '5': a_Value["color"] = Json::Value("dark_purple");	break;
+			case '6': a_Value["color"] = Json::Value("gold");		break;
+			case '7': a_Value["color"] = Json::Value("gray");		break;
+			case '8': a_Value["color"] = Json::Value("dark_gray");		break;
+			case '9': a_Value["color"] = Json::Value("blue");		break;
+			case 'a': a_Value["color"] = Json::Value("green");		break;
+			case 'b': a_Value["color"] = Json::Value("aqua");		break;
+			case 'c': a_Value["color"] = Json::Value("red");		break;
+			case 'd': a_Value["color"] = Json::Value("light_purple");	break;
+			case 'e': a_Value["color"] = Json::Value("yellow");		break;
+			case 'f': a_Value["color"] = Json::Value("white");		break;
 
-			case 'i':
-			{
-				// italic
-				a_Value["italic"] = Json::Value(true);
-				break;
-			}
-
-			case 'u':
-			{
-				// Underlined
-				a_Value["underlined"] = Json::Value(true);
-				break;
-			}
-
-			case 's':
-			{
-				// strikethrough
-				a_Value["strikethrough"] = Json::Value(true);
-				break;
-			}
-
-			case 'o':
-			{
-				// obfuscated
-				a_Value["obfuscated"] = Json::Value(true);
-				break;
-			}
-
-			case '@':
-			{
-				// Color, specified by the next char:
-				i++;
-				if (i >= len)
-				{
-					// String too short, didn't contain a color
-					break;
-				}
-				switch (a_PartStyle[i])
-				{
-					case '0': a_Value["color"] = Json::Value("black");        break;
-					case '1': a_Value["color"] = Json::Value("dark_blue");    break;
-					case '2': a_Value["color"] = Json::Value("dark_green");   break;
-					case '3': a_Value["color"] = Json::Value("dark_aqua");    break;
-					case '4': a_Value["color"] = Json::Value("dark_red");     break;
-					case '5': a_Value["color"] = Json::Value("dark_purple");  break;
-					case '6': a_Value["color"] = Json::Value("gold");         break;
-					case '7': a_Value["color"] = Json::Value("gray");         break;
-					case '8': a_Value["color"] = Json::Value("dark_gray");    break;
-					case '9': a_Value["color"] = Json::Value("blue");         break;
-					case 'a': a_Value["color"] = Json::Value("green");        break;
-					case 'b': a_Value["color"] = Json::Value("aqua");         break;
-					case 'c': a_Value["color"] = Json::Value("red");          break;
-					case 'd': a_Value["color"] = Json::Value("light_purple"); break;
-					case 'e': a_Value["color"] = Json::Value("yellow");       break;
-					case 'f': a_Value["color"] = Json::Value("white");        break;
-				}  // switch (color)
-			}  // case '@'
 		}  // switch (Style[i])
 	}  // for i - a_PartStyle[]
 }

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -99,7 +99,7 @@ void cCompositeChat::AddShowAchievementPart(const AString & a_PlayerName, const 
 /**
 * Parse the input message to add colors or link then add it to the object.
 *
-* It detect every & of the message and the next character for it to colorize.
+* It detects every & of the message and the next character for it to colorize.
 * It detect : in the text to detect link structures.
 *
 * @param a_ParseText The input text to parse

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -394,7 +394,7 @@ void cCompositeChat::AddChatPartStyle(Json::Value & a_Value, const AString & a_P
 				LOGERROR("Value u in AddChatPartStyle() is deprecated");
 			case 'n': a_Value["underlined"] = Json::Value(true); break;
 			case 'i':  // Deprecated
-				LOG("Value i in AddChatPartStyle() is deprecated");
+				LOGERROR("Value i in AddChatPartStyle() is deprecated");
 			case 'o': a_Value["italic"] = Json::Value(true); break;
 			case '0': a_Value["color"] = Json::Value("black"); break;
 			case '1': a_Value["color"] = Json::Value("dark_blue"); break;

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -96,50 +96,32 @@ void cCompositeChat::AddShowAchievementPart(const AString & a_PlayerName, const 
 
 
 
-
+/**
+ * Parse the input message to add colors or link then add it to the object.
+ *
+ * It detect every & of the message and the next character for it to colorize.
+ * It detect : in the text to detect link structures.
+ *
+ * @param a_ParseText The input text to parse
+ */
 void cCompositeChat::ParseText(const AString & a_ParseText)
 {
 	size_t len = a_ParseText.length();
-	size_t first = 0;  // First character of the currently parsed block
+	size_t cursor = 0;  //< First character of the currently parsed block
 	AString CurrentStyle;
 	AString CurrentText;
 	for (size_t i = 0; i < len; i++)
 	{
 		switch (a_ParseText[i])
 		{
-			case '@':
+			case '&': //< Color code
 			{
-				// Color code
-				i++;
-				if (i >= len)
-				{
-					// Not enough following text
+				if(i == len){
 					break;
 				}
-				if (a_ParseText[i] == '@')
+				if(a_ParseText[i-1] == '\\')
 				{
-					// "@@" escape, just put a "@" into the current text and keep parsing as text
-					if (i > first + 1)
-					{
-						CurrentText.append(a_ParseText.c_str() + first, i - first - 1);
-					}
-					first = i + 1;
-					continue;
-				}
-				else
-				{
-					// True color code. Create a part for the CurrentText and start parsing anew:
-					if (i >= first)
-					{
-						CurrentText.append(a_ParseText.c_str() + first, i - first - 1);
-						first = i + 1;
-					}
-					if (!CurrentText.empty())
-					{
-						AddTextPart(CurrentText, CurrentStyle);
-						CurrentText.clear();
-					}
-					AddStyle(CurrentStyle, a_ParseText.substr(i - 1, 2));
+					continue;	
 				}
 				break;
 			}
@@ -190,9 +172,9 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 			}  // case ':'
 		}  // switch (a_ParseText[i])
 	}  // for i - a_ParseText[]
-	if (first < len)
+	if (cursor < len)
 	{
-		AddTextPart(a_ParseText.substr(first, len - first), CurrentStyle);
+		AddTextPart(a_ParseText.substr(cursor, len - cursor), CurrentStyle);
 	}
 }
 

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -126,9 +126,12 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 					continue;
 				}
 
-				CurrentText.append(a_ParseText, cursor, i-cursor);
-				AddTextPart(CurrentText, CurrentStyle);
-				CurrentText.clear();
+				if (cursor < i)
+				{
+					CurrentText.append(a_ParseText, cursor, i-cursor);
+					AddTextPart(CurrentText, CurrentStyle);
+					CurrentText.clear();
+				}
 				i++;
 				cursor = i + 1;
 

--- a/src/CompositeChat.cpp
+++ b/src/CompositeChat.cpp
@@ -108,21 +108,38 @@ void cCompositeChat::AddShowAchievementPart(const AString & a_PlayerName, const 
 void cCompositeChat::ParseText(const AString & a_ParseText)
 {
 	size_t len = a_ParseText.length();
-	size_t cursor = 0;  //< First character of the currently parsed block
+	size_t cursor = 0;
 	AString CurrentStyle;
 	AString CurrentText;
+
 	for (size_t i = 0; i < len; i++)
 	{
 		switch (a_ParseText[i])
 		{
 			case '&': //< Color code
 			{
-				if(i == len){
-					break;
-				}
 				if(a_ParseText[i-1] == '\\')
 				{
-					continue;	
+					CurrentText.append(a_ParseText, cursor, i-1-cursor).append("&");
+					AddTextPart(CurrentText, CurrentStyle);
+					CurrentText.clear();
+					cursor = ++i;
+					continue;
+				}
+
+				CurrentText.append(a_ParseText, cursor, i-cursor);
+				AddTextPart(CurrentText, CurrentStyle);
+				CurrentText.clear();
+				i++;
+				cursor = i + 1;
+
+				if(a_ParseText[i] == 'r')
+				{
+					CurrentStyle = "";
+				}
+				else
+				{
+					CurrentStyle.push_back(a_ParseText[i]);
 				}
 				break;
 			}
@@ -175,7 +192,9 @@ void cCompositeChat::ParseText(const AString & a_ParseText)
 	}  // for i - a_ParseText[]
 	if (cursor < len)
 	{
-		AddTextPart(a_ParseText.substr(cursor, len - cursor), CurrentStyle);
+		CurrentText.clear();
+		CurrentText.append(a_ParseText, cursor, len - cursor);
+		AddTextPart(CurrentText, CurrentStyle);
 	}
 }
 
@@ -253,31 +272,6 @@ eLogLevel cCompositeChat::MessageTypeToLogLevel(eMessageType a_MessageType)
 	}
 	ASSERT(!"Unhandled MessageType");
 	return eLogLevel::Error;
-}
-
-
-
-
-
-// TODO tonitch
-
-void cCompositeChat::AddStyle(AString & a_Style, const AString & a_AddStyle)
-{
-	if (a_AddStyle.empty())
-	{
-		return;
-	}
-	if (a_AddStyle[0] == '@')
-	{
-		size_t idx = a_Style.find('@');
-		if ((idx != AString::npos) && (idx != a_Style.length()))
-		{
-			a_Style.erase(idx, 2);
-		}
-		a_Style.append(a_AddStyle);
-		return;
-	}
-	a_Style.append(a_AddStyle);
 }
 
 

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -21,12 +21,13 @@ Each part corresponds roughly to the behavior supported by the client messaging:
 	- clickable commands (suggest)
 Each part has a text assigned to it that can be styled. The style is specified using a string,
 each character / character combination in the string specifies the style to use:
-	- b = bold
-	- i = italic
-	- u = underlined
-	- s = strikethrough
-	- o = obfuscated
-	- @X = color X (X is 0 - 9 or a - f, same as dye meta
+	- (char from 0 - 9 or a - f) = color X 
+	- k = obfuscated
+	- l = bold
+	- m = strikethrough
+	- n = underlined
+	- o = italic
+	- r = reset
 If the protocol version doesn't support all the features, it degrades gracefully.
 */
 class cCompositeChat
@@ -102,7 +103,7 @@ public:
 	cCompositeChat(void);
 
 	/** Creates a new chat message and parses the text into parts.
-	Recognizes "http:" and "https:" links and @color-codes.
+	Recognizes "http:" and "https:" links and &format-character.
 	Uses ParseText() for the actual parsing.
 	Exported manually due to ToLua++ generating extra output parameter. */
 	cCompositeChat(const AString & a_ParseText, eMessageType a_MessageType = mtCustom);

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -186,8 +186,4 @@ protected:
 	/** Additional data pertaining to message type, for example, the name of a mtPrivateMsg sender */
 	AString m_AdditionalMessageTypeData;
 
-
-	/** Adds a_AddStyle to a_Style; overwrites the existing style if appropriate.
-	If the style already contains something that a_AddStyle overrides, it is erased first. */
-	void AddStyle(AString & a_Style, const AString & a_AddStyle);
 } ;  // tolua_export

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -21,7 +21,7 @@ Each part corresponds roughly to the behavior supported by the client messaging:
 	- clickable commands (suggest)
 Each part has a text assigned to it that can be styled. The style is specified using a string,
 each character / character combination in the string specifies the style to use:
-	- (char from 0 - 9 or a - f) = color X 
+	- (char from 0 - 9 or a - f) = color X
 	- k = obfuscated
 	- l = bold
 	- m = strikethrough

--- a/src/CompositeChat.h
+++ b/src/CompositeChat.h
@@ -122,15 +122,15 @@ public:
 
 	/** Adds a part that opens an URL when clicked.
 	The default style is underlined light blue text. */
-	void AddUrlPart(const AString & a_Text, const AString & a_Url, const AString & a_Style = "u@c");
+	void AddUrlPart(const AString & a_Text, const AString & a_Url, const AString & a_Style = "nc");
 
 	/** Adds a part that runs a command when clicked.
 	The default style is underlined light green text. */
-	void AddRunCommandPart(const AString & a_Text, const AString & a_Command, const AString & a_Style = "u@a");
+	void AddRunCommandPart(const AString & a_Text, const AString & a_Command, const AString & a_Style = "na");
 
 	/** Adds a part that suggests a command (enters it into the chat message area, but doesn't send) when clicked.
 	The default style is underlined yellow text. */
-	void AddSuggestCommandPart(const AString & a_Text, const AString & a_SuggestedCommand, const AString & a_Style = "u@b");
+	void AddSuggestCommandPart(const AString & a_Text, const AString & a_SuggestedCommand, const AString & a_Style = "nb");
 
 	/** Adds a part that fully formats a specified achievement using client translatable strings
 	Takes achievement name and player awarded to. Displays as {player} has earned the achievement {achievement_name}.
@@ -138,7 +138,7 @@ public:
 	void AddShowAchievementPart(const AString & a_PlayerName, const AString & a_Achievement, const AString & a_Style = "");
 
 	/** Parses text into various parts, adds those.
-	Recognizes "http:" and "https:" URLs and @color-codes. */
+	Recognizes "http:" and "https:" URLs and &color-codes. */
 	void ParseText(const AString & a_ParseText);
 
 	/** Adds the "underline" style to each part that is an URL. */

--- a/tests/CompositeChat/CompositeChatTest.cpp
+++ b/tests/CompositeChat/CompositeChatTest.cpp
@@ -14,7 +14,7 @@
 static void TestParser1(void)
 {
 	cCompositeChat Msg;
-	Msg.ParseText("Testing @2color codes and http://links parser");
+	Msg.ParseText("Testing &2color codes and http://links parser");
 	const auto & Parts = Msg.GetParts();
 	TEST_EQUAL(Parts.size(), 4);
 
@@ -22,13 +22,13 @@ static void TestParser1(void)
 	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[0]).Style, "");
 
 	TEST_TRUE(std::holds_alternative<cCompositeChat::TextPart>(Parts[1]));
-	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[1]).Style, "@2");
+	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[1]).Style, "2");
 
 	TEST_TRUE(std::holds_alternative<cCompositeChat::UrlPart>(Parts[2]));
-	TEST_EQUAL(std::get<cCompositeChat::UrlPart>(Parts[2]).Style, "@2");
+	TEST_EQUAL(std::get<cCompositeChat::UrlPart>(Parts[2]).Style, "2");
 
 	TEST_TRUE(std::holds_alternative<cCompositeChat::TextPart>(Parts[3]));
-	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[3]).Style, "@2");
+	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[3]).Style, "2");
 }
 
 
@@ -38,21 +38,21 @@ static void TestParser1(void)
 static void TestParser2(void)
 {
 	cCompositeChat Msg;
-	Msg.ParseText("@3Advanced stuff: @5overriding color codes and http://links.with/@4color-in-them handling");
+	Msg.ParseText("&3Advanced stuff: &5overriding color codes and http://links.with/&4color-in-them handling");
 	const auto & Parts = Msg.GetParts();
 	TEST_EQUAL(Parts.size(), 4);
 
 	TEST_TRUE(std::holds_alternative<cCompositeChat::TextPart>(Parts[0]));
-	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[0]).Style, "@3");
+	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[0]).Style, "3");
 
 	TEST_TRUE(std::holds_alternative<cCompositeChat::TextPart>(Parts[1]));
-	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[1]).Style, "@5");
+	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[1]).Style, "35");
 
 	TEST_TRUE(std::holds_alternative<cCompositeChat::UrlPart>(Parts[2]));
-	TEST_EQUAL(std::get<cCompositeChat::UrlPart>(Parts[2]).Style, "@5");
+	TEST_EQUAL(std::get<cCompositeChat::UrlPart>(Parts[2]).Style, "35");
 
 	TEST_TRUE(std::holds_alternative<cCompositeChat::TextPart>(Parts[3]));
-	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[3]).Style, "@5");
+	TEST_EQUAL(std::get<cCompositeChat::TextPart>(Parts[3]).Style, "35");
 }
 
 


### PR DESCRIPTION
This is a draft for the rework of the chat, as explain in  #5287 (no response so I assume this should be fine)

I want to make it as close as common server as possible so I want to follow this image ![color code](https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7e/Minecraft_Formatting.gif/revision/latest/scale-to-width-down/200?cb=20200828001454) and so using the `&` symbol