### PR TITLE
Now using size_t in item grids and accompanying classes

### DIFF
--- a/src/Bindings/LuaState.cpp
+++ b/src/Bindings/LuaState.cpp
@@ -1099,6 +1099,17 @@ void cLuaState::Push(std::chrono::milliseconds a_Value)
 
 
 
+void cLuaState::Push(std::size_t a_Value)
+{
+	ASSERT(IsValid());
+
+	tolua_pushnumber(m_LuaState, static_cast<lua_Number>(a_Value));
+}
+
+
+
+
+
 void cLuaState::Pop(int a_NumValuesToPop)
 {
 	ASSERT(IsValid());

--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -630,6 +630,7 @@ public:
 	void Push(long a_Value);
 	void Push(const UInt32 a_Value);
 	void Push(std::chrono::milliseconds a_time);
+	void Push(std::size_t a_Value);
 
 	/** Pops the specified number of values off the top of the Lua stack. */
 	void Pop(int a_NumValuesToPop = 1);

--- a/src/Bindings/LuaWindow.cpp
+++ b/src/Bindings/LuaWindow.cpp
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // cLuaWindow:
 
-cLuaWindow::cLuaWindow(cLuaState & a_LuaState, cWindow::WindowType a_WindowType, int a_SlotsX, int a_SlotsY, const AString & a_Title) :
+cLuaWindow::cLuaWindow(cLuaState & a_LuaState, cWindow::WindowType a_WindowType, std::size_t a_SlotsX, std::size_t a_SlotsY, const AString & a_Title) :
 	Super(a_WindowType, a_Title),
 	m_Contents(a_SlotsX, a_SlotsY),
 	m_LuaState(a_LuaState.QueryCanonLuaState())
@@ -176,7 +176,7 @@ void cLuaWindow::Destroy(void)
 
 
 
-void cLuaWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cLuaWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas Areas;
 	for (auto && Area : m_SlotAreas)
@@ -194,7 +194,7 @@ void cLuaWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Pl
 
 
 
-void cLuaWindow::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
+void cLuaWindow::OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum)
 {
 	ASSERT(a_ItemGrid == &m_Contents);
 
@@ -209,7 +209,7 @@ void cLuaWindow::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 
 
 
-void cLuaWindow::Clicked(cPlayer & a_Player, int a_WindowID, short a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem)
+void cLuaWindow::Clicked(cPlayer & a_Player, int a_WindowID, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem)
 {
 	if (m_OnClicked != nullptr)
 	{
@@ -218,7 +218,7 @@ void cLuaWindow::Clicked(cPlayer & a_Player, int a_WindowID, short a_SlotNum, eC
 		if (m_OnClicked->Call(this, &a_Player, a_SlotNum, a_ClickAction, a_ClickedItem, cLuaState::Return, res) && res)
 		{
 			// Tell the client the actual state of the window
-			a_Player.GetClientHandle()->SendInventorySlot(-1, -1, a_Player.GetDraggingItem());
+			a_Player.GetClientHandle()->SendInventorySlot(-1, ILLEGAL_SLOT_NUMBER, a_Player.GetDraggingItem());
 			BroadcastWholeWindow();
 			return;
 		}

--- a/src/Bindings/LuaWindow.h
+++ b/src/Bindings/LuaWindow.h
@@ -39,7 +39,7 @@ class cLuaWindow :
 public:
 	/** Create a window of the specified type, with a slot grid of a_SlotsX * a_SlotsY size.
 	Exported in ManualBindings.cpp */
-	cLuaWindow(cLuaState & a_LuaState, cWindow::WindowType a_WindowType, int a_SlotsX, int a_SlotsY, const AString & a_Title);
+	cLuaWindow(cLuaState & a_LuaState, cWindow::WindowType a_WindowType, std::size_t a_SlotsX, std::size_t a_SlotsY, const AString & a_Title);
 
 	// tolua_begin
 	virtual ~cLuaWindow() override;
@@ -89,15 +89,15 @@ protected:
 	virtual void OpenedByPlayer(cPlayer & a_Player) override;
 	virtual void Clicked(
 		cPlayer & a_Player, int a_WindowID,
-		short a_SlotNum, eClickAction a_ClickAction,
+		std::size_t a_SlotNum, eClickAction a_ClickAction,
 		const cItem & a_ClickedItem
 	) override;
 	virtual bool ClosedByPlayer(cPlayer & a_Player, bool a_CanRefuse) override;
 	virtual void Destroy(void) override;
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 } ;  // tolua_export
 
 

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -2849,13 +2849,13 @@ static int Lua_ItemGrid_GetSlotCoords(lua_State * L)
 
 	{
 		const cItemGrid * self = static_cast<const cItemGrid *>(tolua_tousertype(L, 1, nullptr));
-		int SlotNum = static_cast<int>(tolua_tonumber(L, 2, 0));
+		auto SlotNum = static_cast<std::size_t>(tolua_tonumber(L, 2, 0));
 		if (self == nullptr)
 		{
 			tolua_error(L, "invalid 'self' in function 'cItemGrid:GetSlotCoords'", nullptr);
 			return 0;
 		}
-		int X, Y;
+		std::size_t X, Y;
 		self->GetSlotCoords(SlotNum, X, Y);
 		tolua_pushnumber(L, static_cast<lua_Number>(X));
 		tolua_pushnumber(L, static_cast<lua_Number>(Y));
@@ -3340,7 +3340,7 @@ static int tolua_cLuaWindow_new(lua_State * tolua_S)
 	}
 
 	// Read params:
-	int windowType, slotsX, slotsY;
+	std::size_t windowType, slotsX, slotsY;
 	AString title;
 	if (!L.GetStackValues(2, windowType, slotsX, slotsY, title))
 	{
@@ -3376,7 +3376,7 @@ static int tolua_cLuaWindow_new_local(lua_State * tolua_S)
 	}
 
 	// Read params:
-	int windowType, slotsX, slotsY;
+	std::size_t windowType, slotsX, slotsY;
 	AString title;
 	if (!L.GetStackValues(2, windowType, slotsX, slotsY, title))
 	{

--- a/src/Bindings/Plugin.h
+++ b/src/Bindings/Plugin.h
@@ -64,9 +64,9 @@ public:
 	virtual bool OnExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) = 0;
 	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) = 0;
 	virtual bool OnHandshake                (cClientHandle & a_Client, const AString & a_Username) = 0;
-	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum) = 0;
-	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum) = 0;
-	virtual bool OnDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum) = 0;
+	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, std::size_t a_SrcSlotNum) = 0;
+	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, std::size_t a_DstSlotNum) = 0;
+	virtual bool OnDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, std::size_t a_SlotNum) = 0;
 	virtual bool OnKilled                   (cEntity & a_Victim, TakeDamageInfo & a_TDI, AString & a_DeathMessage) = 0;
 	virtual bool OnKilling                  (cEntity & a_Victim, cEntity * a_Killer, TakeDamageInfo & a_TDI) = 0;
 	virtual bool OnLogin                    (cClientHandle & a_Client, UInt32 a_ProtocolVersion, const AString & a_Username) = 0;

--- a/src/Bindings/Plugin.h
+++ b/src/Bindings/Plugin.h
@@ -64,7 +64,7 @@ public:
 	virtual bool OnExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) = 0;
 	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) = 0;
 	virtual bool OnHandshake                (cClientHandle & a_Client, const AString & a_Username) = 0;
-	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum) = 0;
+	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum) = 0;
 	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum) = 0;
 	virtual bool OnDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum) = 0;
 	virtual bool OnKilled                   (cEntity & a_Victim, TakeDamageInfo & a_TDI, AString & a_DeathMessage) = 0;

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -504,7 +504,7 @@ bool cPluginLua::OnHandshake(cClientHandle & a_Client, const AString & a_Usernam
 
 
 
-bool cPluginLua::OnHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum)
+bool cPluginLua::OnHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, std::size_t a_SrcSlotNum)
 {
 	return CallSimpleHooks(cPluginManager::HOOK_HOPPER_PULLING_ITEM, &a_World, &a_Hopper, a_DstSlotNum, &a_SrcEntity, a_SrcSlotNum);
 }
@@ -513,7 +513,7 @@ bool cPluginLua::OnHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper,
 
 
 
-bool cPluginLua::OnHopperPushingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum)
+bool cPluginLua::OnHopperPushingItem(cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, std::size_t a_DstSlotNum)
 {
 	return CallSimpleHooks(cPluginManager::HOOK_HOPPER_PUSHING_ITEM, &a_World, &a_Hopper, a_SrcSlotNum, &a_DstEntity, a_DstSlotNum);
 }
@@ -522,7 +522,7 @@ bool cPluginLua::OnHopperPushingItem(cWorld & a_World, cHopperEntity & a_Hopper,
 
 
 
-bool cPluginLua::OnDropSpense(cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum)
+bool cPluginLua::OnDropSpense(cWorld & a_World, cDropSpenserEntity & a_DropSpenser, std::size_t a_SlotNum)
 {
 	return CallSimpleHooks(cPluginManager::HOOK_DROPSPENSE, &a_World, &a_DropSpenser, a_SlotNum);
 }

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -504,7 +504,7 @@ bool cPluginLua::OnHandshake(cClientHandle & a_Client, const AString & a_Usernam
 
 
 
-bool cPluginLua::OnHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum)
+bool cPluginLua::OnHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum)
 {
 	return CallSimpleHooks(cPluginManager::HOOK_HOPPER_PULLING_ITEM, &a_World, &a_Hopper, a_DstSlotNum, &a_SrcEntity, a_SrcSlotNum);
 }

--- a/src/Bindings/PluginLua.h
+++ b/src/Bindings/PluginLua.h
@@ -26,7 +26,7 @@ class cPluginLua:
 
 	using Super = cPlugin;
 
-public:
+  public:
 
 	/** A RAII-style mutex lock for accessing the internal LuaState.
 	This will be the only way to retrieve the plugin's LuaState;
@@ -37,7 +37,7 @@ public:
 	*/
 	class cOperation
 	{
-	public:
+	  public:
 		cOperation(cPluginLua & a_Plugin) :
 			m_Plugin(a_Plugin),
 			m_Lock(a_Plugin.m_LuaState)
@@ -46,7 +46,7 @@ public:
 
 		cLuaState & operator ()(void) { return m_Plugin.m_LuaState; }
 
-	protected:
+	  protected:
 		cPluginLua & m_Plugin;
 
 		/** RAII lock for the Lua state. */
@@ -84,9 +84,9 @@ public:
 	virtual bool OnExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) override;
 	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) override;
 	virtual bool OnHandshake                (cClientHandle & a_Client, const AString & a_Username) override;
-	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum) override;
-	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum) override;
-	virtual bool OnDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum) override;
+	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, std::size_t a_SrcSlotNum) override;
+	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, std::size_t a_DstSlotNum) override;
+	virtual bool OnDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, std::size_t a_SlotNum) override;
 	virtual bool OnKilled                   (cEntity & a_Victim, TakeDamageInfo & a_TDI, AString & a_DeathMessage) override;
 	virtual bool OnKilling                  (cEntity & a_Victim, cEntity * a_Killer, TakeDamageInfo & a_TDI) override;
 	virtual bool OnLogin                    (cClientHandle & a_Client, UInt32 a_ProtocolVersion, const AString & a_Username) override;
@@ -162,7 +162,7 @@ public:
 		return cOperation(*this)().Call(a_Fn, a_Args...);
 	}
 
-protected:
+  protected:
 	/** Provides an array of Lua function references */
 	typedef std::vector<cLuaState::cCallbackPtr> cLuaCallbacks;
 

--- a/src/Bindings/PluginLua.h
+++ b/src/Bindings/PluginLua.h
@@ -84,7 +84,7 @@ public:
 	virtual bool OnExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) override;
 	virtual bool OnExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData) override;
 	virtual bool OnHandshake                (cClientHandle & a_Client, const AString & a_Username) override;
-	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum) override;
+	virtual bool OnHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum) override;
 	virtual bool OnHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum) override;
 	virtual bool OnDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum) override;
 	virtual bool OnKilled                   (cEntity & a_Victim, TakeDamageInfo & a_TDI, AString & a_DeathMessage) override;

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -606,7 +606,7 @@ bool cPluginManager::CallHookHandshake(cClientHandle & a_ClientHandle, const ASt
 
 
 
-bool cPluginManager::CallHookHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum)
+bool cPluginManager::CallHookHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, std::size_t a_SrcSlotNum)
 {
 	return GenericCallHook(HOOK_HOPPER_PULLING_ITEM, [&](cPlugin * a_Plugin)
 		{
@@ -619,7 +619,7 @@ bool cPluginManager::CallHookHopperPullingItem(cWorld & a_World, cHopperEntity &
 
 
 
-bool cPluginManager::CallHookHopperPushingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum)
+bool cPluginManager::CallHookHopperPushingItem(cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, std::size_t a_DstSlotNum)
 {
 	return GenericCallHook(HOOK_HOPPER_PUSHING_ITEM, [&](cPlugin * a_Plugin)
 		{
@@ -632,7 +632,7 @@ bool cPluginManager::CallHookHopperPushingItem(cWorld & a_World, cHopperEntity &
 
 
 
-bool cPluginManager::CallHookDropSpense(cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum)
+bool cPluginManager::CallHookDropSpense(cWorld & a_World, cDropSpenserEntity & a_DropSpenser, std::size_t a_SlotNum)
 {
 	return GenericCallHook(HOOK_DROPSPENSE, [&](cPlugin * a_Plugin)
 		{

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -606,7 +606,7 @@ bool cPluginManager::CallHookHandshake(cClientHandle & a_ClientHandle, const ASt
 
 
 
-bool cPluginManager::CallHookHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum)
+bool cPluginManager::CallHookHopperPullingItem(cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum)
 {
 	return GenericCallHook(HOOK_HOPPER_PULLING_ITEM, [&](cPlugin * a_Plugin)
 		{

--- a/src/Bindings/PluginManager.h
+++ b/src/Bindings/PluginManager.h
@@ -257,9 +257,9 @@ public:
 	bool CallHookExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData);
 	bool CallHookExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData);
 	bool CallHookHandshake                (cClientHandle & a_ClientHandle, const AString & a_Username);
-	bool CallHookHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum);
-	bool CallHookHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum);
-	bool CallHookDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum);
+	bool CallHookHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, std::size_t a_SrcSlotNum);
+	bool CallHookHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, std::size_t a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, std::size_t a_DstSlotNum);
+	bool CallHookDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, std::size_t a_SlotNum);
 	bool CallHookKilled                   (cEntity & a_Victim, TakeDamageInfo & a_TDI, AString & a_DeathMessage);
 	bool CallHookKilling                  (cEntity & a_Victim, cEntity * a_Killer, TakeDamageInfo & a_TDI);
 	bool CallHookLogin                    (cClientHandle & a_Client, UInt32 a_ProtocolVersion, const AString & a_Username);

--- a/src/Bindings/PluginManager.h
+++ b/src/Bindings/PluginManager.h
@@ -257,7 +257,7 @@ public:
 	bool CallHookExploded                 (cWorld & a_World, double a_ExplosionSize,   bool a_CanCauseFire,   double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData);
 	bool CallHookExploding                (cWorld & a_World, double & a_ExplosionSize, bool & a_CanCauseFire, double a_X, double a_Y, double a_Z, eExplosionSource a_Source, void * a_SourceData);
 	bool CallHookHandshake                (cClientHandle & a_ClientHandle, const AString & a_Username);
-	bool CallHookHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, int a_SrcSlotNum);
+	bool CallHookHopperPullingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_DstSlotNum, cBlockEntityWithItems & a_SrcEntity, size_t a_SrcSlotNum);
 	bool CallHookHopperPushingItem        (cWorld & a_World, cHopperEntity & a_Hopper, int a_SrcSlotNum, cBlockEntityWithItems & a_DstEntity, int a_DstSlotNum);
 	bool CallHookDropSpense               (cWorld & a_World, cDropSpenserEntity & a_DropSpenser, int a_SlotNum);
 	bool CallHookKilled                   (cEntity & a_Victim, TakeDamageInfo & a_TDI, AString & a_DeathMessage);

--- a/src/BlockEntities/BlockEntityWithItems.cpp
+++ b/src/BlockEntities/BlockEntityWithItems.cpp
@@ -12,7 +12,7 @@ cBlockEntityWithItems::cBlockEntityWithItems(
 	BLOCKTYPE a_BlockType,
 	NIBBLETYPE a_BlockMeta,
 	Vector3i a_Pos,
-	int a_ItemGridWidth, int a_ItemGridHeight,
+	std::size_t a_ItemGridWidth, std::size_t a_ItemGridHeight,
 	cWorld * a_World
 ):
 	Super(a_BlockType, a_BlockMeta, a_Pos, a_World),
@@ -48,7 +48,7 @@ void cBlockEntityWithItems::CopyFrom(const cBlockEntity & a_Src)
 
 
 
-void cBlockEntityWithItems::OnSlotChanged(cItemGrid * a_Grid, int a_SlotNum)
+void cBlockEntityWithItems::OnSlotChanged(cItemGrid * a_Grid, std::size_t a_SlotNum)
 {
 	UNUSED(a_SlotNum);
 	ASSERT(a_Grid == &m_Contents);

--- a/src/BlockEntities/BlockEntityWithItems.h
+++ b/src/BlockEntities/BlockEntityWithItems.h
@@ -46,11 +46,15 @@ public:  // tolua_export
 
 	// tolua_begin
 
-	const cItem & GetSlot(int a_SlotNum)    const { return m_Contents.GetSlot(a_SlotNum); }
+	const cItem & GetSlot(size_t a_SlotNum) const { return m_Contents.GetSlot(a_SlotNum); }
 	const cItem & GetSlot(int a_X, int a_Y) const { return m_Contents.GetSlot(a_X, a_Y); }
+	///! \deprecated See cItemGrid::GetSlot
+	const cItem & GetSlot(int a_SlotNum) const    { return m_Contents.GetSlot(a_SlotNum); }
 
-	void SetSlot(int a_SlotNum,    const cItem & a_Item) { m_Contents.SetSlot(a_SlotNum, a_Item); }
+	void SetSlot(size_t a_SlotNum, const cItem & a_Item) { m_Contents.SetSlot(a_SlotNum, a_Item); }
 	void SetSlot(int a_X, int a_Y, const cItem & a_Item) { m_Contents.SetSlot(a_X, a_Y, a_Item); }
+	///! \deprecated See cItemGrid::GetSlot
+	void SetSlot(int a_SlotNum, const cItem & a_Item)    { m_Contents.SetSlot(a_SlotNum, a_Item); }
 
 	/** Returns the ItemGrid used for storing the contents */
 	cItemGrid & GetContents(void) { return m_Contents; }

--- a/src/BlockEntities/BlockEntityWithItems.h
+++ b/src/BlockEntities/BlockEntityWithItems.h
@@ -33,11 +33,11 @@ class cBlockEntityWithItems :
 public:  // tolua_export
 
 	cBlockEntityWithItems(
-		BLOCKTYPE a_BlockType,                      // Type of the block that the entity represents
-		NIBBLETYPE a_BlockMeta,                     // Meta of the block that the entity represents
-		Vector3i a_Pos,                             // Abs position of the block entity
-		int a_ItemGridWidth, int a_ItemGridHeight,  // Dimensions of the ItemGrid
-		cWorld * a_World                            // Optional world to assign to the entity
+		BLOCKTYPE a_BlockType,                                      // Type of the block that the entity represents
+		NIBBLETYPE a_BlockMeta,                                     // Meta of the block that the entity represents
+		Vector3i a_Pos,                                             // Abs position of the block entity
+		std::size_t a_ItemGridWidth, std::size_t a_ItemGridHeight,  // Dimensions of the ItemGrid
+		cWorld * a_World                                            // Optional world to assign to the entity
 	);
 
 	// cBlockEntity overrides:
@@ -47,14 +47,10 @@ public:  // tolua_export
 	// tolua_begin
 
 	const cItem & GetSlot(size_t a_SlotNum) const { return m_Contents.GetSlot(a_SlotNum); }
-	const cItem & GetSlot(int a_X, int a_Y) const { return m_Contents.GetSlot(a_X, a_Y); }
-	///! \deprecated See cItemGrid::GetSlot
-	const cItem & GetSlot(int a_SlotNum) const    { return m_Contents.GetSlot(a_SlotNum); }
+	const cItem & GetSlot(std::size_t a_X, std::size_t a_Y) const { return m_Contents.GetSlot(a_X, a_Y); }
 
 	void SetSlot(size_t a_SlotNum, const cItem & a_Item) { m_Contents.SetSlot(a_SlotNum, a_Item); }
-	void SetSlot(int a_X, int a_Y, const cItem & a_Item) { m_Contents.SetSlot(a_X, a_Y, a_Item); }
-	///! \deprecated See cItemGrid::GetSlot
-	void SetSlot(int a_SlotNum, const cItem & a_Item)    { m_Contents.SetSlot(a_SlotNum, a_Item); }
+	void SetSlot(std::size_t a_X, std::size_t a_Y, const cItem & a_Item) { m_Contents.SetSlot(a_X, a_Y, a_Item); }
 
 	/** Returns the ItemGrid used for storing the contents */
 	cItemGrid & GetContents(void) { return m_Contents; }
@@ -69,5 +65,5 @@ protected:
 	cItemGrid m_Contents;
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_Grid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_Grid, std::size_t a_SlotNum) override;
 } ;  // tolua_export

--- a/src/BlockEntities/BrewingstandEntity.cpp
+++ b/src/BlockEntities/BrewingstandEntity.cpp
@@ -117,7 +117,7 @@ bool cBrewingstandEntity::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 
 		// Loop over all bottle slots and update available bottles
 		const cBrewingRecipes::cRecipe * Recipe = nullptr;
-		for (int i = 0; i < 3; i++)
+		for (size_t i = 0; i < 3; i++)
 		{
 			if (m_Contents.GetSlot(i).IsEmpty() || (m_CurrentBrewingRecipes[i] == nullptr))
 			{
@@ -234,7 +234,7 @@ void cBrewingstandEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 	cBrewingRecipes * BR = cRoot::Get()->GetBrewingRecipes();
 	const cBrewingRecipes::cRecipe * Recipe = nullptr;
 	bool Stop = true;
-	for (int i = 0; i < 3; i++)
+	for (size_t i = 0; i < 3; i++)
 	{
 		if (GetSlot(i).IsEmpty())
 		{
@@ -323,7 +323,7 @@ void cBrewingstandEntity::LoadRecipes(void)
 
 	cBrewingRecipes * BR = cRoot::Get()->GetBrewingRecipes();
 	const cBrewingRecipes::cRecipe * Recipe = nullptr;
-	for (int i = 0; i < 3; i++)
+	for (size_t i = 0; i < 3; i++)
 	{
 		if (GetSlot(i).IsEmpty())
 		{

--- a/src/BlockEntities/BrewingstandEntity.cpp
+++ b/src/BlockEntities/BrewingstandEntity.cpp
@@ -191,7 +191,7 @@ void cBrewingstandEntity::BroadcastProgress(size_t a_ProgressbarID, short a_Valu
 
 
 
-void cBrewingstandEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
+void cBrewingstandEntity::OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum)
 {
 	Super::OnSlotChanged(a_ItemGrid, a_SlotNum);
 

--- a/src/BlockEntities/BrewingstandEntity.h
+++ b/src/BlockEntities/BrewingstandEntity.h
@@ -78,7 +78,7 @@ public:
 	const cItem & GetFuelSlot(void) const { return GetSlot(bsFuel); }
 
 	/** Get the expected result item for the given slot number */
-	const cItem & GetResultItem(int a_SlotNumber) { return m_Results[a_SlotNumber]; }
+	const cItem & GetResultItem(std::size_t a_SlotNumber) { return m_Results[a_SlotNumber]; }
 
 	/** Sets the item in the left bottle slot  */
 	void SetLeftBottleSlot(const cItem & a_Item) { SetSlot(bsLeftBottle, a_Item); }
@@ -136,5 +136,5 @@ protected:
 	void UpdateProgressBars(bool a_ForceUpdate = false);
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 } ;  // tolua_export

--- a/src/BlockEntities/ChestEntity.cpp
+++ b/src/BlockEntities/ChestEntity.cpp
@@ -237,7 +237,7 @@ bool cChestEntity::UsedBy(cPlayer * a_Player)
 
 
 
-void cChestEntity::OnSlotChanged(cItemGrid * a_Grid, int a_SlotNum)
+void cChestEntity::OnSlotChanged(cItemGrid * a_Grid, std::size_t a_SlotNum)
 {
 	ASSERT(a_Grid == &m_Contents);
 

--- a/src/BlockEntities/ChestEntity.h
+++ b/src/BlockEntities/ChestEntity.h
@@ -77,5 +77,5 @@ private:
 	virtual bool UsedBy(cPlayer * a_Player) override;
 
 	/** cItemGrid::cListener overrides: */
-	virtual void OnSlotChanged(cItemGrid * a_Grid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_Grid, std::size_t a_SlotNum) override;
 } ;  // tolua_export

--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -24,7 +24,7 @@ cDispenserEntity::cDispenserEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta
 
 
 
-void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
+void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, std::size_t a_SlotNum)
 {
 	Vector3i DispRelCoord(GetRelPos());
 	auto Meta = a_Chunk.GetMeta(DispRelCoord);
@@ -308,7 +308,7 @@ Vector3d cDispenserEntity::GetShootVector(NIBBLETYPE a_Meta)
 
 
 
-bool cDispenserEntity::ScoopUpLiquid(int a_SlotNum, short a_ResultingBucketItemType)
+bool cDispenserEntity::ScoopUpLiquid(std::size_t a_SlotNum, short a_ResultingBucketItemType)
 {
 	cItem LiquidBucket(a_ResultingBucketItemType);
 	if (m_Contents.GetSlot(a_SlotNum).m_ItemCount == 1)
@@ -334,7 +334,7 @@ bool cDispenserEntity::ScoopUpLiquid(int a_SlotNum, short a_ResultingBucketItemT
 
 
 
-bool cDispenserEntity::EmptyLiquidBucket(BLOCKTYPE a_BlockInFront, int a_SlotNum)
+bool cDispenserEntity::EmptyLiquidBucket(BLOCKTYPE a_BlockInFront, std::size_t a_SlotNum)
 {
 	if (
 		(a_BlockInFront != E_BLOCK_AIR) &&

--- a/src/BlockEntities/DispenserEntity.h
+++ b/src/BlockEntities/DispenserEntity.h
@@ -54,12 +54,12 @@ public:  // tolua_export
 private:
 
 	// cDropSpenser overrides:
-	virtual void DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum) override;
+	virtual void DropSpenseFromSlot(cChunk & a_Chunk, std::size_t a_SlotNum) override;
 
 	/** If such a bucket can fit, adds it to m_Contents and returns true */
-	bool ScoopUpLiquid(int a_SlotNum, short a_ResultingBucketItemType);
+	bool ScoopUpLiquid(std::size_t a_SlotNum, short a_ResultingBucketItemType);
 
 	/** If the a_BlockInFront can be washed away by liquid and the empty bucket can fit,
 	does the m_Contents processing and returns true. Returns false otherwise. */
-	bool EmptyLiquidBucket(BLOCKTYPE a_BlockInFront, int a_SlotNum);
+	bool EmptyLiquidBucket(BLOCKTYPE a_BlockInFront, std::size_t a_SlotNum);
 } ;  // tolua_export

--- a/src/BlockEntities/DropSpenserEntity.cpp
+++ b/src/BlockEntities/DropSpenserEntity.cpp
@@ -65,8 +65,8 @@ void cDropSpenserEntity::DropSpense(cChunk & a_Chunk)
 		return;
 	}
 
-	const int RandomSlot = m_World->GetTickRandomNumber(SlotsCnt - 1);
-	const int SpenseSlot = OccupiedSlots[RandomSlot];
+	const auto RandomSlot = m_World->GetTickRandomNumber(SlotsCnt - 1);
+	const auto SpenseSlot = OccupiedSlots[RandomSlot];
 
 	if (cPluginManager::Get()->CallHookDropSpense(*m_World, *this, SpenseSlot))
 	{

--- a/src/BlockEntities/DropSpenserEntity.cpp
+++ b/src/BlockEntities/DropSpenserEntity.cpp
@@ -47,9 +47,9 @@ void cDropSpenserEntity::AddDropSpenserDir(Vector3i & a_RelCoord, NIBBLETYPE a_D
 void cDropSpenserEntity::DropSpense(cChunk & a_Chunk)
 {
 	// Pick one of the occupied slots:
-	int OccupiedSlots[9];
-	int SlotsCnt = 0;
-	for (int i = m_Contents.GetNumSlots() - 1; i >= 0; i--)
+	std::array<int, 9> OccupiedSlots;
+	size_t SlotsCnt = 0;
+	for (int i = m_Contents.OldGetNumSlots() - 1; i >= 0; i--)
 	{
 		if (!m_Contents.GetSlot(i).IsEmpty())
 		{

--- a/src/BlockEntities/DropSpenserEntity.cpp
+++ b/src/BlockEntities/DropSpenserEntity.cpp
@@ -47,9 +47,9 @@ void cDropSpenserEntity::AddDropSpenserDir(Vector3i & a_RelCoord, NIBBLETYPE a_D
 void cDropSpenserEntity::DropSpense(cChunk & a_Chunk)
 {
 	// Pick one of the occupied slots:
-	std::array<int, 9> OccupiedSlots;
+	std::array<std::size_t, 9> OccupiedSlots;
 	size_t SlotsCnt = 0;
-	for (int i = m_Contents.OldGetNumSlots() - 1; i >= 0; i--)
+	for (auto i = m_Contents.GetNumSlots() - 1; i > 0; i--)
 	{
 		if (!m_Contents.GetSlot(i).IsEmpty())
 		{
@@ -191,7 +191,7 @@ bool cDropSpenserEntity::UsedBy(cPlayer * a_Player)
 
 
 
-void cDropSpenserEntity::DropFromSlot(cChunk & a_Chunk, int a_SlotNum)
+void cDropSpenserEntity::DropFromSlot(cChunk & a_Chunk, std::size_t a_SlotNum)
 {
 	Vector3i dispCoord(m_Pos);
 	auto Meta = a_Chunk.GetMeta(GetRelPos());

--- a/src/BlockEntities/DropSpenserEntity.h
+++ b/src/BlockEntities/DropSpenserEntity.h
@@ -69,8 +69,8 @@ protected:
 	void DropSpense(cChunk & a_Chunk);
 
 	/** Override this function to provide the specific behavior for item dropspensing (drop / shoot / pour / ...) */
-	virtual void DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum) = 0;
+	virtual void DropSpenseFromSlot(cChunk & a_Chunk, std::size_t a_SlotNum) = 0;
 
 	/** Helper function, drops one item from the specified slot (like a dropper) */
-	void DropFromSlot(cChunk & a_Chunk, int a_SlotNum);
+	void DropFromSlot(cChunk & a_Chunk, std::size_t a_SlotNum);
 } ;  // tolua_export

--- a/src/BlockEntities/DropperEntity.cpp
+++ b/src/BlockEntities/DropperEntity.cpp
@@ -20,7 +20,7 @@ cDropperEntity::cDropperEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Ve
 
 
 
-void cDropperEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
+void cDropperEntity::DropSpenseFromSlot(cChunk & a_Chunk, std::size_t a_SlotNum)
 {
 	DropFromSlot(a_Chunk, a_SlotNum);
 }

--- a/src/BlockEntities/DropperEntity.h
+++ b/src/BlockEntities/DropperEntity.h
@@ -31,5 +31,5 @@ public:  // tolua_export
 protected:
 
 	// cDropSpenserEntity overrides:
-	virtual void DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum) override;
+	virtual void DropSpenseFromSlot(cChunk & a_Chunk, std::size_t a_SlotNum) override;
 } ;  // tolua_export

--- a/src/BlockEntities/EnderChestEntity.cpp
+++ b/src/BlockEntities/EnderChestEntity.cpp
@@ -114,7 +114,7 @@ void cEnderChestEntity::LoadFromJson(const Json::Value & a_Value, cItemGrid & a_
 
 void cEnderChestEntity::SaveToJson(Json::Value & a_Value, const cItemGrid & a_Grid)
 {
-	for (int i = 0; i < a_Grid.GetNumSlots(); i++)
+	for (size_t i = 0; i < a_Grid.GetNumSlots(); i++)
 	{
 		Json::Value Slot;
 		a_Grid.GetSlot(i).GetJson(Slot);

--- a/src/BlockEntities/EnderChestEntity.cpp
+++ b/src/BlockEntities/EnderChestEntity.cpp
@@ -98,7 +98,7 @@ void cEnderChestEntity::OpenNewWindow()
 
 void cEnderChestEntity::LoadFromJson(const Json::Value & a_Value, cItemGrid & a_Grid)
 {
-	int SlotIdx = 0;
+	std::size_t SlotIdx = 0;
 	for (auto & Node : a_Value)
 	{
 		cItem Item;

--- a/src/BlockEntities/FurnaceEntity.cpp
+++ b/src/BlockEntities/FurnaceEntity.cpp
@@ -243,7 +243,7 @@ void cFurnaceEntity::BurnNewFuel(void)
 
 
 
-void cFurnaceEntity::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
+void cFurnaceEntity::OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum)
 {
 	Super::OnSlotChanged(a_ItemGrid, a_SlotNum);
 

--- a/src/BlockEntities/FurnaceEntity.h
+++ b/src/BlockEntities/FurnaceEntity.h
@@ -165,6 +165,6 @@ protected:
 	void SetIsCooking(bool a_IsCooking);
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 
 } ;  // tolua_export

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -429,9 +429,9 @@ bool cHopperEntity::MoveItemsFromFurnace(cChunk & a_Chunk)
 bool cHopperEntity::MoveItemsFromGrid(cBlockEntityWithItems & a_Entity)
 {
 	auto & Grid = a_Entity.GetContents();
-	int NumSlots = Grid.GetNumSlots();
+	size_t NumSlots = Grid.GetNumSlots();
 
-	for (int i = 0; i < NumSlots; i++)
+	for (size_t i = 0; i < NumSlots; i++)
 	{
 		if (Grid.IsSlotEmpty(i))
 		{
@@ -450,7 +450,7 @@ bool cHopperEntity::MoveItemsFromGrid(cBlockEntityWithItems & a_Entity)
 
 
 
-bool cHopperEntity::MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, int a_SlotNum)
+bool cHopperEntity::MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, size_t a_SlotNum)
 {
 	cItem One(a_Entity.GetSlot(a_SlotNum).CopyOne());
 	for (int i = 0; i < ContentsWidth * ContentsHeight; i++)
@@ -537,7 +537,7 @@ bool cHopperEntity::MoveItemsToFurnace(cChunk & a_Chunk, Vector3i a_Coords, NIBB
 bool cHopperEntity::MoveItemsToGrid(cBlockEntityWithItems & a_Entity)
 {
 	// Iterate through our slots, try to move from each one:
-	int NumSlots = a_Entity.GetContents().GetNumSlots();
+	int NumSlots = a_Entity.GetContents().OldGetNumSlots();
 	for (int i = 0; i < NumSlots; i++)
 	{
 		if (MoveItemsToSlot(a_Entity, i))

--- a/src/BlockEntities/HopperEntity.cpp
+++ b/src/BlockEntities/HopperEntity.cpp
@@ -240,7 +240,7 @@ bool cHopperEntity::MovePickupsIn(cChunk & a_Chunk)
 		{
 			cItem & Item = a_Pickup.GetItem();
 
-			for (int i = 0; i < ContentsWidth * ContentsHeight; i++)
+			for (std::size_t i = 0; i < ContentsWidth * ContentsHeight; i++)
 			{
 				if (m_Contents.IsSlotEmpty(i))
 				{
@@ -450,10 +450,10 @@ bool cHopperEntity::MoveItemsFromGrid(cBlockEntityWithItems & a_Entity)
 
 
 
-bool cHopperEntity::MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, size_t a_SlotNum)
+bool cHopperEntity::MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, std::size_t a_SlotNum)
 {
 	cItem One(a_Entity.GetSlot(a_SlotNum).CopyOne());
-	for (int i = 0; i < ContentsWidth * ContentsHeight; i++)
+	for (std::size_t i = 0; i < ContentsWidth * ContentsHeight; i++)
 	{
 		if (m_Contents.IsSlotEmpty(i))
 		{
@@ -537,8 +537,8 @@ bool cHopperEntity::MoveItemsToFurnace(cChunk & a_Chunk, Vector3i a_Coords, NIBB
 bool cHopperEntity::MoveItemsToGrid(cBlockEntityWithItems & a_Entity)
 {
 	// Iterate through our slots, try to move from each one:
-	int NumSlots = a_Entity.GetContents().OldGetNumSlots();
-	for (int i = 0; i < NumSlots; i++)
+	auto NumSlots = a_Entity.GetContents().GetNumSlots();
+	for (std::size_t i = 0; i < NumSlots; i++)
 	{
 		if (MoveItemsToSlot(a_Entity, i))
 		{
@@ -552,13 +552,13 @@ bool cHopperEntity::MoveItemsToGrid(cBlockEntityWithItems & a_Entity)
 
 
 
-bool cHopperEntity::MoveItemsToSlot(cBlockEntityWithItems & a_Entity, int a_DstSlotNum)
+bool cHopperEntity::MoveItemsToSlot(cBlockEntityWithItems & a_Entity, std::size_t a_DstSlotNum)
 {
 	cItemGrid & Grid = a_Entity.GetContents();
 	if (Grid.IsSlotEmpty(a_DstSlotNum))
 	{
 		// The slot is empty, move the first non-empty slot from our contents:
-		for (int i = 0; i < ContentsWidth * ContentsHeight; i++)
+		for (std::size_t i = 0; i < ContentsWidth * ContentsHeight; i++)
 		{
 			if (!m_Contents.IsSlotEmpty(i))
 			{
@@ -582,7 +582,7 @@ bool cHopperEntity::MoveItemsToSlot(cBlockEntityWithItems & a_Entity, int a_DstS
 		{
 			return false;
 		}
-		for (int i = 0; i < ContentsWidth * ContentsHeight; i++)
+		for (std::size_t i = 0; i < ContentsWidth * ContentsHeight; i++)
 		{
 			if (m_Contents.GetSlot(i).IsEqual(DestSlot))
 			{

--- a/src/BlockEntities/HopperEntity.h
+++ b/src/BlockEntities/HopperEntity.h
@@ -78,7 +78,7 @@ protected:
 	bool MoveItemsFromGrid(cBlockEntityWithItems & a_Entity);
 
 	/** Moves one piece from the specified itemstack into this hopper. Returns true if contents have changed. Doesn't change the itemstack. */
-	bool MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, size_t a_SrcSlotNum);
+	bool MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, std::size_t a_SrcSlotNum);
 
 	/** Moves items to the chest at the specified absolute coords. Returns true if contents have changed */
 	bool MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords);
@@ -90,7 +90,7 @@ protected:
 	bool MoveItemsToGrid(cBlockEntityWithItems & a_Entity);
 
 	/** Moves one piece to the specified entity's contents' slot. Returns true if contents have changed. */
-	bool MoveItemsToSlot(cBlockEntityWithItems & a_Entity, int a_DstSlotNum);
+	bool MoveItemsToSlot(cBlockEntityWithItems & a_Entity, std::size_t a_DstSlotNum);
 
 private:
 

--- a/src/BlockEntities/HopperEntity.h
+++ b/src/BlockEntities/HopperEntity.h
@@ -78,7 +78,7 @@ protected:
 	bool MoveItemsFromGrid(cBlockEntityWithItems & a_Entity);
 
 	/** Moves one piece from the specified itemstack into this hopper. Returns true if contents have changed. Doesn't change the itemstack. */
-	bool MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, int a_SrcSlotNum);
+	bool MoveItemsFromSlot(cBlockEntityWithItems & a_Entity, size_t a_SrcSlotNum);
 
 	/** Moves items to the chest at the specified absolute coords. Returns true if contents have changed */
 	bool MoveItemsToChest(cChunk & a_Chunk, Vector3i a_Coords);

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -706,7 +706,7 @@ void cClientHandle::HandleAnimation(const bool a_SwingMainHand)
 
 
 
-void cClientHandle::HandleNPCTrade(int a_SlotNum)
+void cClientHandle::HandleNPCTrade(std::size_t a_SlotNum)
 {
 	// TODO
 	LOGWARNING("%s: Not implemented yet", __FUNCTION__);
@@ -783,7 +783,7 @@ bool cClientHandle::HandleLogin()
 
 
 
-void cClientHandle::HandleCreativeInventory(Int16 a_SlotNum, const cItem & a_HeldItem, eClickAction a_ClickAction)
+void cClientHandle::HandleCreativeInventory(std::size_t a_SlotNum, const cItem & a_HeldItem, eClickAction a_ClickAction)
 {
 	// This is for creative Inventory changes
 	if (!m_Player->IsGameModeCreative())
@@ -1648,7 +1648,7 @@ void cClientHandle::HandlePlayerMoveLook(Vector3d a_Pos, float a_Rotation, float
 
 void cClientHandle::HandleSlotSelected(Int16 a_SlotNum)
 {
-	m_Player->GetInventory().SetEquippedSlotNum(a_SlotNum);
+	m_Player->GetInventory().SetEquippedSlotNum(static_cast<std::size_t>(a_SlotNum));
 	m_Player->GetWorld()->BroadcastEntityEquipment(*m_Player, 0, m_Player->GetInventory().GetEquippedItem(), this);
 }
 
@@ -1711,7 +1711,7 @@ void cClientHandle::HandleWindowClose(UInt8 a_WindowID)
 
 
 
-void cClientHandle::HandleWindowClick(UInt8 a_WindowID, Int16 a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem)
+void cClientHandle::HandleWindowClick(UInt8 a_WindowID, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem)
 {
 	LOGD("WindowClick: WinID %d, SlotNum %d, action: %s, Item %s x %d",
 		a_WindowID, a_SlotNum, ClickActionToString(a_ClickAction),
@@ -2720,7 +2720,7 @@ void cClientHandle::SendHealth(void)
 
 
 
-void cClientHandle::SendHeldItemChange(int a_ItemIndex)
+void cClientHandle::SendHeldItemChange(std::size_t a_ItemIndex)
 {
 	m_Protocol->SendHeldItemChange(a_ItemIndex);
 }
@@ -2738,7 +2738,7 @@ void cClientHandle::SendHideTitle(void)
 
 
 
-void cClientHandle::SendInventorySlot(char a_WindowID, short a_SlotNum, const cItem & a_Item)
+void cClientHandle::SendInventorySlot(char a_WindowID, std::size_t a_SlotNum, const cItem & a_Item)
 {
 	m_Protocol->SendInventorySlot(a_WindowID, a_SlotNum, a_Item);
 }

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -189,9 +189,9 @@ public:  // tolua_export
 	void SendExplosion                  (Vector3f a_Position, float a_Power);
 	void SendGameMode                   (eGameMode a_GameMode);
 	void SendHealth                     (void);
-	void SendHeldItemChange             (int a_ItemIndex);
+	void SendHeldItemChange             (std::size_t a_ItemIndex);
 	void SendHideTitle                  (void);   // tolua_export
-	void SendInventorySlot              (char a_WindowID, short a_SlotNum, const cItem & a_Item);
+	void SendInventorySlot              (char a_WindowID, std::size_t a_SlotNum, const cItem & a_Item);
 	void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo);  // tolua_export
 	void SendMapData                    (const cMap & a_Map, int a_DataStartX, int a_DataStartY);
 	void SendPaintingSpawn              (const cPainting & a_Painting);
@@ -333,7 +333,7 @@ public:  // tolua_export
 
 	/** Called when the client clicks the creative inventory window.
 	a_ClickAction specifies whether the click was inside the window or not (caLeftClick or caLeftClickOutside). */
-	void HandleCreativeInventory(Int16 a_SlotNum, const cItem & a_HeldItem, eClickAction a_ClickAction);
+	void HandleCreativeInventory(std::size_t a_SlotNum, const cItem & a_HeldItem, eClickAction a_ClickAction);
 
 	/** Handles a player sneaking or unsneaking. */
 	void HandleCrouch(bool a_IsCrouching);
@@ -359,7 +359,7 @@ public:  // tolua_export
 
 	/** Called when the protocol receives a MC|TrSel packet, indicating that the player used a trade in
 	the NPC UI. */
-	void HandleNPCTrade(int a_SlotNum);
+	void HandleNPCTrade(std::size_t a_SlotNum);
 
 	/** Handles a player opening his inventory while riding a horse. */
 	void HandleOpenHorseInventory();
@@ -399,7 +399,7 @@ public:  // tolua_export
 	void HandleUnmount          (void);
 	void HandleUseEntity        (UInt32 a_TargetEntityID, bool a_IsLeftClick);
 	void HandleUseItem          (bool a_UsedMainHand);
-	void HandleWindowClick      (UInt8 a_WindowID, Int16 a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem);
+	void HandleWindowClick      (UInt8 a_WindowID, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem);
 	void HandleWindowClose      (UInt8 a_WindowID);
 
 	/** Called when a recipe from the recipe book is selected */

--- a/src/CraftingRecipes.cpp
+++ b/src/CraftingRecipes.cpp
@@ -15,7 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // cCraftingGrid:
 
-cCraftingGrid::cCraftingGrid(int a_Width, int a_Height) :
+cCraftingGrid::cCraftingGrid(std::size_t a_Width, std::size_t a_Height) :
 	m_Width(a_Width),
 	m_Height(a_Height),
 	m_Items(new cItem[ToUnsigned(a_Width * a_Height)])
@@ -26,10 +26,10 @@ cCraftingGrid::cCraftingGrid(int a_Width, int a_Height) :
 
 
 
-cCraftingGrid::cCraftingGrid(const cItem * a_Items, int a_Width, int a_Height) :
+cCraftingGrid::cCraftingGrid(const cItem * a_Items, std::size_t a_Width, std::size_t a_Height) :
 	cCraftingGrid(a_Width, a_Height)
 {
-	for (int i = a_Width * a_Height - 1; i >= 0; i--)
+	for (std::size_t i = a_Width * a_Height - 1; i != 0; i--)
 	{
 		m_Items[i] = a_Items[i];
 	}
@@ -42,7 +42,7 @@ cCraftingGrid::cCraftingGrid(const cItem * a_Items, int a_Width, int a_Height) :
 cCraftingGrid::cCraftingGrid(const cCraftingGrid & a_Original) :
 	cCraftingGrid(a_Original.m_Width, a_Original.m_Height)
 {
-	for (int i = m_Width * m_Height - 1; i >= 0; i--)
+	for (std::size_t i = m_Width * m_Height - 1; i != 0; i--)
 	{
 		m_Items[i] = a_Original.m_Items[i];
 	}
@@ -62,10 +62,10 @@ cCraftingGrid::~cCraftingGrid()
 
 
 
-cItem & cCraftingGrid::GetItem(int x, int y) const
+cItem & cCraftingGrid::GetItem(std::size_t x, std::size_t y) const
 {
 	// Accessible through scripting, must verify parameters:
-	if ((x < 0) || (x >= m_Width) || (y < 0) || (y >= m_Height))
+	if ((x >= m_Width) || (y >= m_Height))
 	{
 		LOGERROR("Attempted to get an invalid item from a crafting grid: (%d, %d), grid dimensions: (%d, %d).",
 			x, y, m_Width, m_Height
@@ -79,10 +79,10 @@ cItem & cCraftingGrid::GetItem(int x, int y) const
 
 
 
-void cCraftingGrid::SetItem(int x, int y, ENUM_ITEM_TYPE a_ItemType, char a_ItemCount, short a_ItemHealth)
+void cCraftingGrid::SetItem(std::size_t x, std::size_t y, ENUM_ITEM_TYPE a_ItemType, char a_ItemCount, short a_ItemHealth)
 {
 	// Accessible through scripting, must verify parameters:
-	if ((x < 0) || (x >= m_Width) || (y < 0) || (y >= m_Height))
+	if ((x >= m_Width) || (y >= m_Height))
 	{
 		LOGERROR("Attempted to set an invalid item in a crafting grid: (%d, %d), grid dimensions: (%d, %d).",
 			x, y, m_Width, m_Height
@@ -97,10 +97,10 @@ void cCraftingGrid::SetItem(int x, int y, ENUM_ITEM_TYPE a_ItemType, char a_Item
 
 
 
-void cCraftingGrid::SetItem(int x, int y, const cItem & a_Item)
+void cCraftingGrid::SetItem(std::size_t x, std::size_t y, const cItem & a_Item)
 {
 	// Accessible through scripting, must verify parameters:
-	if ((x < 0) || (x >= m_Width) || (y < 0) || (y >= m_Height))
+	if ((x >= m_Width) || (y >= m_Height))
 	{
 		LOGERROR("Attempted to set an invalid item in a crafting grid: (%d, %d), grid dimensions: (%d, %d).",
 			x, y, m_Width, m_Height
@@ -117,7 +117,7 @@ void cCraftingGrid::SetItem(int x, int y, const cItem & a_Item)
 
 void cCraftingGrid::Clear(void)
 {
-	for (int y = 0; y < m_Height; y++) for (int x = 0; x < m_Width; x++)
+	for (std::size_t y = 0; y < m_Height; y++) for (std::size_t x = 0; x < m_Width; x++)
 	{
 		m_Items[x + m_Width * y].Empty();
 	}
@@ -135,16 +135,16 @@ void cCraftingGrid::ConsumeGrid(const cCraftingGrid & a_Grid)
 			a_Grid.m_Width, a_Grid.m_Height, m_Width, m_Height
 		);
 	}
-	int MinX = std::min(a_Grid.m_Width,  m_Width);
-	int MinY = std::min(a_Grid.m_Height, m_Height);
-	for (int y = 0; y <  MinY; y++) for (int x = 0; x < MinX; x++)
+	auto MinX = std::min<std::size_t>(a_Grid.m_Width,  m_Width);
+	auto MinY = std::min<std::size_t>(a_Grid.m_Height, m_Height);
+	for (std::size_t y = 0; y <  MinY; y++) for (std::size_t x = 0; x < MinX; x++)
 	{
-		int ThatIdx = x + a_Grid.m_Width * y;
+		auto ThatIdx = x + a_Grid.m_Width * y;
 		if (a_Grid.m_Items[ThatIdx].IsEmpty())
 		{
 			continue;
 		}
-		int ThisIdx = x + m_Width * y;
+		auto ThisIdx = x + m_Width * y;
 		if (a_Grid.m_Items[ThatIdx].m_ItemType != m_Items[ThisIdx].m_ItemType)
 		{
 			LOGWARNING("Consuming incompatible grids: item at (%d, %d) is %d in grid and %d in ingredients. Item not consumed.",
@@ -182,21 +182,21 @@ void cCraftingGrid::ConsumeGrid(const cCraftingGrid & a_Grid)
 
 void cCraftingGrid::CopyToItems(cItem * a_Items) const
 {
-	for (int i = m_Height * m_Width - 1; i >= 0; i--)
+	for (std::size_t i = 0; i < m_Height * m_Width; i++)
 	{
 		a_Items[i] = m_Items[i];
-	}  // for x, for y
+	}
 }
 
 
 
 
 
-void cCraftingGrid::Dump(void)
+void cCraftingGrid::Dump(void) const
 {
-	for (int y = 0; y < m_Height; y++) for (int x = 0; x < m_Width; x++)
+	for (std::size_t y = 0; y < m_Height; y++) for (std::size_t x = 0; x < m_Width; x++)
 	{
-		[[maybe_unused]] const int idx = x + m_Width * y;
+		[[maybe_unused]] const auto idx = x + m_Width * y;
 		LOGD("Slot (%d, %d): Type %d, health %d, count %d",
 			x, y, m_Items[idx].m_ItemType, m_Items[idx].m_ItemDamage, m_Items[idx].m_ItemCount
 		);
@@ -365,9 +365,10 @@ void cCraftingRecipes::GetRecipe(cPlayer & a_Player, cCraftingGrid & a_CraftingG
 		cRoot::Get()->GetPluginManager()->CallHookCraftingNoRecipe(a_Player, a_CraftingGrid, a_Recipe);
 		return;
 	}
-	for (cRecipeSlots::const_iterator itr = Recipe->m_Ingredients.begin(); itr != Recipe->m_Ingredients.end(); ++itr)
+
+	for (const auto & Ingredient : Recipe->m_Ingredients)
 	{
-		a_Recipe.SetIngredient(itr->x, itr->y, itr->m_Item);
+		a_Recipe.SetIngredient(Ingredient.x, Ingredient.y, Ingredient.m_Item);
 	}  // for itr
 	a_Recipe.SetResult(Recipe->m_Result);
 
@@ -579,8 +580,8 @@ bool cCraftingRecipes::ParseIngredient(const AString & a_String, cRecipe * a_Rec
 		{
 			cCraftingRecipes::cRecipeSlot Slot;
 			Slot.m_Item = Item;
-			Slot.x = -1;
-			Slot.y = -1;
+			Slot.x = ILLEGAL_SLOT_NUMBER;
+			Slot.y = ILLEGAL_SLOT_NUMBER;
 			TempSlots.push_back(Slot);
 			continue;
 		}
@@ -601,7 +602,7 @@ bool cCraftingRecipes::ParseIngredient(const AString & a_String, cRecipe * a_Rec
 			case '1': Slot.x = 0;  break;
 			case '2': Slot.x = 1;  break;
 			case '3': Slot.x = 2;  break;
-			case '*': Slot.x = -1; break;
+			case '*': Slot.x = ILLEGAL_SLOT_NUMBER; break;
 			default:
 			{
 				return false;
@@ -612,7 +613,7 @@ bool cCraftingRecipes::ParseIngredient(const AString & a_String, cRecipe * a_Rec
 			case '1': Slot.y = 0;  break;
 			case '2': Slot.y = 1;  break;
 			case '3': Slot.y = 2;  break;
-			case '*': Slot.y = -1; break;
+			case '*': Slot.y = ILLEGAL_SLOT_NUMBER; break;
 			default:
 			{
 				return false;
@@ -633,36 +634,38 @@ bool cCraftingRecipes::ParseIngredient(const AString & a_String, cRecipe * a_Rec
 void cCraftingRecipes::NormalizeIngredients(cCraftingRecipes::cRecipe * a_Recipe)
 {
 	// Calculate the minimum coords for ingredients, excluding the "anywhere" items:
-	int MinX = MAX_GRID_WIDTH, MaxX = 0;
-	int MinY = MAX_GRID_HEIGHT, MaxY = 0;
-	for (cRecipeSlots::const_iterator itr = a_Recipe->m_Ingredients.begin(); itr != a_Recipe->m_Ingredients.end(); ++itr)
+	std::size_t MinX = MAX_GRID_WIDTH;
+	std::size_t MaxX = 0;
+	std::size_t MinY = MAX_GRID_HEIGHT;
+	std::size_t MaxY = 0;
+	for (const auto & Ingredient : a_Recipe->m_Ingredients)
 	{
-		if (itr->x >= 0)
+		if (Ingredient.x != ILLEGAL_SLOT_NUMBER)
 		{
-			MinX = std::min(itr->x, MinX);
-			MaxX = std::max(itr->x, MaxX);
+			MinX = std::min<std::size_t>(Ingredient.x, MinX);
+			MaxX = std::max<std::size_t>(Ingredient.x, MaxX);
 		}
-		if (itr->y >= 0)
+		if (Ingredient.y != ILLEGAL_SLOT_NUMBER)
 		{
-			MinY = std::min(itr->y, MinY);
-			MaxY = std::max(itr->y, MaxY);
+			MinY = std::min<std::size_t>(Ingredient.y, MinY);
+			MaxY = std::max<std::size_t>(Ingredient.y, MaxY);
 		}
 	}  // for itr - a_Recipe->m_Ingredients[]
 
 	// Move ingredients so that the minimum coords are 0:0
-	for (cRecipeSlots::iterator itr = a_Recipe->m_Ingredients.begin(); itr != a_Recipe->m_Ingredients.end(); ++itr)
+	for (auto & Ingredient : a_Recipe->m_Ingredients)
 	{
-		if (itr->x >= 0)
+		if (Ingredient.x != ILLEGAL_SLOT_NUMBER)
 		{
-			itr->x -= MinX;
+			Ingredient.x -= MinX;
 		}
-		if (itr->y >= 0)
+		if (Ingredient.y != ILLEGAL_SLOT_NUMBER)
 		{
-			itr->y -= MinY;
+			Ingredient.y -= MinY;
 		}
 	}  // for itr - a_Recipe->m_Ingredients[]
-	a_Recipe->m_Width  = std::max(MaxX - MinX + 1, 1);
-	a_Recipe->m_Height = std::max(MaxY - MinY + 1, 1);
+	a_Recipe->m_Width  = std::max<std::size_t>(MaxX - MinX + 1, 1);
+	a_Recipe->m_Height = std::max<std::size_t>(MaxY - MinY + 1, 1);
 
 	// TODO: Compress two same ingredients with the same coords into a single ingredient with increased item count
 }
@@ -671,15 +674,15 @@ void cCraftingRecipes::NormalizeIngredients(cCraftingRecipes::cRecipe * a_Recipe
 
 
 
-cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipe(const cItem * a_CraftingGrid, int a_GridWidth, int a_GridHeight)
+cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipe(const cItem * a_CraftingGrid, std::size_t a_GridWidth, std::size_t a_GridHeight)
 {
 	ASSERT(a_GridWidth <= MAX_GRID_WIDTH);
 	ASSERT(a_GridHeight <= MAX_GRID_HEIGHT);
 
 	// Get the real bounds of the crafting grid:
-	int GridLeft = MAX_GRID_WIDTH, GridTop = MAX_GRID_HEIGHT;
-	int GridRight = 0,  GridBottom = 0;
-	for (int y = 0; y < a_GridHeight; y++) for (int x = 0; x < a_GridWidth; x++)
+	std::size_t GridLeft = MAX_GRID_WIDTH, GridTop = MAX_GRID_HEIGHT;
+	std::size_t GridRight = 0,  GridBottom = 0;
+	for (std::size_t y = 0; y < a_GridHeight; y++) for (std::size_t x = 0; x < a_GridWidth; x++)
 	{
 		if (!a_CraftingGrid[x + y * a_GridWidth].IsEmpty())
 		{
@@ -689,8 +692,8 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipe(const cItem * a_Craftin
 			GridTop    = std::min(y, GridTop);
 		}
 	}
-	int GridWidth = GridRight - GridLeft + 1;
-	int GridHeight = GridBottom - GridTop + 1;
+	auto GridWidth = GridRight - GridLeft + 1;
+	auto GridHeight = GridBottom - GridTop + 1;
 
 	// Search in the possibly minimized grid, but keep the stride:
 	const cItem * Grid = a_CraftingGrid + GridLeft + (a_GridWidth * GridTop);
@@ -714,9 +717,9 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipe(const cItem * a_Craftin
 
 
 
-cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipeCropped(const cItem * a_CraftingGrid, int a_GridWidth, int a_GridHeight, int a_GridStride)
+cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipeCropped(const cItem * a_CraftingGrid, std::size_t a_GridWidth, std::size_t a_GridHeight, std::size_t a_GridStride)
 {
-	for (cRecipes::const_iterator itr = m_Recipes.begin(); itr != m_Recipes.end(); ++itr)
+	for (const auto Recipe : m_Recipes)
 	{
 		// Both the crafting grid and the recipes are normalized. The only variable possible is the "anywhere" items.
 		// This still means that the "anywhere" item may be the one that is offsetting the grid contents to the right or downwards, so we need to check all possible positions.
@@ -724,14 +727,14 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipeCropped(const cItem * a_
 		// Calculate the maximum offsets for this recipe relative to the grid size, and iterate through all combinations of offsets.
 		// Also, this calculation automatically filters out recipes that are too large for the current grid - the loop won't be entered at all.
 
-		int MaxOfsX = a_GridWidth  - (*itr)->m_Width;
-		int MaxOfsY = a_GridHeight - (*itr)->m_Height;
-		for (int x = 0; x <= MaxOfsX; x++) for (int y = 0; y <= MaxOfsY; y++)
+		auto MaxOfsX = a_GridWidth  - Recipe->m_Width;
+		auto MaxOfsY = a_GridHeight - Recipe->m_Height;
+		for (std::size_t x = 0; x <= MaxOfsX; x++) for (std::size_t y = 0; y <= MaxOfsY; y++)
 		{
-			cRecipe * Recipe = MatchRecipe(a_CraftingGrid, a_GridWidth, a_GridHeight, a_GridStride, *itr, x, y);
-			if (Recipe != nullptr)
+			auto SearchRecipe = MatchRecipe(a_CraftingGrid, a_GridWidth, a_GridHeight, a_GridStride, Recipe, x, y);
+			if (SearchRecipe != nullptr)
 			{
-				return Recipe;
+				return SearchRecipe;
 			}
 		}  // for y, for x
 	}  // for itr - m_Recipes[]
@@ -744,26 +747,26 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::FindRecipeCropped(const cItem * a_
 
 
 
-cCraftingRecipes::cRecipe * cCraftingRecipes::MatchRecipe(const cItem * a_CraftingGrid, int a_GridWidth, int a_GridHeight, int a_GridStride, const cRecipe * a_Recipe, int a_OffsetX, int a_OffsetY)
+cCraftingRecipes::cRecipe * cCraftingRecipes::MatchRecipe(const cItem * a_CraftingGrid, std::size_t a_GridWidth, std::size_t a_GridHeight, std::size_t a_GridStride, const cRecipe * a_Recipe, std::size_t a_OffsetX, std::size_t a_OffsetY)
 {
 	// Check the regular items first:
-	bool HasMatched[MAX_GRID_WIDTH][MAX_GRID_HEIGHT];
-	memset(HasMatched, 0, sizeof(HasMatched));
-	for (cRecipeSlots::const_iterator itrS = a_Recipe->m_Ingredients.begin(); itrS != a_Recipe->m_Ingredients.end(); ++itrS)
+	std::array<std::array<bool, MAX_GRID_WIDTH>, MAX_GRID_HEIGHT> HasMatched;
+	memset(HasMatched.data(), 0, HasMatched.size());
+	for (auto Ingredient : a_Recipe->m_Ingredients)
 	{
-		if ((itrS->x < 0) || (itrS->y < 0))
+		if ((Ingredient.x == ILLEGAL_SLOT_NUMBER) || (Ingredient.y == ILLEGAL_SLOT_NUMBER))
 		{
 			// "Anywhere" item, process later
 			continue;
 		}
-		ASSERT(itrS->x + a_OffsetX < a_GridWidth);
-		ASSERT(itrS->y + a_OffsetY < a_GridHeight);
-		int GridID = (itrS->x + a_OffsetX) + a_GridStride * (itrS->y + a_OffsetY);
+		ASSERT(Ingredient.x + a_OffsetX < a_GridWidth);
+		ASSERT(Ingredient.y + a_OffsetY < a_GridHeight);
+		std::size_t GridID = (Ingredient.x + a_OffsetX) + a_GridStride * (Ingredient.y + a_OffsetY);
 
-		const cItem & Item = itrS->m_Item;
+		const cItem & Item = Ingredient.m_Item;
 		if (
-			(itrS->x >= a_GridWidth) ||
-			(itrS->y >= a_GridHeight) ||
+			(Ingredient.x >= a_GridWidth) ||
+			(Ingredient.y >= a_GridHeight) ||
 			(Item.m_ItemType != a_CraftingGrid[GridID].m_ItemType) ||   // same item type?
 			(Item.m_ItemCount > a_CraftingGrid[GridID].m_ItemCount) ||  // not enough items
 			(
@@ -775,54 +778,54 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::MatchRecipe(const cItem * a_Crafti
 			// Doesn't match
 			return nullptr;
 		}
-		HasMatched[itrS->x + a_OffsetX][itrS->y + a_OffsetY] = true;
+		HasMatched[Ingredient.x + a_OffsetX][Ingredient.y + a_OffsetY] = true;
 	}  // for itrS - Recipe->m_Ingredients[]
 
 	// Process the "Anywhere" items now, and only in the cells that haven't matched yet
 	// The "anywhere" items are processed on a first-come-first-served basis.
 	// Do not use a recipe with one horizontal and one vertical "anywhere" ("*:1, 1:*") as it may not match properly!
 	cRecipeSlots MatchedSlots;  // Stores the slots of "anywhere" items that have matched, with the match coords
-	for (cRecipeSlots::const_iterator itrS = a_Recipe->m_Ingredients.begin(); itrS != a_Recipe->m_Ingredients.end(); ++itrS)
+	for (auto Ingredient : a_Recipe->m_Ingredients)
 	{
-		if ((itrS->x >= 0) && (itrS->y >= 0))
+		if ((Ingredient.x == ILLEGAL_SLOT_NUMBER) || (Ingredient.y == ILLEGAL_SLOT_NUMBER))
 		{
 			// Regular item, already processed
 			continue;
 		}
-		int StartX = 0, EndX = a_GridWidth  - 1;
-		int StartY = 0, EndY = a_GridHeight - 1;
-		if (itrS->x >= 0)
+		std::size_t StartX = 0, EndX = a_GridWidth  - 1;
+		std::size_t StartY = 0, EndY = a_GridHeight - 1;
+		if (Ingredient.x != ILLEGAL_SLOT_NUMBER)
 		{
-			StartX = itrS->x;
-			EndX = itrS->x;
+			StartX = Ingredient.x;
+			EndX = Ingredient.x;
 		}
-		else if (itrS->y >= 0)
+		else if (Ingredient.y != ILLEGAL_SLOT_NUMBER)
 		{
-			StartY = itrS->y;
-			EndY = itrS->y;
+			StartY = Ingredient.y;
+			EndY = Ingredient.y;
 		}
 		bool Found = false;
-		for (int x = StartX; x <= EndX; x++)
+		for (std::size_t x = StartX; x <= EndX; x++)
 		{
-			for (int y = StartY; y <= EndY; y++)
+			for (std::size_t y = StartY; y <= EndY; y++)
 			{
 				if (HasMatched[x][y])
 				{
 					// Already matched some other item
 					continue;
 				}
-				int GridIdx = x + a_GridStride * y;
+				std::size_t GridIdx = x + a_GridStride * y;
 				if (
-					(a_CraftingGrid[GridIdx].m_ItemType == itrS->m_Item.m_ItemType) &&
+					(a_CraftingGrid[GridIdx].m_ItemType == Ingredient.m_Item.m_ItemType) &&
 					(
-						(itrS->m_Item.m_ItemDamage < 0) ||  // doesn't want damage comparison
-						(itrS->m_Item.m_ItemDamage == a_CraftingGrid[GridIdx].m_ItemDamage)  // the damage matches
+						(Ingredient.m_Item.m_ItemDamage < 0) ||  // doesn't want damage comparison
+						(Ingredient.m_Item.m_ItemDamage == a_CraftingGrid[GridIdx].m_ItemDamage)  // the damage matches
 					)
 				)
 				{
 					HasMatched[x][y] = true;
 					Found = true;
-					MatchedSlots.push_back(*itrS);
+					MatchedSlots.push_back(Ingredient);
 					MatchedSlots.back().x = x;
 					MatchedSlots.back().y = y;
 					break;
@@ -840,7 +843,7 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::MatchRecipe(const cItem * a_Crafti
 	}  // for itrS - a_Recipe->m_Ingredients[]
 
 	// Check if the whole grid has matched:
-	for (int x = 0; x < a_GridWidth; x++) for (int y = 0; y < a_GridHeight; y++)
+	for (std::size_t x = 0; x < a_GridWidth; x++) for (std::size_t y = 0; y < a_GridHeight; y++)
 	{
 		if (!HasMatched[x][y] && !a_CraftingGrid[x + a_GridStride * y].IsEmpty())
 		{
@@ -854,14 +857,14 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::MatchRecipe(const cItem * a_Crafti
 	Recipe->m_Result = a_Recipe->m_Result;
 	Recipe->m_Width  = a_Recipe->m_Width;
 	Recipe->m_Height = a_Recipe->m_Height;
-	for (cRecipeSlots::const_iterator itrS = a_Recipe->m_Ingredients.begin(); itrS != a_Recipe->m_Ingredients.end(); ++itrS)
+	for (auto Ingredient : a_Recipe->m_Ingredients)
 	{
-		if ((itrS->x < 0) || (itrS->y < 0))
+	if ((Ingredient.x == ILLEGAL_SLOT_NUMBER) || (Ingredient.y == ILLEGAL_SLOT_NUMBER))
 		{
 			// "Anywhere" item, process later
 			continue;
 		}
-		Recipe->m_Ingredients.push_back(*itrS);
+		Recipe->m_Ingredients.push_back(Ingredient);
 		Recipe->m_Ingredients.back().x += a_OffsetX;
 		Recipe->m_Ingredients.back().y += a_OffsetY;
 	}
@@ -881,21 +884,21 @@ cCraftingRecipes::cRecipe * cCraftingRecipes::MatchRecipe(const cItem * a_Crafti
 
 
 
-void cCraftingRecipes::HandleFireworks(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, int a_GridStride, int a_OffsetX, int a_OffsetY)
+void cCraftingRecipes::HandleFireworks(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, std::size_t a_GridStride, std::size_t a_OffsetX, std::size_t a_OffsetY)
 {
 	// TODO: add support for more than one dye in the recipe
 	// A manual and temporary solution (listing everything) is in crafting.txt for fade colours, but a programmatic solutions needs to be done for everything else
 
 	if (a_Recipe->m_Result.m_ItemType == E_ITEM_FIREWORK_ROCKET)
 	{
-		for (cRecipeSlots::const_iterator itr = a_Recipe->m_Ingredients.begin(); itr != a_Recipe->m_Ingredients.end(); ++itr)
+		for (auto const & Ingredient : a_Recipe->m_Ingredients)
 		{
-			switch (itr->m_Item.m_ItemType)
+			switch (Ingredient.m_Item.m_ItemType)
 			{
 				case E_ITEM_FIREWORK_STAR:
 				{
 					// Result was a rocket, found a star - copy star data to rocket data
-					int GridID = (itr->x + a_OffsetX) + a_GridStride * (itr->y + a_OffsetY);
+					auto GridID = (Ingredient.x + a_OffsetX) + a_GridStride * (Ingredient.y + a_OffsetY);
 					a_Recipe->m_Result.m_FireworkItem.CopyFrom(a_CraftingGrid[GridID].m_FireworkItem);
 					break;
 				}
@@ -915,21 +918,21 @@ void cCraftingRecipes::HandleFireworks(const cItem * a_CraftingGrid, cCraftingRe
 		std::vector<int> DyeColours;
 		bool FoundStar = false;
 
-		for (cRecipeSlots::const_iterator itr = a_Recipe->m_Ingredients.begin(); itr != a_Recipe->m_Ingredients.end(); ++itr)
+		for (auto const & Ingredient : a_Recipe->m_Ingredients)
 		{
-			switch (itr->m_Item.m_ItemType)
+			switch (Ingredient.m_Item.m_ItemType)
 			{
 				case E_ITEM_FIREWORK_STAR:
 				{
 					// Result was star, found another star - probably adding fade colours, but copy data over anyhow
 					FoundStar = true;
-					int GridID = (itr->x + a_OffsetX) + a_GridStride * (itr->y + a_OffsetY);
+					auto GridID = (Ingredient.x + a_OffsetX) + a_GridStride * (Ingredient.y + a_OffsetY);
 					a_Recipe->m_Result.m_FireworkItem.CopyFrom(a_CraftingGrid[GridID].m_FireworkItem);
 					break;
 				}
 				case E_ITEM_DYE:
 				{
-					int GridID = (itr->x + a_OffsetX) + a_GridStride * (itr->y + a_OffsetY);
+					auto GridID = (Ingredient.x + a_OffsetX) + a_GridStride * (Ingredient.y + a_OffsetY);
 					DyeColours.push_back(cFireworkItem::GetVanillaColourCodeFromDye(static_cast<NIBBLETYPE>(a_CraftingGrid[GridID].m_ItemDamage & 0x0f)));
 					break;
 				}
@@ -962,7 +965,7 @@ void cCraftingRecipes::HandleFireworks(const cItem * a_CraftingGrid, cCraftingRe
 
 
 
-void cCraftingRecipes::HandleDyedLeather(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, int a_GridStride, int a_GridWidth, int a_GridHeight)
+void cCraftingRecipes::HandleDyedLeather(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, std::size_t a_GridStride, std::size_t a_GridWidth, std::size_t a_GridHeight)
 {
 	short result_type = a_Recipe->m_Result.m_ItemType;
 	if ((result_type == E_ITEM_LEATHER_CAP) || (result_type == E_ITEM_LEATHER_TUNIC) || (result_type == E_ITEM_LEATHER_PANTS) || (result_type == E_ITEM_LEATHER_BOOTS))
@@ -975,11 +978,11 @@ void cCraftingRecipes::HandleDyedLeather(const cItem * a_CraftingGrid, cCrafting
 		float blue = 0;
 		float dye_count = 0;
 
-		for (int x = 0; x < a_GridWidth; ++x)
+		for (std::size_t x = 0; x < a_GridWidth; ++x)
 		{
-			for (int y = 0; y < a_GridHeight; ++y)
+			for (std::size_t y = 0; y < a_GridHeight; ++y)
 			{
-				int GridIdx = x + a_GridStride * y;
+				auto GridIdx = x + a_GridStride * y;
 				if ((a_CraftingGrid[GridIdx].m_ItemType == result_type) && !found)
 				{
 					found = true;

--- a/src/CraftingRecipes.h
+++ b/src/CraftingRecipes.h
@@ -21,23 +21,23 @@ class cCraftingGrid  // tolua_export
 {  // tolua_export
 public:
 	cCraftingGrid(const cCraftingGrid & a_Original);
-	cCraftingGrid(int a_Width, int a_Height);  // tolua_export
-	cCraftingGrid(const cItem * a_Items, int a_Width, int a_Height);
+	cCraftingGrid(std::size_t a_Width, std::size_t a_Height);  // tolua_export
+	cCraftingGrid(const cItem * a_Items, std::size_t a_Width, std::size_t a_Height);
 	~cCraftingGrid();
 
 	// tolua_begin
-	int     GetWidth (void) const {return m_Width; }
-	int     GetHeight(void) const {return m_Height; }
-	cItem & GetItem  (int x, int y) const;
-	void    SetItem  (int x, int y, ENUM_ITEM_TYPE a_ItemType, char a_ItemCount, short a_ItemHealth);
-	void    SetItem  (int x, int y, const cItem & a_Item);
+	std::size_t     GetWidth (void) const { return m_Width; }
+	std::size_t     GetHeight(void) const { return m_Height; }
+	cItem & GetItem  (std::size_t x, std::size_t y) const;
+	void    SetItem  (std::size_t x, std::size_t y, ENUM_ITEM_TYPE a_ItemType, char a_ItemCount, short a_ItemHealth);
+	void    SetItem  (std::size_t x, std::size_t y, const cItem & a_Item);
 	void    Clear    (void);
 
 	/** Removes items in a_Grid from m_Items[] (used by cCraftingRecipe::ConsumeIngredients()) */
 	void ConsumeGrid(const cCraftingGrid & a_Grid);
 
 	/** Dumps the entire crafting grid using LOGD() */
-	void Dump(void);
+	void Dump(void) const;
 
 	// tolua_end
 
@@ -48,8 +48,8 @@ public:
 
 protected:
 
-	int     m_Width;
-	int     m_Height;
+	std::size_t     m_Width;
+	std::size_t     m_Height;
 	cItem * m_Items;
 } ;  // tolua_export
 
@@ -64,9 +64,9 @@ public:
 
 	// tolua_begin
 	void          Clear               (void);
-	int           GetIngredientsWidth (void) const {return m_Ingredients.GetWidth(); }
-	int           GetIngredientsHeight(void) const {return m_Ingredients.GetHeight(); }
-	cItem &       GetIngredient       (int x, int y) const {return m_Ingredients.GetItem(x, y); }
+	std::size_t   GetIngredientsWidth (void) const {return m_Ingredients.GetWidth(); }
+	std::size_t   GetIngredientsHeight(void) const {return m_Ingredients.GetHeight(); }
+	cItem &       GetIngredient       (std::size_t x, std::size_t y) const {return m_Ingredients.GetItem(x, y); }
 	const cItem & GetResult           (void) const {return m_Result; }
 	void          SetResult           (ENUM_ITEM_TYPE a_ItemType, char a_ItemCount, short a_ItemHealth);
 	void          SetResult           (const cItem & a_Item)
@@ -74,12 +74,12 @@ public:
 		m_Result = a_Item;
 	}
 
-	void          SetIngredient       (int x, int y, ENUM_ITEM_TYPE a_ItemType, char a_ItemCount, short a_ItemHealth)
+	void          SetIngredient       (std::size_t x, std::size_t y, ENUM_ITEM_TYPE a_ItemType, char a_ItemCount, short a_ItemHealth)
 	{
 		m_Ingredients.SetItem(x, y, a_ItemType, a_ItemCount, a_ItemHealth);
 	}
 
-	void          SetIngredient       (int x, int y, const cItem & a_Item)
+	void          SetIngredient       (std::size_t x, std::size_t y, const cItem & a_Item)
 	{
 		m_Ingredients.SetItem(x, y, a_Item);
 	}
@@ -132,9 +132,9 @@ public:
 	struct cRecipeSlot
 	{
 		cItem m_Item;
-		int x, y;  // 1..3, or -1 for "any"
+		std::size_t x, y;  // 1..3, or ILLEGAL_SLOT_NUMBER for "any"
 	} ;
-	typedef std::vector<cRecipeSlot> cRecipeSlots;
+	using cRecipeSlots = std::vector<cRecipeSlot>;
 
 	/** A single recipe, stored. Each recipe is normalized right after parsing (NormalizeIngredients())
 	A normalized recipe starts at (0, 0) */
@@ -145,8 +145,8 @@ public:
 		AString      m_RecipeName;
 
 		// Size of the regular items in the recipe; "anywhere" items are excluded:
-		int m_Width;
-		int m_Height;
+		std::size_t m_Width;
+		std::size_t m_Height;
 	} ;
 
 	/** Returns the recipe by id */
@@ -177,19 +177,19 @@ protected:
 	void NormalizeIngredients(cRecipe * a_Recipe);
 
 	/** Finds a recipe matching the crafting grid. Returns a newly allocated recipe (with all its coords set) or nullptr if not found. Caller must delete return value! */
-	cRecipe * FindRecipe(const cItem * a_CraftingGrid, int a_GridWidth, int a_GridHeight);
+	cRecipe * FindRecipe(const cItem * a_CraftingGrid, std::size_t a_GridWidth, std::size_t a_GridHeight);
 
 	/** Same as FindRecipe, but the grid is guaranteed to be of minimal dimensions needed */
-	cRecipe * FindRecipeCropped(const cItem * a_CraftingGrid, int a_GridWidth, int a_GridHeight, int a_GridStride);
+	cRecipe * FindRecipeCropped(const cItem * a_CraftingGrid, std::size_t a_GridWidth, std::size_t a_GridHeight, std::size_t a_GridStride);
 
 	/** Checks if the grid matches the specified recipe, offset by the specified offsets. Returns a matched cRecipe * if so, or nullptr if not matching. Caller must delete the return value! */
-	cRecipe * MatchRecipe(const cItem * a_CraftingGrid, int a_GridWidth, int a_GridHeight, int a_GridStride, const cRecipe * a_Recipe, int a_OffsetX, int a_OffsetY);
+	cRecipe * MatchRecipe(const cItem * a_CraftingGrid, std::size_t a_GridWidth, std::size_t a_GridHeight, std::size_t a_GridStride, const cRecipe * a_Recipe, std::size_t a_OffsetX, std::size_t a_OffsetY);
 
 	/** Searches for anything firework related, and does the data setting if appropriate */
-	void HandleFireworks(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, int a_GridStride, int a_OffsetX, int a_OffsetY);
+	void HandleFireworks(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, std::size_t a_GridStride, std::size_t a_OffsetX, std::size_t a_OffsetY);
 
 	/** Searches for anything dye related for leather, calculates the appropriate color value, and sets the resulting value. */
-	void HandleDyedLeather(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, int a_GridStride, int a_GridWidth, int a_GridHeight);
+	void HandleDyedLeather(const cItem * a_CraftingGrid, cCraftingRecipes::cRecipe * a_Recipe, std::size_t a_GridStride, std::size_t a_GridWidth, std::size_t a_GridHeight);
 
 private:
 	/** Mapping the minecraft recipe names to the internal cuberite recipe Ids */

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -6,7 +6,7 @@
 
 
 /** List of slot numbers, used for inventory-painting */
-typedef std::vector<int> cSlotNums;
+using cSlotNums = std::vector<std::size_t>;
 
 
 

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -142,8 +142,8 @@ public:
 		ContentsWidth = 9,
 	};
 
-	const cItem & GetSlot(int a_Idx) const { return m_Contents.GetSlot(a_Idx); }
-	void SetSlot(int a_Idx, const cItem & a_Item) { m_Contents.SetSlot(a_Idx, a_Item); }
+	const cItem & GetSlot(std::size_t a_Idx) const { return m_Contents.GetSlot(a_Idx); }
+	void SetSlot(std::size_t a_Idx, const cItem & a_Item) { m_Contents.SetSlot(a_Idx, a_Item); }
 
 
 protected:
@@ -152,7 +152,7 @@ protected:
 	void OpenNewWindow(void);
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_Grid, int a_SlotNum) override
+	virtual void OnSlotChanged(cItemGrid * a_Grid, std::size_t a_SlotNum) override
 	{
 		UNUSED(a_SlotNum);
 		ASSERT(a_Grid == &m_Contents);

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -568,7 +568,7 @@ void cPlayer::ClearInventoryPaintSlots(void)
 
 
 
-void cPlayer::AddInventoryPaintSlot(int a_SlotNum)
+void cPlayer::AddInventoryPaintSlot(std::size_t a_SlotNum)
 {
 	// Add a slot to the list for inventory painting. Used by cWindow only
 	m_InventoryPaintSlots.push_back(a_SlotNum);
@@ -1334,7 +1334,7 @@ void cPlayer::SetGameMode(eGameMode a_GameMode)
 	}
 
 	m_ClientHandle->SendGameMode(a_GameMode);
-	m_ClientHandle->SendInventorySlot(-1, -1, m_DraggingItem);
+	m_ClientHandle->SendInventorySlot(-1, ILLEGAL_SLOT_NUMBER, m_DraggingItem);
 	m_World->BroadcastPlayerListUpdateGameMode(*this);
 	m_World->BroadcastEntityMetadata(*this);
 }
@@ -1709,7 +1709,7 @@ void cPlayer::SetDraggingItem(const cItem & a_Item)
 	if (GetWindow() != nullptr)
 	{
 		m_DraggingItem = a_Item;
-		GetClientHandle()->SendInventorySlot(-1, -1, m_DraggingItem);
+		GetClientHandle()->SendInventorySlot(-1, ILLEGAL_SLOT_NUMBER, m_DraggingItem);
 	}
 }
 
@@ -1882,7 +1882,7 @@ void cPlayer::LoadFromDisk()
 	m_GameMode = static_cast<eGameMode>(Root.get("gamemode", eGameMode_NotSet).asInt());
 
 	m_Inventory.LoadFromJson(Root["inventory"]);
-	m_Inventory.SetEquippedSlotNum(Root.get("equippedItemSlot", 0).asInt());
+	m_Inventory.SetEquippedSlotNum(Root.get("equippedItemSlot", 0).asUInt());
 
 	cEnderChestEntity::LoadFromJson(Root["enderchestinventory"], m_EnderChestContents);
 
@@ -2060,7 +2060,7 @@ void cPlayer::UseEquippedItem(cItemHandler::eDurabilityLostAction a_Action)
 
 
 
-void cPlayer::UseItem(int a_SlotNumber, short a_Damage)
+void cPlayer::UseItem(std::size_t a_SlotNumber, short a_Damage)
 {
 	const cItem & Item = m_Inventory.GetSlot(a_SlotNumber);
 
@@ -2849,7 +2849,7 @@ void cPlayer::ApplyArmorDamage(int a_DamageBlocked)
 {
 	short ArmorDamage = static_cast<short>(std::max(a_DamageBlocked / 4, 1));
 
-	for (int i = 0; i < 4; i++)
+	for (std::size_t i = 0; i < 4; i++)
 	{
 		UseItem(cInventory::invArmorOffset + i, ArmorDamage);
 	}

--- a/src/Entities/Player.h
+++ b/src/Entities/Player.h
@@ -442,7 +442,7 @@ public:
 
 	/** Damage the item in a_SlotNumber by a_Damage, possibly less if the
 	equipped item is enchanted. */
-	void UseItem(int a_SlotNumber, short a_Damage = 1);
+	void UseItem(std::size_t a_SlotNumber, short a_Damage = 1);
 
 	/** In UI windows, get the item that the player is dragging */
 	cItem & GetDraggingItem(void) {return m_DraggingItem; }  // tolua_export
@@ -455,7 +455,7 @@ public:
 	void ClearInventoryPaintSlots(void);
 
 	/** Adds a slot to the list for inventory painting. To be used by cWindow only */
-	void AddInventoryPaintSlot(int a_SlotNum);
+	void AddInventoryPaintSlot(std::size_t a_SlotNum);
 
 	/** Returns the list of slots currently stored for inventory painting. To be used by cWindow only */
 	const cSlotNums & GetInventoryPaintSlots(void) const;

--- a/src/Generating/DungeonRoomsFinisher.cpp
+++ b/src/Generating/DungeonRoomsFinisher.cpp
@@ -228,7 +228,7 @@ protected:
 		cChestEntity * ChestEntity = static_cast<cChestEntity *>(a_ChunkDesc.GetBlockEntity(RelX, m_FloorHeight + 1, RelZ));
 		ASSERT((ChestEntity != nullptr) && (ChestEntity->GetBlockType() == E_BLOCK_CHEST));
 		cNoise Noise(a_ChunkDesc.GetChunkX() ^ a_ChunkDesc.GetChunkZ());
-		int NumSlots = 3 + ((Noise.IntNoise3DInt(a_Chest.x, a_Chest.y, a_Chest.z) / 11) % 4);
+		std::size_t NumSlots = 3 + ((Noise.IntNoise3DInt(a_Chest.x, a_Chest.y, a_Chest.z) / 11) % 4);
 		int Seed = Noise.IntNoise2DInt(RelX, RelZ);
 		ChestEntity->GetContents().GenerateRandomLootWithBooks(LootProbab, ARRAYCOUNT(LootProbab), NumSlots, Seed);
 	}

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -804,7 +804,7 @@ void cMineShaftCorridor::PlaceChest(cChunkDesc & a_ChunkDesc)
 		cChestEntity * ChestEntity = static_cast<cChestEntity *>(a_ChunkDesc.GetBlockEntity(x, m_BoundingBox.p1.y + 1, z));
 		ASSERT((ChestEntity != nullptr) && (ChestEntity->GetBlockType() == E_BLOCK_CHEST));
 		cNoise Noise(a_ChunkDesc.GetChunkX() ^ a_ChunkDesc.GetChunkZ());
-		int NumSlots = 3 + ((Noise.IntNoise3DInt(x, m_BoundingBox.p1.y, z) / 11) % 4);
+		std::size_t NumSlots = 3 + ((Noise.IntNoise3DInt(x, m_BoundingBox.p1.y, z) / 11) % 4);
 		int Seed = Noise.IntNoise2DInt(x, z);
 		ChestEntity->GetContents().GenerateRandomLootWithBooks(LootProbab, ARRAYCOUNT(LootProbab), NumSlots, Seed);
 	}

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -113,7 +113,7 @@ char cInventory::AddItem(const cItem & a_Item, bool a_AllowNewStacks)
 	// When the item is a armor, try to set it directly to the armor slot.
 	if (ItemCategory::IsArmor(a_Item.m_ItemType))
 	{
-		for (int i = 0; i < m_ArmorSlots.GetNumSlots(); i++)
+		for (int i = 0; i < m_ArmorSlots.OldGetNumSlots(); i++)
 		{
 			if (m_ArmorSlots.GetSlot(i).IsEmpty() && cSlotAreaArmor::CanPlaceArmorInSlot(i, a_Item))
 			{

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -58,16 +58,16 @@ int cInventory::HowManyCanFit(const cItem & a_ItemStack, bool a_ConsiderEmptySlo
 
 
 
-int cInventory::HowManyCanFit(const cItem & a_ItemStack, int a_BeginSlotNum, int a_EndSlotNum, bool a_ConsiderEmptySlots)
+int cInventory::HowManyCanFit(const cItem & a_ItemStack, std::size_t a_BeginSlotNum, std::size_t a_EndSlotNum, bool a_ConsiderEmptySlots)
 {
 
 	UNUSED(a_ConsiderEmptySlots);
-	if ((a_BeginSlotNum < 0) || (a_BeginSlotNum >= invNumSlots))
+	if (a_BeginSlotNum >= invNumSlots)
 	{
 		LOGWARNING("%s: Bad BeginSlotNum, got %d, there are %d slots; correcting to 0.", __FUNCTION__, a_BeginSlotNum, invNumSlots - 1);
 		a_BeginSlotNum = 0;
 	}
-	if ((a_EndSlotNum < 0) || (a_EndSlotNum >= invNumSlots))
+	if (a_EndSlotNum >= invNumSlots)
 	{
 		LOGWARNING("%s: Bad EndSlotNum, got %d, there are %d slots; correcting to %d.", __FUNCTION__, a_BeginSlotNum, invNumSlots, invNumSlots - 1);
 		a_EndSlotNum = invNumSlots - 1;
@@ -77,9 +77,10 @@ int cInventory::HowManyCanFit(const cItem & a_ItemStack, int a_BeginSlotNum, int
 		std::swap(a_BeginSlotNum, a_EndSlotNum);
 	}
 
-	char NumLeft = a_ItemStack.m_ItemCount;
-	char MaxStack = a_ItemStack.GetMaxStackSize();
-	for (int i = a_BeginSlotNum; i <= a_EndSlotNum; i++)
+
+	auto NumLeft = a_ItemStack.m_ItemCount;
+	auto MaxStack = a_ItemStack.GetMaxStackSize();
+	for (std::size_t i = a_BeginSlotNum; i <= a_EndSlotNum; i++)
 	{
 		const cItem & Slot = GetSlot(i);
 		if (Slot.IsEmpty())
@@ -113,7 +114,7 @@ char cInventory::AddItem(const cItem & a_Item, bool a_AllowNewStacks)
 	// When the item is a armor, try to set it directly to the armor slot.
 	if (ItemCategory::IsArmor(a_Item.m_ItemType))
 	{
-		for (int i = 0; i < m_ArmorSlots.OldGetNumSlots(); i++)
+		for (std::size_t i = 0; i < m_ArmorSlots.GetNumSlots(); i++)
 		{
 			if (m_ArmorSlots.GetSlot(i).IsEmpty() && cSlotAreaArmor::CanPlaceArmorInSlot(i, a_Item))
 			{
@@ -186,7 +187,7 @@ char cInventory::AddItems(cItems & a_ItemStackList, bool a_AllowNewStacks)
 
 
 
-int cInventory::RemoveItem(const cItem & a_ItemStack)
+char cInventory::RemoveItem(const cItem & a_ItemStack)
 {
 	char RemovedItems = m_ShieldSlots.RemoveItem(a_ItemStack);
 
@@ -310,15 +311,15 @@ bool cInventory::HasItems(const cItem & a_ItemStack)
 
 
 
-void cInventory::SetSlot(int a_SlotNum, const cItem & a_Item)
+void cInventory::SetSlot(std::size_t a_SlotNum, const cItem & a_Item)
 {
-	if ((a_SlotNum < 0) || (a_SlotNum >= invNumSlots))
+	if (a_SlotNum >= invNumSlots)
 	{
 		LOGWARNING("%s: requesting an invalid slot index: %d out of %d. Ignoring.", __FUNCTION__, a_SlotNum, invNumSlots - 1);
 		return;
 	}
 
-	int GridSlotNum = 0;
+	std::size_t GridSlotNum = 0;
 	cItemGrid * Grid = GetGridForSlotNum(a_SlotNum, GridSlotNum);
 	if (Grid == nullptr)
 	{
@@ -332,7 +333,7 @@ void cInventory::SetSlot(int a_SlotNum, const cItem & a_Item)
 
 
 
-void cInventory::SetArmorSlot(int a_ArmorSlotNum, const cItem & a_Item)
+void cInventory::SetArmorSlot(std::size_t a_ArmorSlotNum, const cItem & a_Item)
 {
 	m_ArmorSlots.SetSlot(a_ArmorSlotNum, a_Item);
 }
@@ -341,7 +342,7 @@ void cInventory::SetArmorSlot(int a_ArmorSlotNum, const cItem & a_Item)
 
 
 
-void cInventory::SetInventorySlot(int a_InventorySlotNum, const cItem & a_Item)
+void cInventory::SetInventorySlot(std::size_t a_InventorySlotNum, const cItem & a_Item)
 {
 	m_InventorySlots.SetSlot(a_InventorySlotNum, a_Item);
 }
@@ -350,7 +351,7 @@ void cInventory::SetInventorySlot(int a_InventorySlotNum, const cItem & a_Item)
 
 
 
-void cInventory::SetHotbarSlot(int a_HotBarSlotNum, const cItem & a_Item)
+void cInventory::SetHotbarSlot(std::size_t a_HotBarSlotNum, const cItem & a_Item)
 {
 	m_HotbarSlots.SetSlot(a_HotBarSlotNum, a_Item);
 }
@@ -379,7 +380,7 @@ void cInventory::SetEquippedItem(const cItem & a_Item)
 
 void cInventory::SendEquippedSlot()
 {
-	int EquippedSlotNum = cInventory::invArmorCount + cInventory::invInventoryCount + GetEquippedSlotNum();
+	std::size_t EquippedSlotNum = cInventory::invArmorCount + cInventory::invInventoryCount + GetEquippedSlotNum();
 	SendSlot(EquippedSlotNum);
 }
 
@@ -387,14 +388,14 @@ void cInventory::SendEquippedSlot()
 
 
 
-const cItem & cInventory::GetSlot(int a_SlotNum) const
+const cItem & cInventory::GetSlot(std::size_t a_SlotNum) const
 {
-	if ((a_SlotNum < 0) || (a_SlotNum >= invNumSlots))
+	if (a_SlotNum >= invNumSlots)
 	{
 		LOGWARNING("%s: requesting an invalid slot index: %d out of %d. Returning the first inventory slot instead.", __FUNCTION__, a_SlotNum, invNumSlots - 1);
 		return m_InventorySlots.GetSlot(0);
 	}
-	int GridSlotNum = 0;
+	std::size_t GridSlotNum = 0;
 	const cItemGrid * Grid = GetGridForSlotNum(a_SlotNum, GridSlotNum);
 	if (Grid == nullptr)
 	{
@@ -409,9 +410,9 @@ const cItem & cInventory::GetSlot(int a_SlotNum) const
 
 
 
-const cItem & cInventory::GetArmorSlot(int a_ArmorSlotNum) const
+const cItem & cInventory::GetArmorSlot(std::size_t a_ArmorSlotNum) const
 {
-	if ((a_ArmorSlotNum < 0) || (a_ArmorSlotNum >= invArmorCount))
+	if (a_ArmorSlotNum >= invArmorCount)
 	{
 		LOGWARNING("%s: requesting an invalid slot index: %d out of %d. Returning the first one instead", __FUNCTION__, a_ArmorSlotNum, invArmorCount - 1);
 		return m_ArmorSlots.GetSlot(0);
@@ -423,9 +424,9 @@ const cItem & cInventory::GetArmorSlot(int a_ArmorSlotNum) const
 
 
 
-const cItem & cInventory::GetInventorySlot(int a_InventorySlotNum) const
+const cItem & cInventory::GetInventorySlot(std::size_t a_InventorySlotNum) const
 {
-	if ((a_InventorySlotNum < 0) || (a_InventorySlotNum >= invInventoryCount))
+	if (a_InventorySlotNum >= invInventoryCount)
 	{
 		LOGWARNING("%s: requesting an invalid slot index: %d out of %d. Returning the first one instead", __FUNCTION__, a_InventorySlotNum, invInventoryCount - 1);
 		return m_InventorySlots.GetSlot(0);
@@ -437,9 +438,9 @@ const cItem & cInventory::GetInventorySlot(int a_InventorySlotNum) const
 
 
 
-const cItem & cInventory::GetHotbarSlot(int a_SlotNum) const
+const cItem & cInventory::GetHotbarSlot(std::size_t a_SlotNum) const
 {
-	if ((a_SlotNum < 0) || (a_SlotNum >= invHotbarCount))
+	if (a_SlotNum >= invHotbarCount)
 	{
 		LOGWARNING("%s: requesting an invalid slot index: %d out of %d. Returning the first one instead", __FUNCTION__, a_SlotNum, invHotbarCount - 1);
 		return m_HotbarSlots.GetSlot(0);
@@ -469,9 +470,9 @@ const cItem & cInventory::GetEquippedItem(void) const
 
 
 
-void cInventory::SetEquippedSlotNum(int a_SlotNum)
+void cInventory::SetEquippedSlotNum(std::size_t a_SlotNum)
 {
-	if ((a_SlotNum < 0) || (a_SlotNum >= invHotbarCount))
+	if (a_SlotNum >= invHotbarCount)
 	{
 		LOGWARNING("%s: requesting invalid slot index: %d out of %d. Setting 0 instead.", __FUNCTION__, a_SlotNum, invHotbarCount - 1);
 		m_EquippedSlotNum = 0;
@@ -495,9 +496,9 @@ bool cInventory::DamageEquippedItem(short a_Amount)
 
 
 
-char cInventory::ChangeSlotCount(int a_SlotNum, char a_AddToCount)
+char cInventory::ChangeSlotCount(std::size_t a_SlotNum, char a_AddToCount)
 {
-	int GridSlotNum = 0;
+	std::size_t GridSlotNum;
 	cItemGrid * Grid = GetGridForSlotNum(a_SlotNum, GridSlotNum);
 	if (Grid == nullptr)
 	{
@@ -511,9 +512,9 @@ char cInventory::ChangeSlotCount(int a_SlotNum, char a_AddToCount)
 
 
 
-bool cInventory::DamageItem(int a_SlotNum, short a_Amount)
+bool cInventory::DamageItem(std::size_t a_SlotNum, short a_Amount)
 {
-	if ((a_SlotNum < 0) || (a_SlotNum >= invNumSlots))
+	if (a_SlotNum >= invNumSlots)
 	{
 		LOGWARNING("%s: requesting an invalid slot index: %d out of %d", __FUNCTION__, a_SlotNum, invNumSlots - 1);
 		return false;
@@ -523,7 +524,7 @@ bool cInventory::DamageItem(int a_SlotNum, short a_Amount)
 		return false;
 	}
 
-	int GridSlotNum = 0;
+	std::size_t GridSlotNum = 0;
 	cItemGrid * Grid = GetGridForSlotNum(a_SlotNum, GridSlotNum);
 	if (Grid == nullptr)
 	{
@@ -557,7 +558,7 @@ void cInventory::CopyToItems(cItems & a_Items)
 
 
 
-void cInventory::SendSlot(int a_SlotNum)
+void cInventory::SendSlot(std::size_t a_SlotNum)
 {
 	cItem Item(GetSlot(a_SlotNum));
 	if (Item.IsEmpty())
@@ -565,7 +566,7 @@ void cInventory::SendSlot(int a_SlotNum)
 		// Sanitize items that are not completely empty (ie. count == 0, but type != empty)
 		Item.Empty();
 	}
-	m_Owner.GetClientHandle()->SendInventorySlot(0, static_cast<short>(a_SlotNum + 5), Item);  // Slots in the client are numbered "+ 5" because of crafting grid and result
+	m_Owner.GetClientHandle()->SendInventorySlot(0, a_SlotNum + 5, Item);  // Slots in the client are numbered "+ 5" because of crafting grid and result
 }
 
 
@@ -702,13 +703,13 @@ void cInventory::SaveToJson(Json::Value & a_Value)
 	cItem EmptyItem;
 	Json::Value EmptyItemJson;
 	EmptyItem.GetJson(EmptyItemJson);
-	for (int i = 0; i < 5; i++)
+	for (std::size_t i = 0; i < 5; i++)
 	{
 		a_Value.append(EmptyItemJson);
 	}
 
 	// The 4 armor slots follow:
-	for (int i = 0; i < invArmorCount; i++)
+	for (std::size_t i = 0; i < invArmorCount; i++)
 	{
 		Json::Value JSON_Item;
 		m_ArmorSlots.GetSlot(i).GetJson(JSON_Item);
@@ -716,7 +717,7 @@ void cInventory::SaveToJson(Json::Value & a_Value)
 	}
 
 	// Next comes the main inventory:
-	for (int i = 0; i < invInventoryCount; i++)
+	for (std::size_t i = 0; i < invInventoryCount; i++)
 	{
 		Json::Value JSON_Item;
 		m_InventorySlots.GetSlot(i).GetJson(JSON_Item);
@@ -724,7 +725,7 @@ void cInventory::SaveToJson(Json::Value & a_Value)
 	}
 
 	// The hotbar:
-	for (int i = 0; i < invHotbarCount; i++)
+	for (std::size_t i = 0; i < invHotbarCount; i++)
 	{
 		Json::Value JSON_Item;
 		m_HotbarSlots.GetSlot(i).GetJson(JSON_Item);
@@ -743,9 +744,9 @@ void cInventory::SaveToJson(Json::Value & a_Value)
 
 bool cInventory::LoadFromJson(Json::Value & a_Value)
 {
-	int SlotIdx = 0;
+	std::size_t SlotIdx = 0;
 
-	for (Json::Value::iterator itr = a_Value.begin(); itr != a_Value.end(); ++itr, SlotIdx++)
+	for (auto itr = a_Value.begin(); itr != a_Value.end(); ++itr, SlotIdx++)
 	{
 		cItem Item;
 		Item.FromJson(*itr);
@@ -762,7 +763,7 @@ bool cInventory::LoadFromJson(Json::Value & a_Value)
 			break;
 		}
 
-		int GridSlotNum = 0;
+		std::size_t GridSlotNum = 0;
 		cItemGrid * Grid = GetGridForSlotNum(SlotIdx - 5, GridSlotNum);
 		ASSERT(Grid != nullptr);
 		Grid->SetSlot(GridSlotNum, Item);
@@ -774,7 +775,7 @@ bool cInventory::LoadFromJson(Json::Value & a_Value)
 
 
 
-const cItemGrid * cInventory::GetGridForSlotNum(int a_SlotNum, int & a_GridSlotNum) const
+const cItemGrid * cInventory::GetGridForSlotNum(std::size_t a_SlotNum, std::size_t & a_GridSlotNum) const
 {
 	ASSERT(a_SlotNum >= 0);
 
@@ -803,7 +804,7 @@ const cItemGrid * cInventory::GetGridForSlotNum(int a_SlotNum, int & a_GridSlotN
 
 
 
-cItemGrid * cInventory::GetGridForSlotNum(int a_SlotNum, int & a_GridSlotNum)
+cItemGrid * cInventory::GetGridForSlotNum(std::size_t a_SlotNum, std::size_t & a_GridSlotNum)
 {
 	ASSERT(a_SlotNum >= 0);
 
@@ -832,7 +833,7 @@ cItemGrid * cInventory::GetGridForSlotNum(int a_SlotNum, int & a_GridSlotNum)
 
 
 
-void cInventory::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
+void cInventory::OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum)
 {
 	// Send the neccessary updates to whoever needs them
 
@@ -859,7 +860,7 @@ void cInventory::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 	}
 
 	// Convert the grid-local a_SlotNum to our global SlotNum:
-	int Base = 0;
+	std::size_t Base = 0;
 	if (a_ItemGrid == &m_ArmorSlots)
 	{
 		Base = invArmorOffset;

--- a/src/Inventory.h
+++ b/src/Inventory.h
@@ -66,7 +66,7 @@ public:
 	int HowManyCanFit(const cItem & a_ItemStack, bool a_ConsiderEmptySlots = true);
 
 	/** Returns how many items of the specified type would fit into the slot range specified */
-	int HowManyCanFit(const cItem & a_ItemStack, int a_BeginSlotNum, int a_EndSlotNum, bool a_ConsiderEmptySlots = true);
+	int HowManyCanFit(const cItem & a_ItemStack, std::size_t a_BeginSlotNum, std::size_t a_EndSlotNum, bool a_ConsiderEmptySlots = true);
 
 	/** Adds as many items out of a_ItemStack as can fit.
 	If a_AllowNewStacks is set to false, only existing stacks can be topped up;
@@ -86,7 +86,7 @@ public:
 
 	/** Removes the specified item from the inventory, as many as possible, up to a_ItemStack.m_ItemCount.
 	Returns the number of items that were removed. */
-	int RemoveItem(const cItem & a_ItemStack);
+	char RemoveItem(const cItem & a_ItemStack);
 
 	/** Finds an item based on ItemType and ItemDamage (<- defines the itemType, too) */
 	cItem * FindItem(const cItem & a_RecipeItem);
@@ -133,42 +133,42 @@ public:
 	// tolua_begin
 
 	/** Returns current item in a_SlotNum slot */
-	const cItem & GetSlot(int a_SlotNum) const;
+	const cItem & GetSlot(std::size_t a_SlotNum) const;
 	/** Returns current item in a_ArmorSlotNum in armor slots */
-	const cItem & GetArmorSlot(int a_ArmorSlotNum) const;
+	const cItem & GetArmorSlot(std::size_t a_ArmorSlotNum) const;
 	/** Returns current item in a_ArmorSlotNum in inventory slots */
-	const cItem & GetInventorySlot(int a_InventorySlotNum) const;
+	const cItem & GetInventorySlot(std::size_t a_InventorySlotNum) const;
 	/** Returns current item in a_ArmorSlotNum in hotbar slots */
-	const cItem & GetHotbarSlot(int a_HotBarSlotNum) const;
+	const cItem & GetHotbarSlot(std::size_t a_HotBarSlotNum) const;
 	/** Returns current item in shield slot */
 	const cItem & GetShieldSlot() const;
 	/** Returns current equiped item */
 	const cItem & GetEquippedItem(void) const;
 	/** Puts a_Item item in a_SlotNum slot number */
-	void          SetSlot(int a_SlotNum, const cItem & a_Item);
+	void          SetSlot(std::size_t a_SlotNum, const cItem & a_Item);
 	/** Puts a_Item item in a_ArmorSlotNum slot number in armor slots */
-	void          SetArmorSlot(int a_ArmorSlotNum, const cItem & a_Item);
+	void          SetArmorSlot(std::size_t a_ArmorSlotNum, const cItem & a_Item);
 	/** Puts a_Item item in a_InventorySlotNum slot number in inventory slots */
-	void          SetInventorySlot(int a_InventorySlotNum, const cItem & a_Item);
+	void          SetInventorySlot(std::size_t a_InventorySlotNum, const cItem & a_Item);
 	/** Puts a_Item item in a_HotBarSlotNum slot number in hotbar slots */
-	void          SetHotbarSlot(int a_HotBarSlotNum, const cItem & a_Item);
+	void          SetHotbarSlot(std::size_t a_HotBarSlotNum, const cItem & a_Item);
 	/** Sets current item in shield slot */
 	void          SetShieldSlot(const cItem & a_Item);
 	/** Sets current item in the equipped hotbar slot */
 	void          SetEquippedItem(const cItem & a_Item);
 	/** Sets equiped item to the a_SlotNum slot number */
-	void          SetEquippedSlotNum(int a_SlotNum);
+	void          SetEquippedSlotNum(std::size_t a_SlotNum);
 	/** Returns slot number of equiped item */
-	int           GetEquippedSlotNum(void) { return m_EquippedSlotNum; }
+	std::size_t   GetEquippedSlotNum(void) { return m_EquippedSlotNum; }
 
 	/** Adds (or subtracts, if a_AddToCount is negative) to the count of items in the specified slot.
 	If the slot is empty, ignores the call.
 	Returns the new count, or -1 if the slot number is invalid.
 	*/
-	char ChangeSlotCount(int a_SlotNum, char a_AddToCount);
+	char ChangeSlotCount(std::size_t a_SlotNum, char a_AddToCount);
 
 	/** Adds the specified damage to the specified item; deletes the item and returns true if the item broke. */
-	bool DamageItem(int a_SlotNum, short a_Amount);
+	bool DamageItem(std::size_t a_SlotNum, short a_Amount);
 
 	/** Adds the specified damage to the currently held item; deletes the item and returns true if the item broke. */
 	bool DamageEquippedItem(short a_Amount = 1);
@@ -181,7 +181,7 @@ public:
 	// tolua_end
 
 	/** Sends the slot contents to the owner */
-	void SendSlot(int a_SlotNum);
+	void SendSlot(std::size_t a_SlotNum);
 
 	/** Update items (e.g. Maps) */
 	void UpdateItems(void);
@@ -200,16 +200,16 @@ protected:
 	cItemGrid m_HotbarSlots;
 	cItemGrid m_ShieldSlots;
 
-	int m_EquippedSlotNum;
+	std::size_t m_EquippedSlotNum;
 
 	cPlayer & m_Owner;
 
 	/** Returns the ItemGrid and the (grid-local) slot number for a (global) slot number; return nullptr for invalid SlotNum */
-	const cItemGrid * GetGridForSlotNum(int a_SlotNum, int & a_GridSlotNum) const;
+	const cItemGrid * GetGridForSlotNum(std::size_t a_SlotNum, std::size_t & a_GridSlotNum) const;
 
 	/** Returns the ItemGrid and the (grid-local) slot number for a (global) slot number; return nullptr for invalid SlotNum */
-	cItemGrid * GetGridForSlotNum(int a_SlotNum, int & a_GridSlotNum);
+	cItemGrid * GetGridForSlotNum(std::size_t a_SlotNum, std::size_t & a_GridSlotNum);
 
 	// cItemGrid::cListener override:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 };  // tolua_export

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -802,7 +802,7 @@ bool cItems::ContainsType(const cItem & a_Item)
 
 void cItems::AddItemGrid(const cItemGrid & a_ItemGrid)
 {
-	for (int i = 0; i < a_ItemGrid.GetNumSlots(); ++i)
+	for (size_t i = 0; i < a_ItemGrid.GetNumSlots(); ++i)
 	{
 		const auto & Slot = a_ItemGrid.GetSlot(i);
 		if (!Slot.IsEmpty())

--- a/src/ItemGrid.cpp
+++ b/src/ItemGrid.cpp
@@ -12,32 +12,33 @@
 
 
 
-cItemGrid::cItemGrid(int a_Width, int a_Height):
+cItemGrid::cItemGrid(std::size_t a_Width, std::size_t a_Height):
 	m_Width(a_Width),
 	m_Height(a_Height),
 	m_Slots(a_Width * a_Height),
 	m_IsInTriggerListeners(false)
 {
+	ASSERT(a_Width * a_Height < ILLEGAL_SLOT_NUMBER);
 }
 
 
 
 
 
-bool cItemGrid::IsValidSlotNum(int a_SlotNum) const
+bool cItemGrid::IsValidSlotNum(std::size_t a_SlotNum) const
 {
-	return ((a_SlotNum >= 0) && (a_SlotNum < m_Slots.size()));
+	return (a_SlotNum < m_Slots.size());
 }
 
 
 
 
 
-bool cItemGrid::IsValidSlotCoords(int a_X, int a_Y) const
+bool cItemGrid::IsValidSlotCoords(std::size_t a_X, std::size_t a_Y) const
 {
 	return (
-		(a_X >= 0) && (a_X < m_Width) &&
-		(a_Y >= 0) && (a_Y < m_Height)
+		(a_X < m_Width) &&
+		(a_Y < m_Height)
 	);
 }
 
@@ -45,14 +46,14 @@ bool cItemGrid::IsValidSlotCoords(int a_X, int a_Y) const
 
 
 
-int cItemGrid::GetSlotNum(int a_X, int a_Y) const
+std::size_t cItemGrid::GetSlotNum(std::size_t a_X, std::size_t a_Y) const
 {
 	if (!IsValidSlotCoords(a_X, a_Y))
 	{
 		LOGWARNING("%s: coords out of range: (%d, %d) in grid of size (%d, %d)",
 			__FUNCTION__, a_X, a_Y, m_Width, m_Height
 		);
-		return -1;
+		return ILLEGAL_SLOT_NUMBER;
 	}
 	return a_X + m_Width * a_Y;
 }
@@ -61,15 +62,15 @@ int cItemGrid::GetSlotNum(int a_X, int a_Y) const
 
 
 
-void cItemGrid::GetSlotCoords(int a_SlotNum, int & a_X, int & a_Y) const
+void cItemGrid::GetSlotCoords(std::size_t a_SlotNum, std::size_t & a_X, std::size_t & a_Y) const
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
 		LOGWARNING("%s: SlotNum out of range: %d in grid of range %d",
 			__FUNCTION__, a_SlotNum, m_Slots.size()
 		);
-		a_X = -1;
-		a_Y = -1;
+		a_X = ILLEGAL_SLOT_NUMBER;
+		a_Y = ILLEGAL_SLOT_NUMBER;
 		return;
 	}
 	a_X = a_SlotNum % m_Width;
@@ -93,7 +94,7 @@ void cItemGrid::CopyFrom(const cItemGrid & a_Src)
 
 
 
-const cItem & cItemGrid::GetSlot(int a_X, int a_Y) const
+const cItem & cItemGrid::GetSlot(std::size_t a_X, std::size_t a_Y) const
 {
 	return GetSlot(GetSlotNum(a_X, a_Y));
 }
@@ -102,7 +103,7 @@ const cItem & cItemGrid::GetSlot(int a_X, int a_Y) const
 
 
 
-const cItem & cItemGrid::GetSlot(int a_SlotNum) const
+const cItem & cItemGrid::GetSlot(std::size_t a_SlotNum) const
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
@@ -118,7 +119,7 @@ const cItem & cItemGrid::GetSlot(int a_SlotNum) const
 
 
 
-void cItemGrid::SetSlot(int a_X, int a_Y, const cItem & a_Item)
+void cItemGrid::SetSlot(std::size_t a_X, std::size_t a_Y, const cItem & a_Item)
 {
 	SetSlot(GetSlotNum(a_X, a_Y), a_Item);
 }
@@ -127,7 +128,7 @@ void cItemGrid::SetSlot(int a_X, int a_Y, const cItem & a_Item)
 
 
 
-void cItemGrid::SetSlot(int a_X, int a_Y, short a_ItemType, char a_ItemCount, short a_ItemDamage)
+void cItemGrid::SetSlot(std::size_t a_X, std::size_t a_Y, short a_ItemType, char a_ItemCount, short a_ItemDamage)
 {
 	SetSlot(GetSlotNum(a_X, a_Y), cItem(a_ItemType, a_ItemCount, a_ItemDamage));
 }
@@ -136,7 +137,7 @@ void cItemGrid::SetSlot(int a_X, int a_Y, short a_ItemType, char a_ItemCount, sh
 
 
 
-void cItemGrid::SetSlot(int a_SlotNum, const cItem & a_Item)
+void cItemGrid::SetSlot(std::size_t a_SlotNum, const cItem & a_Item)
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
@@ -157,7 +158,7 @@ void cItemGrid::SetSlot(int a_SlotNum, const cItem & a_Item)
 
 
 
-void cItemGrid::SetSlot(int a_SlotNum, short a_ItemType, char a_ItemCount, short a_ItemDamage)
+void cItemGrid::SetSlot(std::size_t a_SlotNum, short a_ItemType, char a_ItemCount, short a_ItemDamage)
 {
 	SetSlot(a_SlotNum, cItem(a_ItemType, a_ItemCount, a_ItemDamage));
 }
@@ -166,7 +167,7 @@ void cItemGrid::SetSlot(int a_SlotNum, short a_ItemType, char a_ItemCount, short
 
 
 
-void cItemGrid::EmptySlot(int a_X, int a_Y)
+void cItemGrid::EmptySlot(std::size_t a_X, std::size_t a_Y)
 {
 	EmptySlot(GetSlotNum(a_X, a_Y));
 }
@@ -175,7 +176,7 @@ void cItemGrid::EmptySlot(int a_X, int a_Y)
 
 
 
-void cItemGrid::EmptySlot(int a_SlotNum)
+void cItemGrid::EmptySlot(std::size_t a_SlotNum)
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
@@ -200,7 +201,7 @@ void cItemGrid::EmptySlot(int a_SlotNum)
 
 
 
-bool cItemGrid::IsSlotEmpty(int a_SlotNum) const
+bool cItemGrid::IsSlotEmpty(std::size_t a_SlotNum) const
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
@@ -216,7 +217,7 @@ bool cItemGrid::IsSlotEmpty(int a_SlotNum) const
 
 
 
-bool cItemGrid::IsSlotEmpty(int a_X, int a_Y) const
+bool cItemGrid::IsSlotEmpty(std::size_t a_X, std::size_t a_Y) const
 {
 	return IsSlotEmpty(GetSlotNum(a_X, a_Y));
 }
@@ -232,7 +233,7 @@ void cItemGrid::Clear(void)
 		return;  // Already clear
 	}
 
-	for (int i = 0; i < m_Slots.size(); i++)
+	for (std::size_t i = 0; i < m_Slots.size(); i++)
 	{
 		m_Slots[i].Empty();
 		TriggerListeners(i);
@@ -251,7 +252,7 @@ int cItemGrid::HowManyCanFit(const cItem & a_ItemStack, bool a_AllowNewStacks)
 	if (!m_Slots.IsStorageAllocated())
 	{
 		// Grid is empty, all slots are available
-		return a_AllowNewStacks ? std::min(NumLeft, m_Slots.size() * MaxStack) : 0;
+		return a_AllowNewStacks ? std::min(NumLeft, static_cast<int>(m_Slots.size()) * MaxStack) : 0;
 	}
 
 	for (const auto & Slot : m_Slots)
@@ -280,7 +281,7 @@ int cItemGrid::HowManyCanFit(const cItem & a_ItemStack, bool a_AllowNewStacks)
 
 
 
-char cItemGrid::AddItemToSlot(const cItem & a_ItemStack, int a_Slot, int a_Num, int a_MaxStack)
+char cItemGrid::AddItemToSlot(const cItem & a_ItemStack, std::size_t a_Slot, int a_Num, int a_MaxStack)
 {
 	if (!IsValidSlotNum(a_Slot))
 	{
@@ -310,17 +311,17 @@ char cItemGrid::AddItemToSlot(const cItem & a_ItemStack, int a_Slot, int a_Num, 
 
 
 
-char cItemGrid::AddItem(cItem & a_ItemStack, bool a_AllowNewStacks, int a_PrioritySlot)
+char cItemGrid::AddItem(cItem & a_ItemStack, bool a_AllowNewStacks, std::size_t a_PrioritySlot)
 {
 	char NumLeft = a_ItemStack.m_ItemCount;
 	char MaxStack = a_ItemStack.GetMaxStackSize();
 
-	if ((a_PrioritySlot != -1) && !IsValidSlotNum(a_PrioritySlot))
+	if ((a_PrioritySlot != ILLEGAL_SLOT_NUMBER) && !IsValidSlotNum(a_PrioritySlot))
 	{
 		LOGWARNING("%s: Invalid slot number %d out of %d slots",
 			__FUNCTION__, a_PrioritySlot, m_Slots.size()
 		);
-		a_PrioritySlot = -1;
+		a_PrioritySlot = ILLEGAL_SLOT_NUMBER;
 	}
 
 	if (!a_AllowNewStacks && !m_Slots.IsStorageAllocated())
@@ -330,7 +331,7 @@ char cItemGrid::AddItem(cItem & a_ItemStack, bool a_AllowNewStacks, int a_Priori
 
 	// Try prioritySlot first:
 	if (
-		(a_PrioritySlot != -1) &&
+		(a_PrioritySlot != ILLEGAL_SLOT_NUMBER) &&
 		(
 			m_Slots[a_PrioritySlot].IsEmpty() ||
 			m_Slots[a_PrioritySlot].IsEqual(a_ItemStack)
@@ -341,7 +342,7 @@ char cItemGrid::AddItem(cItem & a_ItemStack, bool a_AllowNewStacks, int a_Priori
 	}
 
 	// Scan existing stacks:
-	for (int i = 0; i < m_Slots.size(); i++)
+	for (std::size_t i = 0; i < m_Slots.size(); i++)
 	{
 		if (m_Slots[i].IsEqual(a_ItemStack))
 		{
@@ -359,7 +360,7 @@ char cItemGrid::AddItem(cItem & a_ItemStack, bool a_AllowNewStacks, int a_Priori
 		return (a_ItemStack.m_ItemCount - NumLeft);
 	}
 
-	for (int i = 0; i < m_Slots.size(); i++)
+	for (std::size_t i = 0; i < m_Slots.size(); i++)
 	{
 		if (m_Slots[i].IsEmpty())
 		{
@@ -378,7 +379,7 @@ char cItemGrid::AddItem(cItem & a_ItemStack, bool a_AllowNewStacks, int a_Priori
 
 
 
-char cItemGrid::AddItems(cItems & a_ItemStackList, bool a_AllowNewStacks, int a_PrioritySlot)
+char cItemGrid::AddItems(cItems & a_ItemStackList, bool a_AllowNewStacks, std::size_t a_PrioritySlot)
 {
 	char TotalAdded = 0;
 	for (cItems::iterator itr = a_ItemStackList.begin(); itr != a_ItemStackList.end();)
@@ -411,7 +412,7 @@ char cItemGrid::RemoveItem(const cItem & a_ItemStack)
 		return 0;  // No items to remove
 	}
 
-	for (int i = 0; i < m_Slots.size(); i++)
+	for (std::size_t i = 0; i < m_Slots.size(); i++)
 	{
 		if (NumLeft <= 0)
 		{
@@ -447,7 +448,7 @@ cItem * cItemGrid::FindItem(const cItem & a_RecipeItem)
 		return nullptr;
 	}
 
-	for (int i = 0; i < m_Slots.size(); i++)
+	for (std::size_t i = 0; i < m_Slots.size(); i++)
 	{
 		// Items are equal if none is greater the other
 		auto compare = cItem::sItemCompare{};
@@ -465,7 +466,7 @@ cItem * cItemGrid::FindItem(const cItem & a_RecipeItem)
 
 
 
-char cItemGrid::ChangeSlotCount(int a_SlotNum, char a_AddToCount)
+char cItemGrid::ChangeSlotCount(std::size_t a_SlotNum, char a_AddToCount)
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
@@ -504,7 +505,7 @@ char cItemGrid::ChangeSlotCount(int a_SlotNum, char a_AddToCount)
 
 
 
-char cItemGrid::ChangeSlotCount(int a_X, int a_Y, char a_AddToCount)
+char cItemGrid::ChangeSlotCount(std::size_t a_X, std::size_t a_Y, char a_AddToCount)
 {
 	return ChangeSlotCount(GetSlotNum(a_X, a_Y), a_AddToCount);
 }
@@ -513,7 +514,7 @@ char cItemGrid::ChangeSlotCount(int a_X, int a_Y, char a_AddToCount)
 
 
 
-cItem cItemGrid::RemoveOneItem(int a_SlotNum)
+cItem cItemGrid::RemoveOneItem(std::size_t a_SlotNum)
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
@@ -551,7 +552,7 @@ cItem cItemGrid::RemoveOneItem(int a_SlotNum)
 
 
 
-cItem cItemGrid::RemoveOneItem(int a_X, int a_Y)
+cItem cItemGrid::RemoveOneItem(std::size_t a_X, std::size_t a_Y)
 {
 	return RemoveOneItem(GetSlotNum(a_X, a_Y));
 }
@@ -568,7 +569,7 @@ int cItemGrid::HowManyItems(const cItem & a_Item)
 	}
 
 	int res = 0;
-	for (auto & Slot : m_Slots)
+	for (auto const & Slot : m_Slots)
 	{
 		if (Slot.IsEqual(a_Item))
 		{
@@ -592,108 +593,108 @@ bool cItemGrid::HasItems(const cItem & a_ItemStack)
 
 
 
-int cItemGrid::GetFirstEmptySlot(void) const
+std::size_t cItemGrid::GetFirstEmptySlot(void) const
 {
-	return GetNextEmptySlot(-1);
+	return GetNextEmptySlot(ILLEGAL_SLOT_NUMBER);
 }
 
 
 
 
 
-int cItemGrid::GetFirstUsedSlot(void) const
+std::size_t cItemGrid::GetFirstUsedSlot(void) const
 {
-	return GetNextUsedSlot(-1);
+	return GetNextUsedSlot(ILLEGAL_SLOT_NUMBER);
 }
 
 
 
 
 
-int cItemGrid::GetLastEmptySlot(void) const
+std::size_t cItemGrid::GetLastEmptySlot(void) const
 {
-	for (int i = m_Slots.size() - 1; i >= 0; i--)
+	for (std::size_t i = m_Slots.size() - 1; i > 0; i--)
 	{
 		if (m_Slots.GetAt(i).IsEmpty())
 		{
 			return i;
 		}
 	}
-	return -1;
+	return ILLEGAL_SLOT_NUMBER;
 }
 
 
 
 
 
-int cItemGrid::GetLastUsedSlot(void) const
+std::size_t cItemGrid::GetLastUsedSlot(void) const
 {
 	if (!m_Slots.IsStorageAllocated())
 	{
-		return -1;  // No slots are used
+		return ILLEGAL_SLOT_NUMBER;  // No slots are used
 	}
 
-	for (int i = m_Slots.size() - 1; i >= 0; i--)
+	for (std::size_t i = m_Slots.size() - 1; i > 0; i--)
 	{
 		if (!m_Slots.GetAt(i).IsEmpty())
 		{
 			return i;
 		}
 	}
-	return -1;
+	return ILLEGAL_SLOT_NUMBER;
 }
 
 
 
 
 
-int cItemGrid::GetNextEmptySlot(int a_StartFrom) const
+std::size_t cItemGrid::GetNextEmptySlot(std::size_t a_StartFrom) const
 {
-	if ((a_StartFrom != -1) && !IsValidSlotNum(a_StartFrom))
+	if ((a_StartFrom != ILLEGAL_SLOT_NUMBER) && !IsValidSlotNum(a_StartFrom))
 	{
 		LOGWARNING("%s: Invalid slot number %d out of %d slots",
 			__FUNCTION__, a_StartFrom, m_Slots.size()
 		);
-		a_StartFrom = -1;
+		a_StartFrom = 0;
 	}
 
-	for (int i = a_StartFrom + 1; i < m_Slots.size(); i++)
+	for (std::size_t i = a_StartFrom + 1; i < m_Slots.size(); i++)
 	{
 		if (m_Slots.GetAt(i).IsEmpty())
 		{
 			return i;
 		}
 	}
-	return -1;
+	return ILLEGAL_SLOT_NUMBER;
 }
 
 
 
 
 
-int cItemGrid::GetNextUsedSlot(int a_StartFrom) const
+std::size_t cItemGrid::GetNextUsedSlot(std::size_t a_StartFrom) const
 {
-	if ((a_StartFrom != -1) && !IsValidSlotNum(a_StartFrom))
+	if ((a_StartFrom != ILLEGAL_SLOT_NUMBER) && !IsValidSlotNum(a_StartFrom))
 	{
 		LOGWARNING("%s: Invalid slot number %d out of %d slots",
 			__FUNCTION__, a_StartFrom, m_Slots.size()
 		);
-		a_StartFrom = -1;
+		a_StartFrom = 0;
 	}
 
 	if (!m_Slots.IsStorageAllocated())
 	{
-		return -1;  // No slots are used
+		return ILLEGAL_SLOT_NUMBER;  // No slots are used
 	}
 
-	for (int i = a_StartFrom + 1; i < m_Slots.size(); i++)
+	for (std::size_t i = a_StartFrom + 1; i < m_Slots.size(); i++)
 	{
 		if (!m_Slots.GetAt(i).IsEmpty())
 		{
 			return i;
 		}
 	}
-	return -1;
+	return ILLEGAL_SLOT_NUMBER;
 }
 
 
@@ -720,7 +721,7 @@ void cItemGrid::CopyToItems(cItems & a_Items) const
 
 
 
-bool cItemGrid::DamageItem(int a_SlotNum, short a_Amount)
+bool cItemGrid::DamageItem(std::size_t a_SlotNum, short a_Amount)
 {
 	if (!IsValidSlotNum(a_SlotNum))
 	{
@@ -740,7 +741,7 @@ bool cItemGrid::DamageItem(int a_SlotNum, short a_Amount)
 
 
 
-bool cItemGrid::DamageItem(int a_X, int a_Y, short a_Amount)
+bool cItemGrid::DamageItem(std::size_t a_X, std::size_t a_Y, short a_Amount)
 {
 	return DamageItem(GetSlotNum(a_X, a_Y), a_Amount);
 }
@@ -749,7 +750,7 @@ bool cItemGrid::DamageItem(int a_X, int a_Y, short a_Amount)
 
 
 
-void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, size_t a_CountLootProbabs, int a_NumSlots, int a_Seed)
+void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, size_t a_CountLootProbabs, std::size_t a_NumSlots, int a_Seed)
 {
 	// Calculate the total weight:
 	int TotalProbab = 1;
@@ -760,10 +761,10 @@ void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, s
 
 	// Pick the loot items:
 	cNoise Noise(a_Seed);
-	for (int i = 0; i < a_NumSlots; i++)
+	for (int i = 0; i < static_cast<int>(a_NumSlots); i++)
 	{
-		int Rnd = (Noise.IntNoise1DInt(i) / 7);
-		int LootRnd = Rnd % TotalProbab;
+		int Rnd = Noise.IntNoise1DInt(i) / 7;
+		int LootRnd = static_cast<int>(Rnd) % TotalProbab;
 		Rnd >>= 8;
 		cItem CurrentLoot = cItem(E_ITEM_ENCHANTED_BOOK, 1, 0);
 
@@ -798,7 +799,7 @@ void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, s
 				break;
 			}
 		}  // for j - a_LootProbabs[]
-		SetSlot(Rnd % m_Slots.size(), CurrentLoot);
+		SetSlot(static_cast<std::size_t>(Rnd) % m_Slots.size(), CurrentLoot);
 	}  // for i - NumSlots
 }
 
@@ -835,7 +836,7 @@ void cItemGrid::RemoveListener(cListener & a_Listener)
 
 
 
-void cItemGrid::TriggerListeners(int a_SlotNum)
+void cItemGrid::TriggerListeners(std::size_t a_SlotNum)
 {
 	cListeners Listeners;
 	{

--- a/src/ItemGrid.h
+++ b/src/ItemGrid.h
@@ -58,9 +58,10 @@ public:
 	// Retrieve slots by coords or slot number; Logs warning and returns the first slot on invalid coords / slotnum
 	const cItem & GetSlot(int a_X, int a_Y) const;
 	const cItem & GetSlot(size_t a_SlotNum) const { return GetSlot(static_cast<int>(a_SlotNum)); }
-	/** \deprecated Slot numbers should be unsigned, as the STL containers require unsigned indexes (in contrast to C-Arrays).
-	                Consistent unsigned slot indexes eliminate a bunch of static_cast/ToUnsigned.
-	                Signed slot indexes should indicate, that there may be some special values (like -1, when no slot is found)
+	/** \deprecated
+	* Slot numbers should be unsigned, as the STL containers require unsigned indexes (in contrast to C-Arrays).
+	* Consistent unsigned slot indexes eliminate a bunch of static_cast/ToUnsigned.
+	* Signed slot indexes should indicate, that there may be some special values (like -1, when no slot is found)
 	*/
 	const cItem & GetSlot(int a_SlotNum) const;
 
@@ -69,7 +70,7 @@ public:
 	void SetSlot(int a_X, int a_Y, short a_ItemType, char a_ItemCount, short a_ItemDamage);
 	void SetSlot(size_t a_SlotNum, const cItem & a_Item) { SetSlot(static_cast<int>(a_SlotNum), a_Item); }
 	void SetSlot(int a_SlotNum, short a_ItemType, char a_ItemCount, short a_ItemDamage);
-	//! \deprecated See GetSlot
+	/** \deprecated See GetSlot */
 	void SetSlot(int a_SlotNum, const cItem & a_Item);
 
 	// Empty the specified slot; Logs warning and doesn't set on invalid coords / slotnum
@@ -78,7 +79,7 @@ public:
 
 	/** Returns true if the specified slot is empty or the slot doesn't exist */
 	bool IsSlotEmpty(size_t a_SlotNum) const { return IsSlotEmpty(static_cast<int>(a_SlotNum)); }
-	///! \deprecated See GetSlot
+	/** \deprecated See GetSlot */
 	bool IsSlotEmpty(int a_SlotNum) const;
 
 	/** Returns true if the specified slot is empty or the slot doesn't exist */
@@ -120,9 +121,9 @@ public:
 	If the slot is empty, ignores the call.
 	Returns the new count.
 	*/
-	int ChangeSlotCount(size_t a_SlotNum, char a_AddToCount) { return ChangeSlotCount(static_cast<int>(a_SlotNum), a_AddToCount); }
-	///! \deprecated See GetSlot
-	int ChangeSlotCount(int a_SlotNum, char a_AddToCount);
+	char ChangeSlotCount(std::size_t a_SlotNum, char a_AddToCount) { return ChangeSlotCount(static_cast<int>(a_SlotNum), a_AddToCount); }
+	// ! \deprecated See GetSlot
+	char ChangeSlotCount(int a_SlotNum, char a_AddToCount);
 
 	/** Adds (or subtracts, if a_AddToCount is negative) to the count of items in the specified slot.
 	If the slot is empty, ignores the call.

--- a/src/ItemGrid.h
+++ b/src/ItemGrid.h
@@ -12,7 +12,7 @@
 #include "LazyArray.h"
 
 
-
+#define ILLEGAL_SLOT_NUMBER std::numeric_limits<std::size_t>::max()
 
 
 // tolua_begin
@@ -28,26 +28,24 @@ public:
 		virtual ~cListener() {}
 
 		/** Called whenever a slot changes */
-		virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) = 0;
+		virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) = 0;
 	} ;
 	typedef std::vector<cListener *> cListeners;
 
-	cItemGrid(int a_Width, int a_Height);
+	cItemGrid(std::size_t a_Width, std::size_t a_Height);
 
 	// tolua_begin
-	int GetWidth      (void) const { return m_Width; }
-	int GetHeight     (void) const { return m_Height; }
-	size_t GetNumSlots(void) const { return static_cast<size_t>(m_Slots.size()); }
-	///! \deprecated See GetSlot
-	int OldGetNumSlots(void) const { return m_Slots.size(); }
+	std::size_t GetWidth      (void) const { return m_Width; }
+	std::size_t GetHeight     (void) const { return m_Height; }
+	size_t GetNumSlots(void) const { return m_Slots.size(); }
 
-	/** Converts XY coords into slot number; returns -1 on invalid coords */
-	int GetSlotNum(int a_X, int a_Y) const;
+	/** Converts XY coords into slot number; returns ILLEGAL_SLOT_NUMBER on invalid coords */
+	std::size_t GetSlotNum(std::size_t a_X, std::size_t a_Y) const;
 
 	// tolua_end
 
-	/** Converts slot number into XY coords; sets coords to -1 on invalid slot number. Exported in ManualBindings.cpp */
-	void GetSlotCoords(int a_SlotNum, int & a_X, int & a_Y) const;
+	/** Converts slot number into XY coords; sets coords to ILLEGAL_SLOT_NUMBER on invalid slot number. Exported in ManualBindings.cpp */
+	void GetSlotCoords(std::size_t a_SlotNum, std::size_t & a_X, std::size_t & a_Y) const;
 
 	/** Copies all items from a_Src to this grid.
 	Doesn't copy the listeners. */
@@ -56,34 +54,24 @@ public:
 	// tolua_begin
 
 	// Retrieve slots by coords or slot number; Logs warning and returns the first slot on invalid coords / slotnum
-	const cItem & GetSlot(int a_X, int a_Y) const;
-	const cItem & GetSlot(size_t a_SlotNum) const { return GetSlot(static_cast<int>(a_SlotNum)); }
-	/** \deprecated
-	* Slot numbers should be unsigned, as the STL containers require unsigned indexes (in contrast to C-Arrays).
-	* Consistent unsigned slot indexes eliminate a bunch of static_cast/ToUnsigned.
-	* Signed slot indexes should indicate, that there may be some special values (like -1, when no slot is found)
-	*/
-	const cItem & GetSlot(int a_SlotNum) const;
+	const cItem & GetSlot(std::size_t a_X, std::size_t a_Y) const;
+	const cItem & GetSlot(std::size_t a_SlotNum) const;
 
 	// Set slot by coords or slot number; Logs warning and doesn't set on invalid coords / slotnum
-	void SetSlot(int a_X, int a_Y, const cItem & a_Item);
-	void SetSlot(int a_X, int a_Y, short a_ItemType, char a_ItemCount, short a_ItemDamage);
-	void SetSlot(size_t a_SlotNum, const cItem & a_Item) { SetSlot(static_cast<int>(a_SlotNum), a_Item); }
-	void SetSlot(int a_SlotNum, short a_ItemType, char a_ItemCount, short a_ItemDamage);
-	/** \deprecated See GetSlot */
-	void SetSlot(int a_SlotNum, const cItem & a_Item);
+	void SetSlot(std::size_t a_X, std::size_t a_Y, const cItem & a_Item);
+	void SetSlot(std::size_t a_X, std::size_t a_Y, short a_ItemType, char a_ItemCount, short a_ItemDamage);
+	void SetSlot(std::size_t a_SlotNum, short a_ItemType, char a_ItemCount, short a_ItemDamage);
+	void SetSlot(std::size_t a_SlotNum, const cItem & a_Item);
 
 	// Empty the specified slot; Logs warning and doesn't set on invalid coords / slotnum
-	void EmptySlot(int a_X, int a_Y);
-	void EmptySlot(int a_SlotNum);
+	void EmptySlot(std::size_t a_X, std::size_t a_Y);
+	void EmptySlot(std::size_t a_SlotNum);
 
 	/** Returns true if the specified slot is empty or the slot doesn't exist */
-	bool IsSlotEmpty(size_t a_SlotNum) const { return IsSlotEmpty(static_cast<int>(a_SlotNum)); }
-	/** \deprecated See GetSlot */
-	bool IsSlotEmpty(int a_SlotNum) const;
+	bool IsSlotEmpty(std::size_t a_SlotNum) const;
 
 	/** Returns true if the specified slot is empty or the slot doesn't exist */
-	bool IsSlotEmpty(int a_X, int a_Y) const;
+	bool IsSlotEmpty(std::size_t a_X, std::size_t a_Y) const;
 
 	/** Sets all items as empty */
 	void Clear(void);
@@ -95,20 +83,20 @@ public:
 	If a_AllowNewStacks is set to false, only existing stacks can be topped up;
 	If a_AllowNewStacks is set to true, empty slots can be used for the rest.
 	If a_PrioritySlot is set to a positive value, then the corresponding slot will be used  first (if empty or compatible with added items).
-	If a_PrioritySlot is set to -1, regular order applies.
+	If a_PrioritySlot is set to ILLEGAL_SLOT_NUMBER, regular order applies.
 	Returns the number of items that fit.
 	*/
-	char AddItem(cItem & a_ItemStack, bool a_AllowNewStacks = true, int a_PrioritySlot = -1);
+	char AddItem(cItem & a_ItemStack, bool a_AllowNewStacks = true, std::size_t a_PrioritySlot = std::numeric_limits<std::size_t>::max());  // tolua assumed that ILLEGAL_SLOT_NUMBER is a user type
 
 	/** Same as AddItem, but works on an entire list of item stacks.
 	The a_ItemStackList is modified to reflect the leftover items.
 	If a_AllowNewStacks is set to false, only existing stacks can be topped up;
 	If a_AllowNewStacks is set to true, empty slots can be used for the rest.
 	If a_PrioritySlot is set to a positive value, then the corresponding slot will be used first (if empty or compatible with added items).
-	If a_PrioritySlot is set to -1, regular order applies.
+	If a_PrioritySlot is set to ILLEGAL_SLOT_NUMBER, regular order applies.
 	Returns the total number of items that fit.
 	*/
-	char AddItems(cItems & a_ItemStackList, bool a_AllowNewStacks = true, int a_PrioritySlot = -1);
+	char AddItems(cItems & a_ItemStackList, bool a_AllowNewStacks = true, std::size_t a_PrioritySlot = std::numeric_limits<std::size_t>::max());  // tolua assumed that ILLEGAL_SLOT_NUMBER is a user type
 
 	/** Removes the specified item from the grid, as many as possible, up to a_ItemStack.m_ItemCount.
 	Returns the number of items that were removed. */
@@ -121,25 +109,23 @@ public:
 	If the slot is empty, ignores the call.
 	Returns the new count.
 	*/
-	char ChangeSlotCount(std::size_t a_SlotNum, char a_AddToCount) { return ChangeSlotCount(static_cast<int>(a_SlotNum), a_AddToCount); }
-	// ! \deprecated See GetSlot
-	char ChangeSlotCount(int a_SlotNum, char a_AddToCount);
+	char ChangeSlotCount(std::size_t a_SlotNum, char a_AddToCount);
 
 	/** Adds (or subtracts, if a_AddToCount is negative) to the count of items in the specified slot.
 	If the slot is empty, ignores the call.
 	Returns the new count.
 	*/
-	char ChangeSlotCount(int a_X, int a_Y, char a_AddToCount);
+	char ChangeSlotCount(std::size_t a_X, std::size_t a_Y, char a_AddToCount);
 
 	/** Removes one item from the stack in the specified slot, and returns it.
 	If the slot was empty, returns an empty item
 	*/
-	cItem RemoveOneItem(int a_SlotNum);
+	cItem RemoveOneItem(std::size_t a_SlotNum);
 
 	/** Removes one item from the stack in the specified slot, and returns it.
 	If the slot was empty, returns an empty item
 	*/
-	cItem RemoveOneItem(int a_X, int a_Y);
+	cItem RemoveOneItem(std::size_t a_X, std::size_t a_Y);
 
 	/** Returns the number of items of type a_Item that are stored */
 	int HowManyItems(const cItem & a_Item);
@@ -147,47 +133,47 @@ public:
 	/** Returns true if there are at least as many items of type a_ItemStack as in a_ItemStack */
 	bool HasItems(const cItem & a_ItemStack);
 
-	/** Returns the index of the first empty slot; -1 if all full */
-	int GetFirstEmptySlot(void) const;
+	/** Returns the index of the first empty slot; ILLEGAL_SLOT_NUMBER if all full */
+	std::size_t GetFirstEmptySlot(void) const;
 
-	/** Returns the index of the first non-empty slot; -1 if all empty */
-	int GetFirstUsedSlot(void) const;
+	/** Returns the index of the first non-empty slot; ILLEGAL_SLOT_NUMBER if all empty */
+	std::size_t GetFirstUsedSlot(void) const;
 
-	/** Returns the index of the last empty slot; -1 if all full */
-	int GetLastEmptySlot(void) const;
+	/** Returns the index of the last empty slot; ILLEGAL_SLOT_NUMBER if all full */
+	std::size_t GetLastEmptySlot(void) const;
 
-	/** Returns the index of the last used slot; -1 if all empty */
-	int GetLastUsedSlot(void) const;
+	/** Returns the index of the last used slot; ILLEGAL_SLOT_NUMBER if all empty */
+	std::size_t GetLastUsedSlot(void) const;
 
 	/** Returns the index of the first empty slot following a_StartFrom (a_StartFrom is not checked) */
-	int GetNextEmptySlot(int a_StartFrom) const;
+	std::size_t GetNextEmptySlot(std::size_t a_StartFrom) const;
 
 	/** Returns the index of the first used slot following a_StartFrom (a_StartFrom is not checked) */
-	int GetNextUsedSlot(int a_StartFrom) const;
+	std::size_t GetNextUsedSlot(std::size_t a_StartFrom) const;
 
 	/** Copies the contents into a cItems object; preserves the original a_Items contents */
 	void CopyToItems(cItems & a_Items) const;
 
 	/** Adds the specified damage to the specified item; returns true if the item broke (but the item is left intact) */
-	bool DamageItem(int a_SlotNum, short a_Amount);
+	bool DamageItem(std::size_t a_SlotNum, short a_Amount);
 
 	/** Adds the specified damage to the specified item; returns true if the item broke (but the item is left intact) */
-	bool DamageItem(int a_X, int a_Y, short a_Amount);
+	bool DamageItem(std::size_t a_X, std::size_t a_Y, short a_Amount);
 
 	// tolua_end
 
 
 	/** Returns true if slot coordinates lie within the grid. */
-	bool IsValidSlotCoords(int a_X, int a_Y) const;
+	bool IsValidSlotCoords(std::size_t a_X, std::size_t a_Y) const;
 
 	/** Returns true if slot number is within the grid. */
-	bool IsValidSlotNum(int a_SlotNum) const;
+	bool IsValidSlotNum(std::size_t a_SlotNum) const;
 
 	/** Generates random loot from the specified loot probability table, with a chance of enchanted books added.
 	A total of a_NumSlots are taken by the loot.
 	Cannot export to Lua due to raw array a_LootProbabs. TODO: Make this exportable / export through ManualBindings.cpp with a Lua table as LootProbabs
 	*/
-	void GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, size_t a_CountLootProbabs, int a_NumSlots, int a_Seed);
+	void GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, size_t a_CountLootProbabs, std::size_t a_NumSlots, int a_Seed);
 
 	/** Adds a callback that gets called whenever a slot changes. Must not be called from within the listener callback! */
 	void AddListener(cListener & a_Listener);
@@ -198,20 +184,20 @@ public:
 	// tolua_begin
 
 protected:
-	int     m_Width;
-	int     m_Height;
-	cLazyArray<cItem> m_Slots;
+	std::size_t     m_Width;
+	std::size_t     m_Height;
+	cLazyArray<cItem, std::size_t> m_Slots;
 
 	cListeners       m_Listeners;    ///< Listeners which should be notified on slot changes; the pointers are not owned by this object
 	cCriticalSection m_CSListeners;  ///< CS that guards the m_Listeners against multi-thread access
 	bool             m_IsInTriggerListeners;  ///< Set to true while TriggerListeners is running, to detect attempts to manipulate listener list while triggerring
 
 	/** Calls all m_Listeners for the specified slot number */
-	void TriggerListeners(int a_SlotNum);
+	void TriggerListeners(std::size_t a_SlotNum);
 
 	/** Adds up to a_Num items out of a_ItemStack, as many as can fit, in specified slot
 	Returns the number of items that did fit.
 	*/
-	char AddItemToSlot(const cItem & a_ItemStack, int a_Slot, int a_Num, int a_MaxStack);
+	char AddItemToSlot(const cItem & a_ItemStack, std::size_t a_Slot, int a_Num, int a_MaxStack);
 } ;
 // tolua_end

--- a/src/ItemGrid.h
+++ b/src/ItemGrid.h
@@ -35,9 +35,11 @@ public:
 	cItemGrid(int a_Width, int a_Height);
 
 	// tolua_begin
-	int GetWidth   (void) const { return m_Width; }
-	int GetHeight  (void) const { return m_Height; }
-	int GetNumSlots(void) const { return m_Slots.size(); }
+	int GetWidth      (void) const { return m_Width; }
+	int GetHeight     (void) const { return m_Height; }
+	size_t GetNumSlots(void) const { return static_cast<size_t>(m_Slots.size()); }
+	///! \deprecated See GetSlot
+	int OldGetNumSlots(void) const { return m_Slots.size(); }
 
 	/** Converts XY coords into slot number; returns -1 on invalid coords */
 	int GetSlotNum(int a_X, int a_Y) const;
@@ -55,19 +57,28 @@ public:
 
 	// Retrieve slots by coords or slot number; Logs warning and returns the first slot on invalid coords / slotnum
 	const cItem & GetSlot(int a_X, int a_Y) const;
+	const cItem & GetSlot(size_t a_SlotNum) const { return GetSlot(static_cast<int>(a_SlotNum)); }
+	/** \deprecated Slot numbers should be unsigned, as the STL containers require unsigned indexes (in contrast to C-Arrays).
+	                Consistent unsigned slot indexes eliminate a bunch of static_cast/ToUnsigned.
+	                Signed slot indexes should indicate, that there may be some special values (like -1, when no slot is found)
+	*/
 	const cItem & GetSlot(int a_SlotNum) const;
 
 	// Set slot by coords or slot number; Logs warning and doesn't set on invalid coords / slotnum
 	void SetSlot(int a_X, int a_Y, const cItem & a_Item);
 	void SetSlot(int a_X, int a_Y, short a_ItemType, char a_ItemCount, short a_ItemDamage);
-	void SetSlot(int a_SlotNum, const cItem & a_Item);
+	void SetSlot(size_t a_SlotNum, const cItem & a_Item) { SetSlot(static_cast<int>(a_SlotNum), a_Item); }
 	void SetSlot(int a_SlotNum, short a_ItemType, char a_ItemCount, short a_ItemDamage);
+	//! \deprecated See GetSlot
+	void SetSlot(int a_SlotNum, const cItem & a_Item);
 
 	// Empty the specified slot; Logs warning and doesn't set on invalid coords / slotnum
 	void EmptySlot(int a_X, int a_Y);
 	void EmptySlot(int a_SlotNum);
 
 	/** Returns true if the specified slot is empty or the slot doesn't exist */
+	bool IsSlotEmpty(size_t a_SlotNum) const { return IsSlotEmpty(static_cast<int>(a_SlotNum)); }
+	///! \deprecated See GetSlot
 	bool IsSlotEmpty(int a_SlotNum) const;
 
 	/** Returns true if the specified slot is empty or the slot doesn't exist */
@@ -109,7 +120,9 @@ public:
 	If the slot is empty, ignores the call.
 	Returns the new count.
 	*/
-	char ChangeSlotCount(int a_SlotNum, char a_AddToCount);
+	int ChangeSlotCount(size_t a_SlotNum, char a_AddToCount) { return ChangeSlotCount(static_cast<int>(a_SlotNum), a_AddToCount); }
+	///! \deprecated See GetSlot
+	int ChangeSlotCount(int a_SlotNum, char a_AddToCount);
 
 	/** Adds (or subtracts, if a_AddToCount is negative) to the count of items in the specified slot.
 	If the slot is empty, ignores the call.

--- a/src/Items/ItemArmor.h
+++ b/src/Items/ItemArmor.h
@@ -31,7 +31,7 @@ public:
 		eBlockFace a_ClickedBlockFace
 	) const override
 	{
-		int SlotNum;
+		std::size_t SlotNum;
 		if (ItemCategory::IsHelmet(a_HeldItem.m_ItemType))
 		{
 			SlotNum = 0;

--- a/src/LazyArray.h
+++ b/src/LazyArray.h
@@ -4,20 +4,21 @@
 /** A dynamic array that defers allocation to the first modifying access.
 Const references from the array before allocation will all be to the same default constructed value.
 It is therefore important that default constructed values are indistinguishable from each other. */
-template <typename T>
+template <typename T, typename size_type=int>
 class cLazyArray
 {
 	static_assert((!std::is_reference<T>::value && !std::is_array<T>::value),
 		"cLazyArray<T>: T must be a value type");
 	static_assert(std::is_default_constructible<T>::value,
 		"cLazyArray<T>: T must be default constructible");
+	static_assert(std::is_integral<size_type>::value,
+	    "cLazyArray<T, size_type>: size_type must be a arithmetic type");
 public:
 	using value_type = T;
 	using pointer = T *;
 	using const_pointer = const T *;
 	using reference = T &;
 	using const_reference = const T &;
-	using size_type = int;
 	using iterator = pointer;
 	using const_iterator = const_pointer;
 

--- a/src/Mobs/Villager.cpp
+++ b/src/Mobs/Villager.cpp
@@ -287,10 +287,10 @@ void cVillager::HandleFarmerTryPlaceCrops()
 	if (IsPlantable(m_CropsPos))
 	{
 		// Finding the item to use to plant a crop
-		int TargetSlot = -1;
+		auto TargetSlot = ILLEGAL_SLOT_NUMBER;
 		BLOCKTYPE CropBlockType = E_BLOCK_AIR;
 
-		for (int I = 0; I < m_Inventory.GetWidth() && TargetSlot < 0; I++)
+		for (std::size_t I = 0; I < m_Inventory.GetWidth() && (TargetSlot == ILLEGAL_SLOT_NUMBER); I++)
 		{
 			const cItem & Slot = m_Inventory.GetSlot(I);
 			switch (Slot.m_ItemType)

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -404,9 +404,9 @@ public:
 	virtual void SendExplosion                  (Vector3f a_Position, float a_Power) = 0;
 	virtual void SendGameMode                   (eGameMode a_GameMode) = 0;
 	virtual void SendHealth                     (void) = 0;
-	virtual void SendHeldItemChange             (int a_ItemIndex) = 0;
+	virtual void SendHeldItemChange             (std::size_t a_ItemIndex) = 0;
 	virtual void SendHideTitle                  (void) = 0;
-	virtual void SendInventorySlot              (char a_WindowID, short a_SlotNum, const cItem & a_Item) = 0;
+	virtual void SendInventorySlot              (char a_WindowID, std::size_t a_SlotNum, const cItem & a_Item) = 0;
 	virtual void SendKeepAlive                  (UInt32 a_PingID) = 0;
 	virtual void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) = 0;
 	virtual void SendLogin                      (const cPlayer & a_Player, const cWorld & a_World) = 0;

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -739,7 +739,7 @@ void cProtocol_1_8_0::SendHealth(void)
 
 
 
-void cProtocol_1_8_0::SendHeldItemChange(int a_ItemIndex)
+void cProtocol_1_8_0::SendHeldItemChange(std::size_t a_ItemIndex)
 {
 	ASSERT((a_ItemIndex >= 0) && (a_ItemIndex <= 8));  // Valid check
 
@@ -763,13 +763,13 @@ void cProtocol_1_8_0::SendHideTitle(void)
 
 
 
-void cProtocol_1_8_0::SendInventorySlot(char a_WindowID, short a_SlotNum, const cItem & a_Item)
+void cProtocol_1_8_0::SendInventorySlot(char a_WindowID, std::size_t a_SlotNum, const cItem & a_Item)
 {
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, pktInventorySlot);
 	Pkt.WriteBEInt8(a_WindowID);
-	Pkt.WriteBEInt16(a_SlotNum);
+	Pkt.WriteBEInt16((a_SlotNum == ILLEGAL_SLOT_NUMBER) ? -1 : static_cast<Int16>(a_SlotNum));
 	WriteItem(Pkt, a_Item);
 }
 
@@ -2458,7 +2458,7 @@ void cProtocol_1_8_0::HandlePacketCreativeInventoryAction(cByteBuffer & a_ByteBu
 	{
 		return;
 	}
-	m_Client->HandleCreativeInventory(SlotNum, Item, (SlotNum == -1) ? caLeftClickOutside : caLeftClick);
+	m_Client->HandleCreativeInventory(static_cast<std::size_t>(SlotNum), Item, (SlotNum == -1) ? caLeftClickOutside : caLeftClick);
 }
 
 
@@ -2810,7 +2810,7 @@ void cProtocol_1_8_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 		}
 	}
 
-	m_Client->HandleWindowClick(WindowID, SlotNum, Action, Item);
+	m_Client->HandleWindowClick(WindowID, static_cast<std::size_t>(SlotNum), Action, Item);
 }
 
 
@@ -2903,7 +2903,9 @@ void cProtocol_1_8_0::HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, con
 	{
 		HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, SlotNum);
 
-		m_Client->HandleNPCTrade(SlotNum);
+		ASSERT(SlotNum >= 0);
+
+		m_Client->HandleNPCTrade(static_cast<std::size_t>(SlotNum));
 	}
 }
 

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -75,9 +75,9 @@ public:
 	virtual void SendExplosion                  (Vector3f a_Position, float a_Power) override;
 	virtual void SendGameMode                   (eGameMode a_GameMode) override;
 	virtual void SendHealth                     (void) override;
-	virtual void SendHeldItemChange             (int a_ItemIndex) override;
+	virtual void SendHeldItemChange             (std::size_t a_ItemIndex) override;
 	virtual void SendHideTitle                  (void) override;
-	virtual void SendInventorySlot              (char a_WindowID, short a_SlotNum, const cItem & a_Item) override;
+	virtual void SendInventorySlot              (char a_WindowID, std::size_t a_SlotNum, const cItem & a_Item) override;
 	virtual void SendKeepAlive                  (UInt32 a_PingID) override;
 	virtual void SendLeashEntity                (const cEntity & a_Entity, const cEntity & a_EntityLeashedTo) override;
 	virtual void SendLogin                      (const cPlayer & a_Player, const cWorld & a_World) override;

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -1240,7 +1240,7 @@ void cProtocol_1_9_0::HandlePacketWindowClick(cByteBuffer & a_ByteBuffer)
 		}
 	}
 
-	m_Client->HandleWindowClick(WindowID, SlotNum, Action, Item);
+	m_Client->HandleWindowClick(WindowID, static_cast<std::size_t>(SlotNum), Action, Item);
 }
 
 

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneComparatorHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneComparatorHandler.h
@@ -60,7 +60,7 @@ namespace RedstoneComparatorHandler
 			auto & Contents = BlockEntityWithItems->GetContents();
 			float Fullness = 0;  // Is a floating-point type to allow later calculation to produce a non-truncated value
 
-			for (int Slot = 0; Slot != Contents.GetNumSlots(); ++Slot)
+			for (int Slot = 0; Slot != Contents.OldGetNumSlots(); ++Slot)
 			{
 				Fullness += static_cast<float>(Contents.GetSlot(Slot).m_ItemCount) / Contents.GetSlot(Slot).GetMaxStackSize();
 			}

--- a/src/Simulator/IncrementalRedstoneSimulator/RedstoneComparatorHandler.h
+++ b/src/Simulator/IncrementalRedstoneSimulator/RedstoneComparatorHandler.h
@@ -60,7 +60,7 @@ namespace RedstoneComparatorHandler
 			auto & Contents = BlockEntityWithItems->GetContents();
 			float Fullness = 0;  // Is a floating-point type to allow later calculation to produce a non-truncated value
 
-			for (int Slot = 0; Slot != Contents.OldGetNumSlots(); ++Slot)
+			for (std::size_t Slot = 0; Slot != Contents.GetNumSlots(); ++Slot)
 			{
 				Fullness += static_cast<float>(Contents.GetSlot(Slot).m_ItemCount) / Contents.GetSlot(Slot).GetMaxStackSize();
 			}

--- a/src/UI/AnvilWindow.cpp
+++ b/src/UI/AnvilWindow.cpp
@@ -47,7 +47,7 @@ void cAnvilWindow::SetRepairedItemName(const AString & a_Name, cPlayer * a_Playe
 
 
 
-void cAnvilWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cAnvilWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/AnvilWindow.h
+++ b/src/UI/AnvilWindow.h
@@ -33,7 +33,7 @@ public:
 	/** Gets the Position from the Anvil */
 	const Vector3i & GetBlockPos() { return m_BlockPos; }
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 protected:
 	cSlotAreaAnvil * m_AnvilSlotArea;

--- a/src/UI/BeaconWindow.cpp
+++ b/src/UI/BeaconWindow.cpp
@@ -26,7 +26,7 @@ cBeaconWindow::cBeaconWindow(cBeaconEntity * a_Beacon):
 
 
 
-void cBeaconWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cBeaconWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/BeaconWindow.h
+++ b/src/UI/BeaconWindow.h
@@ -26,7 +26,7 @@ public:
 
 	cBeaconEntity * GetBeaconEntity(void) const { return m_Beacon; }
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 	// cWindow Overrides:
 	virtual void OpenedByPlayer(cPlayer & a_Player) override;

--- a/src/UI/BrewingstandWindow.cpp
+++ b/src/UI/BrewingstandWindow.cpp
@@ -25,13 +25,13 @@ cBrewingstandWindow::cBrewingstandWindow(cBrewingstandEntity * a_Brewingstand):
 
 
 
-void cBrewingstandWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cBrewingstandWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 
 	if (a_ClickedArea == m_SlotAreas[0])
 	{
-		if ((a_Slot >= 0) && (a_Slot <= 4))
+		if (a_Slot <= 4)
 		{
 			// Brewing stand Area
 			AreasInOrder.push_back(m_SlotAreas[2]);  /* Hotbar */

--- a/src/UI/BrewingstandWindow.h
+++ b/src/UI/BrewingstandWindow.h
@@ -24,7 +24,7 @@ public:
 
 	cBrewingstandWindow(cBrewingstandEntity * a_Brewingstand);
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 };
 
 

--- a/src/UI/ChestWindow.cpp
+++ b/src/UI/ChestWindow.cpp
@@ -106,7 +106,7 @@ void cChestWindow::OpenedByPlayer(cPlayer & a_Player)
 
 
 
-void cChestWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cChestWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/ChestWindow.h
+++ b/src/UI/ChestWindow.h
@@ -32,7 +32,7 @@ public:
 
 	virtual void OpenedByPlayer(cPlayer & a_Player) override;
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 protected:
 	cWorld * m_World;

--- a/src/UI/CraftingWindow.cpp
+++ b/src/UI/CraftingWindow.cpp
@@ -22,7 +22,7 @@ cCraftingWindow::cCraftingWindow() :
 
 
 
-void cCraftingWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cCraftingWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/CraftingWindow.h
+++ b/src/UI/CraftingWindow.h
@@ -24,7 +24,7 @@ public:
 
 	cCraftingWindow();
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 	/** Loads the given Recipe into the crafting grid */
 	void LoadRecipe(cPlayer & a_Player, UInt32 a_RecipeId);

--- a/src/UI/DropSpenserWindow.cpp
+++ b/src/UI/DropSpenserWindow.cpp
@@ -23,7 +23,7 @@ cDropSpenserWindow::cDropSpenserWindow(cDropSpenserEntity * a_DropSpenser):
 
 
 
-void cDropSpenserWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cDropSpenserWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/DropSpenserWindow.h
+++ b/src/UI/DropSpenserWindow.h
@@ -24,7 +24,7 @@ class cDropSpenserWindow :
 public:
 	cDropSpenserWindow(cDropSpenserEntity * a_DropSpenser);
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 };
 
 

--- a/src/UI/EnchantingWindow.cpp
+++ b/src/UI/EnchantingWindow.cpp
@@ -50,7 +50,7 @@ short cEnchantingWindow::GetProperty(size_t a_Property)
 
 
 
-void cEnchantingWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cEnchantingWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/EnchantingWindow.h
+++ b/src/UI/EnchantingWindow.h
@@ -37,7 +37,7 @@ public:
 	/** Return the level requirement of the given enchantment slot. */
 	short GetProperty(size_t a_Property);
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 	cSlotAreaEnchanting * m_SlotArea;
 

--- a/src/UI/EnderChestWindow.cpp
+++ b/src/UI/EnderChestWindow.cpp
@@ -54,7 +54,7 @@ cEnderChestWindow::~cEnderChestWindow()
 
 
 
-void cEnderChestWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cEnderChestWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/EnderChestWindow.h
+++ b/src/UI/EnderChestWindow.h
@@ -27,7 +27,7 @@ public:
 
 	virtual ~cEnderChestWindow() override;
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 protected:
 	cWorld * m_World;

--- a/src/UI/FurnaceWindow.cpp
+++ b/src/UI/FurnaceWindow.cpp
@@ -25,7 +25,7 @@ cFurnaceWindow::cFurnaceWindow(cFurnaceEntity * a_Furnace):
 
 
 
-void cFurnaceWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cFurnaceWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/FurnaceWindow.h
+++ b/src/UI/FurnaceWindow.h
@@ -23,7 +23,7 @@ class cFurnaceWindow :
 public:
 	cFurnaceWindow(cFurnaceEntity * a_Furnace);
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 };
 

--- a/src/UI/HopperWindow.cpp
+++ b/src/UI/HopperWindow.cpp
@@ -25,7 +25,7 @@ cHopperWindow::cHopperWindow(cHopperEntity * a_Hopper):
 
 
 
-void cHopperWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cHopperWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/HopperWindow.h
+++ b/src/UI/HopperWindow.h
@@ -24,7 +24,7 @@ public:
 
 	cHopperWindow(cHopperEntity * a_Hopper);
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 };
 

--- a/src/UI/HorseWindow.cpp
+++ b/src/UI/HorseWindow.cpp
@@ -25,7 +25,7 @@ cHorseWindow::cHorseWindow(cHorse & a_Horse):
 
 
 
-void cHorseWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cHorseWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/HorseWindow.h
+++ b/src/UI/HorseWindow.h
@@ -20,7 +20,7 @@ class cHorseWindow :
 public:
 	cHorseWindow(cHorse & a_Horse);
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 	/** Returns the horse's entity ID. */
 	UInt32 GetHorseID() const;

--- a/src/UI/InventoryWindow.cpp
+++ b/src/UI/InventoryWindow.cpp
@@ -26,7 +26,7 @@ cInventoryWindow::cInventoryWindow(cPlayer & a_Player) :
 
 
 
-void cInventoryWindow::DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
+void cInventoryWindow::DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply)
 {
 	cSlotAreas AreasInOrder;
 

--- a/src/UI/InventoryWindow.h
+++ b/src/UI/InventoryWindow.h
@@ -24,7 +24,7 @@ public:
 
 	cInventoryWindow(cPlayer & a_Player);
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override;
 
 	/** Loads the given Recipe into the crafting grid */
 	void LoadRecipe(cPlayer & a_Player, UInt32 a_RecipeId);

--- a/src/UI/MinecartWithChestWindow.h
+++ b/src/UI/MinecartWithChestWindow.h
@@ -34,7 +34,7 @@ public:
 		a_ChestCart->GetWorld()->BroadcastSoundEffect("block.chest.open", a_ChestCart->GetPosition(), 1, 1);
 	}
 
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) override
 	{
 		cSlotAreas AreasInOrder;
 

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -2602,7 +2602,7 @@ bool cSlotAreaArmor::CanPlaceArmorInSlot(int a_SlotNum, const cItem & a_Item)
 // cSlotAreaItemGrid:
 
 cSlotAreaItemGrid::cSlotAreaItemGrid(cItemGrid & a_ItemGrid, cWindow & a_ParentWindow) :
-	Super(a_ItemGrid.GetNumSlots(), a_ParentWindow),
+	Super(a_ItemGrid.OldGetNumSlots(), a_ParentWindow),
 	m_ItemGrid(a_ItemGrid)
 {
 	m_ItemGrid.AddListener(*this);

--- a/src/UI/SlotArea.h
+++ b/src/UI/SlotArea.h
@@ -33,34 +33,34 @@ class cWorld;
 class cSlotArea
 {
 public:
-	cSlotArea(int a_NumSlots, cWindow & a_ParentWindow);
+	cSlotArea(std::size_t a_NumSlots, cWindow & a_ParentWindow);
 	virtual ~cSlotArea() {}  // force a virtual destructor in all subclasses
 
-	int GetNumSlots(void) const { return m_NumSlots; }
+	std::size_t GetNumSlots(void) const { return m_NumSlots; }
 
 	/** Called to retrieve an item in the specified slot for the specified player. Must return a valid cItem. */
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const = 0;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const = 0;
 
 	/** Called to set an item in the specified slot for the specified player */
-	virtual void SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) = 0;
+	virtual void SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) = 0;
 
 	/** Called when a player clicks in the window. Parameters taken from the click packet. */
-	virtual void Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem);
+	virtual void Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem);
 
 	/** Called from Clicked when the action is a shiftclick (left or right) */
-	virtual void ShiftClicked(cPlayer & a_Player, int a_SlotNum, const cItem & a_ClickedItem);
+	virtual void ShiftClicked(cPlayer & a_Player, std::size_t a_SlotNum, const cItem & a_ClickedItem);
 
 	/** Called from Clicked when the action is a caDblClick */
-	virtual void DblClicked(cPlayer & a_Player, int a_SlotNum);
+	virtual void DblClicked(cPlayer & a_Player, std::size_t a_SlotNum);
 
 	/** Called from Clicked when the action is a middleclick */
-	virtual void MiddleClicked(cPlayer & a_Player, int a_SlotNum);
+	virtual void MiddleClicked(cPlayer & a_Player, std::size_t a_SlotNum);
 
 	/** Called from Clicked when the action is a drop click. */
-	virtual void DropClicked(cPlayer & a_Player, int a_SlotNum, bool a_DropStack);
+	virtual void DropClicked(cPlayer & a_Player, std::size_t a_SlotNum, bool a_DropStack);
 
 	/** Called from Clicked when the action is a number click. */
-	virtual void NumberClicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction);
+	virtual void NumberClicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction);
 
 	/** Called when a new player opens the same parent window. The window already tracks the player. CS-locked. */
 	virtual void OnPlayerAdded(cPlayer & a_Player);
@@ -82,8 +82,9 @@ public:
 	virtual bool CollectItemsToHand(cItem & a_Dragging, cPlayer & a_Player, bool a_CollectFullStacks);
 
 protected:
-	int       m_NumSlots;
-	cWindow & m_ParentWindow;
+	cWindow &   m_ParentWindow;
+private:
+	std::size_t m_NumSlots;
 } ;
 
 
@@ -98,16 +99,16 @@ class cSlotAreaInventoryBase:
 
 public:
 
-	cSlotAreaInventoryBase(int a_NumSlots, int a_SlotOffset, cWindow & a_ParentWindow);
+	cSlotAreaInventoryBase(std::size_t a_NumSlots, std::size_t a_SlotOffset, cWindow & a_ParentWindow);
 
 	// Creative inventory's click handling is somewhat different from survival inventory's, handle that here:
-	virtual void Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
 
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
-	int m_SlotOffset;  // Index that this area's slot 0 has in the underlying cInventory
+	std::size_t m_SlotOffset;  // Index that this area's slot 0 has in the underlying cInventory
 } ;
 
 
@@ -184,9 +185,9 @@ public:
 	virtual void DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
 
 	/** Called when a player clicks in the window. Parameters taken from the click packet. */
-	virtual void Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
 
-	static bool CanPlaceArmorInSlot(int a_SlotNum, const cItem & a_Item);
+	static bool CanPlaceArmorInSlot(std::size_t a_SlotNum, const cItem & a_Item);
 } ;
 
 
@@ -206,14 +207,14 @@ public:
 
 	virtual ~cSlotAreaItemGrid() override;
 
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
 	cItemGrid & m_ItemGrid;
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 } ;
 
 
@@ -230,16 +231,16 @@ class cSlotAreaTemporary:
 
 public:
 
-	cSlotAreaTemporary(int a_NumSlots, cWindow & a_ParentWindow);
+	cSlotAreaTemporary(std::size_t a_NumSlots, cWindow & a_ParentWindow);
 
 	// cSlotArea overrides:
-	virtual const cItem * GetSlot        (int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot        (int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot        (std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot        (std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 	virtual void          OnPlayerAdded  (cPlayer & a_Player) override;
 	virtual void          OnPlayerRemoved(cPlayer & a_Player) override;
 
 	/** Tosses the player's items in slots [a_Begin, a_End) (ie. incl. a_Begin, but excl. a_End) */
-	void TossItems(cPlayer & a_Player, int a_Begin, int a_End);
+	void TossItems(cPlayer & a_Player, std::size_t a_Begin, std::size_t a_End);
 
 protected:
 	using cItemMap = std::map<UInt32, std::vector<cItem> >;  // Maps EntityID -> items
@@ -262,13 +263,13 @@ class cSlotAreaCrafting:
 public:
 
 	/** a_GridSize is allowed to be only 2 or 3 */
-	cSlotAreaCrafting(int a_GridSize, cWindow & a_ParentWindow);
+	cSlotAreaCrafting(std::size_t a_GridSize, cWindow & a_ParentWindow);
 
 	// cSlotAreaTemporary overrides:
-	virtual void Clicked        (cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
-	virtual void DblClicked     (cPlayer & a_Player, int a_SlotNum) override;
+	virtual void Clicked        (cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void DblClicked     (cPlayer & a_Player, std::size_t a_SlotNum) override;
 	virtual void OnPlayerRemoved(cPlayer & a_Player) override;
-	virtual void SetSlot        (int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual void SetSlot        (std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 	// Distributing items into this area is completely disabled
 	virtual void DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
@@ -284,8 +285,8 @@ protected:
 	Not a std::map because cCraftingGrid needs proper constructor params. */
 	typedef std::list<std::pair<UInt32, cCraftingRecipe> > cRecipeMap;
 
-	int        m_GridSize;
-	cRecipeMap m_Recipes;
+	std::size_t m_GridSize;
+	cRecipeMap  m_Recipes;
 
 	/** Handles a click in the result slot.
 	Crafts using the current recipe, if possible. */
@@ -322,8 +323,8 @@ public:
 	cSlotAreaAnvil(cWindow & a_ParentWindow);
 
 	// cSlotArea overrides:
-	virtual void Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
-	virtual void ShiftClicked(cPlayer & a_Player, int a_SlotNum, const cItem & a_ClickedItem) override;
+	virtual void Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void ShiftClicked(cPlayer & a_Player, std::size_t a_SlotNum, const cItem & a_ClickedItem) override;
 	virtual void DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
 
 	// cSlotAreaTemporary overrides:
@@ -363,16 +364,16 @@ public:
 
 	static bool IsPlaceableItem(short a_ItemType);
 
-	virtual void          Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void          Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
 	virtual void          DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
 	cBeaconEntity * m_Beacon;
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 } ;
 
 
@@ -389,9 +390,9 @@ public:
 	cSlotAreaEnchanting(cWindow & a_ParentWindow, Vector3i a_BlockPos);
 
 	// cSlotArea overrides:
-	virtual void Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
 	virtual void DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
-	virtual void SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual void SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 	// cSlotAreaTemporary overrides:
 	virtual void OnPlayerAdded  (cPlayer & a_Player) override;
@@ -423,8 +424,8 @@ class cSlotAreaChest :
 public:
 	cSlotAreaChest(cChestEntity * a_Chest, cWindow & a_ParentWindow);
 
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
 	cChestEntity * m_Chest;
@@ -440,8 +441,8 @@ class cSlotAreaDoubleChest :
 public:
 	cSlotAreaDoubleChest(cChestEntity * a_TopChest, cChestEntity * a_BottomChest, cWindow & a_ParentWindow);
 
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
 	cChestEntity * m_TopChest;
@@ -458,8 +459,8 @@ class cSlotAreaEnderChest :
 public:
 	cSlotAreaEnderChest(cEnderChestEntity * a_EnderChest, cWindow & a_ParentWindow);
 
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
 	cEnderChestEntity * m_EnderChest;
@@ -481,16 +482,16 @@ public:
 
 	virtual ~cSlotAreaFurnace() override;
 
-	virtual void          Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void          Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
 	virtual void          DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
 	cFurnaceEntity * m_Furnace;
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 
 	/** Called after an item has been smelted to handle statistics etc. */
 	void HandleSmeltItem(const cItem & a_Result, cPlayer & a_Player);
@@ -512,15 +513,15 @@ public:
 
 	virtual ~cSlotAreaBrewingstand() override;
 
-	virtual void          Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual void          Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
 	virtual void          DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 protected:
 	cBrewingstandEntity * m_Brewingstand;
 
 	// cItemGrid::cListener overrides:
-	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum) override;
+	virtual void OnSlotChanged(cItemGrid * a_ItemGrid, std::size_t a_SlotNum) override;
 
 	/** Called after an item has been brewed to handle statistics etc. */
 	void HandleBrewedItem(cPlayer & a_Player, const cItem & a_ClickedItem);
@@ -536,8 +537,8 @@ class cSlotAreaMinecartWithChest :
 public:
 	cSlotAreaMinecartWithChest(cMinecartWithChest * a_ChestCart, cWindow & a_ParentWindow);
 
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void          SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void          SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 
 protected:
 	cMinecartWithChest * m_Chest;
@@ -559,9 +560,9 @@ public:
 	};
 
 	cSlotAreaHorse(cHorse & a_Horse, cWindow & a_ParentWindow);
-	virtual void Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
-	virtual const cItem * GetSlot(int a_SlotNum, cPlayer & a_Player) const override;
-	virtual void SetSlot(int a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
+	virtual void Clicked(cPlayer & a_Player, std::size_t a_SlotNum, eClickAction a_ClickAction, const cItem & a_ClickedItem) override;
+	virtual const cItem * GetSlot(std::size_t a_SlotNum, cPlayer & a_Player) const override;
+	virtual void SetSlot(std::size_t a_SlotNum, cPlayer & a_Player, const cItem & a_Item) override;
 	virtual void DistributeStack(cItem & a_ItemStack, cPlayer & a_Player, bool a_ShouldApply, bool a_KeepEmptySlots, bool a_BackFill) override;
 private:
 	cHorse & m_Horse;

--- a/src/UI/Window.h
+++ b/src/UI/Window.h
@@ -87,27 +87,27 @@ public:
 	void SetOwner( cWindowOwner * a_Owner) { m_Owner = a_Owner; }
 
 	/** Returns the total number of slots */
-	int GetNumSlots(void) const;
+	std::size_t GetNumSlots(void) const;
 
 	/** Returns the number of slots, excluding the player's inventory (used for network protocols) */
-	int GetNumNonInventorySlots(void) const { return GetNumSlots() - c_NumInventorySlots; }
+	std::size_t GetNumNonInventorySlots(void) const { return GetNumSlots() - c_NumInventorySlots; }
 
 	// tolua_begin
 
 	/** Returns the item at the specified slot for the specified player. Returns nullptr if invalid SlotNum requested */
-	const cItem * GetSlot(cPlayer & a_Player, int a_SlotNum) const;
+	const cItem * GetSlot(cPlayer & a_Player, std::size_t a_SlotNum) const;
 
 	/** Sets the item to the specified slot for the specified player */
-	void SetSlot(cPlayer & a_Player, int a_SlotNum, const cItem & a_Item);
+	void SetSlot(cPlayer & a_Player, std::size_t a_SlotNum, const cItem & a_Item);
 
 	/** Returns true if the specified slot is in the Player Main Inventory slotarea */
-	bool IsSlotInPlayerMainInventory(int a_SlotNum) const;
+	bool IsSlotInPlayerMainInventory(std::size_t a_SlotNum) const;
 
 	/** Returns true if the specified slot is in the Player Hotbar slotarea */
-	bool IsSlotInPlayerHotbar(int a_SlotNum) const;
+	bool IsSlotInPlayerHotbar(std::size_t a_SlotNum) const;
 
 	/** Returns true if the specified slot is in the Player Main Inventory or Hotbar slotareas. Note that returns false for Armor. */
-	bool IsSlotInPlayerInventory(int a_SlotNum) const;
+	bool IsSlotInPlayerInventory(std::size_t a_SlotNum) const;
 
 	// tolua_end
 
@@ -117,7 +117,7 @@ public:
 	/** Handles a click event from a player */
 	virtual void Clicked(
 		cPlayer & a_Player, int a_WindowID,
-		short a_SlotNum, eClickAction a_ClickAction,
+		std::size_t a_SlotNum, eClickAction a_ClickAction,
 		const cItem & a_ClickedItem
 	);
 
@@ -127,7 +127,7 @@ public:
 	virtual bool ClosedByPlayer(cPlayer & a_Player, bool a_CanRefuse);
 
 	/** Sends the specified slot's contents to all clients of this window; the slot is specified as local in an area */
-	void BroadcastSlot(cSlotArea * a_Area, int a_LocalSlotNum);
+	void BroadcastSlot(cSlotArea * a_Area, std::size_t a_LocalSlotNum);
 
 	/** Sends the contents of the whole window to the specified client */
 	void SendWholeWindow(cClientHandle & a_Client);
@@ -157,7 +157,7 @@ public:
 	/** Called on shift-clicking to distribute the stack into other areas; Modifies a_ItemStack as it is distributed!
 	if a_ShouldApply is true, the changes are written into the slots;
 	if a_ShouldApply is false, only a_ItemStack is modified to reflect the number of fits (for fit-testing purposes) */
-	virtual void DistributeStack(cItem & a_ItemStack, int a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) = 0;
+	virtual void DistributeStack(cItem & a_ItemStack, std::size_t a_Slot, cPlayer & a_Player, cSlotArea * a_ClickedArea, bool a_ShouldApply) = 0;
 
 	/** Called from DistributeStack() to distribute the stack into a_AreasInOrder; Modifies a_ItemStack as it is distributed!
 	If a_ShouldApply is true, the changes are written into the slots;
@@ -172,7 +172,7 @@ public:
 	bool CollectItemsToHand(cItem & a_Dragging, cSlotArea & a_Area, cPlayer & a_Player, bool a_CollectFullStacks);
 
 	/** Used by cSlotAreas to send individual slots to clients, a_RelativeSlotNum is the slot number relative to a_SlotArea */
-	void SendSlot(cPlayer & a_Player, cSlotArea * a_SlotArea, int a_RelativeSlotNum);
+	void SendSlot(cPlayer & a_Player, cSlotArea * a_SlotArea, std::size_t a_RelativeSlotNum);
 
 protected:
 
@@ -197,19 +197,19 @@ protected:
 	/** Returns the correct slot area for the specified window-global SlotNum
 	Also returns the area-local SlotNum corresponding to the GlobalSlotNum
 	If the global SlotNum is out of range, returns nullptr */
-	cSlotArea * GetSlotArea(int a_GlobalSlotNum, int & a_LocalSlotNum);
+	cSlotArea * GetSlotArea(std::size_t a_GlobalSlotNum, std::size_t & a_LocalSlotNum);
 
 	/** Returns the correct slot area for the specified window-global SlotNum
 	Also returns the area-local SlotNum corresponding to the GlobalSlotNum
 	If the global SlotNum is out of range, returns nullptr.
 	Const version. */
-	const cSlotArea * GetSlotArea(int a_GlobalSlotNum, int & a_LocalSlotNum) const;
+	const cSlotArea * GetSlotArea(std::size_t a_GlobalSlotNum, std::size_t & a_LocalSlotNum) const;
 
 	/** Prepares the internal structures for inventory painting from the specified player */
 	void OnPaintBegin(cPlayer & a_Player);
 
 	/** Adds the slot to the internal structures for inventory painting by the specified player */
-	void OnPaintProgress(cPlayer & a_Player, int a_SlotNum);
+	void OnPaintProgress(cPlayer & a_Player, std::size_t);
 
 	/** Processes the entire action stored in the internal structures for inventory painting; distributes as many items as possible */
 	void OnLeftPaintEnd(cPlayer & a_Player);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2984,6 +2984,24 @@ int cWorld::GetTickRandomNumber(int a_Range)
 
 
 
+std::size_t cWorld::GetTickRandomNumber(std::size_t a_Range)
+{
+	return GetRandomProvider().RandInt(a_Range);
+}
+
+
+
+
+
+short cWorld::GetTickRandomNumber(short a_Range)
+{
+	return GetRandomProvider().RandInt(a_Range);
+}
+
+
+
+
+
 void cWorld::TabCompleteUserName(const AString & a_Text, AStringVector & a_Results)
 {
 	typedef std::pair<AString::size_type, AString> pair_t;

--- a/src/World.h
+++ b/src/World.h
@@ -879,6 +879,10 @@ public:
 	/** Returns a random number in range [0 .. a_Range]. */
 	int GetTickRandomNumber(int a_Range);
 
+	std::size_t GetTickRandomNumber(std::size_t a_Range);
+
+	short GetTickRandomNumber(short a_Range);
+
 	/** Appends all usernames starting with a_Text (case-insensitive) into Results */
 	void TabCompleteUserName(const AString & a_Text, AStringVector & a_Results);
 

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -271,13 +271,13 @@ public:
 	/** Writes an item into the writer.
 	If aSlot >= 0, adds the Slot tag.
 	The compound is named as requested (empty name by default). */
-	void AddItem(const cItem & a_Item, int a_Slot, const AString & a_CompoundName = AString())
+	void AddItem(const cItem & a_Item, std::size_t a_Slot, const AString & a_CompoundName = AString())
 	{
 		mWriter.BeginCompound(a_CompoundName);
 		mWriter.AddShort("id",         static_cast<Int16>(a_Item.m_ItemType));
 		mWriter.AddShort("Damage",     static_cast<Int16>((a_Item.m_ItemDamage)));
 		mWriter.AddByte ("Count",      static_cast<Byte>(a_Item.m_ItemCount));
-		if (a_Slot >= 0)
+		if (a_Slot != ILLEGAL_SLOT_NUMBER)
 		{
 			mWriter.AddByte ("Slot", static_cast<unsigned char>(a_Slot));
 		}
@@ -341,10 +341,9 @@ public:
 	/** Writes an item grid into the writer.
 	Begins the stored slot numbers with a_BeginSlotNum.
 	Note that it doesn't begin nor end the list tag, so that multiple grids may be concatenated together using this function. */
-	void AddItemGrid(const cItemGrid & a_Grid, int a_BeginSlotNum = 0)
+	void AddItemGrid(const cItemGrid & a_Grid, std::size_t a_BeginSlotNum = 0)
 	{
-		int NumSlots = a_Grid.OldGetNumSlots();
-		for (int i = 0; i < NumSlots; i++)
+		for (std::size_t i = 0; i < a_Grid.GetNumSlots(); i++)
 		{
 			const cItem & Item = a_Grid.GetSlot(i);
 			if (Item.IsEmpty())
@@ -1017,8 +1016,8 @@ public:
 	{
 		mWriter.BeginCompound("");
 			AddBasicEntity(a_Pickup, "Item");
-			AddItem(a_Pickup->GetItem(), -1, "Item");
-			mWriter.AddShort("Age",    static_cast<Int16>(a_Pickup->GetAge()));
+			AddItem(a_Pickup->GetItem(), ILLEGAL_SLOT_NUMBER, "Item");
+			mWriter.AddShort("Age", static_cast<Int16>(a_Pickup->GetAge()));
 		mWriter.EndCompound();
 	}
 
@@ -1127,7 +1126,7 @@ public:
 		mWriter.BeginCompound("");
 			AddBasicEntity(a_ItemFrame, "ItemFrame");
 			AddHangingEntity(a_ItemFrame);
-			AddItem(a_ItemFrame->GetItem(), -1, "Item");
+			AddItem(a_ItemFrame->GetItem(), ILLEGAL_SLOT_NUMBER, "Item");
 			mWriter.AddByte("ItemRotation", static_cast<Byte>(a_ItemFrame->GetItemRotation()));
 			mWriter.AddFloat("ItemDropChance", 1.0F);
 		mWriter.EndCompound();
@@ -1165,7 +1164,7 @@ public:
 	void AddMinecartChestContents(cMinecartWithChest * a_Minecart)
 	{
 		mWriter.BeginList("Items", TAG_Compound);
-			for (int i = 0; i < cMinecartWithChest::ContentsHeight * cMinecartWithChest::ContentsWidth; i++)
+			for (std::size_t i = 0; i < cMinecartWithChest::ContentsHeight * cMinecartWithChest::ContentsWidth; i++)
 			{
 				const cItem & Item = a_Minecart->GetSlot(i);
 				if (Item.IsEmpty())

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -343,7 +343,7 @@ public:
 	Note that it doesn't begin nor end the list tag, so that multiple grids may be concatenated together using this function. */
 	void AddItemGrid(const cItemGrid & a_Grid, int a_BeginSlotNum = 0)
 	{
-		int NumSlots = a_Grid.GetNumSlots();
+		int NumSlots = a_Grid.OldGetNumSlots();
 		for (int i = 0; i < NumSlots; i++)
 		{
 			const cItem & Item = a_Grid.GetSlot(i);

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -789,7 +789,7 @@ bool cWSSAnvil::LoadItemFromNBT(cItem & a_Item, const cParsedNBT & a_NBT, int a_
 
 void cWSSAnvil::LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a_NBT, int a_ItemsTagIdx, int a_SlotOffset)
 {
-	int NumSlots = a_ItemGrid.GetNumSlots();
+	int NumSlots = a_ItemGrid.OldGetNumSlots();
 	for (int Child = a_NBT.GetFirstChild(a_ItemsTagIdx); Child != -1; Child = a_NBT.GetNextSibling(Child))
 	{
 		int SlotTag = a_NBT.FindChildByName(Child, "Slot");

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -787,9 +787,9 @@ bool cWSSAnvil::LoadItemFromNBT(cItem & a_Item, const cParsedNBT & a_NBT, int a_
 
 
 
-void cWSSAnvil::LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a_NBT, int a_ItemsTagIdx, int a_SlotOffset)
+void cWSSAnvil::LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a_NBT, int a_ItemsTagIdx, std::size_t a_SlotOffset)
 {
-	int NumSlots = a_ItemGrid.OldGetNumSlots();
+	auto NumSlots = a_ItemGrid.GetNumSlots();
 	for (int Child = a_NBT.GetFirstChild(a_ItemsTagIdx); Child != -1; Child = a_NBT.GetNextSibling(Child))
 	{
 		int SlotTag = a_NBT.FindChildByName(Child, "Slot");
@@ -797,8 +797,8 @@ void cWSSAnvil::LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a
 		{
 			continue;
 		}
-		int SlotNum = static_cast<int>(a_NBT.GetByte(SlotTag)) - a_SlotOffset;
-		if ((SlotNum < 0) || (SlotNum >= NumSlots))
+		auto SlotNum = static_cast<std::size_t>(a_NBT.GetByte(SlotTag)) - a_SlotOffset;
+		if (SlotNum >= NumSlots)
 		{
 			// SlotNum outside of the range
 			continue;

--- a/src/WorldStorage/WSSAnvil.h
+++ b/src/WorldStorage/WSSAnvil.h
@@ -145,7 +145,7 @@ protected:
 	/** Loads contentents of an Items[] list tag into a cItemGrid
 	ItemGrid begins at the specified slot offset
 	Slots outside the ItemGrid range are ignored */
-	void LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a_NBT, int a_ItemsTagIdx, int s_SlotOffset = 0);
+	void LoadItemGridFromNBT(cItemGrid & a_ItemGrid, const cParsedNBT & a_NBT, int a_ItemsTagIdx, std::size_t s_SlotOffset = 0);
 
 	/** Decodes the text contained within a sign.
 	Older versions used direct string representation, newer versions use JSON-formatted string.

--- a/tests/Generating/Stubs.cpp
+++ b/tests/Generating/Stubs.cpp
@@ -339,7 +339,7 @@ bool cFireSimulator::DoesBurnForever(BLOCKTYPE a_BlockType)
 
 
 
-void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, size_t a_CountLootProbabs, int a_NumSlots, int a_Seed)
+void cItemGrid::GenerateRandomLootWithBooks(const cLootProbab * a_LootProbabs, size_t a_CountLootProbabs, std::size_t a_NumSlots, int a_Seed)
 {
 }
 


### PR DESCRIPTION
Well that escalated quickly. 

This PR takes over #4979. And changes cItemGrid completely to use `std::size_t` to index everything. Since -1 was used to indicate illegal slot stuff, the best alternative seems `std::numeric_limits<std::size_t>::max()`

