### PR TITLE
Moved end generator back to 3d perlin noise

### DIFF
--- a/src/Generating/ChunkDesc.h
+++ b/src/Generating/ChunkDesc.h
@@ -87,6 +87,24 @@ public:
 	/** Sets the shape in a_Shape to match the heightmap stored currently in m_HeightMap. */
 	void GetShapeFromHeight(Shape & a_Shape) const;
 
+	/** Returns the index into the internal shape array for the specified coords */
+	inline static size_t MakeShapeIndex(int a_X, int a_Y, int a_Z)
+	{
+		return static_cast<size_t>(a_Y + a_X * cChunkDef::Height + a_Z * cChunkDef::Height * cChunkDef::Width);
+	}
+
+	inline static void SetShapeIsSolidAt(Shape & a_Shape, int a_X, int a_Y, int a_Z, bool a_IsSolid)
+	{
+		auto index = MakeShapeIndex(a_X, a_Y, a_Z);
+		a_Shape[index] = a_IsSolid ? 1 : 0;
+	}
+
+	inline static bool GetShapeIsSolidAt(const Shape & a_Shape, int a_X, int a_Y, int a_Z)
+	{
+		auto index = MakeShapeIndex(a_X, a_Y, a_Z);
+		return a_Shape[index];
+	}
+
 	// tolua_begin
 
 	// Default generation:

--- a/src/Generating/EndGen.cpp
+++ b/src/Generating/EndGen.cpp
@@ -41,11 +41,11 @@ cEndGen::cEndGen(int a_Seed) :
 	m_MainIslandFrequencyX(100),
 	m_MainIslandFrequencyY(80),
 	m_MainIslandFrequencyZ(100),
-	m_MainIslandMinThreshold(0.2),
+	m_MainIslandMinThreshold(0.2f),
 	m_SmallIslandFrequencyX(50),
 	m_SmallIslandFrequencyY(80),
 	m_SmallIslandFrequencyZ(50),
-	m_SmallIslandMinThreshold(-0.5),
+	m_SmallIslandMinThreshold(-0.5f),
 	m_LastChunkCoords(0x7fffffff, 0x7fffffff)  // Use dummy coords that won't ever be used by real chunks
 {
 	m_Perlin.AddOctave(1, 1);
@@ -112,7 +112,7 @@ void cEndGen::GenerateNoiseArray(void)
 	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(m_LastChunkCoords.m_ChunkZ       * cChunkDef::Width) / frequencyZ;
 	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>((m_LastChunkCoords.m_ChunkZ + 1) * cChunkDef::Width) / frequencyZ;
 	NOISE_DATATYPE StartY = 0;
-	NOISE_DATATYPE EndY   = static_cast<NOISE_DATATYPE>(257) / frequencyY;
+	NOISE_DATATYPE EndY   = static_cast<NOISE_DATATYPE>(cChunkDef::Height) / frequencyY;
 	m_Perlin.Generate3D(NoiseData, DIM_X, DIM_Z, DIM_Y, StartX, EndX, StartZ, EndZ, StartY, EndY, Workspace);
 
 	// Add distance:
@@ -159,15 +159,15 @@ void cEndGen::GenShape(cChunkCoords a_ChunkCoords, cChunkDesc::Shape & a_Shape)
 
 			for (int y = 0; y < m_IslandYOffset; y++)
 			{
-				a_Shape[y + x * 256 + z * 256 * 16] = 0;
+				cChunkDesc::SetShapeIsSolidAt(a_Shape, x, y, z, false);
 			}
 			for (int y = m_IslandYOffset; y < MaxY; y++)
 			{
-				a_Shape[y + x * 256 + z * 256 * 16] = (m_NoiseArray[(y - m_IslandYOffset) * 17 * 17 + z * 17 + x] <= threshold) ? 1 : 0;
+				cChunkDesc::SetShapeIsSolidAt(a_Shape, x, y, z, m_NoiseArray[(y - m_IslandYOffset) * 17 * 17 + z * 17 + x] <= threshold);
 			}
 			for (int y = MaxY; y < cChunkDef::Height; y++)
 			{
-				a_Shape[y + x * 256 + z * 256 * 16] = 0;
+				cChunkDesc::SetShapeIsSolidAt(a_Shape, x, y, z, false);
 			}
 		}  // for x
 	}  // for z
@@ -186,7 +186,7 @@ void cEndGen::ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc::Shape &
 		{
 			for (int y = 0; y < cChunkDef::Height; y++)
 			{
-				if (a_Shape[(x + 16 * z) * 256 + y] != 0)
+				if (cChunkDesc::GetShapeIsSolidAt(a_Shape, x, y, z))
 				{
 					a_ChunkDesc.SetBlockType(x, y, z, E_BLOCK_END_STONE);
 				}

--- a/src/Generating/EndGen.cpp
+++ b/src/Generating/EndGen.cpp
@@ -60,7 +60,7 @@ cEndGen::cEndGen(int a_Seed) :
 void cEndGen::InitializeShapeGen(cIniFile & a_IniFile)
 {
 	m_MainIslandSize = a_IniFile.GetValueSetI("Generator", "EndGenMainIslandSize", m_MainIslandSize);
-	m_IslandThickness = a_IniFile.GetValueSetI("Generator", "EndGenIslandFlatness", m_IslandThickness);
+	m_IslandThickness = a_IniFile.GetValueSetI("Generator", "EndGenIslandThickness", m_IslandThickness);
 	m_IslandYOffset = a_IniFile.GetValueSetI("Generator", "EndGenIslandYOffset", m_IslandYOffset);
 
 	m_MainIslandFrequencyX   = static_cast<NOISE_DATATYPE>(a_IniFile.GetValueSetF("Generator", "EndGenMainFrequencyX", m_MainIslandFrequencyX));
@@ -101,25 +101,25 @@ void cEndGen::GenerateNoiseArray(void)
 	NOISE_DATATYPE Workspace[DIM_X * DIM_Y * DIM_Z];  // [x + DIM_X * z + DIM_X * DIM_Z * y]
 
 	// Choose the frequency to use depending on the distance from spawn.
-	double distanceFromSpawn = cChunkDef::RelativeToAbsolute({ cChunkDef::Width / 2, 0, cChunkDef::Width / 2 }, m_LastChunkCoords).Length();
-	NOISE_DATATYPE frequencyX = distanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandFrequencyX : m_MainIslandFrequencyX;
-	NOISE_DATATYPE frequencyY = distanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandFrequencyY : m_MainIslandFrequencyY;
-	NOISE_DATATYPE frequencyZ = distanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandFrequencyZ : m_MainIslandFrequencyZ;
+	auto distanceFromSpawn = cChunkDef::RelativeToAbsolute({ cChunkDef::Width / 2, 0, cChunkDef::Width / 2 }, m_LastChunkCoords).Length();
+	auto frequencyX = distanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandFrequencyX : m_MainIslandFrequencyX;
+	auto frequencyY = distanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandFrequencyY : m_MainIslandFrequencyY;
+	auto frequencyZ = distanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandFrequencyZ : m_MainIslandFrequencyZ;
 
 	// Generate the downscaled noise:
-	NOISE_DATATYPE StartX = static_cast<NOISE_DATATYPE>(m_LastChunkCoords.m_ChunkX       * cChunkDef::Width) / frequencyX;
-	NOISE_DATATYPE EndX   = static_cast<NOISE_DATATYPE>((m_LastChunkCoords.m_ChunkX + 1) * cChunkDef::Width) / frequencyX;
-	NOISE_DATATYPE StartZ = static_cast<NOISE_DATATYPE>(m_LastChunkCoords.m_ChunkZ       * cChunkDef::Width) / frequencyZ;
-	NOISE_DATATYPE EndZ   = static_cast<NOISE_DATATYPE>((m_LastChunkCoords.m_ChunkZ + 1) * cChunkDef::Width) / frequencyZ;
-	NOISE_DATATYPE StartY = 0;
-	NOISE_DATATYPE EndY   = static_cast<NOISE_DATATYPE>(cChunkDef::Height) / frequencyY;
+	auto StartX = static_cast<NOISE_DATATYPE>(m_LastChunkCoords.m_ChunkX       * cChunkDef::Width) / frequencyX;
+	auto EndX   = static_cast<NOISE_DATATYPE>((m_LastChunkCoords.m_ChunkX + 1) * cChunkDef::Width) / frequencyX;
+	auto StartZ = static_cast<NOISE_DATATYPE>(m_LastChunkCoords.m_ChunkZ       * cChunkDef::Width) / frequencyZ;
+	auto EndZ   = static_cast<NOISE_DATATYPE>((m_LastChunkCoords.m_ChunkZ + 1) * cChunkDef::Width) / frequencyZ;
+	auto StartY = 0.0f;
+	auto EndY   = static_cast<NOISE_DATATYPE>(cChunkDef::Height) / frequencyY;
 	m_Perlin.Generate3D(NoiseData, DIM_X, DIM_Z, DIM_Y, StartX, EndX, StartZ, EndZ, StartY, EndY, Workspace);
 
 	// Add distance:
 	for (int y = 0; y < DIM_Y; y++)
 	{
-		NOISE_DATATYPE ValY = static_cast<NOISE_DATATYPE>(2 * INTERPOL_Y * y - m_IslandThickness) / m_IslandThickness;
-		ValY = std::pow(ValY, 6);
+		auto ValY = static_cast<NOISE_DATATYPE>(2 * INTERPOL_Y * y - m_IslandThickness) / m_IslandThickness;
+		ValY = static_cast<NOISE_DATATYPE>(std::pow(ValY, 6));
 		for (int z = 0; z < DIM_Z; z++)
 		{
 			for (int x = 0; x < DIM_X; x++)
@@ -144,8 +144,8 @@ void cEndGen::GenShape(cChunkCoords a_ChunkCoords, cChunkDesc::Shape & a_Shape)
 	int MaxY = std::min(static_cast<int>(1.75 * m_IslandThickness + m_IslandYOffset), cChunkDef::Height - 1);
 
 	// Choose which threshold to use depending on the distance from spawn.
-	double distanceFromSpawn = cChunkDef::RelativeToAbsolute({ cChunkDef::Width / 2, 0, cChunkDef::Width / 2 }, a_ChunkCoords).Length();
-	double minThreshold = distanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandMinThreshold : m_MainIslandMinThreshold;
+	double chunkDistanceFromSpawn = cChunkDef::RelativeToAbsolute({ cChunkDef::Width / 2, 0, cChunkDef::Width / 2 }, a_ChunkCoords).Length();
+	double minThreshold = chunkDistanceFromSpawn > m_MainIslandSize * 2 ? m_SmallIslandMinThreshold : m_MainIslandMinThreshold;
 	for (int z = 0; z < cChunkDef::Width; z++)
 	{
 		for (int x = 0; x < cChunkDef::Width; x++)

--- a/src/Generating/EndGen.h
+++ b/src/Generating/EndGen.h
@@ -30,28 +30,41 @@ protected:
 
 	/** The Perlin noise used for generating */
 	cPerlinNoise m_Perlin;
-	cPerlinNoise m_VoidOffsetNoise;
 
-	NOISE_DATATYPE m_AirThresholdMainIsland;
-	NOISE_DATATYPE m_AirThresholdOtherIslands;
+	// XYZ size of the "island", in blocks:
 	int m_MainIslandSize;
-	int m_BaseHeight;
-	int m_TerrainTopMultiplier;
-	int m_TerrainBottomMultiplier;
-	int m_VoidOffsetNoiseMultiplier;
+	int m_IslandThickness;
+	int m_IslandYOffset;
 
 	// XYZ Frequencies of the noise functions:
-	NOISE_DATATYPE m_FrequencyX;
-	NOISE_DATATYPE m_FrequencyY;
-	NOISE_DATATYPE m_FrequencyZ;
+	NOISE_DATATYPE m_MainIslandFrequencyX;
+	NOISE_DATATYPE m_MainIslandFrequencyY;
+	NOISE_DATATYPE m_MainIslandFrequencyZ;
+	NOISE_DATATYPE m_MainIslandMinThreshold;
+
+	// XYZ Frequencies of the noise functions on the smaller islands:
+	NOISE_DATATYPE m_SmallIslandFrequencyX;
+	NOISE_DATATYPE m_SmallIslandFrequencyY;
+	NOISE_DATATYPE m_SmallIslandFrequencyZ;
+	NOISE_DATATYPE m_SmallIslandMinThreshold;
+
+
+	// Noise array for the last chunk (in the noise range)
+	cChunkCoords m_LastChunkCoords;
+	NOISE_DATATYPE m_NoiseArray[17 * 17 * 257];  // x + 17 * z + 17 * 17 * y
+
+
+	/** Unless the LastChunk coords are equal to coords given, prepares the internal state (noise array) */
+	void PrepareState(cChunkCoords a_ChunkCoords);
+
+	/** Generates the m_NoiseArray array for the current chunk */
+	void GenerateNoiseArray(void);
 
 	// cTerrainShapeGen overrides:
 	virtual void GenShape(cChunkCoords a_ChunkCoords, cChunkDesc::Shape & a_Shape) override;
+	virtual void InitializeShapeGen(cIniFile & a_IniFile) override;
 
 
 	// cTerrainCompositionGen overrides:
 	virtual void ComposeTerrain(cChunkDesc & a_ChunkDesc, const cChunkDesc::Shape & a_Shape) override;
-
-	// cTerrainShapeGen overrides:
-	virtual void InitializeShapeGen(cIniFile & a_IniFile) override;
 } ;


### PR DESCRIPTION
In #4973 I changed the end generator to 2 2d perlin noises. Since I still think the 3d noise looked superior I changed it back, but now the world continues generating after a void. A big advantage to this approach is that the islands don't get cut off

**Main island:**
![2024-03-21_21 48 31](https://github.com/cuberite/cuberite/assets/1160867/ad3f54c4-198f-429a-84b7-c1aa00ace540)

**Smaller islands out in the void (higher FOW):**
![2024-03-21_21 50 02](https://github.com/cuberite/cuberite/assets/1160867/93b03fa2-4ec0-474d-9d2f-608978e7df96)

**Minutor overview:**
![overview-pow6](https://github.com/cuberite/cuberite/assets/1160867/97e76aa7-5004-45a1-9a58-e7f0d0ea0531)

The main island could still be improved. It's still possible that the exit portal (coordinates 0, 0) is over a void.