### PR TITLE
Create NBT Support with Variant in cItem

### DIFF
--- a/src/Bindings/DeprecatedBindings.cpp
+++ b/src/Bindings/DeprecatedBindings.cpp
@@ -325,7 +325,12 @@ static int tolua_get_cItem_m_Lore(lua_State * tolua_S)
 	const cItem * Self = nullptr;
 	L.GetStackValue(1, Self);
 
-	AString LoreString = StringJoin(Self->m_LoreTable, "`");
+	AString LoreString;
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>();
+	if (DisplayProperties.has_value())
+	{
+		LoreString = StringJoin(DisplayProperties.value().m_LoreTable, "`");
+	}
 
 	L.Push(LoreString);
 
@@ -354,7 +359,9 @@ static int tolua_set_cItem_m_Lore(lua_State * tolua_S)
 	AString LoreString;
 	L.GetStackValues(1, Self, LoreString);
 
-	Self->m_LoreTable = StringSplit(LoreString, "`");
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+	DisplayProperties.m_LoreTable = StringSplit(LoreString, "`");
+	Self->set<cItem::cDisplayProperties>(DisplayProperties);
 
 	LOGWARNING("cItem.m_Lore is deprecated, use cItem.m_LoreTable instead");
 	L.LogStackTrace(0);

--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -1255,6 +1255,52 @@ bool cLuaState::GetStackValue(int a_StackPos, cCallbackSharedPtr & a_Callback)
 
 
 
+bool cLuaState::GetStackValue(int a_StackPos, cColor & a_Value)
+{
+	if (!lua_istable(m_LuaState, a_StackPos))
+	{
+		return false;
+	}
+	auto ColorPointer = (cColor*)  tolua_tousertype(m_LuaState, 1, nullptr);
+	a_Value = *ColorPointer;
+	return true;
+}
+
+
+
+
+
+bool cLuaState::GetStackValue(int a_StackPos, cEnchantments & a_Value)
+{
+	if (!lua_istable(m_LuaState, a_StackPos))
+	{
+		return false;
+	}
+	auto EnchantmentsPointer = (cEnchantments*) tolua_tousertype(m_LuaState, 1, nullptr);
+	a_Value = *EnchantmentsPointer;
+	return true;
+}
+
+
+
+
+
+bool cLuaState::GetStackValue(int a_StackPos, cFireworkItem & a_Value)
+{
+	if (!lua_istable(m_LuaState, a_StackPos))
+	{
+		return false;
+	}
+
+	auto FireworkItemPointer = (cFireworkItem*) tolua_tousertype(m_LuaState, 1, nullptr);
+	a_Value = *FireworkItemPointer;
+	return true;
+}
+
+
+
+
+
 bool cLuaState::GetStackValue(int a_StackPos, cPluginManager::CommandResult & a_Result)
 {
 	if (lua_isnumber(m_LuaState, a_StackPos))

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -32,11 +32,12 @@ stays valid but doesn't call into Lua code anymore, returning false for "failure
 
 #include "lua/src/lauxlib.h"
 
-#include "../Defines.h"
-#include "../FunctionRef.h"
-#include "../Registries/CustomStatistics.h"
-#include "PluginManager.h"
-#include "LuaState_Typedefs.inc"
+#include "Defines.h"
+#include "FunctionRef.h"
+#include "Registries/CustomStatistics.h"
+#include "WorldStorage/FireworksSerializer.h"
+#include "Bindings/PluginManager.h"
+#include "Bindings/LuaState_Typedefs.inc"
 
 // fwd:
 class cLuaServerHandle;
@@ -644,6 +645,9 @@ public:
 	bool GetStackValue(int a_StackPos, cCallback & a_Callback);
 	bool GetStackValue(int a_StackPos, cCallbackPtr & a_Callback);
 	bool GetStackValue(int a_StackPos, cCallbackSharedPtr & a_Callback);
+	bool GetStackValue(int a_StackPos, cColor & a_Value);
+	bool GetStackValue(int a_StackPos, cEnchantments & a_Value);
+	bool GetStackValue(int a_StackPos, cFireworkItem & a_Value);
 	bool GetStackValue(int a_StackPos, cOptionalCallback & a_Callback);
 	bool GetStackValue(int a_StackPos, cOptionalCallbackPtr & a_Callback);
 	bool GetStackValue(int a_StackPos, cPluginManager::CommandResult & a_Result);

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -2757,6 +2757,114 @@ static int tolua_cMojangAPI_MakeUUIDShort(lua_State * L)
 
 
 
+static int tolua_get_cItem_m_CustomName(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("const cItem"))
+	{
+		return 0;
+	}
+	// Get the params:
+	const cItem * Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	// Push the result:
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+	L.Push(DisplayProperties.m_CustomName);
+	return 1;
+}
+
+
+
+
+
+static int tolua_set_cItem_m_CustomName(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("cItem"))
+	{
+		return 0;
+	}
+
+	// Get the params:
+	cItem * Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	if (!L.CheckParamString(1))
+	{
+		return 0;
+	}
+	AString CustomName;
+	L.GetStackValue(1, CustomName);
+
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+	DisplayProperties.m_CustomName = CustomName;
+	Self->set<cItem::cDisplayProperties>(DisplayProperties);
+	return 1;
+}
+
+
+
+
+
+static int tolua_get_cItem_m_ItemColor(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+
+	if (!L.CheckParamSelf("const cItem"))
+	{
+		return 0;
+	}
+	// Get the params:
+	const cItem * Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	// Push the result:
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+	L.Push(&DisplayProperties.m_Color);
+	return 1;
+}
+
+
+
+
+
+static int tolua_set_cItem_m_ItemColor(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+
+	if (!L.CheckParamSelf("cItem"))
+	{
+		return 0;
+	}
+
+	// Get the params:
+	cItem * Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	if (!L.CheckParamUserType(1, "cColor"))
+	{
+		return 0;
+	}
+
+	cColor Color;
+	L.GetStackValue(1, Color);
+
+	// Push the result:
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+	DisplayProperties.m_Color = Color;
+	Self->set<cItem::cDisplayProperties>(DisplayProperties);
+	return 1;
+}
+
+
+
+
+
 static int tolua_get_cItem_m_LoreTable(lua_State * tolua_S)
 {
 	// Check params:
@@ -2771,7 +2879,110 @@ static int tolua_get_cItem_m_LoreTable(lua_State * tolua_S)
 	L.GetStackValue(1, Self);
 
 	// Push the result:
-	L.Push(Self->m_LoreTable);
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+	L.Push(DisplayProperties.m_LoreTable);
+	return 1;
+}
+
+
+
+
+
+static int tolua_get_cItem_m_Enchantments(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("const cItem"))
+	{
+		return 0;
+	}
+
+	// Get the params:
+	const cItem * Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	// Push the result:
+	auto Enchantments = Self->get<cEnchantments>().value_or(cEnchantments());
+	L.Push(&Enchantments);
+	return 1;
+}
+
+
+
+
+
+static int tolua_set_cItem_m_Enchantments(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("cItem"))
+	{
+		return 0;
+	}
+	// Get the params:
+	cItem * Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	if (!L.CheckParamUserType(1, "cEnchantments"))
+	{
+		return 0;
+	}
+
+	cEnchantments Enchantments;
+	L.GetStackValue(1, Enchantments);
+	Self->set<cEnchantments>(Enchantments);
+	return 1;
+}
+
+
+
+
+
+static int tolua_get_cItem_m_FireworkItem(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("const cItem"))
+	{
+		return 0;
+	}
+
+	// Get the params:
+	const cItem * Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	// Push the result:
+	auto FireworkItem = Self->get<cFireworkItem>().value_or(cFireworkItem());
+	L.Push(&FireworkItem);
+	return 1;
+}
+
+
+
+
+
+static int tolua_set_cItem_m_FireworkItem(lua_State * tolua_S)
+{
+	// Check params:
+	cLuaState L(tolua_S);
+	if (!L.CheckParamSelf("cItem"))
+	{
+		return 0;
+	}
+
+	// Get the params:
+	cItem *Self = nullptr;
+	L.GetStackValue(1, Self);
+
+	// Push the result:
+	if (!L.CheckParamUserType(1, "cFireworkItem"))
+	{
+		return 0;
+	}
+
+	cFireworkItem FireworkItem;
+	L.GetStackValue(1, FireworkItem);
+	Self->set<cFireworkItem>(FireworkItem);
 	return 1;
 }
 
@@ -2823,11 +3034,13 @@ static int tolua_set_cItem_m_LoreTable(lua_State * tolua_S)
 	L.GetStackValue(1, Self);
 
 	// Set the value:
-	Self->m_LoreTable.clear();
-	if (!L.GetStackValue(2, Self->m_LoreTable))
+	auto DisplayProperties = Self->get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+	DisplayProperties.m_LoreTable.clear();
+	if (!L.GetStackValue(2, DisplayProperties.m_LoreTable))
 	{
 		return L.ApiParamError("cItem.m_LoreTable: Could not read value as an array of strings");
 	}
+	Self->set<cItem::cDisplayProperties>(DisplayProperties);
 	return 0;
 }
 
@@ -4628,7 +4841,11 @@ void cManualBindings::Bind(lua_State * tolua_S)
 
 		tolua_beginmodule(tolua_S, "cItem");
 			tolua_function(tolua_S, "EnchantByXPLevels", tolua_cItem_EnchantByXPLevels);
-			tolua_variable(tolua_S, "m_LoreTable",       tolua_get_cItem_m_LoreTable, tolua_set_cItem_m_LoreTable);
+			tolua_variable(tolua_S, "m_CustomName",      tolua_get_cItem_m_CustomName,   tolua_set_cItem_m_CustomName);
+			tolua_variable(tolua_S, "m_ItemColor",       tolua_get_cItem_m_ItemColor,    tolua_set_cItem_m_ItemColor);
+			tolua_variable(tolua_S, "m_LoreTable",       tolua_get_cItem_m_LoreTable,    tolua_set_cItem_m_LoreTable);
+			tolua_variable(tolua_S, "m_Enchantments",    tolua_get_cItem_m_Enchantments, tolua_set_cItem_m_Enchantments);
+			tolua_variable(tolua_S, "m_FireworkItem",    tolua_get_cItem_m_FireworkItem, tolua_set_cItem_m_FireworkItem);
 		tolua_endmodule(tolua_S);
 
 		tolua_beginmodule(tolua_S, "cItemGrid");

--- a/src/BlockEntities/EnchantingTableEntity.cpp
+++ b/src/BlockEntities/EnchantingTableEntity.cpp
@@ -22,7 +22,9 @@ cEnchantingTableEntity::cEnchantingTableEntity(BLOCKTYPE a_BlockType, NIBBLETYPE
 cItems cEnchantingTableEntity::ConvertToPickups() const
 {
 	cItem Item(E_BLOCK_ENCHANTMENT_TABLE);
-	Item.m_CustomName = m_CustomName;
+	cItem::cDisplayProperties DisplayProperties;
+	DisplayProperties.m_CustomName = std::move(m_CustomName);
+	Item.set<cItem::cDisplayProperties>(DisplayProperties);
 	return Item;
 }
 

--- a/src/BlockType.cpp
+++ b/src/BlockType.cpp
@@ -275,7 +275,7 @@ cItem GetIniItemSet(cIniFile & a_IniFile, const char * a_Section, const char * a
 	cItem res;
 	if (!StringToItem(ItemStr, res))
 	{
-		res.Empty();
+		res.Clear();
 	}
 	return res;
 }

--- a/src/Blocks/BlockCauldron.h
+++ b/src/Blocks/BlockCauldron.h
@@ -102,12 +102,19 @@ private:
 			case E_ITEM_LEATHER_PANTS:
 			case E_ITEM_LEATHER_TUNIC:
 			{
+				auto DisplayProperties = EquippedItem.get<cItem::cDisplayProperties>();
+				if (!DisplayProperties.has_value())
+				{
+					break;
+				}
 				// Resets any color to default:
-				if ((Meta > 0) && ((EquippedItem.m_ItemColor.GetRed() != 255) || (EquippedItem.m_ItemColor.GetBlue() != 255) || (EquippedItem.m_ItemColor.GetGreen() != 255)))
+				if ((Meta > 0) && ((DisplayProperties.value().m_Color.GetRed() != 255) || (DisplayProperties.value().m_Color.GetBlue() != 255) || (DisplayProperties.value().m_Color.GetGreen() != 255)))
 				{
 					a_ChunkInterface.SetBlockMeta(a_BlockPos, --Meta);
 					auto NewItem = cItem(EquippedItem);
-					NewItem.m_ItemColor.Clear();
+					auto newDisplayProperties = NewItem.get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties());
+					DisplayProperties->m_Color.Clear();
+					NewItem.set<cItem::cDisplayProperties>(newDisplayProperties);
 					a_Player.ReplaceOneEquippedItemTossRest(NewItem);
 				}
 				break;

--- a/src/Blocks/BlockEnderChest.h
+++ b/src/Blocks/BlockEnderChest.h
@@ -26,7 +26,10 @@ private:
 		)
 		{
 			// Only drop self when mined with a silk-touch pickaxe:
-			if (a_Tool->m_Enchantments.GetLevel(cEnchantments::enchSilkTouch) > 0)
+			if (
+				auto Enchantments = a_Tool->get<cEnchantments>();
+				(Enchantments.has_value() &&
+				Enchantments.value().GetLevel(cEnchantments::enchSilkTouch) > 0))
 			{
 				return cItem(E_BLOCK_ENDER_CHEST);
 			}

--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -592,7 +592,16 @@ ColourID cBlockHandler::GetMapBaseColourID(NIBBLETYPE a_Meta) const
 
 bool cBlockHandler::ToolHasSilkTouch(const cItem * a_Tool)
 {
-	return ((a_Tool != nullptr) && (a_Tool->m_Enchantments.GetLevel(cEnchantments::enchSilkTouch) > 0));
+	if (a_Tool == nullptr)
+	{
+		return false;
+	}
+	auto Enchantments = a_Tool->get<cEnchantments>();
+	if (!Enchantments.has_value())
+	{
+		return false;
+	}
+	return Enchantments.value().GetLevel(cEnchantments::enchSilkTouch) > 0;
 }
 
 
@@ -604,7 +613,12 @@ unsigned char cBlockHandler::ToolFortuneLevel(const cItem * a_Tool)
 	if ((a_Tool != nullptr) && ItemCategory::IsTool(a_Tool->m_ItemType))
 	{
 		// Return enchantment level, limited to avoid spawning excessive pickups (crashing the server) when modified items are used:
-		return static_cast<unsigned char>(std::min(8U, a_Tool->m_Enchantments.GetLevel(cEnchantments::enchFortune)));
+		auto Enchantments = a_Tool->get<cEnchantments>();
+		if (!Enchantments.has_value())
+		{
+			return 0;
+		}
+		return std::min<unsigned char>(8U, Enchantments.value().GetLevel(cEnchantments::enchFortune));
 	}
 
 	// Not a tool:

--- a/src/Blocks/BlockOre.h
+++ b/src/Blocks/BlockOre.h
@@ -88,7 +88,8 @@ private:
 			return;
 		}
 
-		if (Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchSilkTouch) != 0)
+		if (auto Enchantments = Player->GetEquippedItem().get<cEnchantments>();
+			Enchantments.has_value() && Enchantments.value().GetLevel(cEnchantments::enchSilkTouch) != 0)
 		{
 			// Don't drop XP when the ore is mined with the Silk Touch enchantment
 			return;

--- a/src/Entities/FireworkEntity.cpp
+++ b/src/Entities/FireworkEntity.cpp
@@ -10,11 +10,13 @@
 
 cFireworkEntity::cFireworkEntity(cEntity * a_Creator, Vector3d a_Pos, const cItem & a_Item) :
 	Super(pkFirework, a_Creator, a_Pos, 0.25f, 0.25f),
-	m_TicksToExplosion(a_Item.m_FireworkItem.m_FlightTimeInTicks),
 	m_FireworkItem(a_Item)
 {
 	SetGravity(0);
 	SetAirDrag(0);
+
+	auto fireworkItem = a_Item.get<cFireworkItem>();
+	m_TicksToExplosion = fireworkItem.value().m_FlightTimeInTicks;
 }
 
 

--- a/src/Entities/ItemFrame.cpp
+++ b/src/Entities/ItemFrame.cpp
@@ -43,7 +43,7 @@ bool cItemFrame::DoTakeDamage(TakeDamageInfo & a_TDI)
 	}
 
 	// In any case we have a held item and were hit by a player, so clear it:
-	m_Item.Empty();
+	m_Item.Clear();
 	m_ItemRotation = 0;
 	a_TDI.FinalDamage = 0;
 	SetInvulnerableTicks(0);

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1352,7 +1352,7 @@ void cPlayer::UpdateCapabilities()
 	}
 	else if (IsGameModeSpectator())
 	{
-		m_DraggingItem.Empty();  // Clear the current dragging item of spectators.
+		m_DraggingItem.Clear();  // Clear the current dragging item of spectators.
 		m_IsFlightCapable = true;
 		m_IsFlying = true;  // Spectators are always in flight mode.
 		m_IsVisible = false;  // Spectators are invisible.
@@ -1777,7 +1777,7 @@ void cPlayer::TossHeldItem(char a_Amount)
 		}
 		else
 		{
-			Item.Empty();
+			Item.Clear();
 		}
 	}
 
@@ -2070,7 +2070,13 @@ void cPlayer::UseItem(int a_SlotNumber, short a_Damage)
 	}
 
 	// Ref: https://minecraft.gamepedia.com/Enchanting#Unbreaking
-	unsigned int UnbreakingLevel = Item.m_Enchantments.GetLevel(cEnchantments::enchUnbreaking);
+	unsigned int UnbreakingLevel = 0;
+	auto Enchantments = Item.get<cEnchantments>();
+	if (Enchantments.has_value())
+	{
+		UnbreakingLevel = Enchantments.value().GetLevel(cEnchantments::enchUnbreaking);
+	}
+
 	double chance = ItemCategory::IsArmor(Item.m_ItemType)
 		? (0.6 + (0.4 / (UnbreakingLevel + 1))) : (1.0 / (UnbreakingLevel + 1));
 
@@ -2616,7 +2622,12 @@ float cPlayer::GetDigSpeed(BLOCKTYPE a_Block)
 	{
 		if (MiningSpeed > 1.0f)  // If the base multiplier for this block is greater than 1, now we can check enchantments
 		{
-			unsigned int EfficiencyModifier = GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::eEnchantment::enchEfficiency);
+			unsigned int EfficiencyModifier = 0;
+			auto Enchantments = GetEquippedItem().get<cEnchantments>();
+			if (Enchantments.has_value())
+			{
+				EfficiencyModifier = Enchantments.value().GetLevel(cEnchantments::eEnchantment::enchEfficiency);
+			}
 			if (EfficiencyModifier > 0)  // If an efficiency enchantment is present, apply formula as on wiki
 			{
 				MiningSpeed += (EfficiencyModifier * EfficiencyModifier) + 1;
@@ -2652,7 +2663,10 @@ float cPlayer::GetDigSpeed(BLOCKTYPE a_Block)
 	}
 
 	// 5x speed loss for being in water
-	if (IsInsideWater() && !(GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::eEnchantment::enchAquaAffinity) > 0))
+	if (
+		auto Enchantments = GetEquippedItem().get<cEnchantments>();
+		IsInsideWater() && (Enchantments.has_value() && (Enchantments.value().GetLevel(cEnchantments::eEnchantment::enchAquaAffinity) > 0))
+	)
 	{
 		MiningSpeed /= 5.0f;
 	}

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -225,7 +225,7 @@ cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, Vector3d
 	m_CreatorData(
 		((a_Creator != nullptr) ? a_Creator->GetUniqueID() : cEntity::INVALID_ID),
 		((a_Creator != nullptr) ? (a_Creator->IsPlayer() ? static_cast<cPlayer *>(a_Creator)->GetName() : "") : ""),
-		((a_Creator != nullptr) ? a_Creator->GetEquippedWeapon().m_Enchantments : cEnchantments())
+		((a_Creator != nullptr) ? a_Creator->GetEquippedWeapon().get<cEnchantments>().value_or(cEnchantments()) : cEnchantments())
 	),
 	m_IsInGround(false)
 {
@@ -277,7 +277,8 @@ std::unique_ptr<cProjectileEntity> cProjectileEntity::Create(
 		case pkFirework:
 		{
 			ASSERT(a_Item != nullptr);
-			if (a_Item->m_FireworkItem.m_Colours.empty())
+			auto fireworkItem = a_Item->get<cFireworkItem>();
+			if (!fireworkItem.has_value() || fireworkItem.value().m_Colours.empty())
 			{
 				return nullptr;
 			}

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -563,7 +563,7 @@ void cInventory::SendSlot(int a_SlotNum)
 	if (Item.IsEmpty())
 	{
 		// Sanitize items that are not completely empty (ie. count == 0, but type != empty)
-		Item.Empty();
+		Item.Clear();
 	}
 	m_Owner.GetClientHandle()->SendInventorySlot(0, static_cast<short>(a_SlotNum + 5), Item);  // Slots in the client are numbered "+ 5" because of crafting grid and result
 }

--- a/src/ItemGrid.cpp
+++ b/src/ItemGrid.cpp
@@ -192,7 +192,7 @@ void cItemGrid::EmptySlot(int a_SlotNum)
 	}
 
 	// Empty and notify
-	m_Slots[a_SlotNum].Empty();
+	m_Slots[a_SlotNum].Clear();
 	TriggerListeners(a_SlotNum);
 }
 
@@ -234,7 +234,7 @@ void cItemGrid::Clear(void)
 
 	for (int i = 0; i < m_Slots.size(); i++)
 	{
-		m_Slots[i].Empty();
+		m_Slots[i].Clear();
 		TriggerListeners(i);
 	}
 }
@@ -426,7 +426,7 @@ char cItemGrid::RemoveItem(const cItem & a_ItemStack)
 
 			if (m_Slots[i].m_ItemCount <= 0)
 			{
-				m_Slots[i].Empty();
+				m_Slots[i].Clear();
 			}
 
 			TriggerListeners(i);
@@ -484,7 +484,7 @@ char cItemGrid::ChangeSlotCount(int a_SlotNum, char a_AddToCount)
 	if (m_Slots[a_SlotNum].m_ItemCount <= -a_AddToCount)
 	{
 		// Trying to remove more items than there already are, make the item empty
-		m_Slots[a_SlotNum].Empty();
+		m_Slots[a_SlotNum].Clear();
 		TriggerListeners(a_SlotNum);
 		return 0;
 	}
@@ -537,7 +537,7 @@ cItem cItemGrid::RemoveOneItem(int a_SlotNum)
 	// Emptying the slot correctly if appropriate
 	if (m_Slots[a_SlotNum].m_ItemCount == 0)
 	{
-		m_Slots[a_SlotNum].Empty();
+		m_Slots[a_SlotNum].Clear();
 	}
 
 	// Notify everyone of the change
@@ -775,7 +775,9 @@ void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, s
 		for (int j = 0; j <= NumEnchantments; j++)
 		{
 			cEnchantments Enchantment = cEnchantments::SelectEnchantmentFromVector(Enchantments, Noise.IntNoise2DInt(NumEnchantments, i));
-			CurrentLoot.m_Enchantments.Add(Enchantment);
+			auto NewEnchantments = CurrentLoot.get<cEnchantments>().value_or(cEnchantments());
+			NewEnchantments.Add(Enchantment);
+			CurrentLoot.set<cEnchantments>(NewEnchantments);
 			cEnchantments::RemoveEnchantmentWeightFromVector(Enchantments, Enchantment);
 			cEnchantments::CheckEnchantmentConflictsFromVector(Enchantments, Enchantment);
 		}

--- a/src/Items/ItemBow.h
+++ b/src/Items/ItemBow.h
@@ -79,9 +79,21 @@ public:
 			0.5,
 			static_cast<float>(Force)
 		);
+
+		auto Enchantments = a_Player->GetEquippedWeapon().get<cEnchantments>();
+		if (!Enchantments.has_value())
+		{
+			if (!a_Player->IsGameModeCreative())
+			{
+				a_Player->GetInventory().RemoveItem(cItem(E_ITEM_ARROW));
+				a_Player->UseEquippedItem();
+			}
+			return;
+		}
+
 		if (!a_Player->IsGameModeCreative())
 		{
-			if (a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchInfinity) == 0)
+			if (Enchantments.value().GetLevel(cEnchantments::enchInfinity) == 0)
 			{
 				a_Player->GetInventory().RemoveItem(cItem(E_ITEM_ARROW));
 			}
@@ -92,7 +104,7 @@ public:
 
 			a_Player->UseEquippedItem();
 		}
-		if (a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchFlame) > 0)
+		if (Enchantments.value().GetLevel(cEnchantments::enchFlame) > 0)
 		{
 			ArrowPtr->StartBurning(100);
 		}

--- a/src/Items/ItemEnchantingTable.h
+++ b/src/Items/ItemEnchantingTable.h
@@ -36,7 +36,13 @@ private:
 		{
 			ASSERT(a_BlockEntity.GetBlockType() == E_BLOCK_ENCHANTMENT_TABLE);
 
-			static_cast<cEnchantingTableEntity &>(a_BlockEntity).SetCustomName(a_HeldItem.m_CustomName);
+			if (
+				auto DisplayProperties = a_HeldItem.get<cItem::cDisplayProperties>();
+				DisplayProperties.has_value()
+			)
+			{
+				static_cast<cEnchantingTableEntity &>(a_BlockEntity).SetCustomName(DisplayProperties.value().m_CustomName);
+			}
 			return false;
 		});
 

--- a/src/Items/ItemFishingRod.h
+++ b/src/Items/ItemFishingRod.h
@@ -84,7 +84,13 @@ public:
 		{
 			// Cast a hook:
 			auto & Random = GetRandomProvider();
-			auto CountDownTime = Random.RandInt(100, 900) - static_cast<int>(a_Player->GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLure) * 100);
+			unsigned lureLevel = 0;
+			auto Enchantments = a_Player->GetEquippedItem().get<cEnchantments>();
+			if (Enchantments.has_value())
+			{
+				lureLevel = Enchantments.value().GetLevel(cEnchantments::enchLure) * 100;
+			}
+			auto CountDownTime = Random.RandInt<unsigned int>(100, 900) - lureLevel;
 			auto Floater = std::make_unique<cFloater>(
 				a_Player->GetEyePosition(), a_Player->GetLookVector() * 15,
 				a_Player->GetUniqueID(),
@@ -156,7 +162,13 @@ public:
 
 	void ReelInLoot(cWorld & a_World, cPlayer & a_Player, const Vector3d a_FloaterBitePos) const
 	{
-		auto LotSLevel = std::min(a_Player.GetEquippedItem().m_Enchantments.GetLevel(cEnchantments::enchLuckOfTheSea), 3u);
+		auto LotSLevel = 3u;
+
+		auto Enchantments = a_Player.GetEquippedItem().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LotSLevel = std::min(Enchantments.value().GetLevel(cEnchantments::enchLuckOfTheSea), LotSLevel);
+		}
 
 		// Chances for getting an item from the category for each level of Luck of the Sea (0 - 3)
 		const int TreasureChances[] = {50, 71, 92, 113};  // 5% | 7.1% | 9.2% | 11.3%

--- a/src/Mobs/Blaze.cpp
+++ b/src/Mobs/Blaze.cpp
@@ -37,9 +37,20 @@ bool cBlaze::Attack(std::chrono::milliseconds a_Dt)
 
 void cBlaze::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 {
-	if ((a_Killer != nullptr) && (a_Killer->IsPlayer() || a_Killer->IsA("cWolf")))
+	if (a_Killer == nullptr)
 	{
-		unsigned int LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		return;
+	}
+
+	unsigned int LootingLevel = 0;
+	auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+	if (Enchantments.has_value())
+	{
+		LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+	}
+
+	if (a_Killer->IsPlayer() || a_Killer->IsA("cWolf"))
+	{
 		AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, E_ITEM_BLAZE_ROD);
 	}
 }

--- a/src/Mobs/CaveSpider.cpp
+++ b/src/Mobs/CaveSpider.cpp
@@ -56,7 +56,11 @@ void cCaveSpider::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_STRING);
 	if ((a_Killer != nullptr) && (a_Killer->IsPlayer() || a_Killer->IsA("cWolf")))

--- a/src/Mobs/Chicken.cpp
+++ b/src/Mobs/Chicken.cpp
@@ -63,7 +63,11 @@ void cChicken::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_FEATHER);
 	AddRandomDropItem(a_Drops, 1, 1, IsOnFire() ? E_ITEM_COOKED_CHICKEN : E_ITEM_RAW_CHICKEN);

--- a/src/Mobs/Cow.cpp
+++ b/src/Mobs/Cow.cpp
@@ -27,7 +27,11 @@ void cCow::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_LEATHER);
 	AddRandomDropItem(a_Drops, 1, 3 + LootingLevel, IsOnFire() ? E_ITEM_STEAK : E_ITEM_RAW_BEEF);

--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -71,7 +71,11 @@ void cCreeper::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_GUNPOWDER);
 

--- a/src/Mobs/Enderman.cpp
+++ b/src/Mobs/Enderman.cpp
@@ -95,7 +95,11 @@ void cEnderman::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, E_ITEM_ENDER_PEARL);
 }

--- a/src/Mobs/Ghast.cpp
+++ b/src/Mobs/Ghast.cpp
@@ -61,7 +61,11 @@ void cGhast::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_GUNPOWDER);
 	AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, E_ITEM_GHAST_TEAR);

--- a/src/Mobs/Guardian.cpp
+++ b/src/Mobs/Guardian.cpp
@@ -23,7 +23,11 @@ void cGuardian::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_PRISMARINE_SHARD);
 	AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, E_ITEM_RAW_FISH);

--- a/src/Mobs/Horse.cpp
+++ b/src/Mobs/Horse.cpp
@@ -261,7 +261,11 @@ void cHorse::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_LEATHER);
 	if (IsSaddled())

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -693,9 +693,12 @@ void cMonster::OnRightClicked(cPlayer & a_Player)
 	Super::OnRightClicked(a_Player);
 
 	const cItem & EquippedItem = a_Player.GetEquippedItem();
-	if ((EquippedItem.m_ItemType == E_ITEM_NAME_TAG) && !EquippedItem.m_CustomName.empty())
+	if (
+		auto DisplayProperties = EquippedItem.get<cItem::cDisplayProperties>();
+		(EquippedItem.m_ItemType == E_ITEM_NAME_TAG) && !DisplayProperties.value_or(cItem::cDisplayProperties()).m_CustomName.empty()
+	)
 	{
-		SetCustomName(EquippedItem.m_CustomName);
+		SetCustomName(DisplayProperties.value().m_CustomName);
 		if (!a_Player.IsGameModeCreative())
 		{
 			a_Player.GetInventory().RemoveOneEquippedItem();

--- a/src/Mobs/Mooshroom.cpp
+++ b/src/Mobs/Mooshroom.cpp
@@ -27,7 +27,11 @@ void cMooshroom::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_LEATHER);
 	AddRandomDropItem(a_Drops, 1, 3 + LootingLevel, IsOnFire() ? E_ITEM_STEAK : E_ITEM_RAW_BEEF);

--- a/src/Mobs/Pig.cpp
+++ b/src/Mobs/Pig.cpp
@@ -29,7 +29,11 @@ void cPig::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 1, 3 + LootingLevel, IsOnFire() ? E_ITEM_COOKED_PORKCHOP : E_ITEM_RAW_PORKCHOP);
 	if (m_bIsSaddled)

--- a/src/Mobs/Rabbit.cpp
+++ b/src/Mobs/Rabbit.cpp
@@ -41,7 +41,11 @@ void cRabbit::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, IsOnFire() ? E_ITEM_COOKED_RABBIT : E_ITEM_RAW_RABBIT);
 	AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, E_ITEM_RABBIT_HIDE);

--- a/src/Mobs/Sheep.cpp
+++ b/src/Mobs/Sheep.cpp
@@ -48,7 +48,11 @@ void cSheep::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 1, 3 + LootingLevel, IsOnFire() ? E_ITEM_COOKED_MUTTON : E_ITEM_RAW_MUTTON);
 }

--- a/src/Mobs/Skeleton.cpp
+++ b/src/Mobs/Skeleton.cpp
@@ -24,7 +24,11 @@ void cSkeleton::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_ARROW);
 

--- a/src/Mobs/Slime.cpp
+++ b/src/Mobs/Slime.cpp
@@ -33,7 +33,11 @@ void cSlime::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 
 	// Only slimes with the size 1 can drop slimeballs.

--- a/src/Mobs/Spider.cpp
+++ b/src/Mobs/Spider.cpp
@@ -20,9 +20,14 @@ cSpider::cSpider(void) :
 void cSpider::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 {
 	unsigned int LootingLevel = 0;
+
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_STRING);
 	if ((a_Killer != nullptr) && (a_Killer->IsPlayer() || a_Killer->IsA("cWolf")))

--- a/src/Mobs/Squid.cpp
+++ b/src/Mobs/Squid.cpp
@@ -23,7 +23,11 @@ void cSquid::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 3 + LootingLevel, E_ITEM_DYE, E_META_DYE_BLACK);
 }

--- a/src/Mobs/Witch.cpp
+++ b/src/Mobs/Witch.cpp
@@ -22,7 +22,11 @@ void cWitch::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	auto & r1 = GetRandomProvider();
 	int DropTypeCount = r1.RandInt(1, 3);

--- a/src/Mobs/WitherSkeleton.cpp
+++ b/src/Mobs/WitherSkeleton.cpp
@@ -37,7 +37,11 @@ void cWitherSkeleton::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomUncommonDropItem(a_Drops, 33.0f, E_ITEM_COAL);
 	AddRandomUncommonDropItem(a_Drops, 8.5f, E_ITEM_STONE_SWORD, GetRandomProvider().RandInt<short>(50));

--- a/src/Mobs/Zombie.cpp
+++ b/src/Mobs/Zombie.cpp
@@ -23,7 +23,11 @@ void cZombie::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_ROTTEN_FLESH);
 	cItems RareDrops;

--- a/src/Mobs/ZombiePigman.cpp
+++ b/src/Mobs/ZombiePigman.cpp
@@ -22,7 +22,11 @@ void cZombiePigman::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, E_ITEM_ROTTEN_FLESH);
 	AddRandomDropItem(a_Drops, 0, 1 + LootingLevel, E_ITEM_GOLD_NUGGET);

--- a/src/Mobs/ZombieVillager.cpp
+++ b/src/Mobs/ZombieVillager.cpp
@@ -27,7 +27,11 @@ void cZombieVillager::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	unsigned int LootingLevel = 0;
 	if (a_Killer != nullptr)
 	{
-		LootingLevel = a_Killer->GetEquippedWeapon().m_Enchantments.GetLevel(cEnchantments::enchLooting);
+		auto Enchantments = a_Killer->GetEquippedWeapon().get<cEnchantments>();
+		if (Enchantments.has_value())
+		{
+			LootingLevel = Enchantments.value().GetLevel(cEnchantments::enchLooting);
+		}
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_ROTTEN_FLESH);
 	cItems RareDrops;

--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -698,7 +698,7 @@ bool cProtocol_1_13::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t
 	if (ItemID == -1)
 	{
 		// The item is empty, no more data follows
-		a_Item.Empty();
+		a_Item.Clear();
 		return true;
 	}
 
@@ -710,7 +710,7 @@ bool cProtocol_1_13::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_t
 	a_Item.m_ItemCount = ItemCount;
 	if (ItemCount <= 0)
 	{
-		a_Item.Empty();
+		a_Item.Clear();
 	}
 
 	ContiguousByteBuffer Metadata;
@@ -1521,7 +1521,7 @@ bool cProtocol_1_13_2::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size
 	if (!Present)
 	{
 		// The item is empty, no more data follows
-		a_Item.Empty();
+		a_Item.Clear();
 		return true;
 	}
 
@@ -1534,7 +1534,7 @@ bool cProtocol_1_13_2::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size
 	a_Item.m_ItemCount = ItemCount;
 	if (ItemCount <= 0)
 	{
-		a_Item.Empty();
+		a_Item.Clear();
 	}
 
 	ContiguousByteBuffer Metadata;

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -2922,38 +2922,44 @@ void cProtocol_1_8_0::ParseItemMetadata(cItem & a_Item, const ContiguousByteBuff
 		{
 			case TAG_List:
 			{
+				cEnchantments Enchantments;
 				if ((TagName == "ench") || (TagName == "StoredEnchantments"))  // Enchantments tags
 				{
-					EnchantmentSerializer::ParseFromNBT(a_Item.m_Enchantments, NBT, tag);
+					EnchantmentSerializer::ParseFromNBT(Enchantments, NBT, tag);
 				}
+				a_Item.set<cEnchantments>(Enchantments);
 				break;
 			}
 			case TAG_Compound:
 			{
 				if (TagName == "display")  // Custom name and lore tag
 				{
+					cItem::cDisplayProperties DisplayProperties;
 					for (int displaytag = NBT.GetFirstChild(tag); displaytag >= 0; displaytag = NBT.GetNextSibling(displaytag))
 					{
-						if ((NBT.GetType(displaytag) == TAG_String) && (NBT.GetName(displaytag) == "Name"))  // Custon name tag
+						if ((NBT.GetType(displaytag) == TAG_String) && (NBT.GetName(displaytag) == "Name"))  // Custom name tag
 						{
-							a_Item.m_CustomName = NBT.GetString(displaytag);
+							DisplayProperties.m_CustomName = NBT.GetString(displaytag);
 						}
 						else if ((NBT.GetType(displaytag) == TAG_List) && (NBT.GetName(displaytag) == "Lore"))  // Lore tag
 						{
 							for (int loretag = NBT.GetFirstChild(displaytag); loretag >= 0; loretag = NBT.GetNextSibling(loretag))  // Loop through array of strings
 							{
-								a_Item.m_LoreTable.push_back(NBT.GetString(loretag));
+								DisplayProperties.m_LoreTable.push_back(NBT.GetString(loretag));
 							}
 						}
 						else if ((NBT.GetType(displaytag) == TAG_Int) && (NBT.GetName(displaytag) == "color"))
 						{
-							a_Item.m_ItemColor.m_Color = static_cast<unsigned int>(NBT.GetInt(displaytag));
+							DisplayProperties.m_Color.m_Color = (static_cast<unsigned int>(NBT.GetInt(displaytag)));
 						}
 					}
+					a_Item.set<cItem::cDisplayProperties>(DisplayProperties);
 				}
 				else if ((TagName == "Fireworks") || (TagName == "Explosion"))
 				{
-					cFireworkItem::ParseFromNBT(a_Item.m_FireworkItem, NBT, tag, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
+					cFireworkItem fireworkItem;
+					cFireworkItem::ParseFromNBT(fireworkItem, NBT, tag, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
+					a_Item.set<cFireworkItem>(fireworkItem);
 				}
 				break;
 			}
@@ -2981,7 +2987,7 @@ bool cProtocol_1_8_0::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_
 	if (ItemType == -1)
 	{
 		// The item is empty, no more data follows
-		a_Item.Empty();
+		a_Item.Clear();
 		return true;
 	}
 	a_Item.m_ItemType = ItemType;
@@ -2993,7 +2999,7 @@ bool cProtocol_1_8_0::ReadItem(cByteBuffer & a_ByteBuffer, cItem & a_Item, size_
 	a_Item.m_ItemDamage = ItemDamage;
 	if (ItemCount <= 0)
 	{
-		a_Item.Empty();
+		a_Item.Clear();
 	}
 
 	ContiguousByteBuffer Metadata;
@@ -3397,7 +3403,13 @@ void cProtocol_1_8_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const
 	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
 	a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
 
-	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) && (a_Item.m_ItemType != E_ITEM_FIREWORK_STAR) && !a_Item.m_ItemColor.IsValid())
+	if (
+		!a_Item.get<cEnchantments>().has_value() &&
+		a_Item.IsBothNameAndLoreEmpty() &&
+		(a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) &&
+		(a_Item.m_ItemType != E_ITEM_FIREWORK_STAR) &&
+		!a_Item.get<cItem::cDisplayProperties>().value_or(cItem::cDisplayProperties()).m_Color.IsValid()
+	)
 	{
 		a_Pkt.WriteBEInt8(0);
 		return;
@@ -3410,28 +3422,34 @@ void cProtocol_1_8_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const
 	{
 		Writer.AddInt("RepairCost", a_Item.m_RepairCost);
 	}
-	if (!a_Item.m_Enchantments.IsEmpty())
+	if (
+		auto Enchantments = a_Item.get<cEnchantments>();
+		Enchantments.has_value() || !Enchantments.value().IsEmpty()
+	)
 	{
 		const char * TagName = (a_Item.m_ItemType == E_ITEM_BOOK) ? "StoredEnchantments" : "ench";
-		EnchantmentSerializer::WriteToNBTCompound(a_Item.m_Enchantments, Writer, TagName);
+		EnchantmentSerializer::WriteToNBTCompound(Enchantments.value(), Writer, TagName);
 	}
-	if (!a_Item.IsBothNameAndLoreEmpty() || a_Item.m_ItemColor.IsValid())
+	if (
+		auto DisplayProperties = a_Item.get<cItem::cDisplayProperties>();
+		!a_Item.IsBothNameAndLoreEmpty() || (DisplayProperties.has_value() && DisplayProperties.value().m_Color.IsValid())
+	)
 	{
 		Writer.BeginCompound("display");
-		if (a_Item.m_ItemColor.IsValid())
+		if (DisplayProperties.value().m_Color.IsValid())
 		{
-			Writer.AddInt("color", static_cast<Int32>(a_Item.m_ItemColor.m_Color));
+			Writer.AddInt("color", static_cast<Int32>(DisplayProperties.value().m_Color.m_Color));
 		}
 
 		if (!a_Item.IsCustomNameEmpty())
 		{
-			Writer.AddString("Name", a_Item.m_CustomName);
+			Writer.AddString("Name", DisplayProperties.value().m_CustomName);
 		}
 		if (!a_Item.IsLoreEmpty())
 		{
 			Writer.BeginList("Lore", TAG_String);
 
-			for (const auto & Line : a_Item.m_LoreTable)
+			for (const auto & Line : DisplayProperties.value().m_LoreTable)
 			{
 				Writer.AddString("", Line);
 			}
@@ -3440,9 +3458,13 @@ void cProtocol_1_8_0::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item) const
 		}
 		Writer.EndCompound();
 	}
-	if ((a_Item.m_ItemType == E_ITEM_FIREWORK_ROCKET) || (a_Item.m_ItemType == E_ITEM_FIREWORK_STAR))
+	if (
+		auto fireworkItem = a_Item.get<cFireworkItem>();
+		((a_Item.m_ItemType == E_ITEM_FIREWORK_ROCKET) || (a_Item.m_ItemType == E_ITEM_FIREWORK_STAR)) &&
+		fireworkItem.has_value()
+	)
 	{
-		cFireworkItem::WriteToNBTCompound(a_Item.m_FireworkItem, Writer, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
+		cFireworkItem::WriteToNBTCompound(fireworkItem.value(), Writer, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
 	}
 	Writer.Finish();
 

--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -644,7 +644,7 @@ void cWindow::OnLeftPaintEnd(cPlayer & a_Player)
 	a_Player.GetDraggingItem().m_ItemCount -= NumDistributed;
 	if (a_Player.GetDraggingItem().m_ItemCount == 0)
 	{
-		a_Player.GetDraggingItem().Empty();
+		a_Player.GetDraggingItem().Clear();
 	}
 
 	SendWholeWindow(*a_Player.GetClientHandle());
@@ -672,7 +672,7 @@ void cWindow::OnRightPaintEnd(cPlayer & a_Player)
 	a_Player.GetDraggingItem().m_ItemCount -= NumDistributed;
 	if (a_Player.GetDraggingItem().m_ItemCount == 0)
 	{
-		a_Player.GetDraggingItem().Empty();
+		a_Player.GetDraggingItem().Clear();
 	}
 
 	SendWholeWindow(*a_Player.GetClientHandle());
@@ -700,7 +700,7 @@ void cWindow::OnMiddlePaintEnd(cPlayer & a_Player)
 	if (0 < DistributeItemToSlots(a_Player, DraggingItem, StackSize, a_Player.GetInventoryPaintSlots(), false))
 	{
 		// If any items were distibuted, set dragging item empty
-		a_Player.GetDraggingItem().Empty();
+		a_Player.GetDraggingItem().Clear();
 	}
 
 	SendWholeWindow(*a_Player.GetClientHandle());

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -283,7 +283,7 @@ public:
 		}
 
 		// Write the tag compound (for enchantment, firework, custom name and repair cost):
-		if (!a_Item.m_Properties.empty())
+		if (!a_Item.m_Properties.empty() || a_Item.m_RepairCost > 0)
 		{
 			mWriter.BeginCompound("tag");
 				if (a_Item.m_RepairCost > 0)
@@ -295,7 +295,7 @@ public:
 				{
 					std::visit(OverloadedVariantAccess
 					{
-						[&](cItem::cDisplayProperties &a_Property)
+						[&](const cItem::cDisplayProperties &a_Property)
 						{
 							if ((a_Property.m_CustomName != "") || (!a_Property.m_LoreTable.empty()))
 							{
@@ -318,21 +318,21 @@ public:
 								mWriter.EndCompound();
 							}
 						},
-						[&](cFireworkItem & a_Property)
+						[&](const cFireworkItem & a_Property)
 						{
 							if ((a_Item.m_ItemType == E_ITEM_FIREWORK_ROCKET) || (a_Item.m_ItemType == E_ITEM_FIREWORK_STAR))
 							{
 								cFireworkItem::WriteToNBTCompound(a_Property, mWriter, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
 							}
 						},
-						[&](cEnchantments & a_Property)
+						[&](const cEnchantments & a_Property)
 						{
 							if (!a_Property.IsEmpty())
 							{
 								const char * TagName = (a_Item.m_ItemType == E_ITEM_BOOK) ? "StoredEnchantments" : "ench";
 								EnchantmentSerializer::WriteToNBTCompound(a_Property, mWriter, TagName);
 							}
-						},
+						}
 					}, property);
 				}
 			mWriter.EndCompound();

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -708,7 +708,7 @@ bool cWSSAnvil::LoadItemFromNBT(cItem & a_Item, const cParsedNBT & a_NBT, int a_
 
 	if (a_Item.m_ItemType < 0)
 	{
-		a_Item.Empty();
+		a_Item.Clear();
 		return true;
 	}
 
@@ -743,26 +743,28 @@ bool cWSSAnvil::LoadItemFromNBT(cItem & a_Item, const cParsedNBT & a_NBT, int a_
 	int DisplayTag = a_NBT.FindChildByName(TagTag, "display");
 	if (DisplayTag > 0)
 	{
+		cItem::cDisplayProperties DisplayProperties;
 		int DisplayName = a_NBT.FindChildByName(DisplayTag, "Name");
 		if ((DisplayName > 0) && (a_NBT.GetType(DisplayName) == TAG_String))
 		{
-			a_Item.m_CustomName = a_NBT.GetString(DisplayName);
+			DisplayProperties.m_CustomName = a_NBT.GetString(DisplayName);
 		}
 		int Lore = a_NBT.FindChildByName(DisplayTag, "Lore");
 		if ((Lore > 0) && (a_NBT.GetType(Lore) == TAG_String))
 		{
 			// Legacy string lore
-			a_Item.m_LoreTable = StringSplit(a_NBT.GetString(Lore), "`");
+			DisplayProperties.m_LoreTable = StringSplit(a_NBT.GetString(Lore), "`");
 		}
 		else if ((Lore > 0) && (a_NBT.GetType(Lore) == TAG_List))
 		{
 			// Lore table
-			a_Item.m_LoreTable.clear();
+			DisplayProperties.m_LoreTable.clear();
 			for (int loretag = a_NBT.GetFirstChild(Lore); loretag >= 0; loretag = a_NBT.GetNextSibling(loretag))  // Loop through array of strings
 			{
-				a_Item.m_LoreTable.push_back(a_NBT.GetString(loretag));
+				DisplayProperties.m_LoreTable.push_back(a_NBT.GetString(loretag));
 			}
 		}
+		a_Item.set<cItem::cDisplayProperties>(DisplayProperties);
 	}
 
 	// Load enchantments:
@@ -770,14 +772,18 @@ bool cWSSAnvil::LoadItemFromNBT(cItem & a_Item, const cParsedNBT & a_NBT, int a_
 	int EnchTag = a_NBT.FindChildByName(TagTag, EnchName);
 	if (EnchTag > 0)
 	{
-		EnchantmentSerializer::ParseFromNBT(a_Item.m_Enchantments, a_NBT, EnchTag);
+		cEnchantments Enchantments;
+		EnchantmentSerializer::ParseFromNBT(Enchantments, a_NBT, EnchTag);
+		a_Item.set<cEnchantments>(Enchantments);
 	}
 
 	// Load firework data:
 	int FireworksTag = a_NBT.FindChildByName(TagTag, ((a_Item.m_ItemType == E_ITEM_FIREWORK_STAR) ? "Explosion" : "Fireworks"));
 	if (FireworksTag > 0)
 	{
-		cFireworkItem::ParseFromNBT(a_Item.m_FireworkItem, a_NBT, FireworksTag, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
+		cFireworkItem fireworkItem;
+		cFireworkItem::ParseFromNBT(fireworkItem, a_NBT, FireworksTag, static_cast<ENUM_ITEM_TYPE>(a_Item.m_ItemType));
+		a_Item.set<cFireworkItem>(fireworkItem);
 	}
 
 	return true;


### PR DESCRIPTION
This PR tries to kick of further development if additional data is stored into an item.

There is a new member `m_Properties` which is a vector of a variant which stores all possible data.
Access is done with `get<>()` and `set<>()` which both are templated methods which return a optional which contains the requested data.

Any use in the C++ code is adapted to this. Old Lua Binding should be intact by manual binding the old values.

Im am not 100% sure about my Lua implementation, please check that!