### PR TITLE
Allow certain blocks to be placed on top of upside-down stairs/slabs

### DIFF
--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -1446,31 +1446,3 @@ float cBlockInfo::GetHardness(const BLOCKTYPE Block)
 		default:                                    return 0;
 	}
 }
-
-
-
-
-
-bool IsBlockStair(BLOCKTYPE a_BlockType)
-{
-	switch (a_BlockType)
-	{
-		case E_BLOCK_SANDSTONE_STAIRS:
-		case E_BLOCK_BIRCH_WOOD_STAIRS:
-		case E_BLOCK_QUARTZ_STAIRS:
-		case E_BLOCK_JUNGLE_WOOD_STAIRS:
-		case E_BLOCK_RED_SANDSTONE_STAIRS:
-		case E_BLOCK_COBBLESTONE_STAIRS:
-		case E_BLOCK_STONE_BRICK_STAIRS:
-		case E_BLOCK_OAK_WOOD_STAIRS:
-		case E_BLOCK_ACACIA_WOOD_STAIRS:
-		case E_BLOCK_PURPUR_STAIRS:
-		case E_BLOCK_DARK_OAK_WOOD_STAIRS:
-		case E_BLOCK_BRICK_STAIRS:
-		case E_BLOCK_NETHER_BRICK_STAIRS:
-		case E_BLOCK_SPRUCE_WOOD_STAIRS:
-			return true;
-		default:
-			return false;
-	}
-}

--- a/src/BlockInfo.cpp
+++ b/src/BlockInfo.cpp
@@ -1446,3 +1446,31 @@ float cBlockInfo::GetHardness(const BLOCKTYPE Block)
 		default:                                    return 0;
 	}
 }
+
+
+
+
+
+bool IsBlockStair(BLOCKTYPE a_BlockType)
+{
+	switch (a_BlockType)
+	{
+		case E_BLOCK_SANDSTONE_STAIRS:
+		case E_BLOCK_BIRCH_WOOD_STAIRS:
+		case E_BLOCK_QUARTZ_STAIRS:
+		case E_BLOCK_JUNGLE_WOOD_STAIRS:
+		case E_BLOCK_RED_SANDSTONE_STAIRS:
+		case E_BLOCK_COBBLESTONE_STAIRS:
+		case E_BLOCK_STONE_BRICK_STAIRS:
+		case E_BLOCK_OAK_WOOD_STAIRS:
+		case E_BLOCK_ACACIA_WOOD_STAIRS:
+		case E_BLOCK_PURPUR_STAIRS:
+		case E_BLOCK_DARK_OAK_WOOD_STAIRS:
+		case E_BLOCK_BRICK_STAIRS:
+		case E_BLOCK_NETHER_BRICK_STAIRS:
+		case E_BLOCK_SPRUCE_WOOD_STAIRS:
+			return true;
+		default:
+			return false;
+	}
+}

--- a/src/BlockInfo.h
+++ b/src/BlockInfo.h
@@ -65,8 +65,6 @@ public:
 
 
 
-bool IsBlockStair(BLOCKTYPE a_BlockType);
-
 bool IsBlockWater(BLOCKTYPE a_BlockType);
 
 bool IsBlockIce(BLOCKTYPE a_BlockType);

--- a/src/BlockInfo.h
+++ b/src/BlockInfo.h
@@ -65,6 +65,7 @@ public:
 
 
 
+bool IsBlockStair(BLOCKTYPE a_BlockType);
 
 bool IsBlockWater(BLOCKTYPE a_BlockType);
 

--- a/src/Blocks/BlockButton.h
+++ b/src/Blocks/BlockButton.h
@@ -1,10 +1,15 @@
 #pragma once
 
 #include "BlockHandler.h"
+#include "BlockSlab.h"
+#include "BlockStairs.h"
 #include "../BlockInfo.h"
 #include "../Chunk.h"
+#include "Defines.h"
+#include "Entities/Player.h"
 #include "Mixins.h"
 #include "ChunkInterface.h"
+#include "World.h"
 
 
 
@@ -132,7 +137,37 @@ private:
 			return false;
 		}
 		BLOCKTYPE SupportBlockType;
-		a_Chunk.UnboundedRelGetBlockType(SupportRelPos, SupportBlockType);
+		NIBBLETYPE SupportBlockMeta;
+		a_Chunk.UnboundedRelGetBlock(SupportRelPos, SupportBlockType, SupportBlockMeta);
+		eBlockFace Face = BlockMetaDataToBlockFace(a_Meta);
+
+		// upside down slabs
+		if (cBlockSlabHandler::IsAnySlabType(SupportBlockType))
+		{
+			return (Face == BLOCK_FACE_YP) && (SupportBlockMeta & E_META_WOODEN_SLAB_UPSIDE_DOWN);
+		}
+
+		// stairs (top and sides)
+		if (cBlockStairsHandler::IsAnyStairType(SupportBlockType))
+		{
+			switch (Face)
+			{
+				case eBlockFace::BLOCK_FACE_YP:
+					return (SupportBlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN);
+				case eBlockFace::BLOCK_FACE_XP:
+					return ((SupportBlockMeta & 0b11) == E_BLOCK_STAIRS_XP);
+				case eBlockFace::BLOCK_FACE_XM:
+					return ((SupportBlockMeta & 0b11) == E_BLOCK_STAIRS_XM);
+				case eBlockFace::BLOCK_FACE_ZP:
+					return ((SupportBlockMeta & 0b11) == E_BLOCK_STAIRS_ZP);
+				case eBlockFace::BLOCK_FACE_ZM:
+					return ((SupportBlockMeta & 0b11) == E_BLOCK_STAIRS_ZM);
+				default:
+				{
+					return false;
+				}
+			}
+		}
 
 		return cBlockInfo::FullyOccupiesVoxel(SupportBlockType);
 	}

--- a/src/Blocks/BlockComparator.h
+++ b/src/Blocks/BlockComparator.h
@@ -170,10 +170,12 @@ private:
 		else if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
 		{
 			// Check if the slab is turned up side down
-			if ((BelowBlockMeta & 0x08) == 0x08)
-			{
-				return true;
-			}
+			return (BelowBlockMeta & 0x08) == 0x08;
+		}
+		else if (IsBlockStair(BelowBlock))
+		{
+			// Stair must be upside down
+			return ((BelowBlockMeta & 0x04) == 0x04);
 		}
 		return false;
 	}

--- a/src/Blocks/BlockComparator.h
+++ b/src/Blocks/BlockComparator.h
@@ -167,16 +167,19 @@ private:
 		{
 			return true;
 		}
-		else if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
+
+		// upside down slabs
+		if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
 		{
-			// Check if the slab is turned up side down
-			return (BelowBlockMeta & 0x08) == 0x08;
+			return BelowBlockMeta & E_META_WOODEN_SLAB_UPSIDE_DOWN;
 		}
-		else if (IsBlockStair(BelowBlock))
+
+		// upside down stairs
+		if (cBlockStairsHandler::IsAnyStairType(BelowBlock))
 		{
-			// Stair must be upside down
-			return ((BelowBlockMeta & 0x04) == 0x04);
+			return BelowBlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN;
 		}
+
 		return false;
 	}
 

--- a/src/Blocks/BlockLever.h
+++ b/src/Blocks/BlockLever.h
@@ -2,6 +2,9 @@
 
 #include "BlockHandler.h"
 #include "../Chunk.h"
+#include "Blocks/BlockStairs.h"
+#include "ChunkDef.h"
+#include "Defines.h"
 #include "Mixins.h"
 #include "BlockSlab.h"
 
@@ -117,7 +120,28 @@ private:
 				(((NeighborMeta & 0x08) == 0)    && (NeighborFace == BLOCK_FACE_BOTTOM))
 			);
 		}
-
+		else if (cBlockStairsHandler::IsAnyStairType(NeighborBlockType))
+		{
+			switch (NeighborFace)
+			{
+				case eBlockFace::BLOCK_FACE_YM:
+					return !(NeighborMeta & E_BLOCK_STAIRS_UPSIDE_DOWN);
+				case eBlockFace::BLOCK_FACE_YP:
+					return (NeighborMeta & E_BLOCK_STAIRS_UPSIDE_DOWN);
+				case eBlockFace::BLOCK_FACE_XP:
+					return ((NeighborMeta & 0b11) == E_BLOCK_STAIRS_XP);
+				case eBlockFace::BLOCK_FACE_XM:
+					return ((NeighborMeta & 0b11) == E_BLOCK_STAIRS_XM);
+				case eBlockFace::BLOCK_FACE_ZP:
+					return ((NeighborMeta & 0b11) == E_BLOCK_STAIRS_ZP);
+				case eBlockFace::BLOCK_FACE_ZM:
+					return ((NeighborMeta & 0b11) == E_BLOCK_STAIRS_ZM);
+				default:
+				{
+					return false;
+				}
+			}
+		}
 		return false;
 	}
 

--- a/src/Blocks/BlockPressurePlate.h
+++ b/src/Blocks/BlockPressurePlate.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include "BlockHandler.h"
+#include "BlockSlab.h"
+#include "../Chunk.h"
 
 
 
@@ -26,7 +28,22 @@ private:
 
 		// TODO: check if the block is upside-down slab or upside-down stairs
 
-		const auto Block = a_Chunk.GetBlock(a_Position.addedY(-1));
+		BLOCKTYPE Block;
+		NIBBLETYPE BlockMeta;
+		a_Chunk.GetBlockTypeMeta(a_Position.addedY(-1), Block, BlockMeta);
+
+		// upside down slabs
+		if (cBlockSlabHandler::IsAnySlabType(Block))
+		{
+			return ((BlockMeta & 0x08) == 0x08);
+		}
+
+		//upside down stairs
+		if (IsBlockStair(Block))
+		{
+			return ((BlockMeta & 0x04) == 0x04);
+		}
+
 		switch (Block)
 		{
 			case E_BLOCK_ACACIA_FENCE:

--- a/src/Blocks/BlockPressurePlate.h
+++ b/src/Blocks/BlockPressurePlate.h
@@ -26,8 +26,6 @@ private:
 			return false;
 		}
 
-		// TODO: check if the block is upside-down slab or upside-down stairs
-
 		BLOCKTYPE Block;
 		NIBBLETYPE BlockMeta;
 		a_Chunk.GetBlockTypeMeta(a_Position.addedY(-1), Block, BlockMeta);

--- a/src/Blocks/BlockPressurePlate.h
+++ b/src/Blocks/BlockPressurePlate.h
@@ -4,6 +4,7 @@
 #include "BlockHandler.h"
 #include "BlockSlab.h"
 #include "../Chunk.h"
+#include "BlockStairs.h"
 
 
 
@@ -33,13 +34,13 @@ private:
 		// upside down slabs
 		if (cBlockSlabHandler::IsAnySlabType(Block))
 		{
-			return ((BlockMeta & 0x08) == 0x08);
+			return BlockMeta & E_META_WOODEN_SLAB_UPSIDE_DOWN;
 		}
 
-		//upside down stairs
-		if (IsBlockStair(Block))
+		// upside down stairs
+		if (cBlockStairsHandler::IsAnyStairType(Block))
 		{
-			return ((BlockMeta & 0x04) == 0x04);
+			return BlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN;
 		}
 
 		switch (Block)

--- a/src/Blocks/BlockRail.h
+++ b/src/Blocks/BlockRail.h
@@ -1,5 +1,13 @@
-
 #pragma once
+
+#include "BlockHandler.h"
+#include "BlockSlab.h"
+#include "BlockStairs.h"
+#include "BlockType.h"
+#include "Blocks/Mixins.h"
+#include "../BlockInfo.h"
+#include "../Chunk.h"
+#include "ChunkDef.h"
 
 
 
@@ -154,9 +162,26 @@ public:
 
 private:
 
+	static bool CanBeSupportedBy(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta)
+	{
+		if (cBlockSlabHandler::IsAnySlabType(a_BlockType))
+		{
+			return (a_BlockMeta & E_META_WOODEN_SLAB_UPSIDE_DOWN);
+		}
+		else if (cBlockStairsHandler::IsAnyStairType(a_BlockType))
+		{
+			return (a_BlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN);
+		}
+		return cBlockInfo::FullyOccupiesVoxel(a_BlockType);
+	}
+
 	virtual bool CanBeAt(const cChunk & a_Chunk, const Vector3i a_Position, NIBBLETYPE a_Meta) const override
 	{
-		if ((a_Position.y <= 0) || !cBlockInfo::FullyOccupiesVoxel(a_Chunk.GetBlock(a_Position.addedY(-1))))
+		BLOCKTYPE BelowBlock;
+		NIBBLETYPE BelowBlockMeta;
+		a_Chunk.GetBlockTypeMeta(a_Position.addedY(-1), BelowBlock, BelowBlockMeta);
+
+		if ((a_Position.y <= 0) || !CanBeSupportedBy(BelowBlock, BelowBlockMeta))
 		{
 			return false;
 		}
@@ -187,6 +212,7 @@ private:
 				return cBlockInfo::FullyOccupiesVoxel(BlockType);
 			}
 		}
+
 		return true;
 	}
 

--- a/src/Blocks/BlockRedstoneRepeater.h
+++ b/src/Blocks/BlockRedstoneRepeater.h
@@ -2,9 +2,11 @@
 #pragma once
 
 #include "BlockHandler.h"
+#include "BlockType.h"
 #include "Mixins.h"
 #include "ChunkInterface.h"
 #include "BlockSlab.h"
+#include "BlockStairs.h"
 #include "../Chunk.h"
 
 
@@ -120,16 +122,19 @@ private:
 		{
 			return true;
 		}
-		else if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
+
+		// upside down slabs
+		if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
 		{
-			// Check if the slab is turned up side down
-			return (BelowBlockMeta & 0x08) == 0x08;
+			return BelowBlockMeta & E_META_WOODEN_SLAB_UPSIDE_DOWN;
 		}
-		else if (IsBlockStair(BelowBlock))
+
+		// upside down stairs
+		if (cBlockStairsHandler::IsAnyStairType(BelowBlock))
 		{
-			// Stair must be upside down
-			return ((BelowBlockMeta & 0x04) == 0x04);
+			return BelowBlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN;
 		}
+
 		return false;
 	}
 

--- a/src/Blocks/BlockRedstoneRepeater.h
+++ b/src/Blocks/BlockRedstoneRepeater.h
@@ -123,10 +123,12 @@ private:
 		else if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
 		{
 			// Check if the slab is turned up side down
-			if ((BelowBlockMeta & 0x08) == 0x08)
-			{
-				return true;
-			}
+			return (BelowBlockMeta & 0x08) == 0x08;
+		}
+		else if (IsBlockStair(BelowBlock))
+		{
+			// Stair must be upside down
+			return ((BelowBlockMeta & 0x04) == 0x04);
 		}
 		return false;
 	}

--- a/src/Blocks/BlockRedstoneWire.h
+++ b/src/Blocks/BlockRedstoneWire.h
@@ -37,10 +37,12 @@ private:
 		else if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
 		{
 			// Check if the slab is turned up side down
-			if ((BelowBlockMeta & 0x08) == 0x08)
-			{
-				return true;
-			}
+			return (BelowBlockMeta & 0x08) == 0x08;
+		}
+		else if (IsBlockStair(BelowBlock))
+		{
+			//Check if the stair is upside down
+			return (BelowBlockMeta & 0x04) == 0x04;
 		}
 		return false;
 	}

--- a/src/Blocks/BlockRedstoneWire.h
+++ b/src/Blocks/BlockRedstoneWire.h
@@ -3,7 +3,8 @@
 
 #include "BlockHandler.h"
 #include "BlockSlab.h"
-
+#include "BlockStairs.h"
+#include "../Chunk.h"
 
 
 
@@ -34,16 +35,19 @@ private:
 		{
 			return true;
 		}
-		else if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
+
+		// upside down slabs
+		if (cBlockSlabHandler::IsAnySlabType(BelowBlock))
 		{
-			// Check if the slab is turned up side down
-			return (BelowBlockMeta & 0x08) == 0x08;
+			return BelowBlockMeta & E_META_WOODEN_SLAB_UPSIDE_DOWN;
 		}
-		else if (IsBlockStair(BelowBlock))
+
+		// upside down stairs
+		if (cBlockStairsHandler::IsAnyStairType(BelowBlock))
 		{
-			//Check if the stair is upside down
-			return (BelowBlockMeta & 0x04) == 0x04;
+			return BelowBlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN;
 		}
+
 		return false;
 	}
 

--- a/src/Blocks/BlockStairs.h
+++ b/src/Blocks/BlockStairs.h
@@ -16,6 +16,32 @@ public:
 
 	using Super::Super;
 
+	static bool IsAnyStairType(BLOCKTYPE a_Block)
+	{
+		switch (a_Block)
+		{
+			case E_BLOCK_SANDSTONE_STAIRS:
+			case E_BLOCK_BIRCH_WOOD_STAIRS:
+			case E_BLOCK_QUARTZ_STAIRS:
+			case E_BLOCK_JUNGLE_WOOD_STAIRS:
+			case E_BLOCK_RED_SANDSTONE_STAIRS:
+			case E_BLOCK_COBBLESTONE_STAIRS:
+			case E_BLOCK_STONE_BRICK_STAIRS:
+			case E_BLOCK_OAK_WOOD_STAIRS:
+			case E_BLOCK_ACACIA_WOOD_STAIRS:
+			case E_BLOCK_PURPUR_STAIRS:
+			case E_BLOCK_DARK_OAK_WOOD_STAIRS:
+			case E_BLOCK_BRICK_STAIRS:
+			case E_BLOCK_NETHER_BRICK_STAIRS:
+			case E_BLOCK_SPRUCE_WOOD_STAIRS:
+				return true;
+			default:
+			{
+				return false;
+			}
+		}
+	}
+
 private:
 
 	virtual NIBBLETYPE MetaMirrorXZ(NIBBLETYPE a_Meta) const override
@@ -23,9 +49,6 @@ private:
 		// Toggle bit 3:
 		return (a_Meta & 0x0b) | ((~a_Meta) & 0x04);
 	}
-
-
-
 
 
 	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) const override

--- a/src/Blocks/BlockTorch.h
+++ b/src/Blocks/BlockTorch.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include "BlockHandler.h"
+#include "BlockSlab.h"
+#include "BlockStairs.h"
 #include "../Chunk.h"
+#include "BlockType.h"
 #include "ChunkInterface.h"
+#include "Defines.h"
 #include "Mixins.h"
 
 
@@ -22,6 +26,34 @@ public:
 	/** Returns true if the torch can be placed on the specified block's face. */
 	static bool CanBePlacedOn(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, eBlockFace a_BlockFace)
 	{
+		// upside down slabs
+		if (cBlockSlabHandler::IsAnySlabType(a_BlockType))
+		{
+			return (a_BlockFace == BLOCK_FACE_YP) && (a_BlockMeta & E_META_WOODEN_SLAB_UPSIDE_DOWN);
+		}
+
+		// stairs (top and sides)
+		if (cBlockStairsHandler::IsAnyStairType(a_BlockType))
+		{
+			switch (a_BlockFace)
+			{
+				case eBlockFace::BLOCK_FACE_YP:
+					return (a_BlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN);
+				case eBlockFace::BLOCK_FACE_XP:
+					return ((a_BlockMeta & 0b11) == E_BLOCK_STAIRS_XP);
+				case eBlockFace::BLOCK_FACE_XM:
+					return ((a_BlockMeta & 0b11) == E_BLOCK_STAIRS_XM);
+				case eBlockFace::BLOCK_FACE_ZP:
+					return ((a_BlockMeta & 0b11) == E_BLOCK_STAIRS_ZP);
+				case eBlockFace::BLOCK_FACE_ZM:
+					return ((a_BlockMeta & 0b11) == E_BLOCK_STAIRS_ZM);
+				default:
+				{
+					return false;
+				}
+			}
+		}
+
 		switch (a_BlockType)
 		{
 			case E_BLOCK_END_PORTAL_FRAME:
@@ -43,28 +75,6 @@ public:
 			{
 				// Torches can only be placed on top of these blocks
 				return (a_BlockFace == BLOCK_FACE_YP);
-			}
-			case E_BLOCK_STONE_SLAB:
-			case E_BLOCK_WOODEN_SLAB:
-			{
-				// Toches can be placed only on the top of top-half-slabs
-				return ((a_BlockFace == BLOCK_FACE_YP) && ((a_BlockMeta & 0x08) == 0x08));
-			}
-			case E_BLOCK_OAK_WOOD_STAIRS:
-			case E_BLOCK_COBBLESTONE_STAIRS:
-			case E_BLOCK_BRICK_STAIRS:
-			case E_BLOCK_STONE_BRICK_STAIRS:
-			case E_BLOCK_NETHER_BRICK_STAIRS:
-			case E_BLOCK_SANDSTONE_STAIRS:
-			case E_BLOCK_SPRUCE_WOOD_STAIRS:
-			case E_BLOCK_BIRCH_WOOD_STAIRS:
-			case E_BLOCK_JUNGLE_WOOD_STAIRS:
-			case E_BLOCK_QUARTZ_STAIRS:
-			case E_BLOCK_ACACIA_WOOD_STAIRS:
-			case E_BLOCK_DARK_OAK_WOOD_STAIRS:
-			case E_BLOCK_RED_SANDSTONE_STAIRS:
-			{
-				return (a_BlockFace == BLOCK_FACE_TOP) && (a_BlockMeta & E_BLOCK_STAIRS_UPSIDE_DOWN);
 			}
 			default:
 			{


### PR DESCRIPTION
Pressure plates, repeaters, comparators and redstone wire can now be placed on top of upside-down slabs and stairs.