### PR TITLE
AddFaceDirection undefined behavior fix

### DIFF
--- a/src/Defines.cpp
+++ b/src/Defines.cpp
@@ -404,7 +404,7 @@ Vector3i AddFaceDirection(const Vector3i a_Position, const eBlockFace a_BlockFac
 		case BLOCK_FACE_NONE: break;
 	}
 
-	UNREACHABLE("Unsupported block face");
+	return a_Position;
 }
 
 


### PR DESCRIPTION
This change is in response to https://github.com/cuberite/cuberite/issues/5441. This will cause the function AddFaceDirection to return the original position when called with an invalid eBlockFace, rather than crashing the server. An alternative solution is proposed by madmaxoft in a comment on the original issue, which is unfortunately not within my ability to implement at this time, so that may be worth considering as well.  