### PR TITLE
Sound Enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ src/AllFiles.lst
 *.idb
 .vs/
 
+# win build
+VS2017-x64/*
+
 # cmake output folders and files
 ZERO_CHECK.dir/
 Debug/

--- a/src/Blocks/BroadcastInterface.h
+++ b/src/Blocks/BroadcastInterface.h
@@ -3,6 +3,7 @@
 
 #include "../Defines.h"
 #include "../Scoreboard.h"
+#include "../Registries/SoundEvent.h"
 
 // fwd:
 class cClientHandle;
@@ -58,6 +59,7 @@ public:
 	virtual void BroadcastScoreUpdate                (const AString & a_Objective, const AString & a_PlayerName, cObjective::Score a_Score, Byte a_Mode) = 0;
 	virtual void BroadcastDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) = 0;
 	virtual void BroadcastSoundEffect                (const AString & a_SoundName, Vector3d a_Position, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude = nullptr) = 0;
+	virtual void BroadcastSoundEffect                (const SoundEvent a_SoundEvent, Vector3d a_Position, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastSoundParticleEffect        (const EffectID a_EffectID, Vector3i a_SrcPos, int a_Data, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastSpawnEntity                (cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) = 0;
 	virtual void BroadcastThunderbolt                (Vector3i a_BlockPos, const cClientHandle * a_Exclude = nullptr) = 0;

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -553,6 +553,17 @@ void cWorld::BroadcastSoundEffect(const AString & a_SoundName, Vector3d a_Positi
 
 
 
+void cWorld::BroadcastSoundEffect(const SoundEvent a_SoundEvent, Vector3d a_Position, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude)
+{
+	ForClientsWithChunkAtPos(a_Position, *this, a_Exclude, [&](cClientHandle & a_Client) {
+		a_Client.SendSoundEffect(a_SoundEvent, a_Position, a_Volume, a_Pitch);
+	});
+}
+
+
+
+
+
 void cWorld::BroadcastSoundParticleEffect(const EffectID a_EffectID, Vector3i a_SrcPos, int a_Data, const cClientHandle * a_Exclude)
 {
 	ForClientsWithChunkAtPos(a_SrcPos, *this, a_Exclude, [&](cClientHandle & a_Client)

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -3077,7 +3077,18 @@ void cClientHandle::SendSoundEffect(const AString & a_SoundName, double a_X, dou
 
 void cClientHandle::SendSoundEffect(const AString & a_SoundName, Vector3d a_Position, float a_Volume, float a_Pitch)
 {
+	// Do we depricate?
+	// LOG("SendSoundEffect with String is deprecated, use version with SoundEvent enum.");
 	m_Protocol->SendSoundEffect(a_SoundName, a_Position, a_Volume, a_Pitch);
+}
+
+
+
+
+
+void cClientHandle::SendSoundEffect(const SoundEvent a_SoundEvent, Vector3d a_Position, float a_Volume, float a_Pitch)
+{
+	m_Protocol->SendSoundEffect(a_SoundEvent, a_Position, a_Volume, a_Pitch);
 }
 
 

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -223,6 +223,7 @@ public:  // tolua_export
 	void SendSetRawTitle                (const AString & a_Title);  // tolua_export
 	void SendSoundEffect                (const AString & a_SoundName, double a_X, double a_Y, double a_Z, float a_Volume, float a_Pitch);  // tolua_export
 	void SendSoundEffect                (const AString & a_SoundName, Vector3d a_Position, float a_Volume, float a_Pitch);  // tolua_export
+	void SendSoundEffect                (const SoundEvent a_SoundEvent, Vector3d a_Position, float a_Volume, float a_Pitch);  // tolua_export
 	void SendSoundParticleEffect        (const EffectID a_EffectID, Vector3i a_Source, int a_Data);
 	void SendSpawnEntity                (const cEntity & a_Entity);
 	void SendSpawnMob                   (const cMonster & a_Mob);

--- a/src/Protocol/CMakeLists.txt
+++ b/src/Protocol/CMakeLists.txt
@@ -34,3 +34,4 @@ target_sources(
 )
 
 add_subdirectory(Palettes)
+add_subdirectory(Sounds)

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -16,6 +16,9 @@
 #include "../EffectID.h"
 #include "../World.h"
 
+// Enums
+#include "../Registries/SoundEvent.h"
+
 
 
 
@@ -442,6 +445,7 @@ public:
 	virtual void SendSetTitle                   (const cCompositeChat & a_Title) = 0;
 	virtual void SendSetRawTitle                (const AString & a_Title) = 0;
 	virtual void SendSoundEffect                (const AString & a_SoundName, Vector3d a_Origin, float a_Volume, float a_Pitch) = 0;
+	virtual void SendSoundEffect                (const SoundEvent a_SoundEvent, Vector3d a_Origin, float a_Volume, float a_Pitch) = 0;
 	virtual void SendSoundParticleEffect        (const EffectID a_EffectID, Vector3i a_Origin, int a_Data) = 0;
 	virtual void SendSpawnEntity                (const cEntity & a_Entity) = 0;
 	virtual void SendSpawnMob                   (const cMonster & a_Mob) = 0;

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1406,6 +1406,30 @@ void cProtocol_1_8_0::SendSoundEffect(const AString & a_SoundName, Vector3d a_Or
 
 
 
+void cProtocol_1_8_0::SendSoundEffect(SoundEvent a_SoundEvent, Vector3d a_Origin, float a_Volume, float a_Pitch)
+{
+	AString soundName = GetProtocolSoundEffectAsString(a_SoundEvent);
+	if (soundName.empty())
+	{
+		FLOGD("SoundEvent enum {0} is missing a related sound effect.", a_SoundEvent);
+		return;
+	}
+
+	ASSERT(m_State == 3);  // In game mode?
+
+	cPacketizer Pkt(*this, pktSoundEffect);
+	Pkt.WriteString(soundName);
+	Pkt.WriteBEInt32(static_cast<Int32>(a_Origin.x * 8.0));
+	Pkt.WriteBEInt32(static_cast<Int32>(a_Origin.y * 8.0));
+	Pkt.WriteBEInt32(static_cast<Int32>(a_Origin.z * 8.0));
+	Pkt.WriteBEFloat(a_Volume);
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_Pitch * 63));
+}
+
+
+
+
+
 void cProtocol_1_8_0::SendSoundParticleEffect(const EffectID a_EffectID, Vector3i a_Origin, int a_Data)
 {
 	ASSERT(m_State == 3);  // In game mode?

--- a/src/Protocol/Protocol_1_8.h
+++ b/src/Protocol/Protocol_1_8.h
@@ -104,6 +104,7 @@ public:
 	virtual void SendResourcePack               (const AString & a_ResourcePackUrl) override;
 	virtual void SendRespawn                    (eDimension a_Dimension) override;
 	virtual void SendSoundEffect                (const AString & a_SoundName, Vector3d a_Origin, float a_Volume, float a_Pitch) override;
+	virtual void SendSoundEffect                (const SoundEvent a_SoundEvent, Vector3d a_Origin, float a_Volume, float a_Pitch) override;
 	virtual void SendScoreboardObjective        (const AString & a_Name, const AString & a_DisplayName, Byte a_Mode) override;
 	virtual void SendScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) override;
 	virtual void SendDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) override;
@@ -166,6 +167,9 @@ protected:
 
 	/** The 1.8 protocol use a particle id instead of a string. This function converts the name to the id. If the name is incorrect, it returns 0. */
 	virtual int GetProtocolParticleID(const AString & a_ParticleName) const;
+
+	/** A certain era of protocol uses String for SoundEffects. If it doesn't exists, it returns an empty string. */
+	virtual AString GetProtocolSoundEffectAsString(SoundEvent a_SoundEvent) const;
 
 	/** Returns the protocol version. */
 	virtual Version GetProtocolVersion() const override;

--- a/src/Protocol/Sounds/CMakeLists.txt
+++ b/src/Protocol/Sounds/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(
+	${CMAKE_PROJECT_NAME} PRIVATE
+
+	PSounds_1_8.cpp
+)

--- a/src/Protocol/Sounds/PSounds_1_8.cpp
+++ b/src/Protocol/Sounds/PSounds_1_8.cpp
@@ -1,0 +1,13 @@
+#include "../Protocol_1_8.h"
+
+
+AString cProtocol_1_8_0::GetProtocolSoundEffectAsString(SoundEvent a_SoundEvent) const
+{
+	switch (a_SoundEvent)
+	{
+		case SoundEvent::EnderEyeCustomSurvive:  return "random.pop";  // not part of the 1.21.4 sound list
+		case SoundEvent::EnderEyeDeath:          return "dig.glass";
+		case SoundEvent::EnderEyeLaunch:         return "random.bow";
+	}
+	return AString();
+}

--- a/src/Registries/CMakeLists.txt
+++ b/src/Registries/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(
 	BlockTypes.h
 	CustomStatistics.h
 	Items.h
+	SoundEvent.h
 )

--- a/src/Registries/SoundEvent.h
+++ b/src/Registries/SoundEvent.h
@@ -1,0 +1,8 @@
+# pragma once
+enum class SoundEvent
+{
+	// Ender Eye
+	EnderEyeCustomSurvive,
+    EnderEyeDeath,
+	EnderEyeLaunch,
+};

--- a/src/World.h
+++ b/src/World.h
@@ -192,6 +192,7 @@ public:
 	virtual void BroadcastScoreUpdate                (const AString & a_Objective, const AString & a_Player, cObjective::Score a_Score, Byte a_Mode) override;
 	virtual void BroadcastDisplayObjective           (const AString & a_Objective, cScoreboard::eDisplaySlot a_Display) override;
 	virtual void BroadcastSoundEffect                (const AString & a_SoundName, Vector3d a_Position, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude = nullptr) override;  // Exported in ManualBindings_World.cpp
+	virtual void BroadcastSoundEffect                (const SoundEvent a_SoundEvent, Vector3d a_Position, float a_Volume, float a_Pitch, const cClientHandle * a_Exclude = nullptr) override;  // Exported in ManualBindings_World.cpp 
 	virtual void BroadcastSoundParticleEffect        (const EffectID a_EffectID, Vector3i a_SrcPos, int a_Data, const cClientHandle * a_Exclude = nullptr) override;  // Exported in ManualBindings_World.cpp
 	virtual void BroadcastSpawnEntity                (cEntity & a_Entity, const cClientHandle * a_Exclude = nullptr) override;
 	virtual void BroadcastThunderbolt                (Vector3i a_BlockPos, const cClientHandle * a_Exclude = nullptr) override;


### PR DESCRIPTION
# Summary
Begins a basic SoundEvent enum, to be grown off of the current list of sounds in the modern list.

# Description
- Added the VS2017-x64 folder to the .gitignore for easier git management (hopefully this doesn't brick any CDI pipeline)
- Create the SoundEvent enums to help consolidate modern sound names into old sound identifiers (strings in 1.8)


# Added
- `SoundEvent.h`
- `PSounds_1_8.cpp` (file for implementing sounds for `cProtocol_1_8_0`)