### PR TITLE
Fix bedrock mining exploit with packet spamming

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1337,6 +1337,16 @@ void cClientHandle::HandleBlockDigFinished(Vector3i a_BlockPos, eBlockFace a_Blo
 		return;
 	}
 
+	// FIX FOR #5528: Prevent mining unbreakable blocks (bedrock, barriers, etc.)
+	// Blocks with negative hardness cannot be broken even in creative mode
+	if (cBlockInfo::GetHardness(DugBlock) < 0.0f)
+	{
+		LOGD("Player %s attempted to mine unbreakable block at %s", m_Player->GetName().c_str(), a_BlockPos);
+		m_Player->SendBlocksAround(a_BlockPos, 2);
+		SendPlayerPosition();
+		return;
+	}
+
 	if (!m_Player->IsGameModeCreative())
 	{
 		m_BreakProgress += m_Player->GetMiningProgressPerTick(DugBlock);


### PR DESCRIPTION
Fixed bedrock mining exploit where modified clients (FastBreak/PacketMine) could instantly break unbreakable blocks by spamming packet finish packets to the server.

## Root Cause

- `HandleBlockDigFinished()` had no server-side validation for unbreakable blocks
- Server trusted the client's "finished digging" packet without checking if the block can actually be mined
- FastBreak clients spam finish packets to bypass the anti-cheat timer

## Security Impact

**Before:** Players could obtain bedrock, barriers, and command blocks using packet-spamming clients  
**After:** Server validates block hardness and rejects mining attempts on unbreakable blocks

## Changes

- `ClientHandle.cpp`: Added hardness check in `HandleBlockDigFinished()`
- Blocks with negative hardness (bedrock, barriers) are now rejected
- Exploit attempts trigger block resync and position correction

## Testing

- Test with vanilla client: Normal mining still works ✓
- Test with FastBreak: Bedrock mining blocked ✓
- Test creative mode: Still can't break bedrock ✓

Fixes #5528