### PR TITLE
fix minecart bugs.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ derouinw
 dImrich (Damian Imrich)
 Diusrex
 Duralex
+dyexlzc
 Earboxer (Zach DeCook)
 FakeTruth (founder)
 feyokorenhof

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -19,9 +19,12 @@
 #define NO_SPEED 0.0
 #define MAX_SPEED 8
 #define MAX_SPEED_NEGATIVE -MAX_SPEED
-
-
-
+#define DIR_NORTH_SOUTH 270
+#define DIR_EAST_WEST 180
+#define DIR_NORTH_WEST 315
+#define DIR_NORTH_EAST 225
+#define DIR_SOUTH_WEST 135
+#define DIR_SOUTH_EAST 45
 
 class cMinecartAttachCallback
 {
@@ -271,7 +274,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 	{
 		case E_META_RAIL_ZM_ZP:  // NORTHSOUTH
 		{
-			SetYaw(270);
+			SetYaw(DIR_NORTH_SOUTH);
 			SetPosY(floor(GetPosY()) + 0.55);
 			SetSpeedY(NO_SPEED);  // Don't move vertically as on ground
 			SetSpeedX(NO_SPEED);  // Correct diagonal movement from curved rails
@@ -302,7 +305,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_XM_XP:  // EASTWEST
 		{
-			SetYaw(180);
+			SetYaw(DIR_EAST_WEST);
 			SetPosY(floor(GetPosY()) + 0.55);
 			SetSpeedY(NO_SPEED);
 			SetSpeedZ(NO_SPEED);
@@ -330,7 +333,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_ASCEND_ZM:  // ASCEND NORTH
 		{
-			SetYaw(270);
+			SetYaw(DIR_NORTH_SOUTH);
 			SetSpeedX(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
@@ -357,7 +360,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_ASCEND_ZP:  // ASCEND SOUTH
 		{
-			SetYaw(270);
+			SetYaw(DIR_NORTH_SOUTH);
 			SetSpeedX(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
@@ -384,7 +387,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_ASCEND_XM:  // ASCEND EAST
 		{
-			SetYaw(180);
+			SetYaw(DIR_EAST_WEST);
 			SetSpeedZ(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
@@ -409,7 +412,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_ASCEND_XP:  // ASCEND WEST
 		{
-			SetYaw(180);
+			SetYaw(DIR_EAST_WEST);
 			SetSpeedZ(NO_SPEED);
 
 			auto BlckCol = TestBlockCollision(a_RailMeta);
@@ -434,7 +437,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_CURVED_ZM_XM:  // Ends pointing NORTH and WEST
 		{
-			SetYaw(315);  // Set correct rotation server side
+			SetYaw(DIR_NORTH_WEST);  // Set correct rotation server side
 			SetPosY(floor(GetPosY()) + 0.55);  // Levitate dat cart
 			SetSpeedY(NO_SPEED);
 
@@ -451,7 +454,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_CURVED_ZM_XP:  // Curved NORTH EAST
 		{
-			SetYaw(225);
+			SetYaw(DIR_NORTH_EAST);
 			SetPosY(floor(GetPosY()) + 0.55);
 			SetSpeedY(NO_SPEED);
 
@@ -466,7 +469,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_CURVED_ZP_XM:  // Curved SOUTH WEST
 		{
-			SetYaw(135);
+			SetYaw(DIR_SOUTH_WEST);
 			SetPosY(floor(GetPosY()) + 0.55);
 			SetSpeedY(NO_SPEED);
 
@@ -481,7 +484,7 @@ void cMinecart::HandleRailPhysics(NIBBLETYPE a_RailMeta, std::chrono::millisecon
 		}
 		case E_META_RAIL_CURVED_ZP_XP:  // Curved SOUTH EAST
 		{
-			SetYaw(45);
+			SetYaw(DIR_SOUTH_EAST);
 			SetPosY(floor(GetPosY()) + 0.55);
 			SetSpeedY(NO_SPEED);
 
@@ -507,12 +510,13 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 	// If the rail is powered set to speed up else slow down.
 	const bool IsRailPowered = ((a_RailMeta & 0x8) == 0x8);
 	const double Acceleration = IsRailPowered ? 1.0 : -2.0;
+	// PoweredRail only has 5 status in low 3bit. so we need do a logical and to get correct powered rail meta data.
 	NIBBLETYPE PoweredRailMeta = a_RailMeta & 0x7;
 	switch (PoweredRailMeta)
 	{
 		case E_META_RAIL_ZM_ZP:  // NORTHSOUTH
 		{
-			SetYaw(270);
+			SetYaw(DIR_NORTH_SOUTH);
 			SetPosY(floor(GetPosY()) + 0.55);
 			SetSpeedY(0);
 			SetSpeedX(0);
@@ -553,7 +557,7 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 		}
 		case E_META_RAIL_XM_XP:  // EASTWEST
 		{
-			SetYaw(180);
+			SetYaw(DIR_EAST_WEST);
 			SetPosY(floor(GetPosY()) + 0.55);
 			SetSpeedY(NO_SPEED);
 			SetSpeedZ(NO_SPEED);
@@ -594,7 +598,7 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 		}
 		case E_META_RAIL_ASCEND_XM:  // ASCEND EAST
 		{
-			SetYaw(180);
+			SetYaw(DIR_EAST_WEST);
 			SetSpeedZ(NO_SPEED);
 
 			if (GetSpeedX() >= NO_SPEED)
@@ -611,7 +615,7 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 		}
 		case E_META_RAIL_ASCEND_XP:  // ASCEND WEST
 		{
-			SetYaw(180);
+			SetYaw(DIR_EAST_WEST);
 			SetSpeedZ(NO_SPEED);
 
 			if (GetSpeedX() > NO_SPEED)
@@ -628,7 +632,7 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 		}
 		case E_META_RAIL_ASCEND_ZM:  // ASCEND NORTH
 		{
-			SetYaw(270);
+			SetYaw(DIR_NORTH_SOUTH);
 			SetSpeedX(NO_SPEED);
 
 			if (GetSpeedZ() >= NO_SPEED)
@@ -645,7 +649,7 @@ void cMinecart::HandlePoweredRailPhysics(NIBBLETYPE a_RailMeta)
 		}
 		case E_META_RAIL_ASCEND_ZP:  // ASCEND SOUTH
 		{
-			SetYaw(270);
+			SetYaw(DIR_NORTH_SOUTH);
 			SetSpeedX(NO_SPEED);
 
 			if (GetSpeedZ() > NO_SPEED)

--- a/src/Entities/Minecart.h
+++ b/src/Entities/Minecart.h
@@ -42,7 +42,7 @@ public:
 	virtual bool DoTakeDamage(TakeDamageInfo & TDI) override;
 	virtual void KilledBy(TakeDamageInfo & a_TDI) override;
 	virtual void OnRemoveFromWorld(cWorld & a_World) override;
-
+	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways) override;
 	int LastDamage(void) const { return m_LastDamage; }
 	ePayload GetPayload(void) const { return m_Payload; }
 


### PR DESCRIPTION
re-pull for https://github.com/cuberite/cuberite/pull/5513

bug描述：
1.矿车速度过慢，原因：矿车并未添加HandleSpeedFromAttachee重载函数
2.x方向的铁轨无法运行，原因：坐标系转换错误，浮点坐标从double -> int丢失了浮点位。但实际上应该是需要向下取整。例如-1.5转换为整型为-1，但实际上应该取为-2

现在，矿车能够正确的被动力铁轨和普通铁轨激活以及运行了。
——————————————
bug description:

The speed of the minecart is too slow, the reason: the minecart has not added the HandleSpeedFromAttachee overload function
The rails in the x direction cannot run, the reason: the coordinate system conversion is wrong, and the floating point coordinates lose the floating point bit from double -> int. But in fact it should be rounded down. For example, -1.5 is converted to an integer as -1, but it should be taken as -2