### PR TITLE
Remove simple template-id from constructors for Vector3 template.

### DIFF
--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -31,14 +31,14 @@ public:
 	// tolua_end
 	// Conversion constructors where U is not the same as T leaving the copy-constructor implicitly generated
 	template <typename U, std::enable_if_t<(!std::is_same<U, T>::value) && ((!std::is_integral<T>::value) || (std::is_integral<U>::value)), bool> = true>
-	constexpr Vector3<T>(const Vector3<U> & a_Rhs):
+	constexpr Vector3(const Vector3<U> & a_Rhs):
 			x(static_cast<T>(a_Rhs.x)),
 			y(static_cast<T>(a_Rhs.y)),
 			z(static_cast<T>(a_Rhs.z))
 	{
 	}
 	template <typename U, std::enable_if_t<(!std::is_same<U, T>::value) && ((std::is_integral<T>::value) && (!std::is_integral<U>::value)), bool> = true>
-	constexpr Vector3<T>(const Vector3<U> & a_Rhs):
+	constexpr Vector3(const Vector3<U> & a_Rhs):
 			x(static_cast<T>(std::floor(a_Rhs.x))),
 			y(static_cast<T>(std::floor(a_Rhs.y))),
 			z(static_cast<T>(std::floor(a_Rhs.z)))


### PR DESCRIPTION
This was removed from the C++ standard in C++20; annoying warnings are produced by modern C++ compilers.

https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#2237
