### PR TITLE
Fix player respawn for 1.8 clients

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -982,6 +982,13 @@ void cPlayer::Respawn(void)
 		TeleportToCoords(m_RespawnPosition.x, m_RespawnPosition.y, m_RespawnPosition.z);
 	}
 
+	// The Notchian client enters a weird glitched state when trying to "resurrect" dead players
+	// To prevent that, destroy the existing client-side entity, and create a new one with the same ID
+	// This does not make any difference to more modern clients
+	m_World->BroadcastDestroyEntity(*this, &*m_ClientHandle);
+	m_World->BroadcastSpawnEntity(*this, &*m_ClientHandle);
+
+
 	SetVisible(true);
 }
 


### PR DESCRIPTION
1.8 clients seem to dislike "resurrecting" a dead player entity, doing so results in the player entering a glitched state where its nickname is displayed on the feet and they can't be attacked by melee. Destroying and recreating the client-side entity at respawn time seems to fix the glitch, and does not seem to affect more modern clients.