### PR TITLE
Pickups: improve coalescing implementation

### DIFF
--- a/src/BlockEntities/JukeboxEntity.cpp
+++ b/src/BlockEntities/JukeboxEntity.cpp
@@ -115,7 +115,7 @@ bool cJukeboxEntity::EjectRecord(void)
 		return false;
 	}
 
-	m_World->SpawnItemPickups(cItem(static_cast<short>(m_Record)), Vector3d(0.5, 0.5, 0.5) + m_Pos, 10);
+	m_World->SpawnItemPickup(m_Pos.addedY(1), cItem(static_cast<short>(m_Record)), 10);
 	m_World->SetBlockMeta(m_Pos, E_META_JUKEBOX_OFF);
 	m_World->BroadcastSoundParticleEffect(EffectID::SFX_RANDOM_PLAY_MUSIC_DISC, GetPos(), 0);
 

--- a/src/Blocks/BroadcastInterface.h
+++ b/src/Blocks/BroadcastInterface.h
@@ -7,6 +7,7 @@
 // fwd:
 class cClientHandle;
 class cCompositeChat;
+class cPawn;
 class cPlayer;
 class cWorld;
 enum class EffectID : Int32;
@@ -33,7 +34,7 @@ public:
 	virtual void BroadcastChatFatal                  (const AString & a_Message, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastChatDeath                  (const AString & a_Message, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastChat                       (const cCompositeChat & a_Message, const cClientHandle * a_Exclude = nullptr) = 0;
-	virtual void BroadcastCollectEntity              (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count, const cClientHandle * a_Exclude = nullptr) = 0;
+	virtual void BroadcastCollectEntity              (const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastDestroyEntity              (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) = 0;
 	virtual void BroadcastEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, int a_Duration, const cClientHandle * a_Exclude = nullptr) = 0;

--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -101,7 +101,7 @@ void cBoundingBox::Expand(double a_ExpandX, double a_ExpandY, double a_ExpandZ)
 
 
 
-bool cBoundingBox::DoesIntersect(const cBoundingBox & a_Other)
+bool cBoundingBox::DoesIntersect(const cBoundingBox & a_Other) const
 {
 	return (
 		((a_Other.m_Min.x <= m_Max.x) && (a_Other.m_Max.x >= m_Min.x)) &&  // X coords intersect
@@ -114,7 +114,7 @@ bool cBoundingBox::DoesIntersect(const cBoundingBox & a_Other)
 
 
 
-cBoundingBox cBoundingBox::Union(const cBoundingBox & a_Other)
+cBoundingBox cBoundingBox::Union(const cBoundingBox & a_Other) const
 {
 	return cBoundingBox(
 		std::min(m_Min.x, a_Other.m_Min.x),
@@ -130,7 +130,7 @@ cBoundingBox cBoundingBox::Union(const cBoundingBox & a_Other)
 
 
 
-bool cBoundingBox::IsInside(Vector3d a_Point)
+bool cBoundingBox::IsInside(Vector3d a_Point) const
 {
 	return IsInside(m_Min, m_Max, a_Point);
 }
@@ -139,7 +139,7 @@ bool cBoundingBox::IsInside(Vector3d a_Point)
 
 
 
-bool cBoundingBox::IsInside(double a_X, double a_Y, double a_Z)
+bool cBoundingBox::IsInside(double a_X, double a_Y, double a_Z) const
 {
 	return IsInside(m_Min, m_Max, a_X, a_Y, a_Z);
 }
@@ -148,7 +148,7 @@ bool cBoundingBox::IsInside(double a_X, double a_Y, double a_Z)
 
 
 
-bool cBoundingBox::IsInside(cBoundingBox & a_Other)
+bool cBoundingBox::IsInside(cBoundingBox & a_Other) const
 {
 	// If both a_Other's coords are inside this, then the entire a_Other is inside
 	return (IsInside(a_Other.m_Min) && IsInside(a_Other.m_Max));
@@ -158,7 +158,7 @@ bool cBoundingBox::IsInside(cBoundingBox & a_Other)
 
 
 
-bool cBoundingBox::IsInside(Vector3d a_Min, Vector3d a_Max)
+bool cBoundingBox::IsInside(Vector3d a_Min, Vector3d a_Max) const
 {
 	// If both coords are inside this, then the entire a_Other is inside
 	return (IsInside(a_Min) && IsInside(a_Max));
@@ -287,7 +287,3 @@ bool cBoundingBox::Intersect(const cBoundingBox & a_Other, cBoundingBox & a_Inte
 	a_Intersection.m_Max.z = std::min(m_Max.z, a_Other.m_Max.z);
 	return (a_Intersection.m_Min.z < a_Intersection.m_Max.z);
 }
-
-
-
-

--- a/src/BoundingBox.h
+++ b/src/BoundingBox.h
@@ -23,6 +23,7 @@ the boxes are considered non-intersecting. */
 class cBoundingBox
 {
 public:
+
 	cBoundingBox(double a_MinX, double a_MaxX, double a_MinY, double a_MaxY, double a_MinZ, double a_MaxZ);
 	cBoundingBox(Vector3d a_Min, Vector3d a_Max);
 	cBoundingBox(Vector3d a_Pos, double a_Radius, double a_Height);
@@ -46,22 +47,22 @@ public:
 	void Expand(double a_ExpandX, double a_ExpandY, double a_ExpandZ);
 
 	/** Returns true if the two bounding boxes intersect */
-	bool DoesIntersect(const cBoundingBox & a_Other);
+	bool DoesIntersect(const cBoundingBox & a_Other) const;
 
 	/** Returns the union of the two bounding boxes */
-	cBoundingBox Union(const cBoundingBox & a_Other);
+	cBoundingBox Union(const cBoundingBox & a_Other) const;
 
 	/** Returns true if the point is inside the bounding box */
-	bool IsInside(Vector3d a_Point);
+	bool IsInside(Vector3d a_Point) const;
 
 	/** Returns true if the point is inside the bounding box */
-	bool IsInside(double a_X, double a_Y, double a_Z);
+	bool IsInside(double a_X, double a_Y, double a_Z) const;
 
 	/** Returns true if a_Other is inside this bounding box */
-	bool IsInside(cBoundingBox & a_Other);
+	bool IsInside(cBoundingBox & a_Other) const;
 
 	/** Returns true if a boundingbox specified by a_Min and a_Max is inside this bounding box */
-	bool IsInside(Vector3d a_Min, Vector3d a_Max);
+	bool IsInside(Vector3d a_Min, Vector3d a_Max) const;
 
 	/** Returns true if the specified point is inside the bounding box specified by its min / max corners */
 	static bool IsInside(Vector3d a_Min, Vector3d a_Max, Vector3d a_Point);
@@ -107,7 +108,3 @@ protected:
 	Vector3d m_Max;
 
 } ;  // tolua_export
-
-
-
-

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -215,7 +215,7 @@ void cWorld::BroadcastChat(const cCompositeChat & a_Message, const cClientHandle
 
 
 
-void cWorld::BroadcastCollectEntity(const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count, const cClientHandle * a_Exclude)
+void cWorld::BroadcastCollectEntity(const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count, const cClientHandle * a_Exclude)
 {
 	ForClientsWithEntity(a_Collected, *this, a_Exclude, [&](cClientHandle & a_Client)
 		{

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -1016,8 +1016,8 @@ bool cChunkMap::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback a
 	// Calculate the chunk range for the box:
 	int MinChunkX = FloorC(a_Box.GetMinX() / cChunkDef::Width);
 	int MinChunkZ = FloorC(a_Box.GetMinZ() / cChunkDef::Width);
-	int MaxChunkX = FloorC((a_Box.GetMaxX() + cChunkDef::Width) / cChunkDef::Width);
-	int MaxChunkZ = FloorC((a_Box.GetMaxZ() + cChunkDef::Width) / cChunkDef::Width);
+	int MaxChunkX = FloorC(a_Box.GetMaxX() / cChunkDef::Width);
+	int MaxChunkZ = FloorC(a_Box.GetMaxZ() / cChunkDef::Width);
 
 	// Iterate over each chunk in the range:
 	cCSLock Lock(m_CSChunks);

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -916,14 +916,15 @@ void cChunkMap::AddEntity(OwnedEntity a_Entity)
 	}
 
 	const auto EntityPtr = a_Entity.get();
-	ASSERT(EntityPtr->GetWorld() == m_World);
 
 	auto & Chunk = ConstructChunk(a_Entity->GetChunkX(), a_Entity->GetChunkZ());
 	Chunk.AddEntity(std::move(a_Entity));
 
-	EntityPtr->OnAddToWorld(*m_World);
 	ASSERT(!EntityPtr->IsTicking());
+	ASSERT(EntityPtr->GetWorld() == m_World);
+
 	EntityPtr->SetIsTicking(true);
+	EntityPtr->OnAddToWorld(*m_World);
 
 	cPluginManager::Get()->CallHookSpawnedEntity(*m_World, *EntityPtr);
 }

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -624,8 +624,8 @@ void cClientHandle::StreamNextChunks(void)
 
 void cClientHandle::UnloadOutOfRangeChunks(void)
 {
-	int ChunkPosX = FAST_FLOOR_DIV(static_cast<int>(m_Player->GetPosX()), cChunkDef::Width);
-	int ChunkPosZ = FAST_FLOOR_DIV(static_cast<int>(m_Player->GetPosZ()), cChunkDef::Width);
+	int ChunkPosX = FloorC(m_Player->GetPosX() / cChunkDef::Width);
+	int ChunkPosZ = FloorC(m_Player->GetPosZ() / cChunkDef::Width);
 
 	cChunkCoordsList ChunksToRemove;
 	{

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2535,7 +2535,7 @@ void cClientHandle::SendChunkData(int a_ChunkX, int a_ChunkZ, const ContiguousBy
 
 
 
-void cClientHandle::SendCollectEntity(const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count)
+void cClientHandle::SendCollectEntity(const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count)
 {
 	m_Protocol->SendCollectEntity(a_Collected, a_Collector, a_Count);
 }

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -169,7 +169,7 @@ public:  // tolua_export
 	void SendChatSystem                 (const AString & a_Message, eMessageType a_ChatPrefix, const AString & a_AdditionalData = "");
 	void SendChatSystem                 (const cCompositeChat & a_Message);
 	void SendChunkData                  (int a_ChunkX, int a_ChunkZ, ContiguousByteBufferView a_ChunkData);
-	void SendCollectEntity              (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count);   // tolua_export
+	void SendCollectEntity              (const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count);   // tolua_export
 	void SendDestroyEntity              (const cEntity & a_Entity);   // tolua_export
 	void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle);   // tolua_export
 	void SendDisconnect                 (const AString & a_Reason);

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -208,7 +208,7 @@ public:
 	int GetChunkZ(void) const { return FloorC(m_Position.z / cChunkDef::Width); }
 
 	// Get the Entity's axis aligned bounding box, with absolute (world-relative) coordinates.
-	cBoundingBox GetBoundingBox() const { return cBoundingBox(GetPosition(), GetWidth() / 2, GetHeight()); }
+	cBoundingBox GetBoundingBox() const { return cBoundingBox(m_Position, m_Width / 2, m_Height); }
 
 	void SetHeadYaw (double a_HeadYaw);
 	void SetMass    (double a_Mass);

--- a/src/Entities/ItemFrame.cpp
+++ b/src/Entities/ItemFrame.cpp
@@ -39,7 +39,7 @@ bool cItemFrame::DoTakeDamage(TakeDamageInfo & a_TDI)
 		const auto FlyOutSpeed = AddFaceDirection(Vector3i(), ProtocolFaceToBlockFace(m_Facing)) * 2;
 
 		// Spawn the frame's held item:
-		GetWorld()->SpawnItemPickup(SpawnPosition, m_Item, FlyOutSpeed);
+		GetWorld()->SpawnItemPickup(SpawnPosition, std::move(m_Item), FlyOutSpeed);
 	}
 
 	// In any case we have a held item and were hit by a player, so clear it:

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -17,6 +17,7 @@
 #include "../Items/ItemHandler.h"
 #include "../FastRandom.h"
 #include "../ClientHandle.h"
+#include "Entities/Pickup.h"
 
 #include "../WorldStorage/StatisticsSerializer.h"
 #include "../CompositeChat.h"
@@ -469,24 +470,6 @@ bool cPlayer::IsLeftHanded() const
 bool cPlayer::IsStanding() const
 {
 	return std::holds_alternative<BodyStanceStanding>(m_BodyStance);
-}
-
-
-
-
-
-void cPlayer::TossItems(const cItems & a_Items)
-{
-	if (IsGameModeSpectator())  // Players can't toss items in spectator
-	{
-		return;
-	}
-
-	m_Stats.Custom[CustomStatistic::Drop] += static_cast<StatisticsManager::StatValue>(a_Items.Size());
-
-	const auto Speed = (GetLookVector() + Vector3d(0, 0.2, 0)) * 6;  // A dash of height and a dollop of speed
-	const auto Position = GetEyePosition() - Vector3d(0, 0.2, 0);  // Correct for eye-height weirdness
-	m_World->SpawnItemPickups(a_Items, Position, Speed, true);  // 'true' because created by player
 }
 
 
@@ -1719,7 +1702,6 @@ void cPlayer::SetDraggingItem(const cItem & a_Item)
 
 void cPlayer::TossEquippedItem(char a_Amount)
 {
-	cItems Drops;
 	cItem DroppedItem(GetInventory().GetEquippedItem());
 	if (!DroppedItem.IsEmpty())
 	{
@@ -1732,10 +1714,8 @@ void cPlayer::TossEquippedItem(char a_Amount)
 		GetInventory().GetHotbarGrid().ChangeSlotCount(GetInventory().GetEquippedSlotNum() /* Returns hotbar subslot, which HotbarGrid takes */, -a_Amount);
 
 		DroppedItem.m_ItemCount = NewAmount;
-		Drops.push_back(DroppedItem);
+		TossPickup(DroppedItem);
 	}
-
-	TossItems(Drops);
 }
 
 
@@ -1763,13 +1743,12 @@ void cPlayer::ReplaceOneEquippedItemTossRest(const cItem & a_Item)
 
 void cPlayer::TossHeldItem(char a_Amount)
 {
-	cItems Drops;
 	cItem & Item = GetDraggingItem();
 	if (!Item.IsEmpty())
 	{
 		char OriginalItemAmount = Item.m_ItemCount;
 		Item.m_ItemCount = std::min(OriginalItemAmount, a_Amount);
-		Drops.push_back(Item);
+		TossPickup(Item);
 
 		if (OriginalItemAmount > a_Amount)
 		{
@@ -1780,8 +1759,6 @@ void cPlayer::TossHeldItem(char a_Amount)
 			Item.Empty();
 		}
 	}
-
-	TossItems(Drops);
 }
 
 
@@ -1790,10 +1767,16 @@ void cPlayer::TossHeldItem(char a_Amount)
 
 void cPlayer::TossPickup(const cItem & a_Item)
 {
-	cItems Drops;
-	Drops.push_back(a_Item);
+	if (IsGameModeSpectator())  // Players can't toss items in spectator
+	{
+		return;
+	}
 
-	TossItems(Drops);
+	m_Stats.Custom[CustomStatistic::Drop] += 1U;
+
+	const auto Speed = (GetLookVector() + Vector3d(0, 0.2, 0)) * 6;  // A dash of height and a dollop of speed.
+	const auto Position = GetEyePosition() - Vector3d(0, 0.2, 0);  // Eye position, corrected for eye-height weirdness.
+	m_World->SpawnItemPickup(Position, cItem(a_Item), Speed, 40_tick);  // 2s delay before vomited pickups can be collected.
 }
 
 

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -394,9 +394,6 @@ public:
 	/** Returns true if a player is standing normally, that is, in a neutral pose. */
 	bool IsStanding() const;
 
-	/** Tosses a list of items. */
-	void TossItems(const cItems & a_Items);
-
 	/** Sets a player's in-bed state.
 	We can't be sure plugins will keep this value updated, so no exporting.
 	If value is false (not in bed), will update players of the fact that they have been ejected from the bed. */

--- a/src/Mobs/Chicken.cpp
+++ b/src/Mobs/Chicken.cpp
@@ -38,10 +38,8 @@ void cChicken::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		m_EggDropTimer == 12000
 	)
 	{
-		cItems Drops;
 		m_EggDropTimer = 0;
-		Drops.emplace_back(E_ITEM_EGG, static_cast<char>(1));
-		m_World->SpawnItemPickups(Drops, GetPosX(), GetPosY(), GetPosZ(), 10);
+		m_World->SpawnItemPickup(GetPosition(), cItem(E_ITEM_EGG));
 	}
 	else
 	{

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1514,12 +1514,12 @@ void cMonster::AddRandomDropItem(cItems & a_Drops, unsigned int a_Min, unsigned 
 	auto MaxStackSize = static_cast<unsigned int>(cItem(a_Item).GetMaxStackSize());
 	while (Count > MaxStackSize)
 	{
-		a_Drops.emplace_back(a_Item, MaxStackSize, a_ItemHealth);
+		a_Drops.emplace_back(a_Item, static_cast<char>(MaxStackSize), a_ItemHealth);
 		Count -= MaxStackSize;
 	}
 	if (Count > 0)
 	{
-		a_Drops.emplace_back(a_Item, Count, a_ItemHealth);
+		a_Drops.emplace_back(a_Item, static_cast<char>(Count), a_ItemHealth);
 	}
 }
 

--- a/src/Mobs/Mooshroom.cpp
+++ b/src/Mobs/Mooshroom.cpp
@@ -64,9 +64,7 @@ void cMooshroom::OnRightClicked(cPlayer & a_Player)
 				a_Player.UseEquippedItem();
 			}
 
-			cItems Drops;
-			Drops.emplace_back(E_BLOCK_RED_MUSHROOM, static_cast<char>(5), static_cast<char>(0));
-			m_World->SpawnItemPickups(Drops, GetPosX(), GetPosY(), GetPosZ(), 10);
+			m_World->SpawnItemPickup(GetPosition(), cItem(E_BLOCK_RED_MUSHROOM, static_cast<char>(5)));
 			m_World->SpawnMob(GetPosX(), GetPosY(), GetPosZ(), mtCow, false);
 			Destroy();
 		} break;

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -387,7 +387,7 @@ public:
 	virtual void SendChat                       (const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes) = 0;
 	virtual void SendChatRaw                    (const AString & a_MessageRaw, eChatType a_Type) = 0;
 	virtual void SendChunkData                  (ContiguousByteBufferView a_ChunkData) = 0;
-	virtual void SendCollectEntity              (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count) = 0;
+	virtual void SendCollectEntity              (const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count) = 0;
 	virtual void SendDestroyEntity              (const cEntity & a_Entity) = 0;
 	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) = 0;
 	virtual void SendDisconnect                 (const AString & a_Reason) = 0;

--- a/src/Protocol/Protocol_1_11.cpp
+++ b/src/Protocol/Protocol_1_11.cpp
@@ -319,7 +319,7 @@ namespace Metadata_1_11
 ////////////////////////////////////////////////////////////////////////////////
 // cProtocol_1_11_0:
 
-void cProtocol_1_11_0::SendCollectEntity(const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count)
+void cProtocol_1_11_0::SendCollectEntity(const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count)
 {
 	ASSERT(m_State == 3);  // In game mode?
 

--- a/src/Protocol/Protocol_1_11.h
+++ b/src/Protocol/Protocol_1_11.h
@@ -32,7 +32,7 @@ public:
 
 protected:
 
-	virtual void SendCollectEntity    (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count) override;
+	virtual void SendCollectEntity    (const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count) override;
 	virtual void SendEntityAnimation  (const cEntity & a_Entity, EntityAnimation a_Animation) override;
 	virtual void SendHideTitle        (void) override;
 	virtual void SendResetTitle       (void) override;

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -372,7 +372,7 @@ void cProtocol_1_8_0::SendChunkData(const ContiguousByteBufferView a_ChunkData)
 
 
 
-void cProtocol_1_8_0::SendCollectEntity(const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count)
+void cProtocol_1_8_0::SendCollectEntity(const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count)
 {
 	UNUSED(a_Count);
 	ASSERT(m_State == 3);  // In game mode?

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -56,7 +56,7 @@ public:
 	virtual void SendChat                       (const cCompositeChat & a_Message, eChatType a_Type, bool a_ShouldUseChatPrefixes) override;
 	virtual void SendChatRaw                    (const AString & a_MessageRaw, eChatType a_Type) override;
 	virtual void SendChunkData                  (ContiguousByteBufferView a_ChunkData) override;
-	virtual void SendCollectEntity              (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count) override;
+	virtual void SendCollectEntity              (const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count) override;
 	virtual void SendDestroyEntity              (const cEntity & a_Entity) override;
 	virtual void SendDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
 	virtual void SendDisconnect                 (const AString & a_Reason) override;

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -2742,18 +2742,15 @@ void cSlotAreaTemporary::TossItems(cPlayer & a_Player, int a_Begin, int a_End)
 		return;
 	}
 
-	cItems Drops;
 	for (int i = a_Begin; i < a_End; i++)
 	{
 		cItem & Item = itr->second[static_cast<size_t>(i)];
 		if (!Item.IsEmpty())
 		{
-			Drops.push_back(Item);
+			a_Player.TossPickup(Item);
+			Item.Empty();
 		}
-		Item.Empty();
 	}  // for i - itr->second[]
-
-	a_Player.TossItems(Drops);
 }
 
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1817,9 +1817,7 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, double a
 		float SpeedY = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(40, 50));
 		float SpeedZ = static_cast<float>(a_FlyAwaySpeed * Random.RandInt(-10, 10));
 
-		auto Pickup = std::make_unique<cPickup>(a_Pos, *itr, a_IsPlayerCreated, Vector3f{SpeedX, SpeedY, SpeedZ});
-		auto PickupPtr = Pickup.get();
-		PickupPtr->Initialize(std::move(Pickup), *this);
+		SpawnItemPickup(a_Pos, cItem(*itr), { SpeedX, SpeedY, SpeedZ });
 	}
 }
 
@@ -1836,10 +1834,55 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, Vector3d
 			continue;
 		}
 
-		auto pickup = std::make_unique<cPickup>(a_Pos, *itr, a_IsPlayerCreated, a_Speed);
-		auto pickupPtr = pickup.get();
-		pickupPtr->Initialize(std::move(pickup), *this);
+		SpawnItemPickup(a_Pos, cItem(*itr), a_Speed);
 	}
+}
+
+
+
+
+
+UInt32 cWorld::SpawnItemPickup(Vector3d a_Position, cItem && a_Item, Vector3d a_Speed, cTickTime a_CollectionDelay, cTickTime a_Lifetime, bool a_CanCombine)
+{
+	auto Pickup = std::make_unique<cPickup>(a_Position, std::move(a_Item), a_Speed, a_CollectionDelay, a_Lifetime);
+	auto PickupPtr = Pickup.get();
+
+	if (!PickupPtr->Initialize(std::move(Pickup), *this))
+	{
+		return cEntity::INVALID_ID;
+	}
+
+	return PickupPtr->GetUniqueID();
+}
+
+
+
+
+
+UInt32 cWorld::SpawnItemPickup(Vector3d a_Position, cItem && a_Item, Vector3d a_Speed, cBoundingBox a_CombineBounds, cTickTime a_CollectionDelay, cTickTime a_Lifetime)
+{
+	const auto MaxStackSize = a_Item.GetMaxStackSize();
+
+	for (const auto & [Entity, World] : m_EntitiesToAdd)
+	{
+		if (cPickup::TryCombineWithQueuedEntity(*Entity, a_CombineBounds, a_Item, MaxStackSize))
+		{
+			return Entity->GetUniqueID();
+		}
+	}
+
+	return SpawnItemPickup(a_Position, std::move(a_Item), a_Speed, a_CollectionDelay, a_Lifetime, true);
+}
+
+
+
+
+
+UInt32 cWorld::SpawnItemPickup(Vector3d a_Position, cItem && a_Item, double a_SpeedMultiplier, cTickTime a_CollectionDelay, cTickTime a_Lifetime, bool a_CanCombine)
+{
+	auto & Random = GetRandomProvider();
+	const auto InitialSpeed = Vector3d(Random.RandReal(-2.0, 2.0), 4.0, Random.RandReal(-2.0, 2.0)) * a_SpeedMultiplier;
+	return SpawnItemPickup(a_Position, std::move(a_Item), InitialSpeed, a_CollectionDelay, a_Lifetime, a_CanCombine);
 }
 
 
@@ -1848,13 +1891,7 @@ void cWorld::SpawnItemPickups(const cItems & a_Pickups, Vector3d a_Pos, Vector3d
 
 UInt32 cWorld::SpawnItemPickup(Vector3d a_Pos, const cItem & a_Item, Vector3f a_Speed, int a_LifetimeTicks, bool a_CanCombine)
 {
-	auto pickup = std::make_unique<cPickup>(a_Pos, a_Item, false, a_Speed, a_LifetimeTicks, a_CanCombine);
-	auto pickupPtr = pickup.get();
-	if (!pickupPtr->Initialize(std::move(pickup), *this))
-	{
-		return cEntity::INVALID_ID;
-	}
-	return pickupPtr->GetUniqueID();
+	return SpawnItemPickup(a_Pos, cItem(a_Item), a_Speed, 0_tick, cTickTime(a_LifetimeTicks), a_CanCombine);
 }
 
 
@@ -2075,12 +2112,19 @@ bool cWorld::DigBlock(Vector3i a_BlockPos, const cEntity * a_Digger)
 
 bool cWorld::DropBlockAsPickups(Vector3i a_BlockPos, const cEntity * a_Digger, const cItem * a_Tool)
 {
-	auto pickups = PickupsFromBlock(a_BlockPos, a_Digger, a_Tool);
+	auto Pickups = PickupsFromBlock(a_BlockPos, a_Digger, a_Tool);
+
 	if (!DigBlock(a_BlockPos, a_Digger))
 	{
 		return false;
 	}
-	SpawnItemPickups(pickups, Vector3d(0.5, 0.5, 0.5) + a_BlockPos, 10);
+
+	auto & Random = GetRandomProvider();
+	for (auto & Item : Pickups)
+	{
+		SpawnItemPickup(Vector3d(Random.RandReal(0.25, 0.75), Random.RandReal(0.25, 0.75), Random.RandReal(0.25, 0.75)) + a_BlockPos, std::move(Item));
+	}
+
 	return true;
 }
 

--- a/src/World.h
+++ b/src/World.h
@@ -29,6 +29,7 @@ class cFluidSimulator;
 class cSandSimulator;
 class cRedstoneSimulator;
 class cItem;
+class cPawn;
 class cPlayer;
 class cClientHandle;
 class cEntity;
@@ -167,7 +168,7 @@ public:
 	virtual void BroadcastChat       (const cCompositeChat & a_Message, const cClientHandle * a_Exclude = nullptr) override;
 	// tolua_end
 
-	virtual void BroadcastCollectEntity              (const cEntity & a_Collected, const cEntity & a_Collector, unsigned a_Count, const cClientHandle * a_Exclude = nullptr) override;
+	virtual void BroadcastCollectEntity              (const cEntity & a_Collected, const cPawn & a_Collector, unsigned a_Count, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastDestroyEntity              (const cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastDetachEntity               (const cEntity & a_Entity, const cEntity & a_PreviousVehicle) override;
 	virtual void BroadcastEntityEffect               (const cEntity & a_Entity, int a_EffectID, int a_Amplifier, int a_Duration, const cClientHandle * a_Exclude = nullptr) override;
@@ -434,6 +435,20 @@ public:
 		return SpawnItemPickups(a_Pickups, {a_BlockX, a_BlockY, a_BlockZ}, {a_SpeedX, a_SpeedY, a_SpeedZ}, a_IsPlayerCreated);
 	}
 
+	// tolua_end
+
+	/** Spawns a pickup containing the specified item with the specified speed. */
+	UInt32 SpawnItemPickup(Vector3d a_Position, cItem && a_Item, Vector3d a_Speed, cTickTime a_CollectionDelay = 10_tick, cTickTime a_Lifetime = 6000_tick, bool a_CanCombine = true);
+
+	/** With a pickup containing the specified item, either attempt to combine it with another pickup within the given bounds in the entity spawn queue, or spawn a new pickup with the specified speed.
+	This variant is useful for avoiding heavy server load when spawning many pickups at once within a single tick, for example during explosions, by pre-emptively combining them. */
+	UInt32 SpawnItemPickup(Vector3d a_Position, cItem && a_Item, Vector3d a_Speed, cBoundingBox a_CombineBounds, cTickTime a_CollectionDelay = 10_tick, cTickTime a_Lifetime = 6000_tick);
+
+	/** Spawns a pickup containing the specified item with random initial speed. */
+	UInt32 SpawnItemPickup(Vector3d a_Position, cItem && a_Item, double a_SpeedMultiplier = 1.0, cTickTime a_CollectionDelay = 10_tick, cTickTime a_Lifetime = 6000_tick, bool a_CanCombine = true);
+
+	// tolua_begin
+
 	/** Spawns a single pickup containing the specified item. */
 	UInt32 SpawnItemPickup(Vector3d a_Pos, const cItem & a_Item, Vector3f a_Speed, int a_LifetimeTicks = 6000, bool a_CanCombine = true);
 
@@ -561,9 +576,9 @@ public:
 	}
 
 	/** Digs the specified block, and spawns the appropriate pickups for it.
+	The pickup is spawned in a random position at most 0.25 away from the centre of the block along each axis.
 	a_Digger is an optional entity causing the digging, usually the player.
-	a_Tool is an optional item used to dig up the block, used by the handlers (empty hand vs shears produce different pickups from leaves).
-	An empty hand is assumed if a_Tool is nullptr.
+	a_Tool is an optional item used to dig up the block, used by the handlers (empty hand vs shears produce different pickups from leaves). An empty hand is assumed if a_Tool is nullptr.
 	Returns true on success, false if the chunk is not loaded. */
 	bool DropBlockAsPickups(Vector3i a_BlockPos, const cEntity * a_Digger = nullptr, const cItem * a_Tool = nullptr);
 

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -1942,7 +1942,7 @@ void cWSSAnvil::LoadPickupFromNBT(cEntityList & a_Entities, const cParsedNBT & a
 		return;
 	}
 
-	auto Pickup = std::make_unique<cPickup>(Vector3d(), Item, false);  // Pickup delay doesn't matter, just say false
+	auto Pickup = std::make_unique<cPickup>(Vector3d(), std::move(Item), Vector3d(), 0_tick, 0_tick);  // Pickup delay loaded later
 	if (!LoadEntityBaseFromNBT(*Pickup.get(), a_NBT, a_TagIdx))
 	{
 		return;


### PR DESCRIPTION
+ Add ability to coalesce before spawning in to world.
* Adapt coalescing for pickup entities already in the world to be more like Vanilla.

This is a pre-requisite for TNT explosion performance improvements, which rely on these changes to enable coalescing during explosions.