### PR TITLE
Fix item pickup sound for 1.8 clients

### DIFF
--- a/src/Protocol/Protocol_1_8.cpp
+++ b/src/Protocol/Protocol_1_8.cpp
@@ -1461,8 +1461,15 @@ void cProtocol_1_8_0::SendSoundEffect(const AString & a_SoundName, Vector3d a_Or
 {
 	ASSERT(m_State == 3);  // In game mode?
 
+	// Translate 1.9+ sound names to 1.8 format
+	AString soundName = a_SoundName;
+	if (a_SoundName == "entity.item.pickup")
+	{
+		soundName = "random.pop";
+	}
+
 	cPacketizer Pkt(*this, pktSoundEffect);
-	Pkt.WriteString(a_SoundName);
+	Pkt.WriteString(soundName);
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Origin.x * 8.0));
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Origin.y * 8.0));
 	Pkt.WriteBEInt32(static_cast<Int32>(a_Origin.z * 8.0));


### PR DESCRIPTION
Fixed missing item pickup sound for 1.8 clients. The sound was silent because the server was sending 1.9+ sound names that 1.8 clients don't recognize.

## Root Cause

- `Pickup.cpp` and `ArrowEntity.cpp` broadcast `"entity.item.pickup"` sound (1.9+ format)
- `Protocol_1_8::SendSoundEffect()` was sending this name directly to clients without translation
- 1.8 clients don't recognize 1.9+ sound names, so the sound was ignored

## Changes

- `Protocol_1_8.cpp`: Added sound name translation in `SendSoundEffect()`
- Converts `"entity.item.pickup"` to `"random.pop"` for 1.8 clients

## Testing

- Test on 1.8 client: Pick up items and verify sound plays
- Test on 1.9+ clients: Verify sound still works (unchanged)

Fixes #5616