### PR TITLE
handle new anvil item name for 1.13

### DIFF
--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -635,7 +635,7 @@ void cProtocol_1_13::HandlePacketNameItem(cByteBuffer & a_ByteBuffer)
 {
 	HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, NewItemName);
 
-	LOGD("New item name : %s", NewItemName);
+	m_Client->HandleAnvilItemName(NewItemName);
 }
 
 


### PR DESCRIPTION
It was impossible to name an item. Now it should work. The next problem is sending the new named item to the player as the Item serialisation is not implemented yet.
See:
https://github.com/cuberite/cuberite/blob/5f4d2f004bc41bc44d0df7376e48cbb5567db1be/src/Protocol/Protocol_1_13.cpp#L1581

A fast first test seems to indicate, that #5567 does not fix that. It seems like the NBT tags are written, but other kind of tags are expected for the item name.