### PR TITLE
Fix armor not rendering when picked up with chest GUI open

### DIFF
--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -846,9 +846,11 @@ void cInventory::OnSlotChanged(cItemGrid * a_ItemGrid, int a_SlotNum)
 	cWorld * World = m_Owner.GetWorld();
 	if ((a_ItemGrid == &m_ArmorSlots) && (World != nullptr))
 	{
+		// FIX FOR #5518: Send EntityEquipment to all players including owner
+		// This ensures armor renders even when the owner has a different window open (e.g. chest GUI)
 		World->BroadcastEntityEquipment(
 			m_Owner, static_cast<short>(ArmorSlotNumToEntityEquipmentID(static_cast<short>(a_SlotNum))),
-			m_ArmorSlots.GetSlot(a_SlotNum), m_Owner.GetClientHandle()
+			m_ArmorSlots.GetSlot(a_SlotNum), nullptr  // nullptr = don't exclude anyone, send to owner too
 		);
 	}
 


### PR DESCRIPTION
Fixed armor not rendering when picked up while a chest GUI is open. Armor would appear missing from inventory slots and the player avatar, but clicking on the invisible armor slot would reveal it - classic desync bug.

## Root Cause

- `Inventory.cpp`: `OnSlotChanged()` broadcasts `EntityEquipment` to other players but **excludes the owner**
- Owner only receives `SendInventorySlot` update (window ID 0)
- When a different window is open (chest, furnace, etc.), the client doesn't process window 0 slot updates properly
- Result: Armor is equipped server-side but not rendered client-side

## Fix

- Changed `BroadcastEntityEquipment` exclude parameter from `m_Owner.GetClientHandle()` to `nullptr`
- Owner now receives the `EntityEquipment` packet which renders correctly regardless of open window
- The `EntityEquipment` packet updates the player's visual armor model directly

## Testing

- Normal case: Armor pickup with inventory closed still works ✓
- Bug case: Armor pickup with chest open now renders immediately ✓
- Armor visible on both player avatar and in inventory slots ✓

Fixes #5518