### PR TITLE
Fix custom name JSON serialization crash in 1.13+ clients

### DIFF
--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -1107,7 +1107,7 @@ void cProtocol_1_13::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_
 			{
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomName, EntityMetadataType::OptChat);
 				a_Pkt.WriteBool(true);
-				a_Pkt.WriteString(a_Mob.GetCustomName());
+				a_Pkt.WriteString(JsonUtils::SerializeSingleValueJsonObject("text", a_Mob.GetCustomName()));
 
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityNameVisible, EntityMetadataType::Boolean);
 				a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());

--- a/src/Protocol/Protocol_1_14.cpp
+++ b/src/Protocol/Protocol_1_14.cpp
@@ -1034,7 +1034,7 @@ void cProtocol_1_14::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_
 			{
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomName, EntityMetadataType::OptChat);
 				a_Pkt.WriteBool(true);
-				a_Pkt.WriteString(a_Mob.GetCustomName());
+				a_Pkt.WriteString(JsonUtils::SerializeSingleValueJsonObject("text", a_Mob.GetCustomName()));
 
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityNameVisible, EntityMetadataType::Boolean);
 				a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());

--- a/src/Protocol/Protocol_1_15.cpp
+++ b/src/Protocol/Protocol_1_15.cpp
@@ -1151,7 +1151,7 @@ void cProtocol_1_15::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_
 			{
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomName, EntityMetadataType::OptChat);
 				a_Pkt.WriteBool(true);
-				a_Pkt.WriteString(a_Mob.GetCustomName());
+				a_Pkt.WriteString(JsonUtils::SerializeSingleValueJsonObject("text", a_Mob.GetCustomName()));
 
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityNameVisible, EntityMetadataType::Boolean);
 				a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());

--- a/src/Protocol/Protocol_1_19.cpp
+++ b/src/Protocol/Protocol_1_19.cpp
@@ -2962,7 +2962,7 @@ void cProtocol_1_19_4::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & 
 			{
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomName, EntityMetadataType::OptChat);
 				a_Pkt.WriteBool(true);
-				a_Pkt.WriteString(a_Mob.GetCustomName());
+				a_Pkt.WriteString(JsonUtils::SerializeSingleValueJsonObject("text", a_Mob.GetCustomName()));
 
 				WriteEntityMetadata(a_Pkt, EntityMetadata::EntityNameVisible, EntityMetadataType::Boolean);
 				a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());


### PR DESCRIPTION
Fixed client crashes when using name tags on mobs in Minecraft 1.13+. Custom names were sent as plain strings instead of properly formatted JSON chat components, causing invalid JSON error crashes.

## Changes

- Protocol_1_13.cpp: Serialize custom names as JSON chat components
- Protocol_1_14.cpp: Serialize custom names as JSON chat components  
- Protocol_1_15.cpp: Serialize custom names as JSON chat components
- Protocol_1_19.cpp: Fix cProtocol_1_19_4 custom name serialization

All affected protocols now use JsonUtils::SerializeSingleValueJsonObject() to ensure proper JSON formatting with correct escaping of special characters (quotes, backslashes, newlines, etc.).

Fixes #5577