### PR TITLE
Fix minecart and rail bugs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -99,3 +99,4 @@ worktycho
 Xenoxis
 xoft (Mattes Dolak/madmaxoft on GH)
 Yeeeeezus (Donated AlchemistVillage prefabs)
+dyexlzc

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ derouinw
 dImrich (Damian Imrich)
 Diusrex
 Duralex
+dyexlzc
 Earboxer (Zach DeCook)
 FakeTruth (founder)
 feyokorenhof
@@ -99,4 +100,3 @@ worktycho
 Xenoxis
 xoft (Mattes Dolak/madmaxoft on GH)
 Yeeeeezus (Donated AlchemistVillage prefabs)
-dyexlzc

--- a/src/BlockType.cpp
+++ b/src/BlockType.cpp
@@ -260,7 +260,7 @@ AString ItemTypeToString(short a_ItemType)
 
 AString ItemToFullString(const cItem & a_Item)
 {
-	return fmt::format(FMT_STRING("{}:{:d} * {:d}"), ItemToString(a_Item), a_Item.m_ItemDamage, a_Item.m_ItemCount);
+	return fmt::format(FMT_STRING("{}:{} * {:d}"), ItemToString(a_Item), a_Item.m_ItemDamage, a_Item.m_ItemCount);
 }
 
 

--- a/src/BlockType.cpp
+++ b/src/BlockType.cpp
@@ -260,7 +260,7 @@ AString ItemTypeToString(short a_ItemType)
 
 AString ItemToFullString(const cItem & a_Item)
 {
-	return fmt::format(FMT_STRING("{}:{} * {}"), ItemToString(a_Item), a_Item.m_ItemDamage, a_Item.m_ItemCount);
+	return fmt::format(FMT_STRING("{}:{:d} * {:d}"), ItemToString(a_Item), a_Item.m_ItemDamage, a_Item.m_ItemCount);
 }
 
 

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -514,7 +514,8 @@ void cChunk::WriteBlockArea(cBlockArea & a_Area, int a_MinBlockX, int a_MinBlock
 
 			// This block entity is inside the chunk.
 			// The code above should have removed any that were here before:
-			ASSERT(GetBlockEntityRel(cChunkDef::AbsoluteToRelative({ posX, posY, posZ })) == nullptr);
+			Vector3i pos = { posX, posY, posZ };
+			ASSERT(GetBlockEntityRel(cChunkDef::AbsoluteToRelative(pos)) == nullptr);
 
 			// Clone, and add the new one:
 			AddBlockEntity(be->Clone({posX, posY, posZ}));

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -162,13 +162,11 @@ public:
 		return AbsoluteToRelative(a_BlockPosition, chunkPos);
 	}
 
-	inline static Vector3i AbsoluteToRelative(const Vector3d& a_BlockPosition)
+	inline static Vector3i AbsoluteToRelative(const Vector3d & a_BlockPosition)
 	{
-		//pos need floor, then call vec3i overload func
-		//if use default double -> int, will cast -1.xx -> -1(actually need to be -2)
-		Vector3i iPosVec = {int(floor(a_BlockPosition.x)),
-							int(a_BlockPosition.y),
-							int(floor(a_BlockPosition.z))};
+		// pos need floor, then call vec3i overload func
+		// if use default double -> int, will cast -1.xx -> -1(actually need to be -2)
+		Vector3i iPosVec = {int(floor(a_BlockPosition.x)), int(a_BlockPosition.y), int(floor(a_BlockPosition.z))};
 		return AbsoluteToRelative(iPosVec);
 	}
 

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -162,6 +162,16 @@ public:
 		return AbsoluteToRelative(a_BlockPosition, chunkPos);
 	}
 
+	inline static Vector3i AbsoluteToRelative(const Vector3d& a_BlockPosition)
+	{
+		//pos need floor, then call vec3i overload func
+		//if use default double -> int, will cast -1.xx -> -1(actually need to be -2)
+		Vector3i iPosVec = {int(floor(a_BlockPosition.x)),
+							int(a_BlockPosition.y),
+							int(floor(a_BlockPosition.z))};
+		return AbsoluteToRelative(iPosVec);
+	}
+
 
 	/** Converts the absolute coords into coords relative to the specified chunk. */
 	inline static Vector3i AbsoluteToRelative(Vector3i a_BlockPosition, cChunkCoords a_ChunkPos)

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -166,8 +166,7 @@ public:
 	{
 		// pos need floor, then call vec3i overload func
 		// if use default double -> int, will cast -1.xx -> -1(actually need to be -2)
-		Vector3i iPosVec = {int(floor(a_BlockPosition.x)), int(a_BlockPosition.y), int(floor(a_BlockPosition.z))};
-		return AbsoluteToRelative(iPosVec);
+		return AbsoluteToRelative(a_BlockPosition.Floor());
 	}
 
 

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1286,21 +1286,27 @@ void cMinecart::OnRemoveFromWorld(cWorld & a_World)
 	Super::OnRemoveFromWorld(a_World);
 }
 
+
+
+
+
 void cMinecart::HandleSpeedFromAttachee(float a_Forward, float a_Sideways)
 {
-	if (GetSpeed().Length() > 4) // limit normal minecar speed max lower than 4
+	// limit normal minecar speed max lower than 4
+	if (GetSpeed().Length() > 4)
 	{
 		return;
 	}
 	Vector3d LookVector = m_Attachee->GetLookVector();
-	//judge different railway, add different direct speed.
-	//minecart ignore a_Sideways
+	// judge different railway, add different direct speed.
+	// minecart ignore a_Sideways
 	auto relPos = cChunkDef::AbsoluteToRelative(GetPosition());
 
 	Vector3d ToAddSpeed = LookVector * (a_Forward * 0.4) ;
 	ToAddSpeed.y = 0;
 	AddSpeed(ToAddSpeed);
 }
+
 
 
 

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -1298,10 +1298,6 @@ void cMinecart::HandleSpeedFromAttachee(float a_Forward, float a_Sideways)
 		return;
 	}
 	Vector3d LookVector = m_Attachee->GetLookVector();
-	// judge different railway, add different direct speed.
-	// minecart ignore a_Sideways
-	auto relPos = cChunkDef::AbsoluteToRelative(GetPosition());
-
 	Vector3d ToAddSpeed = LookVector * (a_Forward * 0.4) ;
 	ToAddSpeed.y = 0;
 	AddSpeed(ToAddSpeed);

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -167,7 +167,9 @@ void cMinecart::HandlePhysics(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		return;
 	}
 
-	auto relPos = cChunkDef::AbsoluteToRelative(GetPosition());
+	auto pos = GetPosition();
+	auto relPos = cChunkDef::AbsoluteToRelative(pos);
+
 	auto chunk = a_Chunk.GetRelNeighborChunkAdjustCoords(relPos);
 	if (chunk == nullptr)
 	{
@@ -270,8 +272,8 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		{
 			SetYaw(270);
 			SetPosY(floor(GetPosY()) + 0.55);
-			SetSpeedY(0);  // Don't move vertically as on ground
-			SetSpeedX(0);  // Correct diagonal movement from curved rails
+			SetSpeedY(NO_SPEED);  // Don't move vertically as on ground
+			SetSpeedX(NO_SPEED);  // Correct diagonal movement from curved rails
 
 			// Execute both the entity and block collision checks
 			auto BlckCol = TestBlockCollision(a_RailMeta);
@@ -328,7 +330,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		case E_META_RAIL_ASCEND_ZM:  // ASCEND NORTH
 		{
 			SetYaw(270);
-			SetSpeedX(0);
+			SetSpeedX(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
 			auto EntCol = TestEntityCollision(a_RailMeta);
@@ -355,7 +357,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		case E_META_RAIL_ASCEND_ZP:  // ASCEND SOUTH
 		{
 			SetYaw(270);
-			SetSpeedX(0);
+			SetSpeedX(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
 			auto EntCol = TestEntityCollision(a_RailMeta);
@@ -407,7 +409,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		case E_META_RAIL_ASCEND_XP:  // ASCEND WEST
 		{
 			SetYaw(180);
-			SetSpeedZ(0);
+			SetSpeedZ(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
 			auto EntCol = TestEntityCollision(a_RailMeta);
@@ -433,7 +435,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		{
 			SetYaw(315);  // Set correct rotation server side
 			SetPosY(floor(GetPosY()) + 0.55);  // Levitate dat cart
-			SetSpeedY(0);
+			SetSpeedY(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
 			auto EntCol = TestEntityCollision(a_RailMeta);
@@ -450,7 +452,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		{
 			SetYaw(225);
 			SetPosY(floor(GetPosY()) + 0.55);
-			SetSpeedY(0);
+			SetSpeedY(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
 			auto EntCol = TestEntityCollision(a_RailMeta);
@@ -465,7 +467,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		{
 			SetYaw(135);
 			SetPosY(floor(GetPosY()) + 0.55);
-			SetSpeedY(0);
+			SetSpeedY(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
 			auto EntCol = TestEntityCollision(a_RailMeta);
@@ -480,7 +482,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		{
 			SetYaw(45);
 			SetPosY(floor(GetPosY()) + 0.55);
-			SetSpeedY(0);
+			SetSpeedY(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
 			auto EntCol = TestEntityCollision(a_RailMeta);
@@ -1093,7 +1095,7 @@ bool cMinecart::TestEntityCollision(NIBBLETYPE a_RailMeta)
 	cBoundingBox bbMinecart(Vector3d(MinecartPosition.x, floor(MinecartPosition.y), MinecartPosition.z), GetWidth() / 2, GetHeight());
 	m_World->ForEachEntityInBox(bbMinecart, MinecartAttachCallback);
 
-	switch (a_RailMeta)
+	switch (a_RailMeta & 0x07)
 	{
 		case E_META_RAIL_ZM_ZP:
 		{
@@ -1284,6 +1286,21 @@ void cMinecart::OnRemoveFromWorld(cWorld & a_World)
 	Super::OnRemoveFromWorld(a_World);
 }
 
+void cMinecart::HandleSpeedFromAttachee(float a_Forward, float a_Sideways)
+{
+	if (GetSpeed().Length() > 4) // limit normal minecar speed max lower than 4
+	{
+		return;
+	}
+	Vector3d LookVector = m_Attachee->GetLookVector();
+	//judge different railway, add different direct speed.
+	//minecart ignore a_Sideways
+	auto relPos = cChunkDef::AbsoluteToRelative(GetPosition());
+
+	Vector3d ToAddSpeed = LookVector * (a_Forward * 0.4) ;
+	ToAddSpeed.y = 0;
+	AddSpeed(ToAddSpeed);
+}
 
 
 

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -506,8 +506,8 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 	// If the rail is powered set to speed up else slow down.
 	const bool IsRailPowered = ((a_RailMeta & 0x8) == 0x8);
 	const double Acceleration = IsRailPowered ? 1.0 : -2.0;
-
-	switch (a_RailMeta & 0x07)
+	NIBBLETYPE PoweredRailMeta = a_RailMeta & 0x7;
+	switch (PoweredRailMeta)
 	{
 		case E_META_RAIL_ZM_ZP:  // NORTHSOUTH
 		{
@@ -516,7 +516,7 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 			SetSpeedY(0);
 			SetSpeedX(0);
 
-			bool BlckCol = TestBlockCollision(a_RailMeta), EntCol = TestEntityCollision(a_RailMeta);
+			bool BlckCol = TestBlockCollision(PoweredRailMeta), EntCol = TestEntityCollision(PoweredRailMeta);
 			if (EntCol || BlckCol)
 			{
 				return;
@@ -557,7 +557,7 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 			SetSpeedY(NO_SPEED);
 			SetSpeedZ(NO_SPEED);
 
-			bool BlckCol = TestBlockCollision(a_RailMeta), EntCol = TestEntityCollision(a_RailMeta);
+			bool BlckCol = TestBlockCollision(PoweredRailMeta), EntCol = TestEntityCollision(PoweredRailMeta);
 			if (EntCol || BlckCol)
 			{
 				return;
@@ -1292,7 +1292,8 @@ void cMinecart::OnRemoveFromWorld(cWorld & a_World)
 
 void cMinecart::HandleSpeedFromAttachee(float a_Forward, float a_Sideways)
 {
-	// limit normal minecar speed max lower than 4
+	// limit normal minecart speed max lower than 4
+	// once speed is higher than 4, no more add speed.
 	if (GetSpeed().Length() > 4)
 	{
 		return;

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -42,7 +42,7 @@ public:
 	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
 	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;
-
+	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways) override;
 	int LastDamage(void) const { return m_LastDamage; }
 	ePayload GetPayload(void) const { return m_Payload; }
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -4164,7 +4164,7 @@ void cProtocol_1_8_0::HandlePacket(cByteBuffer & a_Buffer)
 			PacketType, a_Buffer.GetUsedSpace(), m_State, PacketDataHex
 		));
 	}
-	//LOGD("PacketType:%d", PacketType);
+
 	if (!HandlePacket(a_Buffer, PacketType))
 	{
 		// Unknown packet, already been reported, but without the length. Log the length here:

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -4164,7 +4164,7 @@ void cProtocol_1_8_0::HandlePacket(cByteBuffer & a_Buffer)
 			PacketType, a_Buffer.GetUsedSpace(), m_State, PacketDataHex
 		));
 	}
-
+	//LOGD("PacketType:%d", PacketType);
 	if (!HandlePacket(a_Buffer, PacketType))
 	{
 		// Unknown packet, already been reported, but without the length. Log the length here:

--- a/src/Resources/Cuberite.rc
+++ b/src/Resources/Cuberite.rc
@@ -6,7 +6,7 @@ STRINGTABLE
 	LANGUAGE LANG_CHINESE_SIMPLIFIED, SUBLANG_CHINESE_SIMPLIFIED
 BEGIN
 	1 "Cuberite"
-	2 "ä¸€ä¸ªè½»å·§ã€å¿«é€Ÿã€å¯æ‰©å±•çš„Minecraftfæ¸¸æˆæœåŠ¡å™¨"
+	2 "Ò»¸öÇáÇÉ¡¢¿ìËÙ¡¢¿ÉÀ©Õ¹µÄMinecraftfÓÎÏ··şÎñÆ÷"
 END
 
 STRINGTABLE
@@ -70,7 +70,7 @@ BEGIN
 	BEGIN
 		BLOCK "080404B0"
 		BEGIN
-			VALUE "CompanyName", "Cuberite ä½œè€…"
+			VALUE "CompanyName", "Cuberite ×÷Õß"
 			VALUE "FileDescription", "Cuberite"
 			VALUE "FileVersion", VERSION_STRING
 			VALUE "InternalName", INTERNAL_NAME

--- a/src/Simulator/SimulatorManager.cpp
+++ b/src/Simulator/SimulatorManager.cpp
@@ -134,7 +134,8 @@ void cSimulatorManager::WakeUp(const cCuboid & a_Area)
 						{
 							for (int x = startX; x <= endX; ++x)
 							{
-								const auto Position = cChunkDef::AbsoluteToRelative({ x, y, z });
+								Vector3i vec = { x, y, z };
+								const auto Position = cChunkDef::AbsoluteToRelative(vec);
 								Simulator->WakeUp(a_CBChunk, Position, a_CBChunk.GetBlock(Position));
 							}  // for x
 						}  // for z


### PR DESCRIPTION
bug描述：
1.矿车速度过慢，原因：矿车并未添加HandleSpeedFromAttachee重载函数
2.x方向的铁轨无法运行，原因：坐标系转换错误，浮点坐标从double -> int丢失了浮点位。但实际上应该是需要向下取整。例如-1.5转换为整型为-1，但实际上应该取为-2

现在，矿车能够正确的被动力铁轨和普通铁轨激活以及运行了。
——————————————
bug description:
1. The speed of the minecart is too slow, the reason: the minecart has not added the HandleSpeedFromAttachee overload function
2. The rails in the x direction cannot run, the reason: the coordinate system conversion is wrong, and the floating point coordinates lose the floating point bit from double -> int. But in fact it should be rounded down. For example, -1.5 is converted to an integer as -1, but it should be taken as -2