### PR TITLE
Convert double to ints with floor rather than truncating

### DIFF
--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -30,11 +30,18 @@ public:
 
 	// tolua_end
 	// Conversion constructors where U is not the same as T leaving the copy-constructor implicitly generated
-	template <typename U, typename = typename std::enable_if<!std::is_same<U, T>::value>::type>
-	constexpr Vector3(const Vector3<U> & a_Rhs):
+	template <typename U, std::enable_if_t<(!std::is_same<U, T>::value) && ((!std::is_integral<T>::value) || (std::is_integral<U>::value)), bool> = true>
+	constexpr Vector3<T>(const Vector3<U> & a_Rhs):
 			x(static_cast<T>(a_Rhs.x)),
 			y(static_cast<T>(a_Rhs.y)),
 			z(static_cast<T>(a_Rhs.z))
+	{
+	}
+	template <typename U, std::enable_if_t<(!std::is_same<U, T>::value) && ((std::is_integral<T>::value) && (!std::is_integral<U>::value)), bool> = true>
+	constexpr Vector3<T>(const Vector3<U> & a_Rhs):
+			x(static_cast<T>(std::floor(a_Rhs.x))),
+			y(static_cast<T>(std::floor(a_Rhs.y))),
+			z(static_cast<T>(std::floor(a_Rhs.z)))
 	{
 	}
 	// tolua_begin


### PR DESCRIPTION
Fixes #5571 

The implicit conversion from double or float to integers simply truncates or rounds towards zero. That's not what we want and leads to off-by-one errors when we have a negative value. One side effect of that is that if an item frame is placed on a block that has one or more negative components in its position vector then the on-tick check to see if the item frame is still attached to a valid block looks at the wrong block and draws an erroneous conclusion (i.e. the item frame drops).

What we want is for Vector3d to be converted to Vector3i by flooring each component rather than truncating.