### PR TITLE
Added extra possible Info.lua parameter that describes the dependencies

### DIFF
--- a/Server/Plugins/InfoDump.lua
+++ b/Server/Plugins/InfoDump.lua
@@ -594,6 +594,55 @@ end
 
 
 
+local function DumpDependenciesForum(a_PluginInfo, f)
+	if (not a_PluginInfo.Dependencies) then
+		return
+	end
+
+	f:write("\n[size=x-large]Dependencies[/size]\n[list]")
+	for idx, dependency in ipairs(a_PluginInfo.Dependencies) do
+		f:write("\n\n [*] [b]", dependency.Name, "[/b]", dependency.Optional == true and " (Optional)" or " (Required)")
+		if (dependency.Description) then
+			f:write("\nDescription: ", ForumizeString(dependency.Description))
+		end
+		if (dependency.Type) then
+			f:write("\nType: ", dependency.Type)
+		end
+		if (dependency.Url) then
+			f:write("\nUrl: ", dependency.Url)
+		end
+	end
+	f:write("\n[/list]")
+end
+
+
+
+
+
+local function DumpDependenciesGithub(a_PluginInfo, f)
+	if (not a_PluginInfo.Dependencies) then
+		return
+	end
+
+	f:write("\n# Dependencies\n")
+	for idx, dependency in ipairs(a_PluginInfo.Dependencies) do
+		f:write("\n\n * **", dependency.Name, "** ", dependency.Optional == true and "(Optional)" or "(Required)")
+		if (dependency.Description) then
+			f:write("<br />\nDescription: ", GithubizeString(dependency.Description))
+		end
+		if (dependency.Type) then
+			f:write("<br />\nType: ", dependency.Type)
+		end
+		if (dependency.Url) then
+			f:write("<br />\nUrl: [", dependency.Url, "](", dependency.Url , ")")
+		end
+	end
+end
+
+
+
+
+
 --- Dumps the forum-format info for the plugin
 -- Returns true on success, nil and error message on failure
 local function DumpPluginInfoForum(a_PluginFolder, a_PluginInfo)
@@ -608,6 +657,7 @@ local function DumpPluginInfoForum(a_PluginFolder, a_PluginInfo)
 	DumpAdditionalInfoForum(a_PluginInfo, f)
 	DumpCommandsForum(a_PluginInfo, f)
 	DumpPermissionsForum(a_PluginInfo, f)
+	DumpDependenciesForum(a_PluginInfo, f)
 	if (a_PluginInfo.SourceLocation ~= nil) then
 		f:write("\n[b]Source[/b]: ", a_PluginInfo.SourceLocation, "\n")
 	end
@@ -641,6 +691,7 @@ local function DumpPluginInfoGithub(a_PluginFolder, a_PluginInfo)
 	DumpAdditionalInfoGithub(a_PluginInfo, f)
 	DumpCommandsGithub(a_PluginInfo, f)
 	DumpPermissionsGithub(a_PluginInfo, f)
+	DumpDependenciesGithub(a_PluginInfo, f)
 
 	f:close()
 	return true


### PR DESCRIPTION
Some plugins might require other plugins or even Luarocks to function. It can be beneficial to show those in the generated plugin descriptions. This PR adds this functionality to the `InfoDump.lua` file.

In the `Info.lua` file the dependencies would look like this:
```lua
Dependencies =
{
	{
		Name = "WorldEdit",
		Type = "Cuberite Plugin",
		Description = "Required to select a region",
		Optional = true,
		Url = "https://forum.cuberite.org/thread-870.html"
	},
	{
		Name = "LuaFileSystem",
		Type = "Luarock",
		Description = "Used to manipulate folders",
		Url = "https://github.com/lunarmodules/luafilesystem"
	}
},  -- Dependencies
```

The generated markdown looks like this:
```md
# Dependencies


 * **WorldEdit** (Optional)<br />
Description: Required to select a region<br />
Type: Cuberite Plugin<br />
Url: [https://forum.cuberite.org/thread-870.html](https://forum.cuberite.org/thread-870.html)

 * **LuaFileSystem** (Required)<br />
Description: Used to manipulate folders<br />
Type: Luarock<br />
Url: [https://github.com/lunarmodules/luafilesystem](https://github.com/lunarmodules/luafilesystem)
```

or the following when rendered:
![image](https://github.com/cuberite/cuberite/assets/1160867/6483944a-4df9-49f6-8683-936a1971f507)


The generated mybb format for the forum would look like this:
```
[size=x-large]Dependencies[/size]
[list]

 [*] [b]WorldEdit[/b] (Optional)
Description: Required to select a region
Type: Cuberite Plugin
Url: https://forum.cuberite.org/thread-870.html

 [*] [b]LuaFileSystem[/b] (Required)
Description: Used to manipulate folders
Type: Luarock
Url: https://github.com/lunarmodules/luafilesystem
[/list]
```

which would look like the following when rendered:
![image](https://github.com/cuberite/cuberite/assets/1160867/488d438b-cde6-4e96-bd1c-c346d200ca1c)
