### PR TITLE
Enable build under clang-16.

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -202,5 +202,11 @@ function(set_exe_flags TARGET)
 				-Wno-reserved-identifier
 			)
 		endif()
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+			target_compile_options(
+				${TARGET} PRIVATE
+				-Wno-unsafe-buffer-usage
+			)
+		endif()
 	endif()
 endfunction()


### PR DESCRIPTION
This enables Cuberite to be built out-of-the-box on FreeBSD with clang-16.

This only masks out the new warnings that were causing the build to fail due to treat-warnings-as-errors, it is NOT fixing the underlying issues!

Fixes #5462 