### PR TITLE
Uninitialised value fix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -80,6 +80,7 @@ Schwertspize
 Seadragon91 (Lukas Pioch)
 sleirsgoevy (Sergey Lisov)
 Sofapriester
+solvictor
 Spekdrum (Pablo Beltran)
 SphinxC0re
 Spongecade (Updated wiki links)

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -74,6 +74,7 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 	m_IPString(a_IPString),
 	m_Player(nullptr),
 	m_CachedSentChunk(std::numeric_limits<decltype(m_CachedSentChunk.m_ChunkX)>::max(), std::numeric_limits<decltype(m_CachedSentChunk.m_ChunkZ)>::max()),
+	m_ProxyConnection(false),
 	m_HasSentDC(false),
 	m_LastStreamedChunkX(std::numeric_limits<decltype(m_LastStreamedChunkX)>::max()),  // bogus chunk coords to force streaming upon login
 	m_LastStreamedChunkZ(std::numeric_limits<decltype(m_LastStreamedChunkZ)>::max()),
@@ -93,8 +94,7 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 	m_HasSentPlayerChunk(false),
 	m_Locale("en_GB"),
 	m_LastPlacedSign(s_IllegalPosition),
-	m_ProtocolVersion(0),
-	m_ProxyConnection(false)
+	m_ProtocolVersion(0)
 {
 	s_ClientCount++;  // Not protected by CS because clients are always constructed from the same thread
 	m_UniqueID = s_ClientCount;

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -93,7 +93,8 @@ cClientHandle::cClientHandle(const AString & a_IPString, int a_ViewDistance) :
 	m_HasSentPlayerChunk(false),
 	m_Locale("en_GB"),
 	m_LastPlacedSign(s_IllegalPosition),
-	m_ProtocolVersion(0)
+	m_ProtocolVersion(0),
+	m_ProxyConnection(false)
 {
 	s_ClientCount++;  // Not protected by CS because clients are always constructed from the same thread
 	m_UniqueID = s_ClientCount;

--- a/src/Noise/InterpolNoise.h
+++ b/src/Noise/InterpolNoise.h
@@ -348,17 +348,13 @@ public:
 		ASSERT(a_StartY < a_EndY);
 
 		// Calculate the integral and fractional parts of each coord:
-		int FloorX[MAX_SIZE];
-		int FloorY[MAX_SIZE];
+		int FloorX[MAX_SIZE] = {};
+		int FloorY[MAX_SIZE] = {};
 		NOISE_DATATYPE FracX[MAX_SIZE];
 		NOISE_DATATYPE FracY[MAX_SIZE];
 		int SameX[MAX_SIZE];
 		int SameY[MAX_SIZE];
 		int NumSameX, NumSameY;
-
-		// Prevent uninitialized value when Cell.move()
-		memset(FloorX, 0, sizeof(int) * MAX_SIZE);
-		memset(FloorY, 0, sizeof(int) * MAX_SIZE);
 
 		CalcFloorFrac(a_SizeX, a_StartX, a_EndX, FloorX, FracX, SameX, NumSameX);
 		CalcFloorFrac(a_SizeY, a_StartY, a_EndY, FloorY, FracY, SameY, NumSameY);
@@ -408,9 +404,9 @@ public:
 		ASSERT(a_StartZ < a_EndZ);
 
 		// Calculate the integral and fractional parts of each coord:
-		int FloorX[MAX_SIZE];
-		int FloorY[MAX_SIZE];
-		int FloorZ[MAX_SIZE];
+		int FloorX[MAX_SIZE] = {};
+		int FloorY[MAX_SIZE] = {};
+		int FloorZ[MAX_SIZE] = {};
 		NOISE_DATATYPE FracX[MAX_SIZE];
 		NOISE_DATATYPE FracY[MAX_SIZE];
 		NOISE_DATATYPE FracZ[MAX_SIZE];
@@ -418,11 +414,6 @@ public:
 		int SameY[MAX_SIZE];
 		int SameZ[MAX_SIZE];
 		int NumSameX, NumSameY, NumSameZ;
-
-		// Prevent uninitialized value when Cell.move()
-		memset(FloorX, 0, sizeof(int) * MAX_SIZE);
-		memset(FloorY, 0, sizeof(int) * MAX_SIZE);
-		memset(FloorZ, 0, sizeof(int) * MAX_SIZE);
 
 		CalcFloorFrac(a_SizeX, a_StartX, a_EndX, FloorX, FracX, SameX, NumSameX);
 		CalcFloorFrac(a_SizeY, a_StartY, a_EndY, FloorY, FracY, SameY, NumSameY);

--- a/src/Noise/InterpolNoise.h
+++ b/src/Noise/InterpolNoise.h
@@ -355,6 +355,11 @@ public:
 		int SameX[MAX_SIZE];
 		int SameY[MAX_SIZE];
 		int NumSameX, NumSameY;
+
+		// Prevent uninitialized value when Cell.move()
+		memset(FloorX, 0, sizeof(int) * MAX_SIZE);
+		memset(FloorY, 0, sizeof(int) * MAX_SIZE);
+
 		CalcFloorFrac(a_SizeX, a_StartX, a_EndX, FloorX, FracX, SameX, NumSameX);
 		CalcFloorFrac(a_SizeY, a_StartY, a_EndY, FloorY, FracY, SameY, NumSameY);
 
@@ -413,6 +418,12 @@ public:
 		int SameY[MAX_SIZE];
 		int SameZ[MAX_SIZE];
 		int NumSameX, NumSameY, NumSameZ;
+
+		// Prevent uninitialized value when Cell.move()
+		memset(FloorX, 0, sizeof(int) * MAX_SIZE);
+		memset(FloorY, 0, sizeof(int) * MAX_SIZE);
+		memset(FloorZ, 0, sizeof(int) * MAX_SIZE);
+
 		CalcFloorFrac(a_SizeX, a_StartX, a_EndX, FloorX, FracX, SameX, NumSameX);
 		CalcFloorFrac(a_SizeY, a_StartY, a_EndY, FloorY, FracY, SameY, NumSameY);
 		CalcFloorFrac(a_SizeZ, a_StartZ, a_EndZ, FloorZ, FracZ, SameZ, NumSameZ);

--- a/src/Noise/InterpolNoise.h
+++ b/src/Noise/InterpolNoise.h
@@ -355,7 +355,6 @@ public:
 		int SameX[MAX_SIZE];
 		int SameY[MAX_SIZE];
 		int NumSameX, NumSameY;
-
 		CalcFloorFrac(a_SizeX, a_StartX, a_EndX, FloorX, FracX, SameX, NumSameX);
 		CalcFloorFrac(a_SizeY, a_StartY, a_EndY, FloorY, FracY, SameY, NumSameY);
 
@@ -414,7 +413,6 @@ public:
 		int SameY[MAX_SIZE];
 		int SameZ[MAX_SIZE];
 		int NumSameX, NumSameY, NumSameZ;
-
 		CalcFloorFrac(a_SizeX, a_StartX, a_EndX, FloorX, FracX, SameX, NumSameX);
 		CalcFloorFrac(a_SizeY, a_StartY, a_EndY, FloorY, FracY, SameY, NumSameY);
 		CalcFloorFrac(a_SizeZ, a_StartZ, a_EndZ, FloorZ, FracZ, SameZ, NumSameZ);

--- a/src/Noise/InterpolNoise.h
+++ b/src/Noise/InterpolNoise.h
@@ -348,8 +348,8 @@ public:
 		ASSERT(a_StartY < a_EndY);
 
 		// Calculate the integral and fractional parts of each coord:
-		int FloorX[MAX_SIZE] = {};
-		int FloorY[MAX_SIZE] = {};
+		int FloorX[MAX_SIZE];
+		int FloorY[MAX_SIZE];
 		NOISE_DATATYPE FracX[MAX_SIZE];
 		NOISE_DATATYPE FracY[MAX_SIZE];
 		int SameX[MAX_SIZE];
@@ -404,9 +404,9 @@ public:
 		ASSERT(a_StartZ < a_EndZ);
 
 		// Calculate the integral and fractional parts of each coord:
-		int FloorX[MAX_SIZE] = {};
-		int FloorY[MAX_SIZE] = {};
-		int FloorZ[MAX_SIZE] = {};
+		int FloorX[MAX_SIZE];
+		int FloorY[MAX_SIZE];
+		int FloorZ[MAX_SIZE];
 		NOISE_DATATYPE FracX[MAX_SIZE];
 		NOISE_DATATYPE FracY[MAX_SIZE];
 		NOISE_DATATYPE FracZ[MAX_SIZE];


### PR DESCRIPTION
Prevent some conditional jumps on uninitialised values. Found with valgrind in the terrain generator and Client Handler.