### PR TITLE
Remove redundant initialisations

### DIFF
--- a/src/ByteBuffer.cpp
+++ b/src/ByteBuffer.cpp
@@ -556,7 +556,7 @@ bool cByteBuffer::ReadUUID(cUUID & a_Value)
 {
 	CHECK_THREAD
 
-	std::array<Byte, 16> UUIDBuf = {0};
+	std::array<Byte, 16> UUIDBuf;
 	if (!ReadBuf(UUIDBuf.data(), UUIDBuf.size()))
 	{
 		return false;

--- a/src/StringCompression.cpp
+++ b/src/StringCompression.cpp
@@ -76,7 +76,7 @@ Compression::Result Compression::Compressor::Compress(const void * const Input, 
 {
 	// First see if the stack buffer has enough space:
 	{
-		Result::Static Buffer = {static_cast<std::byte>(0)};
+		Result::Static Buffer;
 		const auto BytesWrittenOut = Algorithm(m_Handle, Input, Size, Buffer.data(), Buffer.size());
 
 		if (BytesWrittenOut != 0)
@@ -189,7 +189,7 @@ Compression::Result Compression::Extractor::Extract(const ContiguousByteBufferVi
 {
 	// First see if the stack buffer has enough space:
 	{
-		Result::Static Buffer = {static_cast<std::byte>(0)};
+		Result::Static Buffer;
 		size_t BytesWrittenOut;
 
 		switch (Algorithm(m_Handle, Input.data(), Input.size(), Buffer.data(), Buffer.size(), &BytesWrittenOut))


### PR DESCRIPTION
The static buffers here are immediately passed in to be overwritten.