### PR TITLE
Manually specify UTF-8 encoding for Cuberite.rc

### DIFF
--- a/src/Resources/Cuberite.rc
+++ b/src/Resources/Cuberite.rc
@@ -1,3 +1,5 @@
+#pragma code_page(65001) // UTF-8
+
 #include "winres.h"
 
 Favicon ICON "icon.ico"


### PR DESCRIPTION
Fixes #5588

I'm not a Windows user so can't test this, but this blog post suggests this is the correct solution: https://devblogs.microsoft.com/oldnewthing/20190607-00/?p=102569

@66hh can you test that this compiles for your environment?
