### PR TITLE
Temp fix for disappearing chunk sections in 1.14

### DIFF
--- a/src/Protocol/ChunkDataSerializer.cpp
+++ b/src/Protocol/ChunkDataSerializer.cpp
@@ -502,7 +502,7 @@ inline void cChunkDataSerializer::Serialize477(const int a_ChunkX, const int a_C
 	// Write each chunk section...
 	ChunkDef_ForEachSection(a_BlockData, a_LightData,
 	{
-		m_Packet.WriteBEInt16(4096);  // a temp fix to make sure sections don't disappear
+		m_Packet.WriteBEInt16(ChunkBlockData::SectionBlockCount);  // a temp fix to make sure sections don't disappear
 		m_Packet.WriteBEUInt8(BitsPerEntry);
 		m_Packet.WriteVarInt32(static_cast<UInt32>(ChunkSectionDataArraySize));
 		WriteBlockSectionSeamless<&Palette477>(Blocks, Metas, BitsPerEntry);

--- a/src/Protocol/ChunkDataSerializer.cpp
+++ b/src/Protocol/ChunkDataSerializer.cpp
@@ -502,7 +502,7 @@ inline void cChunkDataSerializer::Serialize477(const int a_ChunkX, const int a_C
 	// Write each chunk section...
 	ChunkDef_ForEachSection(a_BlockData, a_LightData,
 	{
-		m_Packet.WriteBEInt16(-1);
+		m_Packet.WriteBEInt16(4096);  // a temp fix to make sure sections don't disappear
 		m_Packet.WriteBEUInt8(BitsPerEntry);
 		m_Packet.WriteVarInt32(static_cast<UInt32>(ChunkSectionDataArraySize));
 		WriteBlockSectionSeamless<&Palette477>(Blocks, Metas, BitsPerEntry);


### PR DESCRIPTION
Previously the value sent for nonEmptyBlocks in each chunk section was -1. This was probably set with the intention to set it to the max value. However, the game also interprets the value as signed. meaning when a block is placed the value is incremented to 0.  But when the nonEmptyBlocks value is 0 the game treats that section as empty and stops rendering blocks in it. 

This patch makes sure that the value sent is 4096, the amount of blocks in any section. This will probably lead to the inverse bug where the game will treat empty sections as non-empty.