### PR TITLE
ensures that Guardians and Squids only spawn in valid biomes

### DIFF
--- a/src/MobSpawner.cpp
+++ b/src/MobSpawner.cpp
@@ -196,6 +196,9 @@ bool cMobSpawner::CanSpawnHere(cChunk * a_Chunk, Vector3i a_RelPos, eMonsterType
 
 		case mtGuardian:
 		{
+			if (a_Biome != biDeepOcean) {
+				return false;
+			}
 			return
 			(
 				IsBlockWater(TargetBlock) &&
@@ -368,12 +371,29 @@ std::set<eMonsterType> cMobSpawner::GetAllowedMobTypes(EMCSBiome a_Biome)
 
 		// Add Squid in ocean and river biomes
 		case biOcean:
+				{
+			ListOfSpawnables.insert(mtSquid);
+			break;
+		}
 		case biFrozenOcean:
+				{
+			ListOfSpawnables.insert(mtSquid);
+			break;
+		}
 		case biFrozenRiver:
+				{
+			ListOfSpawnables.insert(mtSquid);
+			break;
+		}
 		case biRiver:
+				{
+			ListOfSpawnables.insert(mtSquid);
+			break;
+		}
 		case biDeepOcean:
 		{
 			ListOfSpawnables.insert(mtGuardian);
+			ListOfSpawnables.insert(mtSquid);
 			break;
 		}
 


### PR DESCRIPTION
- Restricted Guardians to Deep Ocean biome to prevent spawning in nearby biomes by modifying case for mtGuardian
- Restricted Squids to spawning only in ocean and river biomes
- Fixes #5601