### PR TITLE
Make wall banners actually placeable

### DIFF
--- a/src/Blocks/BlockHandler.cpp
+++ b/src/Blocks/BlockHandler.cpp
@@ -7,7 +7,6 @@
 #include "BlockPluginInterface.h"
 #include "BlockAir.h"
 #include "BlockAnvil.h"
-#include "BlockBanner.h"
 #include "BlockBed.h"
 #include "BlockBigFlower.h"
 #include "BlockBookShelf.h"
@@ -89,6 +88,7 @@
 #include "BlockSnow.h"
 #include "BlockSponge.h"
 #include "BlockStairs.h"
+#include "BlockStandingBanner.h"
 #include "BlockStems.h"
 #include "BlockStone.h"
 #include "BlockSugarCane.h"
@@ -99,6 +99,7 @@
 #include "BlockTripwire.h"
 #include "BlockTripwireHook.h"
 #include "BlockVines.h"
+#include "BlockWallBanner.h"
 #include "BlockWallSign.h"
 #include "BlockWorkbench.h"
 
@@ -413,7 +414,7 @@ namespace
 	constexpr cDefaultBlockHandler            BlockStainedClayHandler           (E_BLOCK_STAINED_CLAY);
 	constexpr cBlockGlassHandler              BlockStainedGlassHandler          (E_BLOCK_STAINED_GLASS);
 	constexpr cBlockGlassHandler              BlockStainedGlassPaneHandler      (E_BLOCK_STAINED_GLASS_PANE);
-	constexpr cBlockBannerHandler             BlockStandingBannerHandler        (E_BLOCK_STANDING_BANNER);
+	constexpr cBlockStandingBannerHandler     BlockStandingBannerHandler        (E_BLOCK_STANDING_BANNER);
 	constexpr cBlockLavaHandler               BlockStationaryLavaHandler        (E_BLOCK_STATIONARY_LAVA);
 	constexpr cBlockWaterHandler              BlockStationaryWaterHandler       (E_BLOCK_STATIONARY_WATER);
 	constexpr cBlockPistonHandler             BlockStickyPistonHandler          (E_BLOCK_STICKY_PISTON);
@@ -434,7 +435,7 @@ namespace
 	constexpr cBlockTripwireHandler           BlockTripwireHandler              (E_BLOCK_TRIPWIRE);
 	constexpr cBlockTripwireHookHandler       BlockTripwireHookHandler          (E_BLOCK_TRIPWIRE_HOOK);
 	constexpr cBlockVinesHandler              BlockVinesHandler                 (E_BLOCK_VINES);
-	constexpr cBlockBannerHandler             BlockWallBannerHandler            (E_BLOCK_WALL_BANNER);
+	constexpr cBlockWallBannerHandler         BlockWallBannerHandler            (E_BLOCK_WALL_BANNER);
 	constexpr cBlockWallSignHandler           BlockWallsignHandler              (E_BLOCK_WALLSIGN);
 	constexpr cBlockWaterHandler              BlockWaterHandler                 (E_BLOCK_WATER);
 	constexpr cBlockGlazedTerracottaHandler   BlockWhiteGlazedTerracottaHandler (E_BLOCK_WHITE_GLAZED_TERRACOTTA);

--- a/src/Blocks/BlockStandingBanner.h
+++ b/src/Blocks/BlockStandingBanner.h
@@ -1,5 +1,5 @@
 
-// BlockBanner.h
+// BlockStandingBanner.h
 
 #pragma once
 
@@ -10,7 +10,7 @@
 
 
 
-class cBlockBannerHandler final :
+class cBlockStandingBannerHandler final :
 	public cBlockEntityHandler
 {
 	using Super = cBlockEntityHandler;

--- a/src/Blocks/BlockWallBanner.h
+++ b/src/Blocks/BlockWallBanner.h
@@ -1,0 +1,64 @@
+
+// BlockWallBanner.h
+
+#pragma once
+
+#include "../BlockInfo.h"
+#include "BlockEntity.h"
+
+
+
+
+
+class cBlockWallBannerHandler final :
+	public cBlockEntityHandler
+{
+	using Super = cBlockEntityHandler;
+
+public:
+
+	using Super::Super;
+
+	virtual cItems ConvertToPickups(const NIBBLETYPE a_BlockMeta, const cItem * const a_Tool) const override
+	{
+		// Drops handled by the block entity:
+		return {};
+	}
+
+
+
+
+
+	virtual bool CanBeAt(const cChunk & a_Chunk, const Vector3i a_Position, const NIBBLETYPE a_Meta) const override
+	{
+		Vector3i Offset;
+
+		switch (a_Meta)
+		{
+			case BLOCK_FACE_ZM: Offset = Vector3i( 0, 0,  1); break;
+			case BLOCK_FACE_ZP: Offset = Vector3i( 0, 0, -1); break;
+			case BLOCK_FACE_XM: Offset = Vector3i( 1, 0,  0); break;
+			case BLOCK_FACE_XP: Offset = Vector3i(-1, 0,  0); break;
+			default: return false;
+		}
+
+		auto NeighborPos = a_Position + Offset;
+		BLOCKTYPE NeighborType;
+		if (!a_Chunk.UnboundedRelGetBlockType(NeighborPos, NeighborType))
+		{
+			// The neighbour is not accessible (unloaded chunk), we'll allow it for now.
+			return true;
+		}
+		return cBlockInfo::IsSolid(NeighborType);
+	}
+
+
+
+
+
+	virtual ColourID GetMapBaseColourID(NIBBLETYPE a_Meta) const override
+	{
+		UNUSED(a_Meta);
+		return 0;
+	}
+} ;

--- a/src/Blocks/CMakeLists.txt
+++ b/src/Blocks/CMakeLists.txt
@@ -9,7 +9,6 @@ target_sources(
 
 	BlockAir.h
 	BlockAnvil.h
-	BlockBanner.h
 	BlockBed.h
 	BlockBigFlower.h
 	BlockBookShelf.h
@@ -94,6 +93,7 @@ target_sources(
 	BlockSnow.h
 	BlockSponge.h
 	BlockStairs.h
+	BlockStandingBanner.h
 	BlockStems.h
 	BlockStone.h
 	BlockSugarCane.h
@@ -104,6 +104,7 @@ target_sources(
 	BlockTripwire.h
 	BlockTripwireHook.h
 	BlockVines.h
+	BlockWallBanner.h
 	BlockWallSign.h
 	BlockWorkbench.h
 	BroadcastInterface.h


### PR DESCRIPTION
All the needed support for wall banners is already in the protocol and storage. However we need to split the block handler so we have separate ones for standing banners and wall banners and make the CanBeAt functions do the right thing in each case.
