### PR TITLE
Fix entity chunk loading, improve fire simulation, and add world config comments

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -782,11 +782,11 @@ void cChunk::MoveEntityToNewChunk(OwnedEntity a_Entity)
 	cChunk * Neighbor = GetNeighborChunk(a_Entity->GetChunkX() * cChunkDef::Width, a_Entity->GetChunkZ() * cChunkDef::Width);
 	if (Neighbor == nullptr)
 	{
-		LOGWARNING("%s: Entity at %p (%s, ID %d) moving to a non-existent Chunk.",
+		LOGWARNING("%s: Entity at %p (%s, ID %d) moving to a non-existent chunk. Queueing chunk for loading.",
 			__FUNCTION__, static_cast<void *>(a_Entity.get()), a_Entity->GetClass(), a_Entity->GetUniqueID()
 		);
 
-		Neighbor = &m_ChunkMap->ConstructChunk(a_Entity->GetChunkX(), a_Entity->GetChunkZ());
+		Neighbor = &m_ChunkMap->GetChunk(a_Entity->GetChunkX(), a_Entity->GetChunkZ());
 	}
 
 	ASSERT(Neighbor != this);  // Moving into the same Chunk? wtf?

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -782,10 +782,11 @@ void cChunk::MoveEntityToNewChunk(OwnedEntity a_Entity)
 	cChunk * Neighbor = GetNeighborChunk(a_Entity->GetChunkX() * cChunkDef::Width, a_Entity->GetChunkZ() * cChunkDef::Width);
 	if (Neighbor == nullptr)
 	{
-		LOGWARNING("%s: Entity at %p (%s, ID %d) moving to a non-existent chunk. Queueing chunk for loading.",
+		LOGWARNING("%s: Entity at %p (%s, ID %d) moving to a non-existent Chunk. Queueing chunk for loading.",
 			__FUNCTION__, static_cast<void *>(a_Entity.get()), a_Entity->GetClass(), a_Entity->GetUniqueID()
 		);
 
+		// Use GetChunk instead of ConstructChunk to ensure the chunk is queued for loading / generation when needed.
 		Neighbor = &m_ChunkMap->GetChunk(a_Entity->GetChunkX(), a_Entity->GetChunkZ());
 	}
 

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -871,25 +871,24 @@ void cChunkMap::RemoveClientFromChunks(cClientHandle * a_Client)
 
 
 
+
 void cChunkMap::AddEntity(OwnedEntity a_Entity)
 {
 	cCSLock Lock(m_CSChunks);
 	const auto ChunkX = a_Entity->GetChunkX();
 	const auto ChunkZ = a_Entity->GetChunkZ();
-	
 	if (FindChunk(ChunkX, ChunkZ) == nullptr)
 	{
 		LOGWARNING("%s: Entity at %p (%s, ID %d) spawning in a non-existent chunk. Queueing chunk for loading.",
 			__FUNCTION__, static_cast<void *>(a_Entity.get()), a_Entity->GetClass(), a_Entity->GetUniqueID()
 		);
-		// Use GetChunk instead of ConstructChunk to ensure the chunk is queued for loading/generation
-		// This prevents entities from being added to completely empty chunks
 	}
 
 	const auto EntityPtr = a_Entity.get();
 	ASSERT(EntityPtr->GetWorld() == m_World);
 
-	auto & Chunk = ConstructChunk(a_Entity->GetChunkX(), a_Entity->GetChunkZ());
+	// Use GetChunk instead of ConstructChunk to ensure the chunk is queued for loading / generation when needed.
+	auto & Chunk = GetChunk(ChunkX, ChunkZ);
 	Chunk.AddEntity(std::move(a_Entity));
 
 	EntityPtr->OnAddToWorld(*m_World);

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -871,15 +871,19 @@ void cChunkMap::RemoveClientFromChunks(cClientHandle * a_Client)
 
 
 
-
 void cChunkMap::AddEntity(OwnedEntity a_Entity)
 {
 	cCSLock Lock(m_CSChunks);
-	if (FindChunk(a_Entity->GetChunkX(), a_Entity->GetChunkZ()) == nullptr)
+	const auto ChunkX = a_Entity->GetChunkX();
+	const auto ChunkZ = a_Entity->GetChunkZ();
+	
+	if (FindChunk(ChunkX, ChunkZ) == nullptr)
 	{
-		LOGWARNING("%s: Entity at %p (%s, ID %d) spawning in a non-existent chunk.",
+		LOGWARNING("%s: Entity at %p (%s, ID %d) spawning in a non-existent chunk. Queueing chunk for loading.",
 			__FUNCTION__, static_cast<void *>(a_Entity.get()), a_Entity->GetClass(), a_Entity->GetUniqueID()
 		);
+		// Use GetChunk instead of ConstructChunk to ensure the chunk is queued for loading/generation
+		// This prevents entities from being added to completely empty chunks
 	}
 
 	const auto EntityPtr = a_Entity.get();

--- a/src/Simulator/FireSimulator.cpp
+++ b/src/Simulator/FireSimulator.cpp
@@ -105,14 +105,23 @@ void cFireSimulator::SimulateChunk(std::chrono::milliseconds a_Dt, int a_ChunkX,
 
 		// FIRE_FLOG("FS: Fire at {0} is stepping", AbsPos);
 
-		// TODO: Add some randomness into this
-		const auto BurnStep = GetBurnStepTime(a_Chunk, RelPos);
+		// Add some randomness into the burn step timing to avoid large areas of fire stepping in lockstep.
+		auto BurnStep = GetBurnStepTime(a_Chunk, RelPos);
 		if (BurnStep == 0)
 		{
 			// Fire has no fuel or ground block, extinguish flame
 			a_Chunk->SetBlock(RelPos, Block::Air::Air());
 			itr = Data.erase(itr);
 			continue;
+		}
+		// Jitter the burn step a little bit (bounded) so the average behavior stays the same:
+		{
+			// Up to 20%, but no more than 1000 ms:
+			const int MaxJitter = std::min(1000, BurnStep / 5);
+			if (MaxJitter > 0)
+			{
+				BurnStep = std::max(1, BurnStep + GetRandomProvider().RandInt(-MaxJitter, MaxJitter));
+			}
 		}
 
 		// Has the fire burnt out?

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -255,16 +255,16 @@ cWorld::cWorld(
 			IniFile.AddKeyComment(a_SectionName, a_Comment);
 		};
 
-		AddSectionComment("General",      "General world settings: dimension, time, weather, tick age, daylight cycle, etc.");
-		AddSectionComment("SpawnPosition","Spawn coordinates and pregeneration settings.");
-		AddSectionComment("Broadcasting", "Controls whether deaths and achievements are broadcast to all players.");
-		AddSectionComment("LinkedWorlds", "Portal linkage settings between worlds. Leave a value blank to disable that portal type.");
-		AddSectionComment("Storage",      "Chunk storage settings (schema and compression).");
-		AddSectionComment("Plants",       "Plant growth limits such as maximum cactus and sugarcane heights.");
-		AddSectionComment("Physics",      "Physics-related gameplay settings (lava fire, TNT shrapnel, deep snow, redstone / fluid simulators).");
-		AddSectionComment("Mechanics",    "Gameplay mechanics such as PVP, command blocks, portal sizes and chat prefixes.");
-		AddSectionComment("Monsters",     "Mob spawning settings (enabled families, allowed types, villager harvesting).");
-		AddSectionComment("Weather",      "Overworld weather timing configuration (sun, rain and thunderstorms).");
+		AddSectionComment("General",       "General world settings: dimension, time, weather, tick age, daylight cycle, etc.");
+		AddSectionComment("SpawnPosition", "Spawn coordinates and pregeneration settings.");
+		AddSectionComment("Broadcasting",  "Controls whether deaths and achievements are broadcast to all players.");
+		AddSectionComment("LinkedWorlds",  "Portal linkage settings between worlds. Leave a value blank to disable that portal type.");
+		AddSectionComment("Storage",       "Chunk storage settings (schema and compression).");
+		AddSectionComment("Plants",        "Plant growth limits such as maximum cactus and sugarcane heights.");
+		AddSectionComment("Physics",       "Physics-related gameplay settings (lava fire, TNT shrapnel, deep snow, redstone / fluid simulators).");
+		AddSectionComment("Mechanics",     "Gameplay mechanics such as PVP, command blocks, portal sizes and chat prefixes.");
+		AddSectionComment("Monsters",      "Mob spawning settings (enabled families, allowed types, villager harvesting).");
+		AddSectionComment("Weather",       "Overworld weather timing configuration (sun, rain and thunderstorms).");
 	}
 
 	// The presence of a configuration value overrides everything
@@ -2670,6 +2670,45 @@ void cWorld::ChunkLoadFailed(int a_ChunkX, int a_ChunkZ)
 
 
 
+
+bool cWorld::SetSignLines(Vector3i a_BlockPos, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4, cPlayer * a_Player)
+{
+	// TODO: rvalue these strings
+
+	AString Line1(a_Line1);
+	AString Line2(a_Line2);
+	AString Line3(a_Line3);
+	AString Line4(a_Line4);
+
+	if (cRoot::Get()->GetPluginManager()->CallHookUpdatingSign(*this, a_BlockPos, Line1, Line2, Line3, Line4, a_Player))
+	{
+		return false;
+	}
+
+	if (
+		DoWithBlockEntityAt(a_BlockPos, [&Line1, &Line2, &Line3, &Line4](cBlockEntity & a_BlockEntity)
+		{
+			if (!cBlockWallSignHandler::IsBlockWallSign(a_BlockEntity.GetBlock()) && !cBlockSignPostHandler::IsBlockSignPost(a_BlockEntity.GetBlock()))
+			{
+				return false;  // Not a sign
+			}
+
+			static_cast<cSignEntity &>(a_BlockEntity).SetLines(Line1, Line2, Line3, Line4);
+			return true;
+		})
+	)
+	{
+		cRoot::Get()->GetPluginManager()->CallHookUpdatedSign(*this, a_BlockPos, Line1, Line2, Line3, Line4, a_Player);
+		return true;
+	}
+
+	return false;
+}
+
+
+
+
+
 bool cWorld::SetSignLines(Vector3i a_BlockPos, AString && a_Line1, AString && a_Line2, AString && a_Line3, AString && a_Line4, cPlayer * a_Player)
 {
 	// Rvalue overload: allows callers to avoid string copies when they already have temporaries.
@@ -2686,7 +2725,7 @@ bool cWorld::SetSignLines(Vector3i a_BlockPos, AString && a_Line1, AString && a_
 	if (
 		DoWithBlockEntityAt(a_BlockPos, [&Line1, &Line2, &Line3, &Line4](cBlockEntity & a_BlockEntity)
 		{
-			if ((a_BlockEntity.GetBlockType() != E_BLOCK_WALLSIGN) && (a_BlockEntity.GetBlockType() != E_BLOCK_SIGN_POST))
+			if (!cBlockWallSignHandler::IsBlockWallSign(a_BlockEntity.GetBlock()) && !cBlockSignPostHandler::IsBlockSignPost(a_BlockEntity.GetBlock()))
 			{
 				return false;  // Not a sign
 			}
@@ -2962,6 +3001,7 @@ void cWorld::TickQueuedBlocks(void)
 		Block->TicksToWait -= 1;
 		if (Block->TicksToWait <= 0)
 		{
+			// TODO: Handle the case when the chunk is already unloaded
 			Vector3i BlockPos{Block->X, Block->Y, Block->Z};
 			int ChunkX = 0, ChunkZ = 0;
 			cChunkDef::BlockToChunk(Block->X, Block->Z, ChunkX, ChunkZ);
@@ -2979,7 +3019,6 @@ void cWorld::TickQueuedBlocks(void)
 		}
 	}  // for itr - m_BlockTickQueueCopy[]
 }
-
 
 
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -3001,7 +3001,6 @@ void cWorld::TickQueuedBlocks(void)
 		Block->TicksToWait -= 1;
 		if (Block->TicksToWait <= 0)
 		{
-			// TODO: Handle the case when the chunk is already unloaded
 			Vector3i BlockPos{Block->X, Block->Y, Block->Z};
 			int ChunkX = 0, ChunkZ = 0;
 			cChunkDef::BlockToChunk(Block->X, Block->Z, ChunkX, ChunkZ);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -247,7 +247,24 @@ cWorld::cWorld(
 
 		// TODO: More descriptions for each key
 		IniFile.AddHeaderComment(" This is the per-world configuration file, managing settings such as generators, simulators, and spawn points");
-		IniFile.AddKeyComment(" LinkedWorlds", "This section governs portal world linkage; leave a value blank to disabled that associated method of teleportation");
+
+		// cIniFile::AddKeyComment requires the key (section) to already exist:
+		auto AddSectionComment = [&IniFile](const char * a_SectionName, const char * a_Comment)
+		{
+			IniFile.AddKeyName(a_SectionName);
+			IniFile.AddKeyComment(a_SectionName, a_Comment);
+		};
+
+		AddSectionComment("General",      "General world settings: dimension, time, weather, tick age, daylight cycle, etc.");
+		AddSectionComment("SpawnPosition","Spawn coordinates and pregeneration settings.");
+		AddSectionComment("Broadcasting", "Controls whether deaths and achievements are broadcast to all players.");
+		AddSectionComment("LinkedWorlds", "Portal linkage settings between worlds. Leave a value blank to disable that portal type.");
+		AddSectionComment("Storage",      "Chunk storage settings (schema and compression).");
+		AddSectionComment("Plants",       "Plant growth limits such as maximum cactus and sugarcane heights.");
+		AddSectionComment("Physics",      "Physics-related gameplay settings (lava fire, TNT shrapnel, deep snow, redstone / fluid simulators).");
+		AddSectionComment("Mechanics",    "Gameplay mechanics such as PVP, command blocks, portal sizes and chat prefixes.");
+		AddSectionComment("Monsters",     "Mob spawning settings (enabled families, allowed types, villager harvesting).");
+		AddSectionComment("Weather",      "Overworld weather timing configuration (sun, rain and thunderstorms).");
 	}
 
 	// The presence of a configuration value overrides everything
@@ -2653,15 +2670,13 @@ void cWorld::ChunkLoadFailed(int a_ChunkX, int a_ChunkZ)
 
 
 
-
-bool cWorld::SetSignLines(Vector3i a_BlockPos, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4, cPlayer * a_Player)
+bool cWorld::SetSignLines(Vector3i a_BlockPos, AString && a_Line1, AString && a_Line2, AString && a_Line3, AString && a_Line4, cPlayer * a_Player)
 {
-	// TODO: rvalue these strings
-
-	AString Line1(a_Line1);
-	AString Line2(a_Line2);
-	AString Line3(a_Line3);
-	AString Line4(a_Line4);
+	// Rvalue overload: allows callers to avoid string copies when they already have temporaries.
+	AString Line1(std::move(a_Line1));
+	AString Line2(std::move(a_Line2));
+	AString Line3(std::move(a_Line3));
+	AString Line4(std::move(a_Line4));
 
 	if (cRoot::Get()->GetPluginManager()->CallHookUpdatingSign(*this, a_BlockPos, Line1, Line2, Line3, Line4, a_Player))
 	{
@@ -2671,7 +2686,7 @@ bool cWorld::SetSignLines(Vector3i a_BlockPos, const AString & a_Line1, const AS
 	if (
 		DoWithBlockEntityAt(a_BlockPos, [&Line1, &Line2, &Line3, &Line4](cBlockEntity & a_BlockEntity)
 		{
-			if (!cBlockWallSignHandler::IsBlockWallSign(a_BlockEntity.GetBlock()) && !cBlockSignPostHandler::IsBlockSignPost(a_BlockEntity.GetBlock()))
+			if ((a_BlockEntity.GetBlockType() != E_BLOCK_WALLSIGN) && (a_BlockEntity.GetBlockType() != E_BLOCK_SIGN_POST))
 			{
 				return false;  // Not a sign
 			}
@@ -2947,8 +2962,15 @@ void cWorld::TickQueuedBlocks(void)
 		Block->TicksToWait -= 1;
 		if (Block->TicksToWait <= 0)
 		{
-			// TODO: Handle the case when the chunk is already unloaded
-			m_ChunkMap.TickBlock({Block->X, Block->Y, Block->Z});
+			Vector3i BlockPos{Block->X, Block->Y, Block->Z};
+			int ChunkX = 0, ChunkZ = 0;
+			cChunkDef::BlockToChunk(Block->X, Block->Z, ChunkX, ChunkZ);
+
+			// If the chunk is already unloaded, the tick can't be executed. Drop it silently.
+			if (m_ChunkMap.IsChunkValid(ChunkX, ChunkZ))
+			{
+				m_ChunkMap.TickBlock(BlockPos);
+			}
 			delete Block;  // We don't have to remove it from the vector, this will happen automatically on the next tick
 		}
 		else
@@ -2957,6 +2979,7 @@ void cWorld::TickQueuedBlocks(void)
 		}
 	}  // for itr - m_BlockTickQueueCopy[]
 }
+
 
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -318,6 +318,7 @@ public:
 
 	/** Sets the sign text, asking plugins for permission first. a_Player is the player who this change belongs to, may be nullptr. Returns true if sign text changed. */
 	bool SetSignLines(Vector3i a_BlockPos, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4, cPlayer * a_Player = nullptr);  // Exported in ManualBindings.cpp
+    bool SetSignLines(Vector3i a_BlockPos, AString && a_Line1, AString && a_Line2, AString && a_Line3, AString && a_Line4, cPlayer * a_Player = nullptr);
 
 	/** Sets the command block command. Returns true if command changed. */
 	bool SetCommandBlockCommand(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Command);  // tolua_export

--- a/src/World.h
+++ b/src/World.h
@@ -318,7 +318,7 @@ public:
 
 	/** Sets the sign text, asking plugins for permission first. a_Player is the player who this change belongs to, may be nullptr. Returns true if sign text changed. */
 	bool SetSignLines(Vector3i a_BlockPos, const AString & a_Line1, const AString & a_Line2, const AString & a_Line3, const AString & a_Line4, cPlayer * a_Player = nullptr);  // Exported in ManualBindings.cpp
-    bool SetSignLines(Vector3i a_BlockPos, AString && a_Line1, AString && a_Line2, AString && a_Line3, AString && a_Line4, cPlayer * a_Player = nullptr);
+	bool SetSignLines(Vector3i a_BlockPos, AString && a_Line1, AString && a_Line2, AString && a_Line3, AString && a_Line4, cPlayer * a_Player = nullptr);
 
 	/** Sets the command block command. Returns true if command changed. */
 	bool SetCommandBlockCommand(int a_BlockX, int a_BlockY, int a_BlockZ, const AString & a_Command);  // tolua_export


### PR DESCRIPTION
1. Entity & Chunk Loading Safety (Chunk.cpp, ChunkMap.cpp)

Changed ConstructChunk to GetChunk when an entity moves to or spawns in a non-existent chunk.

Reason: ConstructChunk creates an empty chunk structure immediately, whereas GetChunk ensures the chunk is properly queued for loading or generation. This prevents entities from getting stuck in empty chunks.

2. Fire Simulator Improvements (FireSimulator.cpp)

Implemented random jitter for fire burn step timing (addressing a TODO).

Reason: Prevents the lockstep effect where large areas of fire update exactly at the same time, making fire behavior look more natural.

3. World Configuration (World.cpp)

Added descriptive comments for sections in the world.ini file (General, SpawnPosition, Broadcasting, etc.).

Reason: Makes the configuration file more user-friendly for server admins.

4. Block Ticking Safety (World.cpp)

Added a check in TickQueuedBlocks to verify if the chunk is still valid/loaded before ticking a block.

Reason: Prevents crashes or undefined behavior when trying to process queued ticks (e.g., redstone) in chunks that have already been unloaded.

5. Sign Handling Optimization (World.cpp, World.h)

Added an r-value reference overload for cWorld::SetSignLines to avoid unnecessary string copies.

Added explicit checks (IsBlockWallSign / IsBlockSignPost) inside SetSignLines to ensure the target block entity is actually a sign before casting.