### PR TITLE
Small Team Creation Fixes

### DIFF
--- a/Server/Plugins/APIDump/APIDesc.lua
+++ b/Server/Plugins/APIDump/APIDesc.lua
@@ -12292,7 +12292,7 @@ end
 							Type = "cTeam",
 						},
 					},
-					Notes = "Registers a new team. Returns the {{cTeam}} instance, nil on error.",
+					Notes = "Registers a new team. Returns the {{cTeam}} instance, nil on error. For example if the team already exists.",
 				},
 				RemoveObjective =
 				{

--- a/src/Scoreboard.cpp
+++ b/src/Scoreboard.cpp
@@ -361,11 +361,15 @@ cTeam * cScoreboard::RegisterTeam(
 	const AString & a_Prefix, const AString & a_Suffix
 )
 {
-	cTeam Team(a_Name, a_DisplayName, a_Prefix, a_Suffix);
+	auto [TeamIterator, TeamExists] = m_Teams.try_emplace(a_Name, a_Name, a_DisplayName, a_Prefix, a_Suffix);
 
-	std::pair<cTeamMap::iterator, bool> Status = m_Teams.insert(cNamedTeam(a_Name, Team));
+	if (!TeamExists && GetTeam(a_Name))
+	{
+		LOGWARNING("Tried to register a team that already exists: %s", a_Name.c_str());
+		return nullptr;
+	}
 
-	return Status.second ? &Status.first->second : nullptr;
+	return &TeamIterator->second;
 }
 
 


### PR DESCRIPTION
- Add additional explanation for team creation
- error message if team creation fails because team already exists

fixes #5466