### PR TITLE
Set TCP_NODELAY on connections

### DIFF
--- a/src/Globals.h
+++ b/src/Globals.h
@@ -98,6 +98,7 @@
 
 	#include <arpa/inet.h>
 	#include <netinet/in.h>
+	#include <netinet/tcp.h>
 	#include <sys/socket.h>
 	#include <unistd.h>
 #endif

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -329,7 +329,7 @@ void cServerHandleImpl::Callback(evconnlistener * a_Listener, evutil_socket_t a_
 	}
 
 	const int one = 1;
-	setsockopt(a_Socket, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+	setsockopt(a_Socket, IPPROTO_TCP, TCP_NODELAY, (const char *)&one, sizeof(one));
 
 	// Create a new cTCPLink for the incoming connection:
 	cTCPLinkImplPtr Link = std::make_shared<cTCPLinkImpl>(a_Socket, LinkCallbacks, Self->m_SelfPtr, a_Addr, static_cast<socklen_t>(a_Len));

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -328,6 +328,9 @@ void cServerHandleImpl::Callback(evconnlistener * a_Listener, evutil_socket_t a_
 		return;
 	}
 
+	const int one = 1;
+	setsockopt(a_Socket, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
 	// Create a new cTCPLink for the incoming connection:
 	cTCPLinkImplPtr Link = std::make_shared<cTCPLinkImpl>(a_Socket, LinkCallbacks, Self->m_SelfPtr, a_Addr, static_cast<socklen_t>(a_Len));
 	{

--- a/src/OSSupport/ServerHandleImpl.cpp
+++ b/src/OSSupport/ServerHandleImpl.cpp
@@ -329,7 +329,7 @@ void cServerHandleImpl::Callback(evconnlistener * a_Listener, evutil_socket_t a_
 	}
 
 	const int one = 1;
-	setsockopt(a_Socket, IPPROTO_TCP, TCP_NODELAY, (const char *)&one, sizeof(one));
+	setsockopt(a_Socket, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&one), sizeof(one));
 
 	// Create a new cTCPLink for the incoming connection:
 	cTCPLinkImplPtr Link = std::make_shared<cTCPLinkImpl>(a_Socket, LinkCallbacks, Self->m_SelfPtr, a_Addr, static_cast<socklen_t>(a_Len));


### PR DESCRIPTION
Fixes #5065 

Minecraft/cuberite does its own buffering at the app layer and there's little point holding back a trailing partial packet.