### PR TITLE
Fix empty chunk serializer for protocol 47 (Minecraft 1.8)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -76,6 +76,7 @@ rs2k
 SamJBarney
 Schwertspize
 Seadragon91 (Lukas Pioch)
+sleirsgoevy (Sergey Lisov)
 Sofapriester
 Spekdrum (Pablo Beltran)
 SphinxC0re


### PR DESCRIPTION
This version of Minecraft does not like chunks that have their section bitmap set to 0 (meaning that the chunk is completely empty/filled with air). When sendings such chunks, at least 1 empty section should be sent.

Although such missing chunks do render as empty, not having them properly loaded causes various bugs, such as the "slow falling" of the player and missing block textures if any blocks get placed there later on.