### PR TITLE
Fix filename template for saved maps

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -59,6 +59,7 @@ mcfadyeni
 MeMuXin
 mgueydan
 MikeHunsinger
+mjagdis (Mike Jagdis)
 Morritz (TJ)
 morsmordere (Anzhelika Iugai)
 mtilden

--- a/src/WorldStorage/MapSerializer.cpp
+++ b/src/WorldStorage/MapSerializer.cpp
@@ -18,7 +18,7 @@ cMapSerializer::cMapSerializer(const AString & a_WorldName, cMap * a_Map):
 	m_Map(a_Map)
 {
 	auto DataPath = fmt::format(FMT_STRING("{}{}data"), a_WorldName, cFile::PathSeparator());
-	m_Path = fmt::format(FMT_STRING("{}{}map_%i.dat"), DataPath, cFile::PathSeparator(), a_Map->GetID());
+	m_Path = fmt::format(FMT_STRING("{}{}map_{}.dat"), DataPath, cFile::PathSeparator(), a_Map->GetID());
 	cFile::CreateFolder(DataPath);
 }
 


### PR DESCRIPTION
The conversion from printf formats missed one. All maps save to the same file :-(