### PR TITLE
Fix access to uninitialized space

### DIFF
--- a/src/Noise/InterpolNoise.h
+++ b/src/Noise/InterpolNoise.h
@@ -441,19 +441,19 @@ public:
 				{
 					int ToX = FromX + SameX[x];
 					Cell.Generate(FromX, ToX, FromY, ToY, FromZ, ToZ);
-					if (++x < NumSameX)
+					if (++x < NumSameX)  // Call Move() every time except for the last loop iteration
 					{
 						Cell.Move(FloorX[ToX], CurFloorY, CurFloorZ);
 						FromX = ToX;
 					}
 				}
-				if (++y < NumSameY)
+				if (++y < NumSameY)  // Call Move() every time except for the last loop iteration
 				{
 					Cell.Move(FloorX[0], FloorY[ToY], CurFloorZ);
 					FromY = ToY;
 				}
 			}  // for y
-			if (++z < NumSameZ)
+			if (++z < NumSameZ)  // Call Move() every time except for the last loop iteration
 			{
 				Cell.Move(FloorX[0], FloorY[0], FloorZ[ToZ]);
 				FromZ = ToZ;

--- a/src/Noise/InterpolNoise.h
+++ b/src/Noise/InterpolNoise.h
@@ -427,28 +427,37 @@ public:
 
 		// Calculate query values using Cell:
 		int FromZ = 0;
-		for (int z = 0; z < NumSameZ; z++)
+		for (int z = 0; z < NumSameZ;)
 		{
 			int ToZ = FromZ + SameZ[z];
 			int CurFloorZ = FloorZ[FromZ];
 			int FromY = 0;
-			for (int y = 0; y < NumSameY; y++)
+			for (int y = 0; y < NumSameY;)
 			{
 				int ToY = FromY + SameY[y];
 				int CurFloorY = FloorY[FromY];
 				int FromX = 0;
-				for (int x = 0; x < NumSameX; x++)
+				for (int x = 0; x < NumSameX;)
 				{
 					int ToX = FromX + SameX[x];
 					Cell.Generate(FromX, ToX, FromY, ToY, FromZ, ToZ);
-					Cell.Move(FloorX[(ToX < a_SizeX) ? ToX : 0], CurFloorY, CurFloorZ);
-					FromX = ToX;
+					if (++x < NumSameX)
+					{
+						Cell.Move(FloorX[ToX], CurFloorY, CurFloorZ);
+						FromX = ToX;
+					}
 				}
-				Cell.Move(FloorX[0], FloorY[(ToY < a_SizeY) ? ToY : 0], CurFloorZ);
-				FromY = ToY;
+				if (++y < NumSameY)
+				{
+					Cell.Move(FloorX[0], FloorY[ToY], CurFloorZ);
+					FromY = ToY;
+				}
 			}  // for y
-			Cell.Move(FloorX[0], FloorY[0], FloorZ[(ToZ < a_SizeZ) ? ToZ : 0]);
-			FromZ = ToZ;
+			if (++z < NumSameZ)
+			{
+				Cell.Move(FloorX[0], FloorY[0], FloorZ[ToZ]);
+				FromZ = ToZ;
+			}
 		}  // for z
 	}
 

--- a/src/Noise/InterpolNoise.h
+++ b/src/Noise/InterpolNoise.h
@@ -441,13 +441,13 @@ public:
 				{
 					int ToX = FromX + SameX[x];
 					Cell.Generate(FromX, ToX, FromY, ToY, FromZ, ToZ);
-					Cell.Move(FloorX[ToX], CurFloorY, CurFloorZ);
+					Cell.Move(FloorX[(ToX < a_SizeX) ? ToX : 0], CurFloorY, CurFloorZ);
 					FromX = ToX;
 				}
-				Cell.Move(FloorX[0], FloorY[ToY], CurFloorZ);
+				Cell.Move(FloorX[0], FloorY[(ToY < a_SizeY) ? ToY : 0], CurFloorZ);
 				FromY = ToY;
 			}  // for y
-			Cell.Move(FloorX[0], FloorY[0], FloorZ[ToZ]);
+			Cell.Move(FloorX[0], FloorY[0], FloorZ[(ToZ < a_SizeZ) ? ToZ : 0]);
 			FromZ = ToZ;
 		}  // for z
 	}

--- a/src/Noise/Noise.cpp
+++ b/src/Noise/Noise.cpp
@@ -743,13 +743,13 @@ void cCubicNoise::Generate2D(
 		{
 			int ToX = FromX + SameX[x];
 			Cell.Generate(FromX, ToX, FromY, ToY);
-			if (++x < NumSameX)
+			if (++x < NumSameX)  // Call Move() every time except for the last loop iteration
 			{
 				Cell.Move(FloorX[ToX], CurFloorY);
 				FromX = ToX;
 			}
 		}
-		if (++y < NumSameY)
+		if (++y < NumSameY)  // Call Move() every time except for the last loop iteration
 		{
 			Cell.Move(FloorX[0], FloorY[ToY]);
 			FromY = ToY;
@@ -815,19 +815,19 @@ void cCubicNoise::Generate3D(
 			{
 				int ToX = FromX + SameX[x];
 				Cell.Generate(FromX, ToX, FromY, ToY, FromZ, ToZ);
-				if (++x < NumSameX)
+				if (++x < NumSameX)  // Call Move() every time except for the last loop iteration
 				{
 					Cell.Move(FloorX[ToX], CurFloorY, CurFloorZ);
 					FromX = ToX;
 				}
 			}
-			if (++y < NumSameY)
+			if (++y < NumSameY)  // Call Move() every time except for the last loop iteration
 			{
 				Cell.Move(FloorX[0], FloorY[ToY], CurFloorZ);
 				FromY = ToY;
 			}
 		}  // for y
-		if (++z < NumSameZ)
+		if (++z < NumSameZ)  // Call Move() every time except for the last loop iteration
 		{
 			Cell.Move(FloorX[0], FloorY[0], FloorZ[ToZ]);
 			FromZ = ToZ;

--- a/src/Noise/Noise.cpp
+++ b/src/Noise/Noise.cpp
@@ -743,10 +743,10 @@ void cCubicNoise::Generate2D(
 		{
 			int ToX = FromX + SameX[x];
 			Cell.Generate(FromX, ToX, FromY, ToY);
-			Cell.Move(FloorX[ToX], CurFloorY);
+			Cell.Move(FloorX[(ToX < a_SizeX) ? ToX : 0], CurFloorY);
 			FromX = ToX;
 		}
-		Cell.Move(FloorX[0], FloorY[ToY]);
+		Cell.Move(FloorX[0], FloorY[(ToY < a_SizeY) ? ToY : 0]);
 		FromY = ToY;
 	}
 }
@@ -809,13 +809,13 @@ void cCubicNoise::Generate3D(
 			{
 				int ToX = FromX + SameX[x];
 				Cell.Generate(FromX, ToX, FromY, ToY, FromZ, ToZ);
-				Cell.Move(FloorX[ToX], CurFloorY, CurFloorZ);
+				Cell.Move(FloorX[(ToX < a_SizeX) ? ToX : 0], CurFloorY, CurFloorZ);
 				FromX = ToX;
 			}
-			Cell.Move(FloorX[0], FloorY[ToY], CurFloorZ);
+			Cell.Move(FloorX[0], FloorY[(ToY < a_SizeY) ? ToY : 0], CurFloorZ);
 			FromY = ToY;
 		}  // for y
-		Cell.Move(FloorX[0], FloorY[0], FloorZ[ToZ]);
+		Cell.Move(FloorX[0], FloorY[0], FloorZ[(ToZ < a_SizeZ) ? ToZ : 0]);
 		FromZ = ToZ;
 	}  // for z
 }

--- a/src/Noise/Noise.cpp
+++ b/src/Noise/Noise.cpp
@@ -734,20 +734,26 @@ void cCubicNoise::Generate2D(
 
 	// Calculate query values using Cell:
 	int FromY = 0;
-	for (int y = 0; y < NumSameY; y++)
+	for (int y = 0; y < NumSameY;)
 	{
 		int ToY = FromY + SameY[y];
 		int FromX = 0;
 		int CurFloorY = FloorY[FromY];
-		for (int x = 0; x < NumSameX; x++)
+		for (int x = 0; x < NumSameX;)
 		{
 			int ToX = FromX + SameX[x];
 			Cell.Generate(FromX, ToX, FromY, ToY);
-			Cell.Move(FloorX[(ToX < a_SizeX) ? ToX : 0], CurFloorY);
-			FromX = ToX;
+			if (++x < NumSameX)
+			{
+				Cell.Move(FloorX[ToX], CurFloorY);
+				FromX = ToX;
+			}
 		}
-		Cell.Move(FloorX[0], FloorY[(ToY < a_SizeY) ? ToY : 0]);
-		FromY = ToY;
+		if (++y < NumSameY)
+		{
+			Cell.Move(FloorX[0], FloorY[ToY]);
+			FromY = ToY;
+		}
 	}
 }
 
@@ -795,28 +801,37 @@ void cCubicNoise::Generate3D(
 
 	// Calculate query values using Cell:
 	int FromZ = 0;
-	for (int z = 0; z < NumSameZ; z++)
+	for (int z = 0; z < NumSameZ;)
 	{
 		int ToZ = FromZ + SameZ[z];
 		int CurFloorZ = FloorZ[FromZ];
 		int FromY = 0;
-		for (int y = 0; y < NumSameY; y++)
+		for (int y = 0; y < NumSameY;)
 		{
 			int ToY = FromY + SameY[y];
 			int CurFloorY = FloorY[FromY];
 			int FromX = 0;
-			for (int x = 0; x < NumSameX; x++)
+			for (int x = 0; x < NumSameX;)
 			{
 				int ToX = FromX + SameX[x];
 				Cell.Generate(FromX, ToX, FromY, ToY, FromZ, ToZ);
-				Cell.Move(FloorX[(ToX < a_SizeX) ? ToX : 0], CurFloorY, CurFloorZ);
-				FromX = ToX;
+				if (++x < NumSameX)
+				{
+					Cell.Move(FloorX[ToX], CurFloorY, CurFloorZ);
+					FromX = ToX;
+				}
 			}
-			Cell.Move(FloorX[0], FloorY[(ToY < a_SizeY) ? ToY : 0], CurFloorZ);
-			FromY = ToY;
+			if (++y < NumSameY)
+			{
+				Cell.Move(FloorX[0], FloorY[ToY], CurFloorZ);
+				FromY = ToY;
+			}
 		}  // for y
-		Cell.Move(FloorX[0], FloorY[0], FloorZ[(ToZ < a_SizeZ) ? ToZ : 0]);
-		FromZ = ToZ;
+		if (++z < NumSameZ)
+		{
+			Cell.Move(FloorX[0], FloorY[0], FloorZ[ToZ]);
+			FromZ = ToZ;
+		}
 	}  // for z
 }
 


### PR DESCRIPTION
Sooo...

CalcFloorFrac sets up the Floor arrays using a_Size element and returning Same and NumSame. We then loop over the x, y, z dimensions from 0 to NumSame doing a Cell.Generate followed by a Cell.Move. The Cell.Generate does the real work, the Cell.Move sets up for the next iteration. But for the last iteration of each loop there is no next and the Floor[To] passed to Cell.Move is off the end of the space used in Floor. For the last iterations it looks like we should be wrapping back to the beginning of the Floor arrays. It doesn't seem to make an observable difference (it's all noise :-) ). It just avoids the dodgy access.
