### PR TITLE
refactor: removed m_MojangAPI from RankManager

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -78,6 +78,7 @@ Seadragon91 (Lukas Pioch)
 Sofapriester
 Spekdrum (Pablo Beltran)
 SphinxC0re
+steve-nzr
 structinf (xdot)
 sweetgiorni
 Sxw1212

--- a/src/RankManager.cpp
+++ b/src/RankManager.cpp
@@ -17,8 +17,7 @@
 
 cRankManager::cRankManager(void) :
 	m_DB("Ranks.sqlite", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE),
-	m_IsInitialized(false),
-	m_MojangAPI(nullptr)
+	m_IsInitialized(false)
 {
 }
 
@@ -28,10 +27,6 @@ cRankManager::cRankManager(void) :
 
 cRankManager::~cRankManager()
 {
-	if (m_MojangAPI != nullptr)
-	{
-		m_MojangAPI->SetRankManager(nullptr);
-	}
 }
 
 

--- a/src/RankManager.h
+++ b/src/RankManager.h
@@ -273,11 +273,6 @@ protected:
 	/** Set to true once the manager is initialized. */
 	bool m_IsInitialized;
 
-	/** The MojangAPI instance that is used for keeping player names and UUIDs in sync.
-	Set in Initialize(), may be nullptr. */
-	cMojangAPI * m_MojangAPI;
-
-
 	/** Returns true if all the DB tables are empty, indicating a fresh new install. */
 	bool AreDBTablesEmpty(void);
 


### PR DESCRIPTION
Hello, new to Cuberite here and first contribution.

## Description

I found that the m_MojangAPI pointer in cRankManager was never initialized, this pointer stays null during the whole program execution. It could be initialized by using the address of the referenced of it passed in the Initialize method, however this sounds bad it term of ownership & lifecycle and could lead to crashes.

## Test

This refactor was tested by compiling the program and running basic operations such as connecting/disconnecting from the game, and closing the server.