### PR TITLE
The second value in Rotation is pitch not roll

### DIFF
--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -3648,7 +3648,7 @@ bool cWSSAnvil::LoadEntityBaseFromNBT(cEntity & a_Entity, const cParsedNBT & a_N
 		Rotation[1] = 0;
 	}
 	a_Entity.SetYaw(Rotation[0]);
-	a_Entity.SetRoll(Rotation[1]);
+	a_Entity.SetPitch(Rotation[1]);
 
 	// Depending on the Minecraft version, the entity's health is
 	// stored either as a float Health tag (HealF prior to 1.9) or


### PR DESCRIPTION
The second value we read for "Rotation" in WSSAnvil entity NBT is pitch not roll (it's correct in the NBT serializer). Getting it wrong messes up the hit boxes of top and bottom placed item frames. Which the server doesn't support. Yet... Maybe there are other things it matters for though?