### PR TITLE
Serialize mob custom names as JSON chat components for 1.13 / 1.14 clients

### DIFF
--- a/src/Protocol/Protocol_1_13.cpp
+++ b/src/Protocol/Protocol_1_13.cpp
@@ -969,7 +969,7 @@ void cProtocol_1_13::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mo
 		// TODO: As of 1.9 _all_ entities can have custom names; should this be moved up?
 		WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomName, EntityMetadataType::OptChat);
 		a_Pkt.WriteBool(true);
-		a_Pkt.WriteString(a_Mob.GetCustomName());
+		a_Pkt.WriteString(JsonUtils::SerializeSingleValueJsonObject("text", a_Mob.GetCustomName()));
 
 		WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomNameVisible, EntityMetadataType::Boolean);
 		a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());

--- a/src/Protocol/Protocol_1_14.cpp
+++ b/src/Protocol/Protocol_1_14.cpp
@@ -1255,7 +1255,7 @@ void cProtocol_1_14::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mo
 		// TODO: As of 1.9 _all_ entities can have custom names; should this be moved up?
 		WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomName, EntityMetadataType::OptChat);
 		a_Pkt.WriteBool(true);
-		a_Pkt.WriteString(a_Mob.GetCustomName());
+		a_Pkt.WriteString(JsonUtils::SerializeSingleValueJsonObject("text", a_Mob.GetCustomName()));
 
 		WriteEntityMetadata(a_Pkt, EntityMetadata::EntityCustomNameVisible, EntityMetadataType::Boolean);
 		a_Pkt.WriteBool(a_Mob.IsCustomNameAlwaysVisible());


### PR DESCRIPTION
1.13+ clients expect the custom-name entity metadata (OptChat) to be a JSON chat component, but cProtocol_1_13 and cProtocol_1_14 write the raw name string, which vanilla clients fail to parse (#5577). This is the same one-line serialization these protocols already use for window titles.

Verified on a local gcc Release build: offline-mode server, zombie spawned with custom name PR5627Test via a small test plugin, client-side metadata captured with node-minecraft-protocol.

Unpatched master, protocols 1.13 and 1.14.4 both receive:

    value = "PR5627Test"

With this change:

    value = {"text":"PR5627Test"}

The experimental branch has the same fix pending in #5627, tested the same way there.

Fixes #5577.