### PR TITLE
Implement ranged attack for snow golems. Fix failed assertion

### DIFF
--- a/Server/monsters.ini
+++ b/Server/monsters.ini
@@ -157,7 +157,7 @@ SightDistance=25.0
 
 [SnowGolem]
 AttackDamage=0.0
-AttackRange=1.0
+AttackRange=10.0
 AttackRate=1.0
 MaxHealth=4
 SightDistance=25.0

--- a/src/Mobs/SnowGolem.cpp
+++ b/src/Mobs/SnowGolem.cpp
@@ -5,6 +5,7 @@
 #include "SnowGolem.h"
 #include "../BlockInfo.h"
 #include "../World.h"
+#include "../Entities/ThrownSnowballEntity.h"
 
 
 
@@ -55,4 +56,33 @@ void cSnowGolem::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 			Chunk->SetBlock(Rel, E_BLOCK_SNOW, 0);
 		}
 	}
+}
+
+
+
+
+
+bool cSnowGolem::Attack(std::chrono::milliseconds a_Dt)
+{
+	// Comment inherited from skeletons
+	StopMovingToPosition();  // Todo handle this in a better way, the snowman does some uneeded recalcs due to inStateChasing
+	auto & Random = GetRandomProvider();
+
+	if ((GetTarget() != nullptr) && (m_AttackCoolDownTicksLeft == 0))
+	{
+		Vector3d Inaccuracy = Vector3d(Random.RandReal<double>(-0.25, 0.25), Random.RandReal<double>(-0.25, 0.25), Random.RandReal<double>(-0.25, 0.25));
+		Vector3d Speed = (GetTarget()->GetPosition() + Inaccuracy - GetPosition()) * 5;
+		Speed.y += Random.RandInt(-1, 1);
+
+		auto Snowball = std::make_unique<cThrownSnowballEntity>(this, GetPosition().addedY(1.5), Speed);
+		auto SnowballPtr = Snowball.get();
+		if (!SnowballPtr->Initialize(std::move(Snowball), *m_World))
+		{
+			return false;
+		}
+
+		ResetAttackCooldown();
+		return true;
+	}
+	return false;
 }

--- a/src/Mobs/SnowGolem.cpp
+++ b/src/Mobs/SnowGolem.cpp
@@ -64,17 +64,24 @@ void cSnowGolem::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 bool cSnowGolem::Attack(std::chrono::milliseconds a_Dt)
 {
+	UNUSED(a_Dt);
+
 	// Comment inherited from skeletons
 	StopMovingToPosition();  // Todo handle this in a better way, the snowman does some uneeded recalcs due to inStateChasing
-	auto & Random = GetRandomProvider();
 
 	if ((GetTarget() != nullptr) && (m_AttackCoolDownTicksLeft == 0))
 	{
-		Vector3d Inaccuracy = Vector3d(Random.RandReal<double>(-0.25, 0.25), Random.RandReal<double>(-0.25, 0.25), Random.RandReal<double>(-0.25, 0.25));
-		Vector3d Speed = (GetTarget()->GetPosition() + Inaccuracy - GetPosition()) * 4;
-		Speed.y += Random.RandInt(-1, 1);
+		auto & Random = GetRandomProvider();
+		Vector3d Inaccuracy = Vector3d(Random.RandReal<double>(-0.75, 0.75), Random.RandReal<double>(-0.75, 0.75), Random.RandReal<double>(-0.75, 0.75));
 
-		auto Snowball = std::make_unique<cThrownSnowballEntity>(this, GetPosition().addedY(1.5), Speed);
+		// The projectile is launched from the head
+		const auto HeadPos = GetPosition().addedY(1.5);
+		// It aims around the head / chest
+		const auto TargetPos = GetTarget()->GetPosition().addedY(GetTarget()->GetHeight() * 0.75);
+		// With this data, we can calculate the speed
+		const auto Speed = (TargetPos + Inaccuracy - HeadPos) * 5;
+
+		auto Snowball = std::make_unique<cThrownSnowballEntity>(this, HeadPos, Speed);
 		auto SnowballPtr = Snowball.get();
 		if (!SnowballPtr->Initialize(std::move(Snowball), *m_World))
 		{

--- a/src/Mobs/SnowGolem.cpp
+++ b/src/Mobs/SnowGolem.cpp
@@ -71,7 +71,7 @@ bool cSnowGolem::Attack(std::chrono::milliseconds a_Dt)
 	if ((GetTarget() != nullptr) && (m_AttackCoolDownTicksLeft == 0))
 	{
 		Vector3d Inaccuracy = Vector3d(Random.RandReal<double>(-0.25, 0.25), Random.RandReal<double>(-0.25, 0.25), Random.RandReal<double>(-0.25, 0.25));
-		Vector3d Speed = (GetTarget()->GetPosition() + Inaccuracy - GetPosition()) * 5;
+		Vector3d Speed = (GetTarget()->GetPosition() + Inaccuracy - GetPosition()) * 4;
 		Speed.y += Random.RandInt(-1, 1);
 
 		auto Snowball = std::make_unique<cThrownSnowballEntity>(this, GetPosition().addedY(1.5), Speed);

--- a/src/Mobs/SnowGolem.cpp
+++ b/src/Mobs/SnowGolem.cpp
@@ -83,7 +83,7 @@ bool cSnowGolem::Attack(std::chrono::milliseconds a_Dt)
 
 		auto Snowball = std::make_unique<cThrownSnowballEntity>(this, HeadPos, Speed);
 		auto SnowballPtr = Snowball.get();
-		if (!SnowballPtr->Initialize(std::move(Snowball), *m_World))
+		if (!SnowballPtr->Initialize(std::move(Snowball), *GetWorld()))
 		{
 			return false;
 		}

--- a/src/Mobs/SnowGolem.h
+++ b/src/Mobs/SnowGolem.h
@@ -20,6 +20,7 @@ public:
 
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override;
 	virtual void GetDrops(cItems & a_Drops, cEntity * a_Killer = nullptr) override;
+	virtual bool Attack(std::chrono::milliseconds a_Dt) override;
 } ;
 
 

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -1064,6 +1064,7 @@ public:
 				case cProjectileEntity::pkFireCharge:
 				case cProjectileEntity::pkWitherSkull:
 				case cProjectileEntity::pkEnderPearl:
+				case cProjectileEntity::pkSnowball:
 				{
 					break;
 				}


### PR DESCRIPTION
This is the easy part from #5415. This PR just implements ranged attack (throwing snowballs) for snow golems, it doesn't change their behavior in any way, which means they're still neutral mobs and will attack only when attacked, and will attack players.

The code is basically copied from `cSkeleton`. As @tonitch has pointed out in #5415, this works poorly when the snowman attack a small mob, such as spider. This was partially compensated for by decreasing the snowball's speed, but the solution is far from perfect. Decreasing the speed improves accuracy for spiders, but decreases it for higher mobs, such as zombies.

Additionaly, it fixes a failed assertion when saving a world with a thrown snowball in it