### PR TITLE
Update clang-tidy.sh to be run local also

### DIFF
--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -2,9 +2,16 @@
 
 set -e
 
+LOCALSTRING="local"
+
+if [ "$3" = "$LOCALSTRING" ]; then
+  REGEX="/cuberite/src/\.?[^\.]"
+else
+  REGEX="cuberite_[^/\.]+/src/\.?[^\.]"
+fi
+
 FIXES_FILE="tidy-fixes.yaml"
-REGEX="cuberite_[^/\.]+/src/\.?[^\.]"
-ARGS="-header-filter $REGEX -quiet -export-fixes $FIXES_FILE "$@" $REGEX"
+ARGS="-header-filter $REGEX -quiet -export-fixes $FIXES_FILE $* $REGEX"
 
 # Generate the compilation database
 mkdir -p tidy-build


### PR DESCRIPTION
Since moving to the jenkins builds running the clang tidy locally is kind of broken since the regex was changed.

This is a brute force way of enabling you to still run it locally without hassle.

I have no idea of bash scripts. If anyone has a better idea: Knock yourself out!

The idea is to pass a additional parameter "local" to the script to indicate that the script is run locally and the appropriate regex needs to be chones