### PR TITLE
Fixed a wrong format string.

### DIFF
--- a/src/BlockType.cpp
+++ b/src/BlockType.cpp
@@ -260,7 +260,7 @@ AString ItemTypeToString(short a_ItemType)
 
 AString ItemToFullString(const cItem & a_Item)
 {
-	return fmt::format(FMT_STRING("{}:{} * {}"), ItemToString(a_Item), a_Item.m_ItemDamage, a_Item.m_ItemCount);
+	return fmt::format(FMT_STRING("{}:{} * {:d}"), ItemToString(a_Item), a_Item.m_ItemDamage, a_Item.m_ItemCount);
 }
 
 


### PR DESCRIPTION
The `m_ItemCount` is a `char`, so it was default-printed as a character, not a number. This seems to be the only instance of the problem.

Thanks to @dyexlzc for noticing. 