### PR TITLE
Make biomal composition gen respect the shapegen when placing bedrock

### DIFF
--- a/src/Generating/CompoGenBiomal.cpp
+++ b/src/Generating/CompoGenBiomal.cpp
@@ -456,7 +456,10 @@ protected:
 			}
 			HasHadWater = true;
 		}  // for y
-		a_ChunkDesc.SetBlockType(a_RelX, 0, a_RelZ, E_BLOCK_BEDROCK);
+		if (a_ShapeColumn[0] > 0)
+		{
+			a_ChunkDesc.SetBlockType(a_RelX, 0, a_RelZ, E_BLOCK_BEDROCK);
+		}
 	}
 
 


### PR DESCRIPTION
I was messing around with the world generator settings through the webadmin configuration plugin I'm working on when I realized I could get floating islands by combining the end shape generator with the biomal composition gen. Unfortunately the bedrock was always placed regardless of the shape generator. This changes it so the bedrock is only placed if the shape generator says it's a non-air block. 

![image](https://github.com/user-attachments/assets/2bd8b5dd-94a9-4ae6-87af-d70bebc1ba30)
