### PR TITLE
Preserve banner names across place and pick up

### DIFF
--- a/src/BlockEntities/BannerEntity.cpp
+++ b/src/BlockEntities/BannerEntity.cpp
@@ -13,18 +13,10 @@
 
 
 
-cBannerEntity::cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World) :
-	cBannerEntity(a_BlockType, a_BlockMeta, a_Pos, a_World, 1)
-{
-}
-
-
-
-
-
-cBannerEntity::cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, unsigned char a_BaseColor):
+cBannerEntity::cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, unsigned char a_BaseColor, AString a_CustomName):
 	Super(a_BlockType, a_BlockMeta, a_Pos, a_World),
-	m_BaseColor(a_BaseColor)
+	m_BaseColor(a_BaseColor),
+	m_CustomName(std::move(a_CustomName))
 {
 	ASSERT((a_BlockType == E_BLOCK_WALL_BANNER) || (a_BlockType == E_BLOCK_STANDING_BANNER));
 }
@@ -33,27 +25,11 @@ cBannerEntity::cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vect
 
 
 
-unsigned char cBannerEntity::GetBaseColor() const
-{
-	return m_BaseColor;
-}
-
-
-
-
-
-void cBannerEntity::SetBaseColor(const unsigned char a_Color)
-{
-	m_BaseColor = a_Color;
-}
-
-
-
-
-
 cItems cBannerEntity::ConvertToPickups() const
 {
-	return cItem(E_ITEM_BANNER, 1, static_cast<NIBBLETYPE>(GetBaseColor()));
+	cItem Item(E_ITEM_BANNER, 1, static_cast<NIBBLETYPE>(GetBaseColor()));
+	Item.m_CustomName = m_CustomName;
+	return Item;
 }
 
 
@@ -65,6 +41,7 @@ void cBannerEntity::CopyFrom(const cBlockEntity & a_Src)
 	Super::CopyFrom(a_Src);
 	auto & src = static_cast<const cBannerEntity &>(a_Src);
 	m_BaseColor = src.m_BaseColor;
+	m_CustomName = src.m_CustomName;
 }
 
 

--- a/src/BlockEntities/BannerEntity.h
+++ b/src/BlockEntities/BannerEntity.h
@@ -25,15 +25,19 @@ class cBannerEntity :
 
 public:
 
-	cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World);
-	cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, unsigned char a_BaseColor);
+	cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, unsigned char a_BaseColor = 15, AString a_CustomName = "");
 
-	unsigned char GetBaseColor() const;
-	void SetBaseColor(unsigned char a_Color);
+	unsigned char GetBaseColor() const { return m_BaseColor; }
+	void SetBaseColor(unsigned char a_Color) { m_BaseColor = a_Color; }
+
+	const AString & GetCustomName() const { return m_CustomName; }
+	void SetCustomName(const AString & a_CustomName) { m_CustomName = a_CustomName; }
 
 private:
 
 	unsigned char m_BaseColor;
+
+	AString m_CustomName;
 
 	// cBlockEntity overrides:
 	virtual cItems ConvertToPickups() const override;

--- a/src/BlockEntities/BannerEntity.h
+++ b/src/BlockEntities/BannerEntity.h
@@ -25,7 +25,7 @@ class cBannerEntity :
 
 public:
 
-	cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, unsigned char a_BaseColor = 15, AString a_CustomName = "");
+	cBannerEntity(BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta, Vector3i a_Pos, cWorld * a_World, unsigned char a_BaseColor = 1, AString a_CustomName = "");
 
 	unsigned char GetBaseColor() const { return m_BaseColor; }
 	void SetBaseColor(unsigned char a_Color) { m_BaseColor = a_Color; }

--- a/src/Items/ItemBanner.h
+++ b/src/Items/ItemBanner.h
@@ -40,7 +40,9 @@ private:
 		{
 			ASSERT((a_BlockEntity.GetBlockType() == E_BLOCK_STANDING_BANNER) || (a_BlockEntity.GetBlockType() == E_BLOCK_WALL_BANNER));
 
-			static_cast<cBannerEntity &>(a_BlockEntity).SetBaseColor(static_cast<NIBBLETYPE>(a_HeldItem.m_ItemDamage));
+			cBannerEntity & BannerEntity = static_cast<cBannerEntity &>(a_BlockEntity);
+			BannerEntity.SetBaseColor(static_cast<NIBBLETYPE>(a_HeldItem.m_ItemDamage));
+			BannerEntity.SetCustomName(a_HeldItem.m_CustomName);
 			return false;
 		});
 

--- a/src/WorldStorage/NBTChunkSerializer.cpp
+++ b/src/WorldStorage/NBTChunkSerializer.cpp
@@ -376,6 +376,10 @@ public:
 		mWriter.BeginCompound("");
 			AddBasicTileEntity(a_Entity,"Banner");
 			mWriter.AddInt("Base", static_cast<int>(a_Entity->GetBaseColor()));
+			if (!a_Entity->GetCustomName().empty())
+			{
+				mWriter.AddString("CustomName", a_Entity->GetCustomName());
+			}
 		mWriter.EndCompound();
 	}
 

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -890,15 +890,23 @@ OwnedBlockEntity cWSSAnvil::LoadBannerFromNBT(const cParsedNBT & a_NBT, int a_Ta
 		return nullptr;
 	}
 
+	unsigned char Color = 15;
+	AString CustomName;
+
 	// Reads base color from NBT
 	int CurrentLine = a_NBT.FindChildByName(a_TagIdx, "Base");
 	if (CurrentLine >= 0)
 	{
-		const auto Color = static_cast<unsigned char>(a_NBT.GetInt(CurrentLine));
-		return std::make_unique<cBannerEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World, Color);
+		Color = static_cast<unsigned char>(a_NBT.GetInt(CurrentLine));
 	}
 
-	return nullptr;
+	CurrentLine = a_NBT.FindChildByName(a_TagIdx, "CustomName");
+	if ((CurrentLine >= 0) && (a_NBT.GetType(CurrentLine) == TAG_String))
+	{
+		CustomName = a_NBT.GetString(CurrentLine);
+	}
+
+	return std::make_unique<cBannerEntity>(a_BlockType, a_BlockMeta, a_Pos, m_World, Color, CustomName);
 }
 
 


### PR DESCRIPTION
As with named enchanting tables, copy banner names back and forth between items and block entities. NBT format verified against actual Java Edition chunk saves.

Fixes #5564 

