### PR TITLE
Updated LTO Check to new standard.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# The need for speed (in Release):
-if(WHOLE_PROGRAM_OPTIMISATION)
-	include(CheckIPOSupported)
-	check_ipo_supported(RESULT IPO_SUPPORTED)
-	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ${IPO_SUPPORTED})
-endif()
-
 # Static CRT:
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
@@ -97,6 +90,17 @@ if(SELF_TEST)
 	message(STATUS "Tests enabled")
 	enable_testing()
 	add_subdirectory(tests)
+endif()
+
+# The need for speed (in Release):
+if(WHOLE_PROGRAM_OPTIMISATION)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_CHECK_OUTPUT)
+    if(IPO_SUPPORTED)
+        set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    else()
+        message(WARNING "IPO is not supported: ${IPO_CHECK_OUTPUT}")
+    endif()
 endif()
 
 emit_fixups()


### PR DESCRIPTION
The due to LTO the Release build didn't link on my machine. The official cmake page suggest it to do it like this:

 https://cmake.org/cmake/help/latest/module/CheckIPOSupported.html