### PR TITLE
Fix tools build on FreeBSD

### DIFF
--- a/src/Globals.h
+++ b/src/Globals.h
@@ -97,6 +97,8 @@
 	#define PLATFORM_CRYPTOGRAPHY 0
 
 	#include <arpa/inet.h>
+	#include <netinet/in.h>
+	#include <sys/socket.h>
 	#include <unistd.h>
 #endif
 


### PR DESCRIPTION
Regession from #5085

```
[ 79%] Building CXX object Tools/ProtoProxy/CMakeFiles/ProtoProxy.dir/Connection.cpp.o
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:337:26: error: use of undeclared identifier 'AF_INET'
        m_ServerSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
                                ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:337:35: error: use of undeclared identifier 'SOCK_STREAM'
        m_ServerSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
                                         ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:337:48: error: use of undeclared identifier 'IPPROTO_TCP'
        m_ServerSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
                                                      ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:342:2: error: unknown type name 'sockaddr_in'
        sockaddr_in localhost;
        ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:343:25: error: use of undeclared identifier 'AF_INET'
        localhost.sin_family = AF_INET;
                               ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:346:53: error: unknown type name 'sockaddr'
        if (connect(m_ServerSocket, reinterpret_cast<const sockaddr *>(&localhost), sizeof(localhost)) != 0)
                                                           ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:362:29: error: use of undeclared identifier 'recv'
        int res = static_cast<int>(recv(m_ServerSocket, Buffer, sizeof(Buffer), 0));  // recv returns int on windows, ssize_t on linux
                                   ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:402:29: error: use of undeclared identifier 'recv'
        int res = static_cast<int>(recv(m_ClientSocket, Buffer, sizeof(Buffer), 0));  // recv returns int on Windows, ssize_t on Linux
                                   ^
/home/bond/dev/cuberite/Tools/ProtoProxy/Connection.cpp:451:29: error: use of undeclared identifier 'send'
        int res = static_cast<int>(send(a_Socket, reinterpret_cast<const char *>(a_Data.data()), a_Data.size(), 0));  // Windows uses int for a_Size, Linux uses size_t; but Windows doesn't complain. Return type is int on Windows and ssize_t on Linux
                                   ^
[ 79%] Building CXX object CMakeFiles/Cuberite.dir/Unity/unity_38_cxx.cxx.o
9 errors generated.
```