### PR TITLE
Updated to C++23 and update FMT lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	ignore = dirty
 [submodule "lib/TCLAP"]
 	path = lib/TCLAP
-	url = https://github.com/cuberite/TCLAP.git
+	url = https://github.com/DAarno/tclap.git
 	ignore = dirty
 [submodule "lib/cmake-coverage"]
 	path = lib/cmake-coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include("SetFlags.cmake")
 include("CMake/StampBuild.cmake")
 
 # We need C++17 features:
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -139,7 +139,9 @@ function(set_exe_flags TARGET)
 		-fsigned-char
 
 		# We support non-IEEE 754 FPUs so can make no guarantees about error:
-		-ffast-math
+		-fno-math-errno
+		-funsafe-math-optimizations
+		-fno-rounding-math
 
 		# All warnings:
 		-Wall -Wextra
@@ -156,6 +158,9 @@ function(set_exe_flags TARGET)
 			# or at least disable on a file-level basis:
 			-Wno-missing-noreturn -Wno-padded -Wno-implicit-fallthrough
 			-Wno-double-promotion
+			-Wno-switch-default
+			-Wno-switch
+			-Wno-nrvo
 
 			# This is a pretty useless warning, we've already got -Wswitch which is what we need:
 			-Wno-switch-enum

--- a/Tools/GrownBiomeGenVisualiser/GrownBiomeGenVisualiser.cpp
+++ b/Tools/GrownBiomeGenVisualiser/GrownBiomeGenVisualiser.cpp
@@ -156,7 +156,7 @@ static const struct
 template <typename ... Args>
 void log(const char * a_Fmt, const Args & ... a_Args)
 {
-	fmt::printf(a_Fmt, a_Args...);
+	fmt::printf(fmt::detail::to_string_view(a_Fmt), a_Args...);
 	putchar('\n');
 	fflush(stdout);
 }

--- a/Tools/ProtoProxy/Connection.cpp
+++ b/Tools/ProtoProxy/Connection.cpp
@@ -290,7 +290,7 @@ void cConnection::vLog(const char * a_Format, fmt::printf_args a_ArgList)
 	// Log to file:
 	cCSLock Lock(m_CSLog);
 	fmt::fprintf(m_LogFile, "[%5.3f] ", GetRelativeTime());
-	fmt::vfprintf(m_LogFile, a_Format, a_ArgList);
+	fmt::vfprintf(m_LogFile, fmt::detail::to_string_view(a_Format), a_ArgList);
 	fmt::fprintf(m_LogFile, "\n");
 	#ifdef _DEBUG
 		fflush(m_LogFile);
@@ -312,7 +312,7 @@ void cConnection::vDataLog(const void * a_Data, size_t a_Size, const char * a_Fo
 	// Log to file:
 	cCSLock Lock(m_CSLog);
 	fmt::fprintf(m_LogFile, "[%5.3f] ", GetRelativeTime());
-	fmt::vfprintf(m_LogFile, a_Format, a_ArgList);
+	fmt::vfprintf(m_LogFile, fmt::detail::to_string_view(a_Format), a_ArgList);
 	fmt::fprintf(m_LogFile, "\n%s\n", Hex);
 
 	// Log to screen:

--- a/src/Bindings/LuaChunkStay.cpp
+++ b/src/Bindings/LuaChunkStay.cpp
@@ -25,7 +25,7 @@ bool cLuaChunkStay::AddChunks(const cLuaState::cStackTable & a_ChunkCoordsTable)
 	ASSERT(m_Chunks.empty());
 
 	// Add each set of coords:
-	a_ChunkCoordsTable.ForEachArrayElement([=](cLuaState & a_LuaState, int a_Index)
+	a_ChunkCoordsTable.ForEachArrayElement([this](cLuaState & a_LuaState, int a_Index)
 		{
 			if (!lua_istable(a_LuaState, -1))
 			{

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -129,7 +129,7 @@ int cManualBindings::vlua_do_error(lua_State * L, const char * a_pFormat, fmt::p
 
 	// Copied from luaL_error and modified
 	luaL_where(L, 1);
-	auto Msg = fmt::vsprintf(msg, a_ArgList);
+	auto Msg = fmt::vsprintf(fmt::detail::to_string_view(msg), a_ArgList);
 	lua_pushlstring(L, Msg.data(), Msg.size());
 	lua_concat(L, 2);
 	return lua_error(L);

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -1148,7 +1148,7 @@ const char * cPluginLua::GetHookFnName(int a_HookType)
 			break;
 		}
 	}  // switch (a_Hook)
-	LOGWARNING("Requested name of an unknown hook type function: %d (max is %d)", a_HookType, cPluginManager::HOOK_MAX);
+	LOGWARNING("Requested name of an unknown hook type function: %d (max is %d)", static_cast<int>(a_HookType), static_cast<int>(cPluginManager::HOOK_MAX));
 	ASSERT(!"Unknown hook requested!");
 	return nullptr;
 }

--- a/src/BlockEntities/FurnaceEntity.cpp
+++ b/src/BlockEntities/FurnaceEntity.cpp
@@ -206,7 +206,7 @@ void cFurnaceEntity::FinishOne()
 	{
 		m_Contents.ChangeSlotCount(fsOutput, m_CurrentRecipe->Out->m_ItemCount);
 	}
-	m_Contents.ChangeSlotCount(fsInput, -m_CurrentRecipe->In->m_ItemCount);
+	m_Contents.ChangeSlotCount(fsInput, static_cast<char>(-m_CurrentRecipe->In->m_ItemCount));
 }
 
 

--- a/src/ChunkDef.h
+++ b/src/ChunkDef.h
@@ -104,7 +104,7 @@ namespace fmt
 {
 	template <> struct formatter<cChunkCoords>: formatter<int>
 	{
-		auto format(cChunkCoords a_Coords, format_context & a_Ctx)
+		auto format(cChunkCoords a_Coords, format_context & a_Ctx) const
 		{
 			return format_to(a_Ctx.out(), "[{}, {}]", a_Coords.m_ChunkX, a_Coords.m_ChunkZ);
 		}

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1668,7 +1668,7 @@ void cClientHandle::HandleSpectate(const cUUID & a_PlayerUUID)
 		return;
 	}
 
-	m_Player->GetWorld()->DoWithPlayerByUUID(a_PlayerUUID, [=](cPlayer & a_ToSpectate)
+	m_Player->GetWorld()->DoWithPlayerByUUID(a_PlayerUUID, [this](cPlayer & a_ToSpectate)
 	{
 		m_Player->TeleportToEntity(a_ToSpectate);
 		return true;
@@ -1760,7 +1760,7 @@ void cClientHandle::HandleUseEntity(UInt32 a_TargetEntityID, bool a_IsLeftClick)
 	// If the player is a spectator, let him spectate
 	if (m_Player->IsGameModeSpectator() && a_IsLeftClick)
 	{
-		m_Player->GetWorld()->DoWithEntityByID(a_TargetEntityID, [=](cEntity & a_Entity)
+		m_Player->GetWorld()->DoWithEntityByID(a_TargetEntityID, [this](cEntity & a_Entity)
 		{
 			m_Player->SpectateEntity(&a_Entity);
 			return true;
@@ -1772,7 +1772,7 @@ void cClientHandle::HandleUseEntity(UInt32 a_TargetEntityID, bool a_IsLeftClick)
 	if (!a_IsLeftClick)
 	{
 		cWorld * World = m_Player->GetWorld();
-		World->DoWithEntityByID(a_TargetEntityID, [=](cEntity & a_Entity)
+		World->DoWithEntityByID(a_TargetEntityID, [this](cEntity & a_Entity)
 			{
 				if (
 					cPluginManager::Get()->CallHookPlayerRightClickingEntity(*m_Player, a_Entity) ||
@@ -1798,7 +1798,7 @@ void cClientHandle::HandleUseEntity(UInt32 a_TargetEntityID, bool a_IsLeftClick)
 	}
 
 	// If it is a left click, attack the entity:
-	m_Player->GetWorld()->DoWithEntityByID(a_TargetEntityID, [=](cEntity & a_Entity)
+	m_Player->GetWorld()->DoWithEntityByID(a_TargetEntityID, [this](cEntity & a_Entity)
 		{
 			if (!a_Entity.GetWorld()->IsPVPEnabled())
 			{

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1094,7 +1094,7 @@ void cClientHandle::HandleAnvilItemName(const AString & a_ItemName)
 void cClientHandle::HandleLeftClick(Vector3i a_BlockPos, eBlockFace a_BlockFace, UInt8 a_Status)
 {
 	FLOGD("HandleLeftClick: {0}; Face: {1}; Stat: {2}",
-		a_BlockPos, a_BlockFace, a_Status
+		a_BlockPos, static_cast<int>(a_BlockFace), a_Status
 	);
 
 	m_NumBlockChangeInteractionsThisTick++;
@@ -1438,7 +1438,7 @@ void cClientHandle::HandleRightClick(Vector3i a_BlockPos, eBlockFace a_BlockFace
 	cPluginManager * PlgMgr = cRoot::Get()->GetPluginManager();
 	const cItem & HeldItem = a_UsedMainHand ? m_Player->GetEquippedItem() : m_Player->GetInventory().GetShieldSlot();
 
-	FLOGD("HandleRightClick: {0}, face {1}, Cursor {2}, Hand: {3}, HeldItem: {4}", a_BlockPos, a_BlockFace, a_CursorPos, a_UsedMainHand, ItemToFullString(HeldItem));
+	FLOGD("HandleRightClick: {0}, face {1}, Cursor {2}, Hand: {3}, HeldItem: {4}", a_BlockPos, static_cast<int>(a_BlockFace), a_CursorPos, a_UsedMainHand, ItemToFullString(HeldItem));
 
 	if (!PlgMgr->CallHookPlayerRightClick(*m_Player, a_BlockPos, a_BlockFace, a_CursorPos) && IsWithinReach(a_BlockPos) && !m_Player->IsFrozen())
 	{

--- a/src/DeadlockDetect.cpp
+++ b/src/DeadlockDetect.cpp
@@ -56,7 +56,7 @@ void cDeadlockDetect::Start(int a_IntervalSec)
 	m_IntervalSec = a_IntervalSec;
 
 	// Read the initial world data:
-	cRoot::Get()->ForEachWorld([=](cWorld & a_World)
+	cRoot::Get()->ForEachWorld([this](cWorld & a_World)
 	{
 		SetWorldAge(a_World.GetName(), a_World.GetWorldAge());
 		return false;
@@ -102,7 +102,7 @@ void cDeadlockDetect::Execute(void)
 	while (!m_ShouldTerminate)
 	{
 		// Check the world ages:
-		cRoot::Get()->ForEachWorld([=](cWorld & a_World)
+		cRoot::Get()->ForEachWorld([this](cWorld & a_World)
 		{
 			CheckWorldAge(a_World.GetName(), a_World.GetWorldAge());
 			return false;

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -1,6 +1,6 @@
 
 #pragma once
-#include "fmt/format.h"
+
 
 
 
@@ -449,6 +449,9 @@ enum class BossBarDivisionType
 };
 
 // tolua_end
+
+
+
 
 
 enum class EntityAnimation

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -1,6 +1,6 @@
 
 #pragma once
-
+#include "fmt/format.h"
 
 
 
@@ -449,9 +449,9 @@ enum class BossBarDivisionType
 };
 
 // tolua_end
-
-
-
+auto static format_as(eGameMode f) { return fmt::underlying(f); }
+auto static format_as(eClickAction f) { return fmt::underlying(f); }
+auto static format_as(eBlockFace f) { return fmt::underlying(f); }
 
 
 enum class EntityAnimation

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -449,9 +449,6 @@ enum class BossBarDivisionType
 };
 
 // tolua_end
-auto static format_as(eGameMode f) { return fmt::underlying(f); }
-auto static format_as(eClickAction f) { return fmt::underlying(f); }
-auto static format_as(eBlockFace f) { return fmt::underlying(f); }
 
 
 enum class EntityAnimation

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -295,7 +295,7 @@ void cEntity::TakeDamage(eDamageType a_DamageType, cEntity * a_Attacker, int a_R
 
 void cEntity::TakeDamage(eDamageType a_DamageType, UInt32 a_AttackerID, int a_RawDamage, double a_KnockbackAmount)
 {
-	m_World->DoWithEntityByID(a_AttackerID, [=](cEntity & a_Attacker)
+	m_World->DoWithEntityByID(a_AttackerID, [=, this](cEntity & a_Attacker)
 		{
 			cPawn * Attacker;
 			if (a_Attacker.IsPawn())

--- a/src/Entities/Pawn.cpp
+++ b/src/Entities/Pawn.cpp
@@ -66,7 +66,7 @@ void cPawn::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	// Spectators cannot push entities around
 	if ((!IsPlayer()) || (!static_cast<cPlayer *>(this)->IsGameModeSpectator()))
 	{
-		m_World->ForEachEntityInBox(GetBoundingBox(), [=](cEntity & a_Entity)
+		m_World->ForEachEntityInBox(GetBoundingBox(), [this](cEntity & a_Entity)
 			{
 				if (a_Entity.GetUniqueID() == GetUniqueID())
 				{

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1316,7 +1316,7 @@ void cPlayer::SetGameMode(eGameMode a_GameMode)
 {
 	if ((a_GameMode < gmMin) || (a_GameMode >= gmMax))
 	{
-		LOGWARNING("%s: Setting invalid gamemode: %d", GetName().c_str(), a_GameMode);
+		LOGWARNING("%s: Setting invalid gamemode: %d", GetName().c_str(), static_cast<int>(a_GameMode));
 		return;
 	}
 
@@ -1736,7 +1736,7 @@ void cPlayer::TossEquippedItem(char a_Amount)
 			NewAmount = GetInventory().GetEquippedItem().m_ItemCount;  // Drop only what's there
 		}
 
-		GetInventory().GetHotbarGrid().ChangeSlotCount(GetInventory().GetEquippedSlotNum() /* Returns hotbar subslot, which HotbarGrid takes */, -a_Amount);
+		GetInventory().GetHotbarGrid().ChangeSlotCount(GetInventory().GetEquippedSlotNum() /* Returns hotbar subslot, which HotbarGrid takes */, static_cast<char>(-a_Amount));
 
 		DroppedItem.m_ItemCount = NewAmount;
 		Drops.push_back(DroppedItem);

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -286,7 +286,7 @@ std::unique_ptr<cProjectileEntity> cProjectileEntity::Create(
 		}
 	}
 
-	LOGWARNING("%s: Unknown projectile kind: %d", __FUNCTION__, a_Kind);
+	LOGWARNING("%s: Unknown projectile kind: %d", __FUNCTION__, static_cast<int>(a_Kind));
 	return nullptr;
 }
 

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -302,7 +302,7 @@ void cProjectileEntity::OnHitSolidBlock(Vector3d a_HitPos, eBlockFace a_HitFace)
 
 	// DEBUG:
 	FLOGD("Projectile {0}: pos {1:.02f}, hit solid block at face {2}",
-		m_UniqueID, a_HitPos, a_HitFace
+		m_UniqueID, a_HitPos, static_cast<int>(a_HitFace)
 	);
 
 	m_IsInGround = true;

--- a/src/Entities/ThrownEnderPearlEntity.cpp
+++ b/src/Entities/ThrownEnderPearlEntity.cpp
@@ -60,7 +60,7 @@ void cThrownEnderPearlEntity::TeleportCreator(Vector3d a_HitPos)
 
 
 
-	GetWorld()->FindAndDoWithPlayer(m_CreatorData.m_Name, [=](cPlayer & a_Entity)
+	GetWorld()->FindAndDoWithPlayer(m_CreatorData.m_Name, [=, this](cPlayer & a_Entity)
 	{
 
 		auto & Random = GetRandomProvider();

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -19,6 +19,8 @@
 	// Use non-standard defines in <cmath>
 	#define _USE_MATH_DEFINES
 
+	// Breaks in C++20 and above
+	/*
 	#ifndef NDEBUG
 		// Override the "new" operator to include file and line specification for debugging memory leaks
 		// Ref.: https://social.msdn.microsoft.com/Forums/en-US/ebc7dd7a-f3c6-49f1-8a60-e381052f21b6/debugging-memory-leaks?forum=vcgeneral#53f0cc89-62fe-45e8-bbf0-56b89f2a1901
@@ -34,7 +36,7 @@
 		// For some reason this works magically - each "new X" gets replaced as "new(_CLIENT_BLOCK, "file", line) X"
 		// The CRT has a definition for this operator new that stores the debugging info for leak-finding later.
 	#endif
-
+	*/
 	#define UNREACHABLE_INTRINSIC __assume(false)
 
 #elif defined(__GNUC__)
@@ -206,7 +208,7 @@ template class SizeChecker<UInt8, 1>;
 		std::string_view a_Format, eLogLevel, fmt::printf_args a_ArgList
 	)
 	{
-		fmt::vprintf(a_Format, a_ArgList);
+		fmt::vfprintf(stdout, fmt::detail::to_string_view(a_Format), a_ArgList);
 		putchar('\n');
 		fflush(stdout);
 	}

--- a/src/HTTP/TransferEncodingParser.cpp
+++ b/src/HTTP/TransferEncodingParser.cpp
@@ -296,7 +296,7 @@ protected:
 	{
 		if (m_State != psFinished)
 		{
-			Error(fmt::format(FMT_STRING("ChunkedTransferEncoding: Finish signal received before the data stream ended (state: {})"), m_State));
+			Error(fmt::format(FMT_STRING("ChunkedTransferEncoding: Finish signal received before the data stream ended (state: {})"), static_cast<int>(m_State)));
 		}
 		m_State = psFinished;
 	}

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -69,7 +69,7 @@ int cInventory::HowManyCanFit(const cItem & a_ItemStack, int a_BeginSlotNum, int
 	}
 	if ((a_EndSlotNum < 0) || (a_EndSlotNum >= invNumSlots))
 	{
-		LOGWARNING("%s: Bad EndSlotNum, got %d, there are %d slots; correcting to %d.", __FUNCTION__, a_BeginSlotNum, invNumSlots, invNumSlots - 1);
+		LOGWARNING("%s: Bad EndSlotNum, got %d, there are %d slots; correcting to %d.", __FUNCTION__, a_BeginSlotNum, static_cast<int>(invNumSlots), (invNumSlots - 1));
 		a_EndSlotNum = invNumSlots - 1;
 	}
 	if (a_BeginSlotNum > a_EndSlotNum)
@@ -501,7 +501,7 @@ char cInventory::ChangeSlotCount(int a_SlotNum, char a_AddToCount)
 	cItemGrid * Grid = GetGridForSlotNum(a_SlotNum, GridSlotNum);
 	if (Grid == nullptr)
 	{
-		LOGWARNING("%s: invalid slot number, expected 0 .. %d, got %d; ignoring", __FUNCTION__, invNumSlots, a_SlotNum);
+		LOGWARNING("%s: invalid slot number, expected 0 .. %d, got %d; ignoring", __FUNCTION__, static_cast<int>(invNumSlots), a_SlotNum);
 		return -1;
 	}
 	return Grid->ChangeSlotCount(GridSlotNum, a_AddToCount);

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -25,7 +25,7 @@ static void WriteLogOpener(fmt::memory_buffer & Buffer)
 #ifndef NDEBUG
 	const auto ThreadID = std::hash<std::thread::id>()(std::this_thread::get_id());
 	fmt::format_to(
-		Buffer, "[{0:04x}|{1:02d}:{2:02d}:{3:02d}] ",
+		std::back_inserter(Buffer), "[{0:04x}|{1:02d}:{2:02d}:{3:02d}] ",
 		ThreadID, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec
 	);
 #else
@@ -63,7 +63,7 @@ void cLogger::LogSimple(std::string_view a_Message, eLogLevel a_LogLevel)
 {
 	fmt::memory_buffer Buffer;
 	WriteLogOpener(Buffer);
-	fmt::format_to(Buffer, "{0}\n", a_Message);
+	fmt::format_to(std::back_inserter(Buffer), "{0}\n", a_Message);
 	LogLine(std::string_view(Buffer.data(), Buffer.size()), a_LogLevel);
 }
 
@@ -88,8 +88,8 @@ void cLogger::LogPrintf(std::string_view a_Format, eLogLevel a_LogLevel, fmt::pr
 {
 	fmt::memory_buffer Buffer;
 	WriteLogOpener(Buffer);
-	fmt::vprintf(Buffer, fmt::to_string_view(a_Format), a_ArgList);
-	fmt::format_to(Buffer, "\n");
+	Buffer.append(fmt::vsprintf(fmt::string_view(a_Format), a_ArgList));
+	fmt::format_to(std::back_inserter(Buffer), "\n");
 
 	LogLine(std::string_view(Buffer.data(), Buffer.size()), a_LogLevel);
 }
@@ -102,8 +102,8 @@ void cLogger::LogFormat(std::string_view a_Format, eLogLevel a_LogLevel, fmt::fo
 {
 	fmt::memory_buffer Buffer;
 	WriteLogOpener(Buffer);
-	fmt::vformat_to(Buffer, a_Format, a_ArgList);
-	fmt::format_to(Buffer, "\n");
+	fmt::vformat_to(std::back_inserter(Buffer), a_Format, a_ArgList);
+	fmt::format_to(std::back_inserter(Buffer), "\n");
 
 	LogLine(std::string_view(Buffer.data(), Buffer.size()), a_LogLevel);
 }

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -30,7 +30,7 @@ static void WriteLogOpener(fmt::memory_buffer & Buffer)
 	);
 #else
 	fmt::format_to(
-		Buffer, "[{0:02d}:{1:02d}:{2:02d}] ",
+		std::back_inserter(Buffer), "[{0:02d}:{1:02d}:{2:02d}] ",
 		timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec
 	);
 #endif

--- a/src/MobSpawner.cpp
+++ b/src/MobSpawner.cpp
@@ -341,7 +341,7 @@ bool cMobSpawner::CanSpawnHere(cChunk * a_Chunk, Vector3i a_RelPos, eMonsterType
 
 		default:
 		{
-			LOGD("MG TODO: Write spawning rule for mob type %d", a_MobType);
+			LOGD("MG TODO: Write spawning rule for mob type %d", static_cast<int>(a_MobType));
 			return false;
 		}
 	}

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -1433,7 +1433,7 @@ void cMonster::LoveTick(void)
 	{
 		if (m_LovePartner == nullptr)
 		{
-			m_World->ForEachEntityInBox(cBoundingBox(GetPosition(), 8, 8), [=](cEntity & a_Entity)
+			m_World->ForEachEntityInBox(cBoundingBox(GetPosition(), 8, 8), [this](cEntity & a_Entity)
 			{
 				// If the entity is not a monster, don't breed with it
 				// Also, do not self-breed

--- a/src/Mobs/MonsterTypes.h
+++ b/src/Mobs/MonsterTypes.h
@@ -1,6 +1,6 @@
 
 #pragma once
-#include "fmt/format.h"
+
 
 
 

--- a/src/Mobs/MonsterTypes.h
+++ b/src/Mobs/MonsterTypes.h
@@ -1,6 +1,6 @@
 
 #pragma once
-
+#include "fmt/format.h"
 
 
 
@@ -86,3 +86,4 @@ enum eMonsterType
 } ;
 
 // tolua_end
+auto static format_as(eMonsterType f) { return fmt::underlying(f); }

--- a/src/Mobs/MonsterTypes.h
+++ b/src/Mobs/MonsterTypes.h
@@ -86,4 +86,3 @@ enum eMonsterType
 } ;
 
 // tolua_end
-auto static format_as(eMonsterType f) { return fmt::underlying(f); }

--- a/src/Protocol/Packetizer.cpp
+++ b/src/Protocol/Packetizer.cpp
@@ -135,5 +135,5 @@ AString cPacketizer::PacketTypeToStr(cProtocol::ePacketType a_PacketType)
 		case cProtocol::pktWindowOpen:             return "pktWindowOpen";
 		case cProtocol::pktWindowProperty:         return "pktWindowProperty";
 	}
-	return fmt::format(FMT_STRING("Unknown packet type: 0x{:02x}"), a_PacketType);
+	return fmt::format(FMT_STRING("Unknown packet type: 0x{:02x}"),  static_cast<int>(a_PacketType));
 }

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include "../Defines.h"
 #include "../Scoreboard.h"
 #include "../ByteBuffer.h"
@@ -492,3 +493,5 @@ protected:
 	The cPacketizer's destructor calls this to send the contained packet; protocol may transform the data (compression in 1.8 etc). */
 	virtual void SendPacket(cPacketizer & a_Packet) = 0;
 } ;
+
+auto static format_as(cProtocol::State f) { return fmt::underlying(f); }

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -494,4 +494,3 @@ protected:
 	virtual void SendPacket(cPacketizer & a_Packet) = 0;
 } ;
 
-auto static format_as(cProtocol::State f) { return fmt::underlying(f); }

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
 #include "../Defines.h"
 #include "../Scoreboard.h"
 #include "../ByteBuffer.h"
@@ -493,4 +492,3 @@ protected:
 	The cPacketizer's destructor calls this to send the contained packet; protocol may transform the data (compression in 1.8 etc). */
 	virtual void SendPacket(cPacketizer & a_Packet) = 0;
 } ;
-

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -73,7 +73,7 @@ AString cMultiVersionProtocol::GetVersionTextFromInt(cProtocol::Version a_Protoc
 	}
 
 	ASSERT(!"Unknown protocol version");
-	return fmt::format(FMT_STRING("Unknown protocol ({})"), a_ProtocolVersion);
+	return fmt::format(FMT_STRING("Unknown protocol ({})"), static_cast<int>(a_ProtocolVersion));
 }
 
 
@@ -259,11 +259,11 @@ bool cMultiVersionProtocol::TryHandleHTTPRequest(cClientHandle & a_Client, Conti
 	m_Buffer.ResetRead();
 
 	// The request line, hastily decoded with the hope that it's encoded in US-ASCII.
-	const std::string_view Value(reinterpret_cast<const char *>(Buffer.data()), Buffer.size());
+	const std::u8string_view Value(reinterpret_cast<const char8_t *>(Buffer.data()), Buffer.size());
 
 	if (Value == u8"GET / HTTP")
 	{
-		const auto Response = fmt::format(u8"HTTP/1.0 303 See Other\r\nLocation: {}\r\n\r\n", cRoot::Get()->GetServer()->GetCustomRedirectUrl());
+		const auto Response = fmt::format("HTTP/1.0 303 See Other\r\nLocation: {}\r\n\r\n", cRoot::Get()->GetServer()->GetCustomRedirectUrl());
 		a_Client.SendData({ reinterpret_cast<const std::byte *>(Response.data()), Response.size() });
 		a_Client.Destroy();
 		return true;

--- a/src/Protocol/Protocol_1_12.cpp
+++ b/src/Protocol/Protocol_1_12.cpp
@@ -1334,7 +1334,7 @@ void cProtocol_1_12_2::SendKeepAlive(UInt32 a_PingID)
 	// Drop the packet if the protocol is not in the Game state yet (caused a client crash):
 	if (m_State != 3)
 	{
-		LOGWARNING("Trying to send a KeepAlive packet to a player who's not yet fully logged in (%d). The protocol class prevented the packet.", m_State);
+		LOGWARNING("Trying to send a KeepAlive packet to a player who's not yet fully logged in (%d). The protocol class prevented the packet.", static_cast<int>(m_State));
 		return;
 	}
 

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1965,7 +1965,7 @@ UInt32 cProtocol_1_8_0::GetPacketID(ePacketType a_PacketType) const
 		case pktWindowProperty:         return 0x31;
 		default:
 		{
-			LOG("Unhandled outgoing packet type: %s (0x%02x)", cPacketizer::PacketTypeToStr(a_PacketType), a_PacketType);
+			LOG("Unhandled outgoing packet type: %s (0x%02x)", cPacketizer::PacketTypeToStr(a_PacketType), static_cast<int>(a_PacketType));
 			ASSERT(!"Unhandled outgoing packet type");
 			return 0;
 		}

--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -782,7 +782,7 @@ void cProtocol_1_8_0::SendKeepAlive(UInt32 a_PingID)
 	// Drop the packet if the protocol is not in the Game state yet (caused a client crash):
 	if (m_State != 3)
 	{
-		LOGWARNING("Trying to send a KeepAlive packet to a player who's not yet fully logged in (%d). The protocol class prevented the packet.", m_State);
+		LOGWARNING("Trying to send a KeepAlive packet to a player who's not yet fully logged in (%d). The protocol class prevented the packet.", static_cast<int>(m_State));
 		return;
 	}
 
@@ -3087,7 +3087,7 @@ void cProtocol_1_8_0::SendPacket(cPacketizer & a_Pkt)
 		m_CommLogFile.Write(fmt::format(
 			FMT_STRING("Outgoing packet: type {} (translated to 0x{:02x}), length {} (0x{:04x}), state {}. Payload (incl. type):\n{}\n"),
 			cPacketizer::PacketTypeToStr(a_Pkt.GetPacketType()), GetPacketID(a_Pkt.GetPacketType()),
-			PacketData.size(), PacketData.size(), m_State, Hex
+			PacketData.size(), PacketData.size(), static_cast<int>(m_State), Hex
 		));
 		/*
 		// Useful for debugging a new protocol:
@@ -4161,14 +4161,14 @@ void cProtocol_1_8_0::HandlePacket(cByteBuffer & a_Buffer)
 		CreateHexDump(PacketDataHex, PacketData.data(), PacketData.size(), 16);
 		m_CommLogFile.Write(fmt::format(
 			FMT_STRING("Next incoming packet is type {0} (0x{0:x}), length {1} (0x{1:x}) at state {2}. Payload:\n{3}\n"),
-			PacketType, a_Buffer.GetUsedSpace(), m_State, PacketDataHex
+			PacketType, a_Buffer.GetUsedSpace(), static_cast<int>(m_State), PacketDataHex
 		));
 	}
 
 	if (!HandlePacket(a_Buffer, PacketType))
 	{
 		// Unknown packet, already been reported, but without the length. Log the length here:
-		LOGWARNING("Unhandled packet: type 0x%x, state %d, length %u", PacketType, m_State, a_Buffer.GetUsedSpace());
+		LOGWARNING("Unhandled packet: type 0x%x, state %d, length %u", PacketType, static_cast<int>(m_State), a_Buffer.GetUsedSpace());
 
 #ifndef NDEBUG
 		// Dump the packet contents into the log:
@@ -4195,7 +4195,7 @@ void cProtocol_1_8_0::HandlePacket(cByteBuffer & a_Buffer)
 	{
 		// Read more or less than packet length, report as error
 		LOGWARNING("Protocol 1.8: Wrong number of bytes read for packet 0x%x, state %d. Read %zu bytes, packet contained %u bytes",
-			PacketType, m_State, a_Buffer.GetUsedSpace() - a_Buffer.GetReadableSpace(), a_Buffer.GetUsedSpace()
+			PacketType, static_cast<int>(m_State), a_Buffer.GetUsedSpace() - a_Buffer.GetReadableSpace(), a_Buffer.GetUsedSpace()
 		);
 
 		// Put a message in the comm log:

--- a/src/Protocol/Protocol_1_9.cpp
+++ b/src/Protocol/Protocol_1_9.cpp
@@ -381,7 +381,7 @@ void cProtocol_1_9_0::SendKeepAlive(UInt32 a_PingID)
 	// Drop the packet if the protocol is not in the Game state yet (caused a client crash):
 	if (m_State != 3)
 	{
-		LOG("Trying to send a KeepAlive packet to a player who's not yet fully logged in (%d). The protocol class prevented the packet.", m_State);
+		LOG("Trying to send a KeepAlive packet to a player who's not yet fully logged in (%d). The protocol class prevented the packet.", static_cast<int>(m_State));
 		return;
 	}
 

--- a/src/Server.h
+++ b/src/Server.h
@@ -12,6 +12,7 @@
 #include "RCONServer.h"
 #include "OSSupport/IsThread.h"
 #include "OSSupport/Network.h"
+#include <functional>
 
 #ifdef _MSC_VER
 	#pragma warning(push)

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -642,7 +642,7 @@ AString & CreateHexDump(AString & a_Out, const void * a_Data, size_t a_Size, siz
 		auto HexStr = fmt::string_view(Hex.data(), Hex.size());
 		auto CharsStr = fmt::string_view(Chars.data(), Chars.size());
 		fmt::format_to(
-			Output, "{0:08x}: {1:{2}}   {3}\n",
+			std::back_inserter(Output), "{0:08x}: {1:{2}}   {3}\n",
 			i, HexStr, a_BytesPerLine * 3, CharsStr
 		);
 

--- a/src/UI/SlotArea.cpp
+++ b/src/UI/SlotArea.cpp
@@ -195,7 +195,7 @@ void cSlotArea::Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_ClickA
 		}
 		default:
 		{
-			LOGWARNING("SlotArea: Unhandled click action: %d (%s)", a_ClickAction, ClickActionToString(a_ClickAction));
+			LOGWARNING("SlotArea: Unhandled click action: %d (%s)", static_cast<int>(a_ClickAction), ClickActionToString(a_ClickAction));
 			m_ParentWindow.BroadcastWholeWindow();
 			return;
 		}
@@ -2561,7 +2561,7 @@ void cSlotAreaArmor::Clicked(cPlayer & a_Player, int a_SlotNum, eClickAction a_C
 	cItem & DraggingItem = a_Player.GetDraggingItem();
 	if ((a_ClickAction != caRightClick) && (a_ClickAction != caLeftClick))
 	{
-		LOGWARNING("SlotArea: Unhandled click action: %d (%s)", a_ClickAction, ClickActionToString(a_ClickAction));
+		LOGWARNING("SlotArea: Unhandled click action: %d (%s)", static_cast<int>(a_ClickAction), ClickActionToString(a_ClickAction));
 		m_ParentWindow.BroadcastWholeWindow();
 		return;
 	}

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -416,14 +416,14 @@ class fmt::formatter<Vector3<What>> : public fmt::formatter<What>
 	using Super = fmt::formatter<What>;
 
 	template <typename FormatContext, size_t Len>
-	void Write(FormatContext & a_Ctx, const char (& a_Str)[Len])
+	void Write(FormatContext & a_Ctx, const char (& a_Str)[Len]) const
 	{
 		const auto Itr = std::copy_n(&a_Str[0], Len - 1, a_Ctx.out());
 		a_Ctx.advance_to(Itr);
 	}
 
 	template <typename FormatContext>
-	void Write(FormatContext & a_Ctx, const What & a_Arg)
+	void Write(FormatContext & a_Ctx, const What & a_Arg) const
 	{
 		const auto Itr = Super::format(a_Arg, a_Ctx);
 		a_Ctx.advance_to(Itr);
@@ -432,7 +432,7 @@ class fmt::formatter<Vector3<What>> : public fmt::formatter<What>
 public:
 
 	template <typename FormatContext>
-	auto format(const Vector3<What> & a_Vec, FormatContext & a_Ctx)
+	auto format(const Vector3<What> & a_Vec, FormatContext & a_Ctx) const
 	{
 		Write(a_Ctx, "{");
 		Write(a_Ctx, a_Vec.x);

--- a/src/World.h
+++ b/src/World.h
@@ -90,10 +90,10 @@ public:
 	int GetTicksUntilWeatherChange(void) const { return m_WeatherInterval; }
 
 	/** Is the daylight cycle enabled? */
-	virtual bool IsDaylightCycleEnabled(void) const { return m_IsDaylightCycleEnabled; }
+	bool IsDaylightCycleEnabled(void) const { return m_IsDaylightCycleEnabled; }
 
 	/** Sets the daylight cycle to true / false. */
-	virtual void SetDaylightCycleEnabled(bool a_IsDaylightCycleEnabled)
+	void SetDaylightCycleEnabled(bool a_IsDaylightCycleEnabled)
 	{
 		m_IsDaylightCycleEnabled = a_IsDaylightCycleEnabled;
 		BroadcastTimeUpdate();

--- a/src/World.h
+++ b/src/World.h
@@ -22,6 +22,8 @@
 #include "Blocks/BroadcastInterface.h"
 #include "EffectID.h"
 
+#include <functional>
+
 
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -27,7 +27,6 @@
 
 
 
-
 class cFireSimulator;
 class cFluidSimulator;
 class cSandSimulator;

--- a/src/WorldStorage/EnchantmentSerializer.cpp
+++ b/src/WorldStorage/EnchantmentSerializer.cpp
@@ -33,7 +33,7 @@ void EnchantmentSerializer::ParseFromNBT(cEnchantments & a_Enchantments, const c
 	if (a_NBT.GetType(a_EnchListTagIdx) != TAG_List)
 	{
 		LOGWARNING("%s: Invalid EnchListTag type: exp %d, got %d. Enchantments not parsed",
-			__FUNCTION__, TAG_List, a_NBT.GetType(a_EnchListTagIdx)
+			__FUNCTION__, static_cast<int>(TAG_List), static_cast<int>(a_NBT.GetType(a_EnchListTagIdx))
 		);
 		ASSERT(!"Bad EnchListTag type");
 		return;
@@ -43,7 +43,7 @@ void EnchantmentSerializer::ParseFromNBT(cEnchantments & a_Enchantments, const c
 	if (a_NBT.GetChildrenType(a_EnchListTagIdx) != TAG_Compound)
 	{
 		LOGWARNING("%s: Invalid NBT list children type: exp %d, got %d. Enchantments not parsed",
-			__FUNCTION__, TAG_Compound, a_NBT.GetChildrenType(a_EnchListTagIdx)
+			__FUNCTION__, static_cast<int>(TAG_Compound), static_cast<int>(a_NBT.GetChildrenType(a_EnchListTagIdx))
 		);
 		ASSERT(!"Bad EnchListTag children type");
 		return;

--- a/src/WorldStorage/FastNBT.h
+++ b/src/WorldStorage/FastNBT.h
@@ -21,7 +21,7 @@ It directly outputs a string containing the serialized NBT data.
 
 #include <system_error>
 #include "../Endianness.h"
-
+#include <fmt/format.h>
 
 
 
@@ -45,7 +45,7 @@ enum eTagType
 } ;
 
 
-
+auto static format_as(eTagType f) { return fmt::underlying(f); }
 
 
 /** This structure is used for all NBT tags.

--- a/src/WorldStorage/FastNBT.h
+++ b/src/WorldStorage/FastNBT.h
@@ -21,7 +21,7 @@ It directly outputs a string containing the serialized NBT data.
 
 #include <system_error>
 #include "../Endianness.h"
-#include <fmt/format.h>
+
 
 
 

--- a/src/WorldStorage/FastNBT.h
+++ b/src/WorldStorage/FastNBT.h
@@ -45,7 +45,7 @@ enum eTagType
 } ;
 
 
-auto static format_as(eTagType f) { return fmt::underlying(f); }
+
 
 
 /** This structure is used for all NBT tags.

--- a/src/mbedTLS++/Sha1Checksum.cpp
+++ b/src/mbedTLS++/Sha1Checksum.cpp
@@ -111,7 +111,7 @@ void cSha1Checksum::DigestToJava(const Checksum & a_Digest, AString & a_Out)
 		bool carry = true;  // Add one to the whole number
 		for (int i = 19; i >= 0; i--)
 		{
-			Digest[i] = ~Digest[i];
+			Digest[i] = static_cast<Byte>(~Digest[i]);
 			if (carry)
 			{
 				carry = (Digest[i] == 0xff);

--- a/tests/BoundingBox/BoundingBoxTest.cpp
+++ b/tests/BoundingBox/BoundingBoxTest.cpp
@@ -40,7 +40,7 @@ static int Test(void)
 			LOGERROR("LineIntersection({%.02f, %.02f, %.02f}, {%.02f, %.02f, %.02f}) -> %d, %.05f, %d",
 				Line1.x, Line1.y, Line1.z,
 				Line2.x, Line2.y, Line2.z,
-				res ? 1 : 0, LineCoeff, Face
+				res ? 1 : 0, LineCoeff, static_cast<int>(Face)
 			);
 			NumFailed += 1;
 		}
@@ -51,7 +51,7 @@ static int Test(void)
 				LOGERROR("LineIntersection({%.02f, %.02f, %.02f}, {%.02f, %.02f, %.02f}) -> %d, %.05f, %d",
 					Line1.x, Line1.y, Line1.z,
 					Line2.x, Line2.y, Line2.z,
-					res ? 1 : 0, LineCoeff, Face
+					res ? 1 : 0, LineCoeff, static_cast<int>(Face)
 				);
 				NumFailed += 1;
 			}

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -94,14 +94,8 @@ if(WIN32)
 			TARGET LuaThreadStress  POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_BINARY_DIR}/Server/lua51.dll # Source
-			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/) # Destination
-	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/)
-
-	get_cmake_property(_variableNames VARIABLES)
-	list (SORT _variableNames)
-	foreach (_variableName ${_variableNames})
-		message(STATUS "${_variableName}=${${_variableName}}")
-	endforeach()
+			${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/) # Destination
+	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/)
 endif()
 
 

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -95,7 +95,7 @@ if(WIN32)
 			COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_BINARY_DIR}/Server/lua51.dll # Source
 			${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/) # Destination
-	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/)
+	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/)
 endif()
 
 

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -89,13 +89,14 @@ add_test(NAME LuaThreadStress-test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 # Necessary for the test to run.
 # Otherwise they crash with the error STATUS_DLL_NOT_FOUND (0xC0000135) because they can't find the lua51.dll
 
-if(WIN32)
+# Disable this for now
+if(WIN32 && false)
 	add_custom_command(
 			TARGET LuaThreadStress  POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_BINARY_DIR}/Server/lua51.dll # Source
-			${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/) # Destination
-	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/)
+			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/) # Destination
+	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/)
 endif()
 
 

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -94,8 +94,8 @@ if(WIN32)
 			TARGET LuaThreadStress  POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_BINARY_DIR}/Server/lua51.dll # Source
-			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/) # Destination
-	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/)
+			${CMAKE_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE}/) # Destination
+	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE}/)
 endif()
 
 

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -94,8 +94,14 @@ if(WIN32)
 			TARGET LuaThreadStress  POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_BINARY_DIR}/Server/lua51.dll # Source
-			${CMAKE_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE}/) # Destination
-	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_BINARY_DIR}/bin/${CMAKE_BUILD_TYPE}/)
+			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/) # Destination
+	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/)
+
+	get_cmake_property(_variableNames VARIABLES)
+	list (SORT _variableNames)
+	foreach (_variableName ${_variableNames})
+		message(STATUS "${_variableName}=${${_variableName}}")
+	endforeach()
 endif()
 
 

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -90,7 +90,7 @@ add_test(NAME LuaThreadStress-test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 # Otherwise they crash with the error STATUS_DLL_NOT_FOUND (0xC0000135) because they can't find the lua51.dll
 
 # Disable this for now
-if(WIN32 && false)
+if(WIN32 AND false)
 	add_custom_command(
 			TARGET LuaThreadStress  POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -94,8 +94,8 @@ if(WIN32)
 			TARGET LuaThreadStress  POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_BINARY_DIR}/Server/lua51.dll # Source
-			${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/) # Destination
-	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/)
+			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/) # Destination
+	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/)
 endif()
 
 

--- a/tests/LuaThreadStress/CMakeLists.txt
+++ b/tests/LuaThreadStress/CMakeLists.txt
@@ -94,7 +94,7 @@ if(WIN32)
 			TARGET LuaThreadStress  POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_BINARY_DIR}/Server/lua51.dll # Source
-			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/) # Destination
+			${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/) # Destination
 	message("Copying lua51.dll from " ${CMAKE_BINARY_DIR}/Server/lua51.dll " to " ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/)
 endif()
 


### PR DESCRIPTION
Fixed implicit capture in lambdas.
Disable a macro in Globals.h that overrides the new operator because it causes builds to fail on MSVC. 
Updated FMT lib.
Fixed broken api changes.
Explicitly cast enums in print functions as ints because they are no longer done so implicitly